### PR TITLE
Use near notation in bigO

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,7 @@ before_script: &before_script
           echo "real-closed#" >> "deps.ver"
           git ls-remote https://github.com/math-comp/real-closed.git HEAD >> "deps.ver"
           echo "-" >> "deps.ver"
-          echo "finmap#" >> "deps.ver"
-          git ls-remote https://github.com/math-comp/finmap.git HEAD >> "deps.ver"
+          echo "finmap.${FINMAPVERSION}-" >> "deps.ver"
           cat deps.ver
     - restore_cache:
         keys:
@@ -63,7 +62,8 @@ before_script: &before_script
         name: Install MathComp
         command: |
           env -u OPAMSWITCH opam pin add -n coq-mathcomp-ssreflect ${MATHCOMPVERSION}
-          env -u OPAMSWITCH opam install coq-mathcomp-ssreflect ${MATHCOMPPKG}
+          env -u OPAMSWITCH opam pin add -n coq-mathcomp-finmap ${FINMAPVERSION}
+          env -u OPAMSWITCH opam install coq-mathcomp-ssreflect coq-mathcomp-finmap ${MATHCOMPPKG}
     - run:
         name: Clean cache
         command: |
@@ -84,7 +84,8 @@ jobs:
       COMPILER: 4.05.0
       COQVERSION: 8.8.0
       MATHCOMPVERSION: 1.7.0
-      MATHCOMPPKG: coq-mathcomp-algebra coq-mathcomp-field coq-mathcomp-real-closed coq-mathcomp-finmap
+      FINMAPVERSION: 1.0.0
+      MATHCOMPPKG: coq-mathcomp-algebra coq-mathcomp-field coq-mathcomp-real-closed
 
   build:
     <<: *params

--- a/derive.v
+++ b/derive.v
@@ -140,10 +140,9 @@ Lemma differentiable_continuous (x : V) (f : V -> W) :
 Proof.
 move=> /diff_locallyP [dfc]; rewrite -addrA.
 rewrite (littleo_bigO_eqo (cst (1 : R^o))); last first.
-  apply/eqOP; exists 1 => //; rewrite /cst mul1r [`|[1 : R^o]|]absr1.
-  near=> y; rewrite ltrW //; near: y.
-  by apply/locally_normP; eexists=> [|?];
-    last (rewrite /= ?sub0r ?normmN; apply).
+  apply/eqOP; near=> k; rewrite /cst [`|[1 : R^o]|]absr1 mulr1.
+  near=> y; rewrite ltrW //; near: y; apply/locally_normP.
+  by exists k; [near: k; exists 0|move=> ? /=; rewrite sub0r normmN].
 rewrite addfo; first by move=> /eqolim; rewrite flim_shift add0r.
 by apply/eqolim0P; apply: (flim_trans (dfc 0)); rewrite linear0.
 Grab Existential Variables. all: end_near. Qed.
@@ -588,7 +587,7 @@ Qed.
 Lemma linear_eqO (V' W' : normedModType R) (f : {linear V' -> W'}) :
   continuous f -> (f : V' -> W') =O_ (0 : V') id.
 Proof.
-move=> /linear_lipschitz [k kgt0 flip]; apply/eqOP; exists k => //.
+move=> /linear_lipschitz [k kgt0 flip]; apply/eqOFP; exists k => //.
 exact: filterS filterT.
 Qed.
 
@@ -602,8 +601,8 @@ Lemma compoO_eqo (K : absRingType) (U V' W' : normedModType K) (f : U -> V')
   [o_ (0 : V') id of g] \o [O_ (0 : U) id of f] =o_ (0 : U) id.
 Proof.
 apply/eqoP => _ /posnumP[e].
-have /eqO_bigO [_ /posnumP[k]] : [O_ (0 : U) id of f] =O_ (0 : U) id by [].
-have /eq_some_oP : [o_ (0 : V') id of g] =o_ (0 : V') id by [].
+have /bigOFI [_ /posnumP[k]] := bigOP [bigO of [O_ (0 : U) id of f]].
+have := littleoP [littleo of [o_ (0 : V') id of g]].
 move=>  /(_ (e%:num / k%:num)) /(_ _) /locallyP [//|_ /posnumP[d] hd].
 apply: filter_app; near=> x => leOxkx; apply: ler_trans (hd _ _) _; last first.
   rewrite -ler_pdivl_mull //; apply: ler_trans leOxkx _.
@@ -625,12 +624,11 @@ Lemma compOo_eqo (K : absRingType) (U V' W' : normedModType K) (f : U -> V')
   [O_ (0 : V') id of g] \o [o_ (0 : U) id of f] =o_ (0 : U) id.
 Proof.
 apply/eqoP => _ /posnumP[e].
-have /eqO_bigO [_ /posnumP[k]] : [O_ (0 : V') id of g] =O_ (0 : V') id by [].
+have /bigOFI [_ /posnumP[k]] := bigOP [bigO of [O_ (0 : V') id of g]].
 move=> /locallyP [_ /posnumP[d] hd].
-have /eq_some_oP : [o_ (0 : U) id of f] =o_ (0 : U) id by [].
 have ekgt0 : e%:num / k%:num > 0 by [].
-move=> /(_ _ ekgt0); apply: filter_app; near=> x.
-move=> leoxekx; apply: ler_trans (hd _ _) _; last first.
+have /(_ _ ekgt0) := littleoP [littleo of [o_ (0 : U) id of f]].
+apply: filter_app; near=> x => leoxekx; apply: ler_trans (hd _ _) _; last first.
   by rewrite -ler_pdivl_mull // mulrA [_^-1 * _]mulrC.
 rewrite -ball_normE /= normmB subr0; apply: ler_lt_trans leoxekx _.
 rewrite -ltr_pdivl_mull //; near: x; rewrite /= locally_simpl.

--- a/hierarchy.v
+++ b/hierarchy.v
@@ -1249,6 +1249,22 @@ exact: (Rbar_locally'_filter -oo).
 Qed.
 Typeclasses Opaque Rbar_locally.
 
+Lemma near_pinfty_div2 (A : set R) :
+  (\forall k \near +oo, A k) -> (\forall k \near +oo, A (k / 2)).
+Proof.
+by move=> [M AM]; exists (M * 2) => x; rewrite -ltr_pdivl_mulr //; apply: AM.
+Qed.
+
+Lemma locally_pinfty_gt c : \forall x \near +oo, c < x.
+Proof. by exists c. Qed.
+
+Lemma locally_pinfty_ge c : \forall x \near +oo, c <= x.
+Proof. by exists c; apply: ltrW. Qed.
+
+Hint Extern 0 (is_true (0 < _)) => match goal with
+  H : ?x \is_near (locally +oo) |- _ =>
+    solve[near: x; exists 0 => _/posnumP[x] //] end : core.
+
 (** ** Modules with a norm *)
 
 Reserved Notation  "`|[ x ]|" (at level 0, x at level 99, format "`|[ x ]|").
@@ -1805,9 +1821,7 @@ rewrite (@distm_lt_split _ _ (k *: z)) // -?(scalerBr, scalerBl).
 rewrite (ler_lt_trans (ler_normmZ _ _)) //.
 have zM: `|[z]| < M by near: z; near: M; apply: flim_bounded; apply: flim_refl.
 rewrite (ler_lt_trans (ler_pmul _ _ (lerr _) (_ : _ <= M))) // ?ltrW//.
-rewrite -ltr_pdivl_mulr //; last by rewrite (ler_lt_trans _ zM).
-near: l; apply: (flim_norm (_ : K^o)) => //; rewrite mulr_gt0 ?invr_gt0 //.
-by near: M; exists 1 => ? /(ler_lt_trans ler01).
+by rewrite -ltr_pdivl_mulr //; near: l; apply: (flim_norm (_ : K^o)).
 Grab Existential Variables. all: end_near. Qed.
 
 Arguments scale_continuous _ _ : clear implicits.

--- a/topology.v
+++ b/topology.v
@@ -597,7 +597,7 @@ Qed.
 Tactic Notation "near=>" ident(x) := apply: filter_near_of => x ?.
 
 Ltac just_discharge_near x :=
-  tryif match goal with Hx : x \is_near _ |- _ => move: (x) Hx end
+  tryif match goal with Hx : x \is_near _ |- _ => move: (x) (Hx) end
         then idtac else fail "the variable" x "is not a ""near"" variable".
 Tactic Notation "near:" ident(x) :=
   just_discharge_near x;
@@ -638,6 +638,14 @@ Lemma filter_app (T : Type) (F : set (set T)) :
 Proof.
 by move=> FF P Q subPQ FP; near=> x; suff: P x; near: x.
 Grab Existential Variables. by end_near. Qed.
+
+Lemma near_app (T U : Type) (F : set (set T)) (G : set (set U))
+  (GF : Filter G) (P : T -> set U) (Q : set U)
+  (FGP : \forall t \near F, \forall u \near G, P t u) (t : T) :
+  prop_of (InFilter FGP) t -> (\forall u \near G, P t u -> Q u) ->
+  \forall u \near G, Q u.
+Proof. by move=> GPt ?; apply: filter_app (near FGP t GPt). Qed.
+Arguments near_app {T U F G GF P Q} FGP t.
 
 Lemma filter_app2 (T : Type) (F : set (set T)) :
   Filter F -> forall P Q R : set T,  F (fun x => P x -> Q x -> R x) ->


### PR DESCRIPTION
To be consistent with our paper on asymptotic reasoning I swapped `bigO` and `bigOF`. This PR also:
- fixes the compilation which was broken by recent changes in finmap
- fixes the `near:` tactic: in nested uses of the near tactics, hypotheses could be removed from the context of some evars when calling the `near:` tactic
- improves the automation of positivity proofs involving points `x` such that `x \is_near +oo`