### PR TITLE
New near tactics + typeclasses speedup!

### DIFF
--- a/derive.v
+++ b/derive.v
@@ -37,6 +37,7 @@ Class is_diff_def (F : filter_on V) (Fph : phantom (set (set V)) F) (f : V -> W)
     ex_diff : differentiable F f;
     diff_val : 'd_F f = df :> (V -> W)
   }.
+Hint Mode is_diff_def - - ! - : typeclass_instances.
 
 Lemma diffP (F : filter_on V) (f : V -> W) :
   differentiable F f <->
@@ -140,12 +141,12 @@ Proof.
 move=> /diff_locallyP [dfc]; rewrite -addrA.
 rewrite (littleo_bigO_eqo (cst (1 : R^o))); last first.
   apply/eqOP; exists 1 => //; rewrite /cst mul1r [`|[1 : R^o]|]absr1.
-  near=> y; [rewrite ltrW //; near: y|end_near].
+  near=> y; rewrite ltrW //; near: y.
   by apply/locally_normP; eexists=> [|?];
     last (rewrite /= ?sub0r ?normmN; apply).
 rewrite addfo; first by move=> /eqolim; rewrite flim_shift add0r.
 by apply/eqolim0P; apply: (flim_trans (dfc 0)); rewrite linear0.
-Qed.
+Grab Existential Variables. all: end_near. Qed.
 
 Section littleo_lemmas.
 
@@ -207,16 +208,14 @@ rewrite -locally_nearE locally_simpl /= locallyE'; split; last first.
   by rewrite addrA subrr add0r normmN scale0r !normm0 mulr0.
 have /eqolimP := df; rewrite -[lim _]/(derive _ _ _).
 move=> /eqaddoP /(_ e%:num) /(_ [gt0 of e%:num]).
-apply: filter_app; near=> h.
-  rewrite /= opprD -![(_ + _ : _ -> _) _]/(_ + _) -![(- _ : _ -> _) _]/(- _).
-  rewrite /cst /= [`|[1 : R^o]|]absr1 mulr1 => dfv.
-  rewrite addrA -[X in X + _]scale1r -(@mulVf _ h); last by near: h.
-  rewrite mulrC -scalerA -scalerBr; apply: ler_trans (ler_normmZ _ _) _.
-  rewrite -ler_pdivl_mull; last by rewrite absRE normr_gt0; near: h.
-  rewrite mulrCA mulVf; last by rewrite absr_eq0; near: h.
-  by rewrite mulr1.
-by end_near; rewrite /= locally_simpl; exists 1 => // ?? /eqP.
-Qed.
+apply: filter_app; rewrite /= !near_simpl near_withinE; near=> h => hN0.
+rewrite /= opprD -![(_ + _ : _ -> _) _]/(_ + _) -![(- _ : _ -> _) _]/(- _).
+rewrite /cst /= [`|[1 : R^o]|]absr1 mulr1 => dfv.
+rewrite addrA -[X in X + _]scale1r -(@mulVf _ h) //.
+rewrite mulrC -scalerA -scalerBr; apply: ler_trans (ler_normmZ _ _) _.
+rewrite -ler_pdivl_mull; last by rewrite absRE normr_gt0.
+by rewrite mulrCA mulVf ?mulr1; last by rewrite absr_eq0.
+Grab Existential Variables. all: end_near. Qed.
 
 Lemma derivable_locallyP (f : V -> W) a v :
   derivable f a v <->
@@ -227,16 +226,13 @@ split; first exact: derivable_locally.
 move=> df; apply/cvg_ex; exists (derive f a v).
 apply/(@eqolimP _ _ _ (locally'_filter_on _))/eqaddoP => _/posnumP[e].
 have /eqaddoP /(_ e%:num) /(_ [gt0 of e%:num]) := df.
-rewrite -locally_nearE locally_simpl /= locallyE' => -[dfa _]; move: dfa.
-apply: filter_app; near=> h.
-  rewrite /= opprD -![(_ + _ : _ -> _) _]/(_ + _) -![(- _ : _ -> _) _]/(- _).
-  rewrite /cst /= [`|[1 : R^o]|]absr1 mulr1 addrA => dfv.
-  rewrite -[X in _ - X]scale1r -(@mulVf _ h); last by near: h.
-  rewrite -scalerA -scalerBr; apply: ler_trans (ler_normmZ _ _) _.
-  rewrite absRE normfV ler_pdivr_mull; last by rewrite normr_gt0; near: h.
-  by rewrite mulrC -absRE.
-by end_near; exists 1 => // ?? /eqP.
-Qed.
+rewrite /= !(near_simpl, near_withinE); apply: filter_app; near=> h.
+rewrite /= opprD -![(_ + _ : _ -> _) _]/(_ + _) -![(- _ : _ -> _) _]/(- _).
+rewrite /cst /= [`|[1 : R^o]|]absr1 mulr1 addrA => dfv hN0.
+rewrite -[X in _ - X]scale1r -(@mulVf _ h) //.
+rewrite -scalerA -scalerBr (ler_trans (ler_normmZ _ _)) //.
+by rewrite absRE normfV ler_pdivr_mull ?normr_gt0 // mulrC -absRE.
+Grab Existential Variables. all: end_near. Qed.
 
 Lemma derivable_locallyx (f : V -> W) a v :
   derivable f a v -> forall h, f (a + h *: v) = f a + h *: derive f a v
@@ -609,16 +605,14 @@ apply/eqoP => _ /posnumP[e].
 have /eqO_bigO [_ /posnumP[k]] : [O_ (0 : U) id of f] =O_ (0 : U) id by [].
 have /eq_some_oP : [o_ (0 : V') id of g] =o_ (0 : V') id by [].
 move=>  /(_ (e%:num / k%:num)) /(_ _) /locallyP [//|_ /posnumP[d] hd].
-apply: filter_app; near=> x.
-  move=> leOxkx; apply: ler_trans (hd _ _) _; last first.
-    rewrite -ler_pdivl_mull //; apply: ler_trans leOxkx _.
-    by rewrite invf_div mulrA -[_ / _ * _]mulrA mulVf // mulr1.
-  rewrite -ball_normE /= normmB subr0; apply: ler_lt_trans leOxkx _.
-  by rewrite -ltr_pdivl_mull //; near: x.
-end_near; rewrite /= locally_simpl.
+apply: filter_app; near=> x => leOxkx; apply: ler_trans (hd _ _) _; last first.
+  rewrite -ler_pdivl_mull //; apply: ler_trans leOxkx _.
+  by rewrite invf_div mulrA -[_ / _ * _]mulrA mulVf // mulr1.
+rewrite -ball_normE /= normmB subr0 (ler_lt_trans leOxkx) //.
+rewrite -ltr_pdivl_mull //; near: x; rewrite /= !locally_simpl.
 apply/locallyP; exists (k%:num ^-1 * d%:num)=> // x.
 by rewrite -ball_normE /= normmB subr0.
-Qed.
+Grab Existential Variables. all: end_near. Qed.
 
 Lemma compoO_eqox (K : absRingType) (U V' W' : normedModType K) (f : U -> V')
   (g : V' -> W') :
@@ -636,14 +630,13 @@ move=> /locallyP [_ /posnumP[d] hd].
 have /eq_some_oP : [o_ (0 : U) id of f] =o_ (0 : U) id by [].
 have ekgt0 : e%:num / k%:num > 0 by [].
 move=> /(_ _ ekgt0); apply: filter_app; near=> x.
-  move=> leoxekx; apply: ler_trans (hd _ _) _; last first.
-    by rewrite -ler_pdivl_mull // mulrA [_^-1 * _]mulrC.
-  rewrite -ball_normE /= normmB subr0; apply: ler_lt_trans leoxekx _.
-  by rewrite -ltr_pdivl_mull //; near: x.
-end_near; rewrite /= locally_simpl.
+move=> leoxekx; apply: ler_trans (hd _ _) _; last first.
+  by rewrite -ler_pdivl_mull // mulrA [_^-1 * _]mulrC.
+rewrite -ball_normE /= normmB subr0; apply: ler_lt_trans leoxekx _.
+rewrite -ltr_pdivl_mull //; near: x; rewrite /= locally_simpl.
 apply/locallyP; exists ((e%:num / k%:num) ^-1 * d%:num)=> // x.
 by rewrite -ball_normE /= normmB subr0.
-Qed.
+Grab Existential Variables. all: end_near. Qed.
 
 Lemma compOo_eqox (K : absRingType) (U V' W' : normedModType K) (f : U -> V')
   (g : V' -> W') : forall x,
@@ -723,15 +716,13 @@ Lemma bilinear_eqo (U V' W' : normedModType R) (f : {bilinear U -> V' -> W'}) :
   continuous (fun p => f p.1 p.2) -> (fun p => f p.1 p.2) =o_ (0 : U * V') id.
 Proof.
 move=> fc; have [_ /posnumP[k] fschwarz] := bilinear_schwarz fc.
-apply/eqoP=> _ /posnumP[e]; near=> x.
-  apply: ler_trans (fschwarz _ _) _.
-  apply: ler_pmul => //; last by rewrite ler_maxr orbC lerr.
-    by rewrite pmulr_rge0.
-  rewrite -ler_pdivl_mull //; have : `|[x]| <= k%:num ^-1 * e%:num by near: x.
-  by apply: ler_trans; rewrite ler_maxr lerr.
-end_near; rewrite /= locally_filterE; apply/locally_le_locally_norm.
+apply/eqoP=> _ /posnumP[e]; near=> x; rewrite (ler_trans (fschwarz _ _))//.
+rewrite ler_pmul ?pmulr_rge0 //; last by rewrite ler_maxr orbC lerr.
+rewrite -ler_pdivl_mull //.
+suff : `|[x]| <= k%:num ^-1 * e%:num by apply: ler_trans; rewrite ler_maxr lerr.
+near: x; rewrite /= locally_filterE; apply/locally_le_locally_norm.
 by exists (k%:num ^-1 * e%:num) => // ? /=; rewrite normmB subr0 => /ltrW.
-Qed.
+Grab Existential Variables. all: end_near. Qed.
 
 Fact dbilin (U V' W' : normedModType R) (f : {bilinear U -> V' -> W'}) p :
   continuous (fun p => f p.1 p.2) ->
@@ -792,10 +783,9 @@ Lemma eqo_pair (K : absRingType) (U V' W' : normedModType K) (F : filter_on U)
   (f : U -> V') (g : U -> W') :
   (fun t => ([o_F id of f] t, [o_F id of g] t)) =o_F id.
 Proof.
-apply/eqoP => e egt0; near=> x.
-  by rewrite ler_maxl /=; apply/andP; split; near: x.
-by end_near; move: e egt0 => /=; apply/eqoP.
-Qed.
+apply/eqoP => _/posnumP[e]; near=> x; rewrite ler_maxl /=.
+by apply/andP; split; near: x; apply: littleoP.
+Grab Existential Variables. all: end_near. Qed.
 
 Fact dpair (U V' W' : normedModType R) (f : U -> V') (g : U -> W') x :
   differentiable x f -> differentiable x g ->
@@ -866,46 +856,42 @@ Fact dinv (x : R) :
 Proof.
 move=> xn0; split; first by move=> ?; apply: continuousZ.
 apply/eqaddoP => _ /posnumP[e]; near=> h.
-  rewrite -[(_ + _ : R -> R) h]/(_ + _) -[(- _ : R -> R) h]/(- _) /=.
-  rewrite opprD scaleNr opprK /cst /=.
-  rewrite -[- _]mulr1 -[X in - _ * X](mulfVK xn0) mulrA mulNr -expr2 mulNr.
-  rewrite [- _ + _]addrC -mulrBr.
-  rewrite -[X in X + _]mulr1 -[X in 1 / _ * X](@mulfVK _ (x ^+ 2)); last first.
-    by rewrite sqrf_eq0.
-  rewrite mulrA mulf_div mulr1.
-  rewrite addrC -[X in X * _]mulr1 -{2}[1](@mulfVK _ (h + x)); last by near: h.
-  rewrite mulrA expr_div_n expr1n mulf_div mulr1 [_ ^+ 2 * _]mulrC -mulrA.
-  rewrite -mulrDr mulrBr [1 / _ * _]mulrC [`|[ _ ]|]absRE normrM.
-  rewrite mulrDl mulrDl opprD addrACA addrA [x * _]mulrC expr2.
-  do 2 ?[rewrite -addrA [- _ + _]addrC subrr addr0].
-  rewrite div1r normfV [X in _ / X]normrM invrM; last 2 first.
-      by rewrite unitfE normr_eq0; near: h.
-    by rewrite unitfE normr_eq0 mulf_neq0.
-  rewrite mulrA mulrAC ler_pdivr_mulr; last by rewrite normr_gt0 mulf_neq0.
-  rewrite mulrAC ler_pdivr_mulr; last by rewrite normr_gt0; near: h.
-  have : `|h * h| <= `|x / 2| * (e%:num * `|x * x| * `|[h : R^o]|).
-    by rewrite !mulrA; near: h.
-  move/ler_trans; apply; rewrite [X in X <= _]mulrC; apply: ler_pmul => //.
-    by rewrite !mulr_ge0.
-  by near: h.
-end_near; rewrite /= locally_filterE; apply/locally_normP.
-- exists `|x|; first by rewrite normr_gt0.
+rewrite -[(_ + _ : R -> R) h]/(_ + _) -[(- _ : R -> R) h]/(- _) /=.
+rewrite opprD scaleNr opprK /cst /=.
+rewrite -[- _]mulr1 -[X in - _ * X](mulfVK xn0) mulrA mulNr -expr2 mulNr.
+rewrite [- _ + _]addrC -mulrBr.
+rewrite -[X in X + _]mulr1 -[X in 1 / _ * X](@mulfVK _ (x ^+ 2)); last first.
+  by rewrite sqrf_eq0.
+rewrite mulrA mulf_div mulr1.
+have hDx_neq0 : h + x != 0.
+  near: h; rewrite /= locally_filterE; apply/locally_normP.
+  exists `|x|; first by rewrite normr_gt0.
   move=> h /=; rewrite normmB subr0 -subr_gt0 => lthx.
   rewrite -(normm_gt0 (h + x : R^o)) addrC -[h]opprK.
   apply: ltr_le_trans (ler_distm_dist _ _).
   by rewrite absRE ger0_norm normmN //; apply: ltrW.
-- exists (`|x / 2| * e%:num * `|x * x|).
+rewrite addrC -[X in X * _]mulr1 -{2}[1](@mulfVK _ (h + x)) //.
+rewrite mulrA expr_div_n expr1n mulf_div mulr1 [_ ^+ 2 * _]mulrC -mulrA.
+rewrite -mulrDr mulrBr [1 / _ * _]mulrC [`|[ _ ]|]absRE normrM.
+rewrite mulrDl mulrDl opprD addrACA addrA [x * _]mulrC expr2.
+do 2 ?[rewrite -addrA [- _ + _]addrC subrr addr0].
+rewrite div1r normfV [X in _ / X]normrM invfM [X in _ * X]mulrC.
+rewrite mulrA mulrAC ler_pdivr_mulr ?normr_gt0 ?mulf_neq0 //.
+rewrite mulrAC ler_pdivr_mulr ?normr_gt0 //.
+have : `|h * h| <= `|x / 2| * (e%:num * `|x * x| * `|[h : R^o]|).
+  rewrite !mulrA; near: h; exists (`|x / 2| * e%:num * `|x * x|).
     by rewrite !pmulr_rgt0 // normr_gt0 mulf_neq0.
-  by move=> h /ltrW; rewrite normmB subr0 [`|h * _|]normrM => /ler_pmul; apply.
-- exists (`|x| / 2); first by apply/divr_gt0 => //; rewrite normr_gt0.
-  move=> h /=; rewrite normmB subr0 => lthhx; rewrite addrC -[h]opprK.
-  apply: ler_trans (@ler_distm_dist _ [normedModType R of R^o] _ _).
-  rewrite absRE normmN [X in _ <= X]ger0_norm; last first.
-    rewrite subr_ge0; apply: ltrW; apply: ltr_le_trans lthhx _.
-    by rewrite [`|[_]|]splitr ler_addl; apply: divr_ge0.
-  rewrite ler_subr_addr -ler_subr_addl (splitr `|[x : R^o]|).
-  by rewrite normrM normfV (@ger0_norm _ 2) // -addrA subrr addr0; apply: ltrW.
-Qed.
+  by move=> h /ltrW; rewrite absrB subr0 [`|h * _|]normrM => /ler_pmul; apply.
+move=> /ler_trans-> //; rewrite [X in X <= _]mulrC ler_pmul ?mulr_ge0 //.
+near: h; exists (`|x| / 2); first by rewrite divr_gt0 ?normr_gt0.
+move=> h; rewrite /AbsRing_ball /= absrB subr0 => lthhx; rewrite addrC -[h]opprK.
+apply: ler_trans (@ler_distm_dist _ [normedModType R of R^o] _ _).
+rewrite absRE normmN [X in _ <= X]ger0_norm; last first.
+  rewrite subr_ge0; apply: ltrW; apply: ltr_le_trans lthhx _.
+  by rewrite [`|[_]|]splitr ler_addl; apply: divr_ge0.
+rewrite ler_subr_addr -ler_subr_addl (splitr `|[x : R^o]|).
+by rewrite normrM normfV (@ger0_norm _ 2) // -addrA subrr addr0; apply: ltrW.
+Grab Existential Variables. all: end_near. Qed.
 
 Lemma diff_Rinv (x : R^o) : x != 0 ->
   'd_x (fun y => 1 / y) = (fun h => - (1 / x) ^+ 2 *: h) :> (R^o -> R^o).
@@ -1239,19 +1225,17 @@ have : (fun h => - ((1 / f x) * (1 / f (h *: v + x))) *:
   apply: (@lim_opp _ [normedModType R of R^o]); rewrite expr2.
   exact/lim_scaler/lim_inv.
 apply: flim_trans => A [_/posnumP[e] /= Ae].
-move: fn0; rewrite !near_simpl; apply: filter_app; near=> h.
-  move=> fhvxn0; have he : AbsRing_ball 0 e%:num h by near: h.
-  have hn0 : h != 0 by near: h.
-  suff <- :
-    - ((1 / f x) * (1 / f (h *: v + x))) *: (h^-1 *: (f (h *: v + x) - f x)) =
-    h^-1 *: (1 / f (h *: v + x) - 1 / f x).
-    exact: Ae.
-  rewrite scalerA mulrC -scalerA; congr (_ *: _).
-  apply/eqP; rewrite scaleNr eqr_oppLR opprB !div1r scalerBr.
-  rewrite -scalerA [_ *: f _]mulVf // [_%:A]mulr1.
-   by rewrite mulrC -scalerA [_ *: f _]mulVf // [_%:A]mulr1.
-by end_near; exists e%:num.
-Qed.
+move: fn0; apply: filter_app; near=> h => /=.
+move=> fhvxn0; have he : AbsRing_ball 0 e%:num h by near: h; exists e%:num.
+have hn0 : h != 0 by near: h; exists e%:num.
+suff <- :
+  - ((1 / f x) * (1 / f (h *: v + x))) *: (h^-1 *: (f (h *: v + x) - f x)) =
+  h^-1 *: (1 / f (h *: v + x) - 1 / f x) by exact: Ae.
+rewrite scalerA mulrC -scalerA; congr (_ *: _).
+apply/eqP; rewrite scaleNr eqr_oppLR opprB !div1r scalerBr.
+rewrite -scalerA [_ *: f _]mulVf // [_%:A]mulr1.
+by rewrite mulrC -scalerA [_ *: f _]mulVf // [_%:A]mulr1.
+Grab Existential Variables. all: end_near. Qed.
 
 Lemma deriveV (f : V -> R^o) x v : f x != 0 -> derivable f x v ->
   derive (fun y => 1 / f y) x v = - (1 / f x) ^+2 *: derive f x v.
@@ -1348,16 +1332,14 @@ Lemma le0r_flim_map (T : topologicalType) (F : set (set T))
   (\forall x \near F, 0 <= f x) -> cvg (f @ F) -> 0 <= lim (f @ F).
 Proof.
 move=> fge0 fcv; case: (lerP 0 (lim (f @ F))) => // limlt0; near F => x.
-  by have := near fge0 x; rewrite lerNgt => /(_ _) /negbTE<-; near: x.
-end_near.
+have := near fge0 x; rewrite lerNgt => /(_ _) /negbTE<- //; near: x.
 have normlimgt0 : `|[lim (f @ F)]| > 0 by rewrite normm_gt0 ltr0_neq0.
 have /fcv := locally_ball_norm (lim (f @ F)) (PosNum normlimgt0).
-rewrite /= !near_simpl; apply: filter_app; near=> x.
-  rewrite /= normmB [ `|[_]| ]absRE => /(ler_lt_trans (ler_norm _)).
-  rewrite ltr_subl_addr => /ltr_le_trans; apply.
-  by rewrite [ `|[_]| ]absRE ltr0_norm // addrC subrr.
-by end_near.
-Qed.
+rewrite /= !near_simpl; apply: filterS => x.
+rewrite /= normmB [ `|[_]| ]absRE => /(ler_lt_trans (ler_norm _)).
+rewrite ltr_subl_addr => /ltr_le_trans; apply.
+by rewrite [ `|[_]| ]absRE ltr0_norm // addrC subrr.
+Grab Existential Variables. all: end_near. Qed.
 
 Lemma ler0_flim_map (T : topologicalType) (F : set (set T))
   (FF : ProperFilter F) (f : T -> R^o) :
@@ -1367,7 +1349,7 @@ move=> fle0 fcv; rewrite -oppr_ge0.
 have limopp : - lim (f @ F) = lim (- f @ F).
   exact/Logic.eq_sym/flim_map_lim/lim_opp.
 rewrite limopp; apply: le0r_flim_map; last by rewrite -limopp; apply: lim_opp.
-by move: fle0; apply: filter_app; near=> x; [rewrite oppr_ge0|end_near].
+by move: fle0; apply: filterS => x; rewrite oppr_ge0.
 Qed.
 
 Lemma ler_flim_map (T : topologicalType) (F : set (set T)) (FF : ProperFilter F)
@@ -1380,7 +1362,7 @@ have eqlim : lim (g @ F) - lim (f @ F) = lim ((g - f) @ F).
   by apply/Logic.eq_sym/flim_map_lim/lim_add => //; apply: lim_opp.
 rewrite eqlim; apply: le0r_flim_map; last first.
   by rewrite /(cvg _) -eqlim /=; apply: lim_add => //; apply: lim_opp.
-by move: lefg; apply: filter_app; near=> x; [rewrite subr_ge0|end_near].
+by move: lefg; apply: filterS => x; rewrite subr_ge0.
 Qed.
 
 Lemma derive1_at_max (f : R^o -> R^o) (a b c : R) :
@@ -1395,10 +1377,9 @@ apply/eqP; rewrite eqr_le; apply/andP; split.
     apply: flim_trans dfc; apply: flim_app.
     move=> A [e egt0 Ae]; exists e => // x xe xgt0; apply: Ae => //.
     exact/lt0r_neq0.
-  near=> h.
-    apply: mulr_ge0_le0; first by rewrite invr_ge0; apply: ltrW; near: h.
-    by rewrite subr_le0 [_%:A]mulr1; apply: cmax; near: h.
-  end_near; first by exists 1.
+  near=> h; apply: mulr_ge0_le0.
+    by rewrite invr_ge0; apply: ltrW; near: h; exists 1.
+  rewrite subr_le0 [_%:A]mulr1; apply: cmax; near: h.
   exists (b - c); first by rewrite subr_gt0 (itvP cab).
   move=> h; rewrite /AbsRing_ball /= absrB subr0 absRE.
   move=> /(ler_lt_trans (ler_norm _)); rewrite ltr_subr_addr inE => ->.
@@ -1409,15 +1390,14 @@ apply: le0r_flim_map; last first.
   apply: flim_trans dfc; apply: flim_app.
   move=> A [e egt0 Ae]; exists e => // x xe xgt0; apply: Ae => //.
   exact/ltr0_neq0.
-near=> h.
-  apply: mulr_le0; first by rewrite invr_le0; apply: ltrW; near: h.
-  by rewrite subr_le0 [_%:A]mulr1; apply: cmax; near: h.
-end_near; first by exists 1.
+near=> h; apply: mulr_le0.
+  by rewrite invr_le0; apply: ltrW; near: h; exists 1.
+rewrite subr_le0 [_%:A]mulr1; apply: cmax; near: h.
 exists (c - a); first by rewrite subr_gt0 (itvP cab).
 move=> h; rewrite /AbsRing_ball /= absrB subr0 absRE.
 move=> /ltr_normlP []; rewrite ltr_subr_addl ltr_subl_addl inE => -> _.
 by move=> /ltr_snsaddl -> //; rewrite (itvP cab).
-Qed.
+Grab Existential Variables. all: end_near. Qed.
 
 Lemma derive1_at_min (f : R^o -> R^o) (a b c : R) :
   a <= b -> (forall t, t \in `]a, b[ -> derivable f t 1) -> c \in `]a, b[ ->

--- a/hierarchy.v
+++ b/hierarchy.v
@@ -332,6 +332,7 @@ apply: filter_from_filter; first by exists 1; rewrite ltr01.
 move=> _ _ /posnumP[i] /posnumP[j]; exists (minr i j) => // [[/= x y]] bxy.
 by eexists => /=; apply: ball_ler bxy; rewrite ler_minl lerr ?orbT.
 Qed.
+Typeclasses Opaque entourages.
 
 Definition ball_set (A : set M) e := \bigcup_(p in A) ball p e.
 Canonical set_filter_source :=
@@ -655,9 +656,9 @@ Qed.
 Lemma flim_close {F} {FF : ProperFilter F} (x y : T) :
   F --> x -> F --> y -> close x y.
 Proof.
-move=> Fx Fy e; near F => z; first by apply: (@ball_splitl _ z); near: z.
-by end_near; [apply/Fx/locally_ball|apply/Fy/locally_ball].
-Qed.
+move=> Fx Fy e; near F => z; apply: (@ball_splitl _ z); near: z;
+by [apply/Fx/locally_ball|apply/Fy/locally_ball].
+Grab Existential Variables. all: end_near. Qed.
 
 Lemma flimx_close (x y : T) : x --> y -> close x y.
 Proof. exact: flim_close. Qed.
@@ -907,10 +908,9 @@ Proof.
 split=> [Fy _/posnumP[eps] |Fy P] /=; first exact/Fy/locally_ball.
 move=> /locallyP[_ /posnumP[eps] subP].
 rewrite near_simpl near_mapi; near=> x.
-  have [//|z [fxz yz]] := near (Fy _ (posnum_gt0 eps)) x.
-  by exists z => //; split => //; apply: subP.
-by end_near.
-Qed.
+have [//|z [fxz yz]] := near (Fy _ (posnum_gt0 eps)) x.
+by exists z => //; split => //; apply: subP.
+Unshelve. all: end_near. Qed.
 Definition flimi_locally := @flimi_ballP.
 
 Lemma flimi_ball {F} {FF : Filter F} (f : T -> U -> Prop) y :
@@ -923,10 +923,9 @@ Lemma flimi_close {F} {FF: ProperFilter F} (f : T -> set U) (l l' : U) :
 Proof.
 move=> f_prop fFl fFl'.
 suff f_totalfun: infer {near F, is_totalfun f} by exact: flim_close fFl fFl'.
-apply: filter_app f_prop; near=> x; first split=> //=.
-  by have [//|y [fxy _]] := near (flimi_ball fFl [gt0 of 1]) x; exists y.
-by end_near.
-Qed.
+apply: filter_app f_prop; near=> x; split=> //=.
+by have [//|y [fxy _]] := near (flimi_ball fFl [gt0 of 1]) x; exists y.
+Grab Existential Variables. all: end_near. Qed.
 Definition flimi_locally_close := @flimi_close.
 
 End Locally_fct.
@@ -992,8 +991,8 @@ Proof.
 move=> FF; split=> cauchyF; last first.
   by move=> _/posnumP[eps]; apply: cauchyF; exists eps%:num.
 move=> U [_/posnumP[eps] xyepsU].
-by near=> x; [by apply: xyepsU; near: x|end_near; apply: cauchyF].
-Qed.
+by near=> x; apply: xyepsU; near: x; apply: cauchyF.
+Grab Existential Variables. all: end_near. Qed.
 
 Lemma cvg_cauchy_ex {T : uniformType} (F : set (set T)) :
   [cvg F in T] -> cauchy_ex F.
@@ -1012,9 +1011,8 @@ Lemma cauchyP (T : uniformType) (F : set (set T)) : ProperFilter F ->
   cauchy F <-> cauchy_ex F.
 Proof.
 move=> FF; split=> [Fcauchy _/posnumP[e] |/cauchy_exP//].
-near F => x; first by exists x; near: x.
-by end_near; apply: (@nearP_dep _ _ F F); apply: Fcauchy.
-Qed.
+by near F => x; exists x; near: x; apply: (@nearP_dep _ _ F F); apply: Fcauchy.
+Grab Existential Variables. all: end_near. Qed.
 
 Lemma cvg_cauchy {T : uniformType} (F : set (set T)) : Filter F ->
   [cvg F in T] -> cauchy F.
@@ -1112,12 +1110,11 @@ have /(_ _ _) /complete_cauchy cvF :
   by move=> ?? _ /posnumP[e]; rewrite near_simpl; apply: filterS (Fc _ _).
 apply/cvg_ex.
 exists (\matrix_(i, j) (lim ((fun M : 'M[T]_(m, n) => M i j) @ F) : T)).
-apply/flim_ballP => _ /posnumP[e]; near=> M.
-  move=> i j; rewrite mxE; near F => M' => /=.
-    by apply: (@ball_splitl _ (M' i j)); last move: (i) (j); near: M'.
-  by end_near; [apply/cvF/locally_ball|near: M].
-by end_near; apply: nearP_dep; apply: filterS (Fc _ _).
-Qed.
+apply/flim_ballP => _ /posnumP[e]; near=> M => i j.
+rewrite mxE; near F => M' => /=; apply: (@ball_splitl _ (M' i j)).
+  by near: M'; apply/cvF/locally_ball.
+by move: (i) (j); near: M'; near: M; apply: nearP_dep; apply: filterS (Fc _ _).
+Grab Existential Variables. all: end_near. Qed.
 
 Canonical matrix_completeType := CompleteType 'M[T]_(m, n) mx_complete.
 
@@ -1133,12 +1130,10 @@ Proof.
 move=> Fc; have /(_ _) /complete_cauchy Ft_cvg : cauchy (@^~_ @ F).
   by move=> t e ?; rewrite near_simpl; apply: filterS (Fc _ _).
 apply/cvg_ex; exists (fun t => lim (@^~t @ F)).
-apply/flim_ballPpos => e; near=> f => [t|].
-  near F => g => /=.
-    by apply: (@ball_splitl _ (g t)); last move: (t); near: g.
-  by end_near; [exact/Ft_cvg/locally_ball|near: f].
-by end_near; apply: nearP_dep; apply: filterS (Fc _ _).
-Qed.
+apply/flim_ballPpos => e; near=> f => t; near F => g => /=.
+apply: (@ball_splitl _ (g t)); first by near: g; exact/Ft_cvg/locally_ball.
+by move: (t); near: g; near: f; apply: nearP_dep; apply: filterS (Fc _ _).
+Grab Existential Variables. all: end_near. Qed.
 
 Canonical fun_completeType := CompleteType (T -> U) fun_complete.
 
@@ -1156,13 +1151,12 @@ Lemma flim_switch_1 {U : uniformType}
   f @ F1 --> g -> (forall x1, f x1 @ F2 --> h x1) -> h @ F1 --> l ->
   g @ F2 --> l.
 Proof.
-move=> fg fh hl; apply/flim_ballPpos => e; rewrite near_simpl.
-near F1 => x1; first near=> x2.
-- apply: (@ball_split _ (h x1)); first by near: x1.
-  by apply: (@ball_splitl _ (f x1 x2)); [near: x2|move: (x2); near: x1].
-- by end_near; apply/fh/locally_ball.
-- by end_near; [exact/hl/locally_ball|exact/(flim_ball fg)].
-Qed.
+move=> fg fh hl; apply/flim_ballPpos => e.
+rewrite near_simpl; near F1 => x1; near=> x2.
+apply: (@ball_split _ (h x1)); first by near: x1; apply/hl/locally_ball.
+apply: (@ball_splitl _ (f x1 x2)); first by near: x2; apply/fh/locally_ball.
+by move: (x2); near: x1; apply/(flim_ball fg).
+Grab Existential Variables. all: end_near. Qed.
 
 Lemma flim_switch_2 {U : completeType}
   F1 {FF1 : ProperFilter F1} F2 {FF2 : ProperFilter F2}
@@ -1170,14 +1164,13 @@ Lemma flim_switch_2 {U : completeType}
   f @ F1 --> g -> (forall x, f x @ F2 --> h x) ->
   [cvg h @ F1 in U].
 Proof.
-move=> fg fh; apply: complete_cauchy => _/posnumP[e]; rewrite !near_simpl.
-near=> x1 y1=> /=; first near F2 => x2.
-- apply: (@ball_splitl _ (f x1 x2)); first by near: x2.
-  apply: (@ball_split _ (f y1 x2)); first by near: x2.
-  apply: (@ball_splitr _ (g x2)); move: (x2); [near: y1|near: x1].
-- by end_near; apply/fh/locally_ball.
-- by split; end_near; apply/(flim_ball fg).
-Qed.
+move=> fg fh; apply: complete_cauchy => _/posnumP[e].
+rewrite !near_simpl; near=> x1 y1=> /=; near F2 => x2.
+apply: (@ball_splitl _ (f x1 x2)); first by near: x2; apply/fh/locally_ball.
+apply: (@ball_split _ (f y1 x2)); first by near: x2; apply/fh/locally_ball.
+apply: (@ball_splitr _ (g x2)); move: (x2); [near: y1|near: x1];
+by apply/(flim_ball fg).
+Grab Existential Variables. all: end_near. Qed.
 
 (* Alternative version *)
 (* Lemma flim_switch {U : completeType} *)
@@ -1515,9 +1508,8 @@ Lemma flim_normW {F : set (set V)} {FF : Filter F} (y : V) :
   F --> y.
 Proof.
 move=> cv; apply/flim_normP => _/posnumP[e]; near=> x.
-  by rewrite [e%:num]splitr ltr_spaddl //; near: x.
-by end_near; apply: cv.
-Qed.
+by rewrite [e%:num]splitr ltr_spaddl //; near: x; apply: cv.
+Grab Existential Variables. all: end_near. Qed.
 
 Lemma flim_norm {F : set (set V)} {FF : Filter F} (y : V) :
   F --> y -> forall eps, eps > 0 -> \forall y' \near F, `|[y - y']| < eps.
@@ -1713,32 +1705,30 @@ Lemma add_continuous : continuous (fun z : V * V => z.1 + z.2).
 Proof.
 move=> [/=x y]; apply/flim_normP=> _/posnumP[e].
 rewrite !near_simpl /=; near=> a b => /=.
-  rewrite opprD addrACA [e%:num]splitr (ler_lt_trans (ler_normm_add _ _)) //.
-  by rewrite ltr_add //=; [near: a|near: b].
-by split; end_near=> /=; apply: flim_norm.
-Qed.
+rewrite opprD addrACA [e%:num]splitr (ler_lt_trans (ler_normm_add _ _)) //.
+by rewrite ltr_add //=; [near: a|near: b]; apply: flim_norm.
+Grab Existential Variables. all: end_near. Qed.
 
 Lemma scale_continuous : continuous (fun z : K * V => z.1 *: z.2).
 Proof.
 move=> [k x]; apply/flim_normP=> _/posnumP[e].
 rewrite !near_simpl /=; near=> z.
-  rewrite (@subr_trans _ (k *: z.2)).
-  rewrite (splitr e%:num) (ler_lt_trans (ler_normm_add _ _)) //.
-  rewrite ltr_add // -?(scalerBr, scalerBl).
-    rewrite (ler_lt_trans (ler_normmZ _ _)) //.
-    rewrite (ler_lt_trans (ler_pmul _ _ (_ : _ <= `|k|%real + 1) (lerr _)))
-            ?ler_addl //.
-    by rewrite -ltr_pdivl_mull // ?(ltr_le_trans ltr01) ?ler_addr //; near: z.
+rewrite (@subr_trans _ (k *: z.2)).
+rewrite (splitr e%:num) (ler_lt_trans (ler_normm_add _ _)) //.
+rewrite ltr_add // -?(scalerBr, scalerBl).
   rewrite (ler_lt_trans (ler_normmZ _ _)) //.
-  rewrite (ler_lt_trans (ler_pmul _ _ (lerr _) (_ : _ <= `|[x]| + 1))) //.
-    by rewrite ltrW //; near: z.
-  by rewrite -ltr_pdivl_mulr // ?(ltr_le_trans ltr01) ?ler_addr //; near: z.
-end_near; rewrite /= ?near_simpl.
-- by apply: (flim_norm _ flim_snd); rewrite mulr_gt0 // ?invr_gt0 ltr_paddl.
-- by apply: (flim_bounded _ flim_snd); rewrite ltr_addl.
-- apply: (flim_norm (_ : K^o) flim_fst).
-  by rewrite mulr_gt0 // ?invr_gt0 ltr_paddl.
-Qed.
+  rewrite (ler_lt_trans (ler_pmul _ _ (_ : _ <= `|k|%real + 1) (lerr _)))
+          ?ler_addl //.
+  rewrite -ltr_pdivl_mull // ?(ltr_le_trans ltr01) ?ler_addr //; near: z.
+  by apply: (flim_norm _ flim_snd); rewrite mulr_gt0 // ?invr_gt0 ltr_paddl.
+rewrite (ler_lt_trans (ler_normmZ _ _)) //.
+rewrite (ler_lt_trans (ler_pmul _ _ (lerr _) (_ : _ <= `|[x]| + 1))) // ?ltrW//.
+  by near: z; apply: (flim_bounded _ flim_snd); rewrite ltr_addl.
+rewrite -ltr_pdivl_mulr // ?(ltr_le_trans ltr01) ?ler_addr //; near: z.
+apply: (flim_norm (_ : K^o) flim_fst).
+by rewrite mulr_gt0 // ?invr_gt0 ltr_paddl.
+Grab Existential Variables. all: end_near. Qed.
+
 Arguments scale_continuous _ _ : clear implicits.
 
 Lemma scaler_continuous k : continuous (fun x : V => k *: x).
@@ -2036,20 +2026,20 @@ have D_has_sup : has_sup (mem D); first split.
   by move=> /(ler_trans _) yx01 _ /yx01.
 exists (sup (mem D)).
 apply: (flim_normW (_ : R^o)) => /= _ /posnumP[eps]; near=> x.
-  rewrite ler_distl sup_upper_bound //=.
-    apply: sup_le_ub => //; first by case: D_has_sup.
-    apply/forallbP => y; apply/implyP; rewrite in_setE.
-    move=> /(_ (ball_ norm x eps%:num) _) /existsbP []; first by near: x.
-    move=> z /andP[]; rewrite in_setE /ball_ ltr_distl ltr_subl_addr.
-    by move=> /andP [/ltrW /(ler_trans _) le_xeps _ /le_xeps].
-  rewrite in_setE /D /= => A FA; near F => y.
-    apply/existsbP; exists y; apply/andP; split.
-      by rewrite in_setE; near: y.
-    rewrite ler_subl_addl -ler_subl_addr ltrW //.
-    by suff: `|x - y| < eps%:num; [by rewrite ltr_norml => /andP[_] | near: y].
-  end_near; near: x.
-by end_near; rewrite /= !near_simpl; apply: nearP_dep; apply: F_cauchy.
-Qed.
+rewrite ler_distl sup_upper_bound //=.
+  apply: sup_le_ub => //; first by case: D_has_sup.
+  apply/forallbP => y; apply/implyP; rewrite in_setE.
+  move=> /(_ (ball_ norm x eps%:num) _) /existsbP [].
+    by near: x; apply: nearP_dep; apply: F_cauchy.
+  move=> z /andP[]; rewrite in_setE /ball_ ltr_distl ltr_subl_addr.
+  by move=> /andP [/ltrW /(ler_trans _) le_xeps _ /le_xeps].
+rewrite in_setE /D /= => A FA; near F => y.
+apply/existsbP; exists y; apply/andP; split.
+  by rewrite in_setE; near: y.
+rewrite ler_subl_addl -ler_subl_addr ltrW //.
+suff: `|x - y| < eps%:num by rewrite ltr_norml => /andP[_].
+by near: y; near: x; apply: nearP_dep; apply: F_cauchy.
+Grab Existential Variables. all: end_near. Qed.
 
 Canonical R_completeType := CompleteType R R_complete.
 Canonical R_NormedModule := [normedModType R of R^o].
@@ -2083,6 +2073,7 @@ apply; last (by rewrite ltr_subl_addl ltr_addr); rewrite /AbsRing_ball /=.
 rewrite opprD !addrA subrr add0r opprK absRE normf_div !ger0_norm //.
 by rewrite ltr_pdivr_mulr // ltr_pmulr // (_ : 1 = 1%:R) // ltr_nat.
 Qed.
+Typeclasses Opaque at_left at_right.
 
 (** Continuity of norm *)
 
@@ -2357,20 +2348,20 @@ rewrite -subr_le0; apply/ler0_addgt0P => _/posnumP[e].
 rewrite ler_subl_addr -ler_subl_addl ltrW //.
 have /fcont /(_ _ (locally_ball _ e)) [_/posnumP[d] supdfe] := supAab.
 have atrF := at_right_proper_filter (sup A); near (at_right (sup A)) => x.
-  have /supdfe /= : ball (sup A) d%:num x by near: x.
-  rewrite ball_absE /= absRE => /ltr_distW; apply: ler_lt_trans.
-  rewrite ler_add2r ltrW //; suff : forall t, t \in `](sup A), b] -> v < f t.
-    by apply; rewrite inE; apply/andP; split; near: x.
-  move=> t /andP [ltsupt letb]; rewrite ltrNge; apply/negP => leftv.
-  move: ltsupt; rewrite ltrNge => /negP; apply; apply: sup_upper_bound => //.
-  by rewrite inE letb leftv.
-end_near; rewrite /= locally_simpl; [exists d%:num|exists 1|] => //.
-exists (b - sup A).
-  rewrite subr_gt0 ltr_def (itvP supAab) andbT; apply/negP => /eqP besup.
-  by move: lefsupv; rewrite lerNgt -besup ltvfb.
-move=> t lttb ltsupt; move: lttb; rewrite /AbsRing_ball /= absrB absRE.
-by rewrite gtr0_norm ?subr_gt0 // ltr_add2r; apply: ltrW.
-Qed.
+have /supdfe /= : ball (sup A) d%:num x.
+  by near: x; rewrite /= locally_simpl; exists d%:num => //.
+rewrite ball_absE /= absRE => /ltr_distW; apply: ler_lt_trans.
+rewrite ler_add2r ltrW //; suff : forall t, t \in `](sup A), b] -> v < f t.
+  apply; rewrite inE; apply/andP; split; first by near: x; exists 1.
+  near: x; exists (b - sup A).
+    rewrite subr_gt0 ltr_def (itvP supAab) andbT; apply/negP => /eqP besup.
+    by move: lefsupv; rewrite lerNgt -besup ltvfb.
+  move=> t lttb ltsupt; move: lttb; rewrite /AbsRing_ball /= absrB absRE.
+  by rewrite gtr0_norm ?subr_gt0 // ltr_add2r; apply: ltrW.
+move=> t /andP [ltsupt letb]; rewrite ltrNge; apply/negP => leftv.
+move: ltsupt; rewrite ltrNge => /negP; apply; apply: sup_upper_bound => //.
+by rewrite inE letb leftv.
+Grab Existential Variables. all: end_near. Qed.
 
 (** Local properties in [R] *)
 
@@ -2570,6 +2561,8 @@ split=> /= [|P Q [MP ltMP] [MQ ltMQ] |P Q sPQ [M ltMP]]; first by exists 0.
   by exists (minr MP MQ) => ?; rewrite ltr_minr => /andP [/ltMP ? /ltMQ].
 by exists M => ? /ltMP /sPQ.
 Qed.
+Typeclasses Opaque Rbar_locally'.
+
 
 Global Instance Rbar_locally_filter : forall x, ProperFilter (Rbar_locally x).
 Proof.
@@ -2578,6 +2571,7 @@ by apply/locally_filter.
 exact: (Rbar_locally'_filter +oo).
 exact: (Rbar_locally'_filter -oo).
 Qed.
+Typeclasses Opaque Rbar_locally.
 
 Definition bounded (K : absRingType) (V : normedModType K) (A : set V) :=
   \forall M \near +oo, A `<=` [set x | `|[x]| < M].
@@ -2805,9 +2799,8 @@ split=> - cfx P /= fxP.
     because the type of the filter is not infered *)
 rewrite !locally_nearE !near_map !near_locally in fxP *; have /= := cfx P fxP.
 rewrite !near_simpl near_withinE near_simpl => Pf; near=> y.
-  by have [->|] := eqVneq y x; [apply: locally_singleton|near: y].
-by end_near.
-Qed.
+by have [->|] := eqVneq y x; [by apply: locally_singleton|near: y].
+Grab Existential Variables. all: end_near. Qed.
 
 Lemma continuity_pt_flim' f x :
   continuity_pt f x <-> f @ locally' x --> f x.

--- a/landau.v
+++ b/landau.v
@@ -439,9 +439,9 @@ Canonical the_littleo_littelo (tag : unit) (F : filter_on T)
 Lemma opp_littleo_subproof (F : filter_on T) e (df : {o_F e}) :
    littleo F (- (df : _ -> _)) e.
 Proof.
-move=> _/posnumP[eps]; near=> x; [rewrite normmN; near: x|end_near].
-by apply: littleoP.
-Qed.
+by move=> _/posnumP[eps]; near=> x; rewrite normmN; near: x; apply: littleoP.
+Grab Existential Variables. all: end_near. Qed.
+
 
 Canonical opp_littleo (F : filter_on T) e (df : {o_F e}) :=
   Littleo (asboolT (opp_littleo_subproof df)).
@@ -457,10 +457,10 @@ Lemma add_littleo_subproof (F : filter_on T) e (df dg : {o_F e}) :
   littleo F (df \+ dg) e.
 Proof.
 move=> _/posnumP[eps]; near=> x => /=.
-  rewrite [eps%:num]splitr mulrDl.
-  rewrite (ler_trans (ler_normm_add _ _)) // ler_add //; near: x.
-by end_near; apply: littleoP.
-Qed.
+rewrite [eps%:num]splitr mulrDl (ler_trans (ler_normm_add _ _)) // ler_add //;
+by near: x; apply: littleoP.
+Grab Existential Variables. all: end_near. Qed.
+
 
 Canonical add_littleo (F : filter_on T) e (df dg : {o_F e}) :=
   @Littleo _ _ (_ + _) (asboolT (add_littleo_subproof df dg)).
@@ -528,10 +528,10 @@ Lemma scale_littleo_subproof (F : filter_on T) e (df : {o_F e}) a :
 Proof.
 have [->|a0] := eqVneq a 0; first by rewrite scale0r.
 move=> _ /posnumP[eps]; have aa := absr_eq0 a; near=> x => /=.
-  rewrite (ler_trans (ler_normmZ _ _)) //.
-  by rewrite -ler_pdivl_mull ?ltr_def ?aa ?a0 //= mulrA; near: x.
-by end_near; apply: littleoP; rewrite mulr_gt0 // invr_gt0 ?ltr_def ?aa ?a0 /=.
-Qed.
+rewrite (ler_trans (ler_normmZ _ _)) //.
+rewrite -ler_pdivl_mull ?ltr_def ?aa ?a0 //= mulrA; near: x.
+by apply: littleoP; rewrite mulr_gt0 // invr_gt0 ?ltr_def ?aa ?a0 /=.
+Grab Existential Variables. all: end_near. Qed.
 
 Canonical scale_littleo (F : filter_on T) e a (df : {o_F e}) :=
   Littleo (asboolT (scale_littleo_subproof df a)).
@@ -554,13 +554,10 @@ Definition bigOW (F : set (set T)) (f : T -> V) (g : T -> W) :=
 Lemma bigOWFE (F : set (set T)) : Filter F -> bigOW F = bigOF F.
 Proof.
 rewrite predeq2E => FF f g; split=> [[k] |] kP; last first.
-  by near +oo => k; [exists k; near: k|end_near].
-near=> k'.
-  near=> x.
-    by rewrite (ler_trans (near kP _ _)) // ler_wpmul2r // ltrW //; near: k'.
-  by end_near.
-by end_near; exists k.
-Qed.
+  by near +oo => k; exists k; near: k.
+near=> k'; near=> x; rewrite (ler_trans (near kP _ _)) // ler_wpmul2r //.
+by rewrite ltrW //; near: k'; exists k.
+Grab Existential Variables. all: end_near. Qed.
 
 Definition bigO (F : set (set T)) (f : T -> V) (g : T -> W) :=
   exists2 k, k > 0 & \forall x \near F, `|[f x]| <= k * `|[g x]|.
@@ -682,8 +679,8 @@ Lemma opp_bigO_subproof (F : filter_on T) e (df : {O_F e}) :
    bigO F (- (df : _ -> _)) e.
 Proof.
 have [_/posnumP[k] kP] := bigOP [bigO of df]; apply: bigOWP; exists k%:num.
-by near=> x; [rewrite normmN; near: x|end_near].
-Qed.
+by near=> x; rewrite normmN; near: x.
+Grab Existential Variables. all: end_near. Qed.
 
 Canonical Opp_bigO (F : filter_on T) e (df : {O_F e}) :=
   BigO (asboolT (opp_bigO_subproof df)).
@@ -919,13 +916,10 @@ have [->|a0] := eqVneq a 0.
 move=> _/posnumP[eps].
 have ea : 0 < eps%:num / `|[ a ]| by rewrite divr_gt0 // normm_gt0.
 set g := 'o _.
-have /(_ _ ea) ? := littleoP [littleo of g].
-near=> y.
-  rewrite (ler_trans (ler_normmZ _ _)) //.
-  rewrite -ler_pdivl_mulr ?ltr_def ?normm_eq0 ?a0 ?normm_ge0 // mulrAC.
-  by near: y.
-end_near.
-Qed.
+have /(_ _ ea) ? := littleoP [littleo of g]; near=> y.
+rewrite (ler_trans (ler_normmZ _ _)) //.
+by rewrite -ler_pdivl_mulr ?ltr_def ?normm_eq0 ?a0 ?normm_ge0// mulrAC; near: y.
+Grab Existential Variables. all: end_near. Qed.
 
 Section Limit.
 
@@ -936,16 +930,15 @@ Lemma eqolimP (F : filter_on T) (f : T -> V) (l : V) :
 Proof.
 split=> fFl.
   apply/eqaddoP => _/posnumP[eps]; near=> x.
-    by rewrite /cst ltrW //= normmB; near: x.
-  by end_near; apply: (flim_norm _ fFl); rewrite mulr_gt0 // ?absr1_gt0.
-apply/flim_normP=> _/posnumP[eps]; rewrite !near_simpl.
+  rewrite /cst ltrW //= normmB; near: x.
+  by apply: (flim_norm _ fFl); rewrite mulr_gt0 // ?absr1_gt0.
+apply/flim_normP=> _/posnumP[eps]; rewrite /= near_simpl.
 have lt_eps x : x <= (eps%:num / 2%:R) * `|1 : K^o|%real -> x < eps.
   rewrite absr1 mulr1 => /ler_lt_trans; apply.
   by rewrite ltr_pdivr_mulr // ltr_pmulr // ltr1n.
-near=> x.
-  by rewrite [X in X x]fFl opprD addNKr normmN lt_eps //; near: x.
-by end_near; rewrite /= !near_simpl; apply: littleoP; rewrite divr_gt0.
-Qed.
+near=> x; rewrite [X in X x]fFl opprD addNKr normmN lt_eps //; near: x.
+by rewrite /= !near_simpl; apply: littleoP; rewrite divr_gt0.
+Grab Existential Variables. all: end_near. Qed.
 
 Lemma eqolim (F : filter_on T) (f : T -> V) (l : V) e :
   f = cst l + [o_F (cst (1 : K^o)) of e] -> f @ F --> l.
@@ -968,11 +961,9 @@ Lemma littleo_bigO_eqo {F : filter_on T}
 Proof.
 move->; apply/eqoP => _/posnumP[eps] /=.
 set k := 'O g; have [/= _/posnumP[c]] := bigOP [bigO of k].
-apply: filter_app; near=> x.
-  rewrite -!ler_pdivr_mull //; apply: ler_trans.
-  by rewrite ler_pdivr_mull // mulrA; near: x.
-by end_near; rewrite /= !near_simpl; apply: littleoP.
-Qed.
+apply: filter_app; near=> x; rewrite -!ler_pdivr_mull //; apply: ler_trans.
+by rewrite ler_pdivr_mull // mulrA; near: x; apply: littleoP.
+Grab Existential Variables. all: end_near. Qed.
 Arguments littleo_bigO_eqo {F}.
 
 Lemma bigO_littleo_eqo {F : filter_on T} (g : T -> W) (f : T -> V) (h : T -> X) :
@@ -980,10 +971,9 @@ Lemma bigO_littleo_eqo {F : filter_on T} (g : T -> W) (f : T -> V) (h : T -> X) 
 Proof.
 move->; apply/eqoP => _/posnumP[eps].
 set k := 'O _; have [/= _/posnumP[c]] := bigOP [bigO of k].
-apply: filter_app; near=> x.
-  by move=> /ler_trans; apply; rewrite -ler_pdivl_mull // mulrA; near: x.
-by end_near; rewrite /= !near_simpl; apply: littleoP.
-Qed.
+apply: filter_app; near=> x => /ler_trans.
+by apply; rewrite -ler_pdivl_mull // mulrA; near: x; apply: littleoP.
+Grab Existential Variables. all: end_near. Qed.
 Arguments bigO_littleo_eqo {F}.
 
 Lemma bigO_bigO_eqO {F : filter_on T} (g : T -> W) (f : T -> V) (h : T -> X) :
@@ -1080,24 +1070,21 @@ Lemma mulo (F : filter_on pT) (h1 h2 f g : pT -> R^o) :
   [o_F h1 of f] * [o_F h2 of g] =o_F (h1 * h2).
 Proof.
 rewrite [in RHS]littleoE // => _/posnumP[e]; near=> x.
-  rewrite (ler_trans (absrM _ _)) // -(sqr_sqrtr (ltrW [gt0 of e%:num])) expr2.
-  rewrite [`|[_]|]normrM mulrACA ler_pmul //; near: x.
-by end_near=> /=; set h := 'o _; apply: (littleoP [littleo of h]).
-Qed.
+rewrite (ler_trans (absrM _ _)) // -(sqr_sqrtr (ltrW [gt0 of e%:num])) expr2.
+rewrite [`|[_]|]normrM mulrACA ler_pmul //; near: x;
+by set h := 'o _; apply: (littleoP [littleo of h]).
+Grab Existential Variables. all: end_near. Qed.
 
 Lemma mulO (F : filter_on pT) (h1 h2 f g : pT -> R^o) :
   [O_F h1 of f] * [O_F h2 of g] =O_F (h1 * h2).
 Proof.
 rewrite [in RHS]bigOE // -bigOFE; set O1 := 'O _; set O2 := 'O _.
 have [k1 _ k1P] := bigOP [bigO of O1]; have [k2 _ k2P] := bigOP [bigO of O2].
-near=> k; first near=> x.
-- rewrite (ler_trans (absrM _ _)) //.
-  rewrite (@ler_trans _ ((k1 * k2) * `|[(h1 * h2) x]|)) //.
-    by rewrite [`|[_]|]normrM mulrACA ler_pmul //; near: x.
-  by rewrite ler_wpmul2r // ltrW //; near: k.
-- by end_near.
-- by end_near; exists (k1 * k2).
-Qed.
+near=> k; near=> x; rewrite (ler_trans (absrM _ _)) //.
+rewrite (@ler_trans _ ((k1 * k2) * `|[(h1 * h2) x]|)) //.
+  by rewrite [`|[_]|]normrM mulrACA ler_pmul //; near: x.
+by rewrite ler_wpmul2r // ltrW //; near: k; exists (k1 * k2).
+Grab Existential Variables. all: end_near. Qed.
 
 End rule_of_products_in_R.
 
@@ -1169,9 +1156,8 @@ have [{l fl}_ /posnumP[l] f_lipshitz] :
   admit.
 move=> x; apply/flim_normP => _/posnumP[eps]; rewrite !near_simpl.
 rewrite (near_shift 0) /= subr0; near=> y => /=.
-  rewrite -linearB opprD addrC addrNK linearN normmN.
-  by rewrite (ler_lt_trans (f_lipshitz _)) // -ltr_pdivl_mull //; near: y.
-end_near.
+rewrite -linearB opprD addrC addrNK linearN normmN.
+rewrite (ler_lt_trans (f_lipshitz _)) // -ltr_pdivl_mull //; near: y.
 apply/locally_normP.
 by eexists; last by move=> ?; rewrite /= sub0r normmN; apply.
 Admitted.
@@ -1200,14 +1186,13 @@ Lemma equivoRL (W' : normedModType K) F (f g : T -> V) (h : T -> W') :
   f ~_F g -> [o_F g of h] =o_F f.
 Proof.
 move=> ->; apply/eqoP; move=> _/posnumP[eps]; near=> x.
-  rewrite -ler_pdivr_mull // -[X in g + X]opprK oppo.
-  rewrite (ler_trans _ (ler_distm_dist _ _)) //.
-  rewrite [X in _ <= X]ger0_norm ?ler_subr_addr ?add0r; last first.
-    by rewrite -[X in _ <= X]mul1r; near: x.
-  rewrite [X in _ <= X]splitr [_ / 2]mulrC.
-  rewrite ler_add ?ler_pdivr_mull ?mulrA //; near: x.
-by end_near; apply: littleoP.
-Qed.
+rewrite -ler_pdivr_mull // -[X in g + X]opprK oppo.
+rewrite (ler_trans _ (ler_distm_dist _ _)) //.
+rewrite [X in _ <= X]ger0_norm ?ler_subr_addr ?add0r; last first.
+  by rewrite -[X in _ <= X]mul1r; near: x; apply: littleoP.
+rewrite [X in _ <= X]splitr [_ / 2]mulrC.
+by rewrite ler_add ?ler_pdivr_mull ?mulrA //; near: x; apply: littleoP.
+Grab Existential Variables. all: end_near. Qed.
 
 Lemma equiv_sym F (f g : T -> V) : f ~_F g -> g ~_F f.
 Proof.
@@ -1267,7 +1252,9 @@ Notation "[bigOmega 'of' f 'for' fT ]" := (@bigOmega_clone _ _ _ f fT _ idfun).
 Notation "[bigOmega 'of' f ]" := (@bigOmega_clone _ _ _ f _ _ idfun).
 
 Lemma bigOmega_refl_subproof F g : Filter F -> bigOmega F g g.
-Proof. move=> FF; exists 1 => //; near=> x; by [rewrite mul1r|end_near]. Qed.
+Proof.
+by move=> FF; exists 1 => //; near=> x; rewrite mul1r.
+Grab Existential Variables. all: end_near. Qed.
 
 Definition bigOmega_refl (F : filter_on T) g :=
   BigOmega (asboolT (@bigOmega_refl_subproof F g _)).
@@ -1305,12 +1292,12 @@ Lemma eqOmegaO {W} (F : filter_on T) (f : T -> V) (e : T -> W) :
   (f \is 'Omega_F(e)) = (e =O_F f) :> Prop.
 Proof.
 rewrite propeqE; split => [| /eqOP[x x0 Hx] ];
-  [rewrite qualifE => /asboolP[x x0 Hx]; apply/eqOP |
-   rewrite qualifE; apply/asboolP];
-  exists x^-1; rewrite ?invr_gt0 //.
-- near=> y; [by rewrite ler_pdivl_mull //; near: y | end_near].
-- near=> y; [by rewrite ler_pdivr_mull //; near: y | end_near].
-Qed.
+[rewrite qualifE => /asboolP[x x0 Hx]; apply/eqOP |
+rewrite qualifE; apply/asboolP];
+exists x^-1; rewrite ?invr_gt0 //; near=> y.
+  by rewrite ler_pdivl_mull //; near: y.
+by rewrite ler_pdivr_mull //; near: y.
+Grab Existential Variables. all: end_near. Qed.
 
 Lemma eqOmegaE (F : filter_on T) (f e : T -> V) :
   (f =Omega_F(e)) = (f \is 'Omega_F(e)).
@@ -1344,34 +1331,26 @@ Lemma addOmega (F : filter_on pT) (f g h : _ -> R^o)
 Proof.
 rewrite 2!eqOmegaE !eqOmegaO => /eqOP[k k0 hOf].
 apply/eqOP; exists k => //; near=> x.
-  rewrite (@ler_trans _ (k * `|[f x]|)) //; first by near: x.
-  rewrite ler_pmul //; first by rewrite ltrW.
-  rewrite [X in X <= _]absRE [X in _ <= X]absRE ger0_norm //.
-  by rewrite ger0_norm ?addr_ge0 // ler_addl.
-end_near.
-Qed.
+rewrite (@ler_trans _ (k * `|[f x]|)) //; first by near: x.
+rewrite ler_pmul //; first by rewrite ltrW.
+rewrite [X in X <= _]absRE [X in _ <= X]absRE ger0_norm //.
+by rewrite ger0_norm ?addr_ge0 // ler_addl.
+Grab Existential Variables. all: end_near. Qed.
 
 Lemma mulOmega (F : filter_on pT) (h1 h2 f g : pT -> R^o) :
   [Omega_F h1 of f] * [Omega_F h2 of g] =Omega_F (h1 * h2).
 Proof.
 rewrite eqOmegaE eqOmegaO [in RHS]bigOE // -bigOFE.
 set W1 := [Omega_F _ of _]; set W2 := [Omega_F _ of _].
-have [k1 ? ?] := bigOmegaP [bigOmega of W1].
-have [k2 ? ?] := bigOmegaP [bigOmega of W2].
-near=> k; first near=> x.
-- rewrite (ler_trans (absrM _ _)) //.
-  rewrite (@ler_trans _ ((k2 * k1)^-1 * `|[(W1 * W2) x]|)) //.
-  + rewrite invrM ?unitfE ?gtr_eqF // -mulrA ler_pdivl_mull //.
-    rewrite ler_pdivl_mull // (mulrA k1) mulrCA [`|[_]|]normrM.
-    rewrite ler_pmul //.
-    by rewrite mulr_ge0 // ltrW.
-    by rewrite mulr_ge0 // ltrW.
-    near: x.
-    near: x.
-  + rewrite ler_wpmul2r // ltrW //; near: k.
-- end_near.
-- by end_near; exists (k2 * k1)^-1.
-Qed.
+have [_/posnumP[k1] ?] := bigOmegaP [bigOmega of W1].
+have [_/posnumP[k2] ?] := bigOmegaP [bigOmega of W2].
+near=> k; near=> x; rewrite (ler_trans (absrM _ _)) //.
+rewrite (@ler_trans _ ((k2%:num * k1%:num)^-1 * `|[(W1 * W2) x]|)) //.
+  rewrite invrM ?unitfE ?gtr_eqF // -mulrA ler_pdivl_mull //.
+  rewrite ler_pdivl_mull // (mulrA k1%:num) mulrCA [`|[_]|]normrM.
+  by rewrite ler_pmul ?mulr_ge0 //; near: x.
+by rewrite ler_wpmul2r // ltrW //; near: k; exists (k2%:num * k1%:num)^-1.
+Grab Existential Variables. all: end_near. Qed.
 
 End big_omega_in_R.
 
@@ -1407,9 +1386,8 @@ Notation "[bigTheta 'of' f ]" := (@bigTheta_clone _ _ _ f _ _ idfun).
 
 Lemma bigTheta_refl_subproof F g : Filter F -> bigTheta F g g.
 Proof.
-move=> FF; exists 1 => /=; rewrite ?ltr01 //.
-near=> x; by [rewrite mul1r|end_near].
-Qed.
+by move=> FF; exists 1 => /=; rewrite ?ltr01 //; near=> x; by rewrite mul1r.
+Grab Existential Variables. all: end_near. Qed.
 
 Definition bigTheta_refl (F : filter_on T) g :=
   BigTheta (asboolT (@bigTheta_refl_subproof F g _)).
@@ -1451,7 +1429,7 @@ rewrite propeqE; split.
   split; by [rewrite eqOP; exists k2|rewrite qualifE; apply/asboolP; exists k1].
 - case; rewrite eqOP qualifE => -[k1 k10 H1] /asboolP[k2 k20 H2].
   rewrite qualifE; apply/asboolP; exists (k2, k1) => /=; first by rewrite k20.
-  apply/near_andP; split; by near=> x; [near: x|end_near].
+  by apply/near_andP; split.
 Qed.
 
 Lemma eqThetaE (F : filter_on T) (f e : T -> V) :
@@ -1509,8 +1487,8 @@ rewrite -eqOmegaE; apply: addOmega.
 - rewrite eqOmegaE eqOmegaO. set T1 := [Theta_F _ of _].
   have [/= -[k1 _] /= /andP[? _] /near_andP[? _]] := bigThetaP [bigTheta of T1].
   rewrite bigOE //; exists k1^-1 => //; first by rewrite invr_gt0.
-  near=> x; [by rewrite ler_pdivl_mull //; near: x | end_near].
-Qed.
+  by near=> x; rewrite ler_pdivl_mull //; near: x.
+Grab Existential Variables. all: end_near. Qed.
 
 Lemma mulTheta (F : filter_on pT) (h1 h2 f g : pT -> R^o) :
   [Theta_F h1 of f] * [Theta_F h2 of g] =Theta_F h1 * h2.
@@ -1523,17 +1501,12 @@ set T1 := [Theta_F _ of _]; set T2 := [Theta_F _ of _].
 have [[k1 l1] /andP[k10 _] /near_andP[/= P1 _]] := bigThetaP [bigTheta of T1].
 have [[k2 l2] /andP[k20 _] /near_andP[/= P2 _]] := bigThetaP [bigTheta of T2].
 near=> k; first near=> x.
-- rewrite (ler_trans (absrM _ _)) //.
-  rewrite (@ler_trans _ ((k2 * k1)^-1 * `|[(T1 * T2) x]|)) //.
-  + rewrite invrM ?unitfE ?gtr_eqF // -mulrA ler_pdivl_mull //.
-    rewrite ler_pdivl_mull // (mulrA k1) mulrCA [`|[_]|]normrM ler_pmul //.
-    by rewrite mulr_ge0 // ltrW.
-    by rewrite mulr_ge0 // ltrW.
-    near: x.
-    near: x.
-  + rewrite ler_wpmul2r // ltrW //; near: k.
-- end_near.
-- by end_near; exists (k2 * k1)^-1.
-Qed.
+rewrite (ler_trans (absrM _ _)) //.
+rewrite (@ler_trans _ ((k2 * k1)^-1 * `|[(T1 * T2) x]|)) //.
+  rewrite invrM ?unitfE ?gtr_eqF // -mulrA ler_pdivl_mull //.
+  rewrite ler_pdivl_mull // (mulrA k1) mulrCA [`|[_]|]normrM ler_pmul //;
+  by [rewrite mulr_ge0 // ltrW|near: x].
+by rewrite ler_wpmul2r // ltrW //; near: k; exists (k2 * k1)^-1.
+Grab Existential Variables. all: end_near. Qed.
 
 End big_theta_in_R.


### PR DESCRIPTION
- near tactics proof flow is more natural.
  + `near=> x` behaves like an intro for `\forall x \near F, P x`
  + and `near: x` behaves like a discharge, so that the proof obligation related to it immediately follows the tactic call (it used to be delayed to after end_near)
  + Need to replace `Qed.` by `Grab Existential Variables. all: end_near. Qed." until a feature request is made in Coq
- speedup of typeclasses inference using some opacity