### PR TITLE
Remove definitions in landau

### DIFF
--- a/derive.v
+++ b/derive.v
@@ -580,8 +580,8 @@ Qed.
 Lemma linear_eqO (V' W' : normedModType R) (f : {linear V' -> W'}) :
   continuous f -> (f : V' -> W') =O_ (0 : V') id.
 Proof.
-move=> /linear_lipschitz [k kgt0 flip]; apply/eqOFP; exists k => //.
-exact: filterS filterT.
+move=> /linear_lipschitz [k kgt0 flip]; apply/eqO_exP; exists k => //.
+exact: filterE.
 Qed.
 
 Lemma diff_eqO (V' W' : normedModType R) (F : filter_on V') (f : V' -> W') :
@@ -594,7 +594,7 @@ Lemma compoO_eqo (K : absRingType) (U V' W' : normedModType K) (f : U -> V')
   [o_ (0 : V') id of g] \o [O_ (0 : U) id of f] =o_ (0 : U) id.
 Proof.
 apply/eqoP => _ /posnumP[e].
-have /bigOFP [_ /posnumP[k]] := bigOP [bigO of [O_ (0 : U) id of f]].
+have /bigO_exP [_ /posnumP[k]] := bigOP [bigO of [O_ (0 : U) id of f]].
 have := littleoP [littleo of [o_ (0 : V') id of g]].
 move=>  /(_ (e%:num / k%:num)) /(_ _) /locallyP [//|_ /posnumP[d] hd].
 apply: filter_app; near=> x => leOxkx; apply: ler_trans (hd _ _) _; last first.
@@ -617,7 +617,7 @@ Lemma compOo_eqo (K : absRingType) (U V' W' : normedModType K) (f : U -> V')
   [O_ (0 : V') id of g] \o [o_ (0 : U) id of f] =o_ (0 : U) id.
 Proof.
 apply/eqoP => _ /posnumP[e].
-have /bigOFP [_ /posnumP[k]] := bigOP [bigO of [O_ (0 : V') id of g]].
+have /bigO_exP [_ /posnumP[k]] := bigOP [bigO of [O_ (0 : V') id of g]].
 move=> /locallyP [_ /posnumP[d] hd].
 have ekgt0 : e%:num / k%:num > 0 by [].
 have /(_ _ ekgt0) := littleoP [littleo of [o_ (0 : U) id of f]].

--- a/derive.v
+++ b/derive.v
@@ -56,23 +56,16 @@ Lemma diffE (F : filter_on V) (f : V -> W) :
   forall x, f x = f (lim F) + 'd_F f (x - lim F) +o_(x \near F) (x - lim F).
 Proof. by move=> /diffP []. Qed.
 
-Lemma littleo_shift (y x : V) (f : V -> W) (e : V -> V) :
-  littleo (locally y) (f \o shift (x - y)) (e \o shift (x - y)) ->
-  littleo (locally x) f e.
-Proof.
-move=> fe _/posnumP[eps]; rewrite near_simpl (near_shift y).
-exact: filterS (fe _ [gt0 of eps%:num]).
-Qed.
-
 Lemma littleo_center0 (x : V) (f : V -> W) (e : V -> V) :
   [o_x e of f] = [o_ (0 : V) (e \o shift x) of f \o shift x] \o center x.
 Proof.
 rewrite /the_littleo /insubd /=; have [g /= _ <-{f}|/asboolP Nfe] /= := insubP.
-  rewrite insubT //= ?comp_shiftK //; apply/asboolP; apply: (@littleo_shift x).
-  by rewrite sub0r !comp_shiftK => ?; apply: littleoP.
-rewrite insubF //; apply/asboolP => fe; apply: Nfe.
-by apply: (@littleo_shift 0); rewrite subr0.
-Qed.
+  rewrite insubT //= ?comp_shiftK //; apply/asboolP => _/posnumP[eps].
+  rewrite [\forall x \near _, _ <= _](near_shift x) sub0r; near=> y.
+  by rewrite /= subrK; near: y; have /eqoP := littleo_eqo g; apply.
+rewrite insubF //; apply/asboolP => fe; apply: Nfe => _/posnumP[eps].
+by rewrite [\forall x \near _, _ <= _](near_shift 0) subr0; apply: fe.
+Grab Existential Variables. end_near. Qed.
 
 Lemma diff_locallyxP (x : V) (f : V -> W) :
   differentiable x f <-> continuous ('d_x f) /\
@@ -601,7 +594,7 @@ Lemma compoO_eqo (K : absRingType) (U V' W' : normedModType K) (f : U -> V')
   [o_ (0 : V') id of g] \o [O_ (0 : U) id of f] =o_ (0 : U) id.
 Proof.
 apply/eqoP => _ /posnumP[e].
-have /bigOFI [_ /posnumP[k]] := bigOP [bigO of [O_ (0 : U) id of f]].
+have /bigOFP [_ /posnumP[k]] := bigOP [bigO of [O_ (0 : U) id of f]].
 have := littleoP [littleo of [o_ (0 : V') id of g]].
 move=>  /(_ (e%:num / k%:num)) /(_ _) /locallyP [//|_ /posnumP[d] hd].
 apply: filter_app; near=> x => leOxkx; apply: ler_trans (hd _ _) _; last first.
@@ -624,7 +617,7 @@ Lemma compOo_eqo (K : absRingType) (U V' W' : normedModType K) (f : U -> V')
   [O_ (0 : V') id of g] \o [o_ (0 : U) id of f] =o_ (0 : U) id.
 Proof.
 apply/eqoP => _ /posnumP[e].
-have /bigOFI [_ /posnumP[k]] := bigOP [bigO of [O_ (0 : V') id of g]].
+have /bigOFP [_ /posnumP[k]] := bigOP [bigO of [O_ (0 : V') id of g]].
 move=> /locallyP [_ /posnumP[d] hd].
 have ekgt0 : e%:num / k%:num > 0 by [].
 have /(_ _ ekgt0) := littleoP [littleo of [o_ (0 : U) id of f]].
@@ -718,7 +711,7 @@ apply/eqoP=> _ /posnumP[e]; near=> x; rewrite (ler_trans (fschwarz _ _))//.
 rewrite ler_pmul ?pmulr_rge0 //; last by rewrite ler_maxr orbC lerr.
 rewrite -ler_pdivl_mull //.
 suff : `|[x]| <= k%:num ^-1 * e%:num by apply: ler_trans; rewrite ler_maxr lerr.
-near: x; rewrite /= locally_filterE; apply/locally_le_locally_norm.
+near: x; rewrite !near_simpl; apply/locally_le_locally_norm.
 by exists (k%:num ^-1 * e%:num) => // ? /=; rewrite normmB subr0 => /ltrW.
 Grab Existential Variables. all: end_near. Qed.
 
@@ -862,7 +855,7 @@ rewrite -[X in X + _]mulr1 -[X in 1 / _ * X](@mulfVK _ (x ^+ 2)); last first.
   by rewrite sqrf_eq0.
 rewrite mulrA mulf_div mulr1.
 have hDx_neq0 : h + x != 0.
-  near: h; rewrite /= locally_filterE; apply/locally_normP.
+  near: h; rewrite !locally_simpl; apply/locally_normP.
   exists `|x|; first by rewrite normr_gt0.
   move=> h /=; rewrite normmB subr0 -subr_gt0 => lthx.
   rewrite -(normm_gt0 (h + x : R^o)) addrC -[h]opprK.

--- a/landau.v
+++ b/landau.v
@@ -348,20 +348,21 @@ Section Domination.
 
 Context {K : absRingType} {T : Type} {V W : normedModType K}.
 
-Notation littleo F f g :=
+Local Notation littleo_def F f g :=
   (forall eps : R, is_true (0 < eps) ->
   \forall x \near F, is_true (`|[f x]| <= eps * `|[g x]|)).
 
 Structure littleo_type (F : set (set T)) (g : T -> W) := Littleo {
   littleo_fun :> T -> V;
-  _ : `[< littleo F littleo_fun g >]
+  _ : `[< littleo_def F littleo_fun g >]
 }.
 Notation "{o_ F f }" := (littleo_type F f).
 
 Canonical littleo_subtype (F : set (set T)) (g : T -> W) :=
   [subType for (@littleo_fun F g)].
 
-Lemma littleo_class (F : set (set T)) (g : T -> W) (f : {o_F g}) : `[<littleo F f g>].
+Lemma littleo_class (F : set (set T)) (g : T -> W) (f : {o_F g}) :
+  `[< littleo_def F f g >].
 Proof. by case: f => ?. Qed.
 Hint Resolve littleo_class.
 
@@ -370,7 +371,8 @@ Definition littleo_clone (F : set (set T)) (g : T -> W) (f : T -> V) (fT : {o_F 
 Notation "[littleo 'of' f 'for' fT ]" := (@littleo_clone _ _ f fT _ idfun).
 Notation "[littleo 'of' f ]" := (@littleo_clone _ _ f _ _ idfun).
 
-Lemma littleo0_subproof F (g : T -> W) : Filter F -> littleo F (0 : T -> V) g.
+Lemma littleo0_subproof F (g : T -> W) :
+  Filter F -> littleo_def F (0 : T -> V) g.
 Proof.
 move=> FF _/posnumP[eps] /=; apply: filterE => x; rewrite normm0.
 by rewrite mulr_ge0 // ltrW.
@@ -424,23 +426,23 @@ Notation "fx == gx '+o_(' x \near F ')' hx" :=
 Notation "fx '==o_(' x \near F ')' hx" :=
   (fx == (mklittleo the_tag F (fun x => fx) (fun x => hx) x)).
 
-Lemma littleoP (F : set (set T)) (g : T -> W) (f : {o_F g}) : littleo F f g.
+Lemma littleoP (F : set (set T)) (g : T -> W) (f : {o_F g}) : littleo_def F f g.
 Proof. exact/asboolP. Qed.
-Hint Extern 0 (littleo _ _ _) => solve[apply: littleoP] : core.
+Hint Extern 0 (littleo_def _ _ _) => solve[apply: littleoP] : core.
 Hint Extern 0 (locally _ _) => solve[apply: littleoP] : core.
 Hint Extern 0 (prop_near1 _) => solve[apply: littleoP] : core.
 Hint Extern 0 (prop_near2 _) => solve[apply: littleoP] : core.
 
 Lemma littleoE (tag : unit) (F : filter_on T)
    (phF : phantom (set (set T)) F) f h :
-   littleo F f h -> the_littleo tag F phF f h = f.
+   littleo_def F f h -> the_littleo tag F phF f h = f.
 Proof. by move=> /asboolP?; rewrite /the_littleo /insubd insubT. Qed.
 
-Canonical the_littleo_littelo (tag : unit) (F : filter_on T)
+Canonical the_littleo_littleo (tag : unit) (F : filter_on T)
   (phF : phantom (set (set T)) F) f h := [littleo of the_littleo tag F phF f h].
 
 Lemma opp_littleo_subproof (F : filter_on T) e (df : {o_F e}) :
-   littleo F (- (df : _ -> _)) e.
+   littleo_def F (- (df : _ -> _)) e.
 Proof.
 by move=> _/posnumP[eps]; near=> x; rewrite normmN; near: x; apply: littleoP.
 Grab Existential Variables. all: end_near. Qed.
@@ -457,7 +459,7 @@ Lemma oppox (F : filter_on T) (f : T -> V) e x :
 Proof. by move: x; rewrite -/(- _ =1 _) {1}oppo. Qed.
 
 Lemma add_littleo_subproof (F : filter_on T) e (df dg : {o_F e}) :
-  littleo F (df \+ dg) e.
+  littleo_def F (df \+ dg) e.
 Proof.
 move=> _/posnumP[eps]; near=> x => /=.
 rewrite [eps%:num]splitr mulrDl (ler_trans (ler_normm_add _ _)) // ler_add //;
@@ -480,7 +482,7 @@ Lemma addox (F : filter_on T) (f g: T -> V) e x :
 Proof. by move: x; rewrite -/(_ + _ =1 _) {1}addo. Qed.
 
 Lemma eqadd_some_oP (F : filter_on T) (f g : T -> V) (e : T -> W) h :
-  f = g + [o_F e of h] -> littleo F (f - g) e.
+  f = g + [o_F e of h] -> littleo_def F (f - g) e.
 Proof.
 rewrite /the_littleo /insubd=> ->.
 case: insubP => /= [u /asboolP fg_o_e ->|_] eps  /=.
@@ -489,17 +491,17 @@ by rewrite addrC addKr; apply: littleoP.
 Qed.
 
 Lemma eqaddoP (F : filter_on T) (f g : T -> V) (e : T -> W) :
-   (f = g +o_ F e) <-> (littleo F (f - g) e).
+   (f = g +o_ F e) <-> (littleo_def F (f - g) e).
 Proof.
 by split=> [/eqadd_some_oP|fg_o_e]; rewrite ?littleoE // addrC addrNK.
 Qed.
 
 Lemma eqoP (F : filter_on T) (e : T -> W) (f : T -> V) :
-   (f =o_ F e) <-> (littleo F f e).
+   (f =o_ F e) <-> (littleo_def F f e).
 Proof. by rewrite -[f]subr0 -eqaddoP -[f \- 0]/(f - 0) subr0 add0r. Qed.
 
 Lemma eq_some_oP (F : filter_on T) (e : T -> W) (f : T -> V) h :
-   f = [o_F e of h] -> littleo F f e.
+   f = [o_F e of h] -> littleo_def F f e.
 Proof. by have := @eqadd_some_oP F f 0 e h; rewrite add0r subr0. Qed.
 
 (* replaces a 'o_F e by a "canonical one" *)
@@ -527,7 +529,7 @@ Lemma littleo_eqo (F : filter_on T) (g : T -> W) (f : {o_F g}) :
 Proof. by apply/eqoP. Qed.
 
 Lemma scale_littleo_subproof (F : filter_on T) e (df : {o_F e}) a :
-  littleo F (a *: (df : _ -> _)) e.
+  littleo_def F (a *: (df : _ -> _)) e.
 Proof.
 have [->|a0] := eqVneq a 0; first by rewrite scale0r.
 move=> _ /posnumP[eps]; have aa := absr_eq0 a; near=> x => /=.
@@ -547,14 +549,14 @@ Lemma scaleox (F : filter_on T) a (f : T -> V) e x :
   a *: ([o_F e of f] x) = [o_F e of a *: [o_F e of f]] x.
 Proof. by move: x; rewrite -/(_ *: _ =1 _) {1}scaleo. Qed.
 
-Notation bigO F f g :=
+Local Notation bigO_def F f g :=
   (\forall k \near +oo, \forall x \near F, is_true (`|[f x]| <= k * `|[g x]|)).
 
-Notation bigOF F f g :=
+Local Notation bigO_ex_def F f g :=
   (exists2 k, k > 0 & \forall x \near F, `|[f x]| <= k * `|[g x]|).
 
-Lemma bigOFP (F : set (set T)) (f : T -> V) (g : T -> W) :
-  Filter F -> bigOF F f g <-> bigO F f g.
+Lemma bigO_exP (F : set (set T)) (f : T -> V) (g : T -> W) :
+  Filter F -> bigO_ex_def F f g <-> bigO_def F f g.
 Proof.
 split=> [[k _ fOg] | [k fOg]].
   exists k => l ltkl; move: fOg; apply: filter_app; near=> x.
@@ -565,14 +567,15 @@ Unshelve. end_near. Qed.
 
 Structure bigO_type (F : set (set T)) (g : T -> W) := BigO {
   bigO_fun :> T -> V;
-  _ : `[< bigO F bigO_fun g >]
+  _ : `[< bigO_def F bigO_fun g >]
 }.
 Notation "{O_ F f }" := (bigO_type F f).
 
 Canonical bigO_subtype (F : set (set T)) (g : T -> W) :=
   [subType for (@bigO_fun F g)].
 
-Lemma bigO_class (F : set (set T)) (g : T -> W) (f : {O_F g}) : `[<bigO F f g>].
+Lemma bigO_class (F : set (set T)) (g : T -> W) (f : {O_F g}) :
+  `[< bigO_def F f g >].
 Proof. by case: f => ?. Qed.
 Hint Resolve bigO_class.
 
@@ -581,7 +584,7 @@ Definition bigO_clone (F : set (set T)) (g : T -> W) (f : T -> V) (fT : {O_F g})
 Notation "[bigO 'of' f 'for' fT ]" := (@bigO_clone _ _ f fT _ idfun).
 Notation "[bigO 'of' f ]" := (@bigO_clone _ _ f _ _ idfun).
 
-Lemma bigO0_subproof F (g : T -> W) : Filter F -> bigO F (0 : T -> V) g.
+Lemma bigO0_subproof F (g : T -> W) : Filter F -> bigO_def F (0 : T -> V) g.
 Proof.
 by move=> FF; near=> k; apply: filterE => x; rewrite normm0 pmulr_rge0.
 Grab Existential Variables. end_near. Qed.
@@ -632,22 +635,22 @@ Notation "fx == gx '+O_(' x \near F ')' hx" :=
 Notation "fx '==O_(' x \near F ')' hx" :=
   (fx == (mkbigO the_tag F (fun x => fx) (fun x => hx) x)).
 
-Lemma bigOP (F : set (set T)) (g : T -> W) (f : {O_F g}) : bigO F f g.
+Lemma bigOP (F : set (set T)) (g : T -> W) (f : {O_F g}) : bigO_def F f g.
 Proof. exact/asboolP. Qed.
-Hint Extern 0 (bigO _ _ _) => solve[apply: bigOP] : core.
+Hint Extern 0 (bigO_def _ _ _) => solve[apply: bigOP] : core.
 Hint Extern 0 (locally _ _) => solve[apply: bigOP] : core.
 Hint Extern 0 (prop_near1 _) => solve[apply: bigOP] : core.
 Hint Extern 0 (prop_near2 _) => solve[apply: bigOP] : core.
 
 Lemma bigOE (tag : unit) (F : filter_on T) (phF : phantom (set (set T)) F) f h :
-   bigO F f h -> the_bigO tag F phF f h = f.
+   bigO_def F f h -> the_bigO tag F phF f h = f.
 Proof. by move=> /asboolP?; rewrite /the_bigO /insubd insubT. Qed.
 
 Canonical the_bigO_bigO (tag : unit) (F : filter_on T)
   (phF : phantom (set (set T)) F) f h := [bigO of the_bigO tag F phF f h].
 
 Lemma opp_bigO_subproof (F : filter_on T) e (df : {O_F e}) :
-   bigO F (- (df : _ -> _)) e.
+   bigO_def F (- (df : _ -> _)) e.
 Proof.
 have := bigOP [bigO of df]; apply: filter_app; near=> k.
 by apply: filter_app; near=> x; rewrite normmN.
@@ -664,7 +667,7 @@ Lemma oppOx (F : filter_on T) (f : T -> V) e x :
 Proof. by move: x; rewrite -/(- _ =1 _) {1}oppO. Qed.
 
 Lemma add_bigO_subproof (F : filter_on T) e (df dg : {O_F e}) :
-  bigO F (df \+ dg) e.
+  bigO_def F (df \+ dg) e.
 Proof.
 near=> k; near=> x; apply: ler_trans (ler_normm_add _ _) _.
 by rewrite (splitr k) mulrDl ler_add //; near: x; near: k;
@@ -686,7 +689,7 @@ Lemma addOx (F : filter_on T) (f g: T -> V) e x :
 Proof. by move: x; rewrite -/(_ + _ =1 _) {1}addO. Qed.
 
 Lemma eqadd_some_OP (F : filter_on T) (f g : T -> V) (e : T -> W) h :
-  f = g + [O_F e of h] -> bigO F (f - g) e.
+  f = g + [O_F e of h] -> bigO_def F (f - g) e.
 Proof.
 rewrite /the_bigO /insubd=> ->.
 case: insubP => /= [u /asboolP fg_o_e ->|_].
@@ -695,19 +698,19 @@ by rewrite addrC addKr; apply: bigOP.
 Qed.
 
 Lemma eqaddOP (F : filter_on T) (f g : T -> V) (e : T -> W) :
-   (f = g +O_ F e) <-> (bigO F (f - g) e).
+   (f = g +O_ F e) <-> (bigO_def F (f - g) e).
 Proof. by split=> [/eqadd_some_OP|fg_O_e]; rewrite ?bigOE // addrC addrNK. Qed.
 
 Lemma eqOP (F : filter_on T) (e : T -> W) (f : T -> V) :
-   (f =O_ F e) <-> (bigO F f e).
+   (f =O_ F e) <-> (bigO_def F f e).
 Proof. by rewrite -[f]subr0 -eqaddOP -[f \- 0]/(f - 0) subr0 add0r. Qed.
 
-Lemma eqOFP (F : filter_on T) (e : T -> W) (f : T -> V) :
-   (f =O_ F e) <-> (bigOF F f e).
-Proof. apply: iff_trans (iff_sym (bigOFP _ _ _)); apply: eqOP. Qed.
+Lemma eqO_exP (F : filter_on T) (e : T -> W) (f : T -> V) :
+   (f =O_ F e) <-> (bigO_ex_def F f e).
+Proof. apply: iff_trans (iff_sym (bigO_exP _ _ _)); apply: eqOP. Qed.
 
 Lemma eq_some_OP (F : filter_on T) (e : T -> W) (f : T -> V) h :
-   f = [O_F e of h] -> bigO F f e.
+   f = [O_F e of h] -> bigO_def F f e.
 Proof. by have := @eqadd_some_OP F f 0 e h; rewrite add0r subr0. Qed.
 
 Lemma bigO_eqO (F : filter_on T) (g : T -> W) (f : {O_F g}) :
@@ -715,7 +718,7 @@ Lemma bigO_eqO (F : filter_on T) (g : T -> W) (f : {O_F g}) :
 Proof. by apply/eqOP; apply: bigOP. Qed.
 
 Lemma eqO_bigO (F : filter_on T) (e : T -> W) (f : T -> V) :
-   f =O_ F e -> bigO F f e.
+   f =O_ F e -> bigO_def F f e.
 Proof. by rewrite eqOP. Qed.
 
 (* replaces a 'O_F e by a "canonical one" *)
@@ -856,7 +859,7 @@ Hint Extern 0 (_ = 'O__ _) => apply: eqoO; reflexivity : core.
 Hint Extern 0 (_ = _ + 'o__ _) => apply: eqaddoE; reflexivity : core.
 Hint Extern 0 (_ = _ + 'O__ _) => apply: eqaddOE; reflexivity : core.
 Hint Extern 0 (\forall k \near +oo, \forall x \near _,
-  is_true (`|[_ x]| <= k * `|[_ x]|)) => solve[apply: littleoP] : core.
+  is_true (`|[_ x]| <= k * `|[_ x]|)) => solve[apply: bigOP] : core.
 Hint Extern 0 (locally _ _) => solve[apply: bigOP] : core.
 Hint Extern 0 (prop_near1 _) => solve[apply: bigOP] : core.
 Hint Extern 0 (prop_near2 _) => solve[apply: bigOP] : core.
@@ -925,7 +928,7 @@ Lemma littleo_bigO_eqo {F : filter_on T}
   f =O_F g -> [o_F f of h] =o_F g.
 Proof.
 move->; apply/eqoP => _/posnumP[e]; set k := 'O g.
-have /bigOFP [_/posnumP[c]] := bigOP [bigO of k].
+have /bigO_exP [_/posnumP[c]] := bigOP [bigO of k].
 apply: filter_app; near=> x; rewrite -!ler_pdivr_mull //; apply: ler_trans.
 by rewrite ler_pdivr_mull // mulrA; near: x; apply: littleoP.
 Grab Existential Variables. all: end_near. Qed.
@@ -935,7 +938,7 @@ Lemma bigO_littleo_eqo {F : filter_on T} (g : T -> W) (f : T -> V) (h : T -> X) 
   f =o_F g -> [O_F f of h] =o_F g.
 Proof.
 move->; apply/eqoP => _/posnumP[e]; set k := 'O _.
-have /bigOFP [_/posnumP[c]] := bigOP [bigO of k].
+have /bigO_exP [_/posnumP[c]] := bigOP [bigO of k].
 apply: filter_app; near=> x => /ler_trans; apply.
 by rewrite -ler_pdivl_mull // mulrA; near: x; apply: littleoP.
 Grab Existential Variables. all: end_near. Qed.
@@ -945,8 +948,8 @@ Lemma bigO_bigO_eqO {F : filter_on T} (g : T -> W) (f : T -> V) (h : T -> X) :
   f =O_F g -> ([O_F f of h] : _ -> _) =O_F g.
 Proof.
 move->; apply/eqOP; set k := 'O g; set k' := 'O k.
-have /bigOFP [_/posnumP[c1] kOg] := bigOP [bigO of k].
-have /bigOFP [_/posnumP[c2] k'Ok] := bigOP [bigO of k'].
+have /bigO_exP [_/posnumP[c1] kOg] := bigOP [bigO of k].
+have /bigO_exP [_/posnumP[c2] k'Ok] := bigOP [bigO of k'].
 near=> c; move: k'Ok kOg; apply: filter_app2; near=> x => lek'c2k.
 rewrite -(@ler_pmul2l _ c2) // mulrA => /(ler_trans lek'c2k) /ler_trans; apply.
 by rewrite ler_pmul //; near: c; apply: locally_pinfty_ge.
@@ -978,7 +981,7 @@ Lemma oppfO (F : filter_on T) (h f : T -> V) (e : T -> W) :
 Proof. by move->; rewrite oppO. Qed.
 
 Lemma idO (F : filter_on T) (e : T -> W) : e =O_F e.
-Proof. by apply/eqOFP; exists 1 => //; apply: filterE => x; rewrite mul1r. Qed.
+Proof. by apply/eqO_exP; exists 1 => //; apply: filterE=> x; rewrite mul1r. Qed.
 
 Lemma littleo_littleo (F : filter_on T) (f : T -> V) (g : T -> W) (h : T -> X) :
   f =o_F g -> [o_F f of h] =o_F g.
@@ -1045,8 +1048,8 @@ Lemma mulO (F : filter_on pT) (h1 h2 f g : pT -> R^o) :
   [O_F h1 of f] * [O_F h2 of g] =O_F (h1 * h2).
 Proof.
 rewrite [RHS]bigOE //; set O1 := 'O _; set O2 := 'O _.
-have /bigOFP [_/posnumP[k1] Oh1] := bigOP [bigO of O1].
-have /bigOFP [_/posnumP[k2] Oh2] := bigOP [bigO of O2].
+have /bigO_exP [_/posnumP[k1] Oh1] := bigOP [bigO of O1].
+have /bigO_exP [_/posnumP[k2] Oh2] := bigOP [bigO of O2].
 near=> k; move: Oh1 Oh2; apply: filter_app2; near=> x => leOh1 leOh2.
 rewrite (ler_trans (absrM _ _)) // (ler_trans (ler_pmul _ _ leOh1 leOh2)) //.
 rewrite mulrACA [`|[_]| in X in _ <= X]normrM ler_wpmul2r // ?mulr_ge0 //.
@@ -1196,13 +1199,13 @@ Section big_omega.
 Context {K : absRingType} {T : Type} {V : normedModType K}.
 Implicit Types W : normedModType K.
 
-Notation bigOmega F f g :=
+Local Notation bigOmega_def F f g :=
   (exists2 k, is_true (k > 0) &
   \forall x \near F, is_true (`|[f x]| >= k * `|[g x]|)).
 
 Structure bigOmega_type {W} (F : set (set T)) (g : T -> W) := BigOmega {
   bigOmega_fun :> T -> V;
-  _ : `[< bigOmega F bigOmega_fun g >]
+  _ : `[< bigOmega_def F bigOmega_fun g >]
 }.
 
 Notation "{Omega_ F g }" := (@bigOmega_type _ F g).
@@ -1211,7 +1214,7 @@ Canonical bigOmega_subtype {W} (F : set (set T)) (g : T -> W) :=
   [subType for (@bigOmega_fun W F g)].
 
 Lemma bigOmega_class {W} (F : set (set T)) (g : T -> W) (f : {Omega_F g}) :
-  `[<bigOmega F f g>].
+  `[< bigOmega_def F f g >].
 Proof. by case: f => ?. Qed.
 Hint Resolve bigOmega_class.
 
@@ -1220,7 +1223,7 @@ Definition bigOmega_clone {W} (F : set (set T)) (g : T -> W) (f : T -> V)
 Notation "[bigOmega 'of' f 'for' fT ]" := (@bigOmega_clone _ _ _ f fT _ idfun).
 Notation "[bigOmega 'of' f ]" := (@bigOmega_clone _ _ _ f _ _ idfun).
 
-Lemma bigOmega_refl_subproof F (g : T -> V) : Filter F -> bigOmega F g g.
+Lemma bigOmega_refl_subproof F (g : T -> V) : Filter F -> bigOmega_def F g g.
 Proof.
 by move=> FF; exists 1 => //; near=> x; rewrite mul1r.
 Grab Existential Variables. all: end_near. Qed.
@@ -1238,7 +1241,7 @@ Notation "[Omega_ x e 'of' f ]" := (mkbigOmega gen_tag x f e). (* parsing *)
 Notation "[Omega '_' x e 'of' f ]" := (the_bigOmega _ _ (PhantomF x) f e).
 
 Definition is_bigOmega {W} (F : set (set T)) (g : T -> W) :=
-  [qualify f : T -> V | `[<bigOmega F f g>] ].
+  [qualify f : T -> V | `[< bigOmega_def F f g >] ].
 Fact is_bigOmega_key {W} (F : set (set T)) (g : T -> W) : pred_key (is_bigOmega F g).
 Proof. by []. Qed.
 Canonical is_bigOmega_keyed {W} (F : set (set T)) (g : T -> W) :=
@@ -1246,9 +1249,9 @@ Canonical is_bigOmega_keyed {W} (F : set (set T)) (g : T -> W) :=
 Notation "'Omega_ F g" := (is_bigOmega F g).
 
 Lemma bigOmegaP {W} (F : set (set T)) (g : T -> W) (f : {Omega_F g}) :
-  bigOmega F f g.
+  bigOmega_def F f g.
 Proof. exact/asboolP. Qed.
-Hint Extern 0 (bigOmega _ _ _) => solve[apply: bigOmegaP] : core.
+Hint Extern 0 (bigOmega_def _ _ _) => solve[apply: bigOmegaP] : core.
 Hint Extern 0 (locally _ _) => solve[apply: bigOmegaP] : core.
 Hint Extern 0 (prop_near1 _) => solve[apply: bigOmegaP] : core.
 Hint Extern 0 (prop_near2 _) => solve[apply: bigOmegaP] : core.
@@ -1260,8 +1263,8 @@ Notation "f '=Omega_' F h" := (f%function = mkbigOmega the_tag F f h).
 Lemma eqOmegaO {W} (F : filter_on T) (f : T -> V) (e : T -> W) :
   (f \is 'Omega_F(e)) = (e =O_F f) :> Prop.
 Proof.
-rewrite propeqE; split => [| /eqOFP[x x0 Hx] ];
-[rewrite qualifE => /asboolP[x x0 Hx]; apply/eqOFP |
+rewrite propeqE; split => [| /eqO_exP[x x0 Hx] ];
+[rewrite qualifE => /asboolP[x x0 Hx]; apply/eqO_exP |
 rewrite qualifE; apply/asboolP];
 exists x^-1; rewrite ?invr_gt0 //; near=> y.
   by rewrite ler_pdivl_mull //; near: y.
@@ -1327,14 +1330,14 @@ Section big_theta.
 Context {K : absRingType} {T : Type} {V : normedModType K}.
 Implicit Types W : normedModType K.
 
-Notation bigTheta F f g :=
+Local Notation bigTheta_def F f g :=
   (exists2 k, is_true ((k.1 > 0) && (k.2 > 0)) &
     \forall x \near F, is_true (k.1 * `|[g x]| <= `|[f x]|) /\
     is_true (`|[f x]| <= k.2 * `|[g x]|)).
 
 Structure bigTheta_type {W} (F : set (set T)) (g : T -> W) := BigTheta {
   bigTheta_fun :> T -> V;
-  _ : `[< bigTheta F bigTheta_fun g >]
+  _ : `[< bigTheta_def F bigTheta_fun g >]
 }.
 
 Notation "{Theta_ F g }" := (@bigTheta_type _ F g).
@@ -1343,7 +1346,7 @@ Canonical bigTheta_subtype {W} (F : set (set T)) (g : T -> W) :=
   [subType for (@bigTheta_fun W F g)].
 
 Lemma bigTheta_class {W} (F : set (set T)) (g : T -> W) (f : {Theta_F g}) :
-  `[<bigTheta F f g>].
+  `[< bigTheta_def F f g >].
 Proof. by case: f => ?. Qed.
 Hint Resolve bigTheta_class.
 
@@ -1352,7 +1355,7 @@ Definition bigTheta_clone {W} (F : set (set T)) (g : T -> W) (f : T -> V)
 Notation "[bigTheta 'of' f 'for' fT ]" := (@bigTheta_clone _ _ _ f fT _ idfun).
 Notation "[bigTheta 'of' f ]" := (@bigTheta_clone _ _ _ f _ _ idfun).
 
-Lemma bigTheta_refl_subproof F (g : T -> V) : Filter F -> bigTheta F g g.
+Lemma bigTheta_refl_subproof F (g : T -> V) : Filter F -> bigTheta_def F g g.
 Proof.
 by move=> FF; exists 1 => /=; rewrite ?ltr01 //; near=> x; by rewrite mul1r.
 Grab Existential Variables. all: end_near. Qed.
@@ -1370,7 +1373,7 @@ Notation "[Theta_ x e 'of' f ]" := (mkbigTheta gen_tag x f e). (* parsing *)
 Notation "[Theta '_' x e 'of' f ]" := (the_bigTheta _ _ (PhantomF x) f e).
 
 Definition is_bigTheta {W} (F : set (set T)) (g : T -> W) :=
-  [qualify f : T -> V | `[<bigTheta F f g>] ].
+  [qualify f : T -> V | `[< bigTheta_def F f g >] ].
 Fact is_bigTheta_key {W} (F : set (set T)) (g : T -> W) : pred_key (is_bigTheta F g).
 Proof. by []. Qed.
 Canonical is_bigTheta_keyed {W} (F : set (set T)) (g : T -> W) :=
@@ -1378,9 +1381,9 @@ Canonical is_bigTheta_keyed {W} (F : set (set T)) (g : T -> W) :=
 Notation "'Theta_ F g" := (@is_bigTheta _ F g).
 
 Lemma bigThetaP {W} (F : set (set T)) (g : T -> W) (f : {Theta_F g}) :
-  bigTheta F f g.
+  bigTheta_def F f g.
 Proof. exact/asboolP. Qed.
-Hint Extern 0 (bigTheta _ _ _) => solve[apply: bigThetaP] : core.
+Hint Extern 0 (bigTheta_def _ _ _) => solve[apply: bigThetaP] : core.
 Hint Extern 0 (locally _ _) => solve[apply: bigThetaP] : core.
 Hint Extern 0 (prop_near1 _) => solve[apply: bigThetaP] : core.
 Hint Extern 0 (prop_near2 _) => solve[apply: bigThetaP] : core.
@@ -1394,8 +1397,9 @@ Lemma bigThetaE {W} (F : filter_on T) (f : T -> V) (g : T -> W) :
 Proof.
 rewrite propeqE; split.
 - rewrite qualifE => /asboolP[[/= k1 k2] /andP[k10 k20]] /near_andP[Hx1 Hx2].
-  split; by [rewrite eqOFP; exists k2|rewrite qualifE; apply/asboolP; exists k1].
-- case; rewrite eqOFP qualifE => -[k1 k10 H1] /asboolP[k2 k20 H2].
+  by split; [rewrite eqO_exP; exists k2|
+    rewrite qualifE; apply/asboolP; exists k1].
+- case; rewrite eqO_exP qualifE => -[k1 k10 H1] /asboolP[k2 k20 H2].
   rewrite qualifE; apply/asboolP; exists (k2, k1) => /=; first by rewrite k20.
   by apply/near_andP; split.
 Qed.
@@ -1412,7 +1416,7 @@ Lemma eqThetaO (F : filter_on T) (f g : T -> V) : [Theta_F g of f] =O_F g.
 Proof.
 set T1 := [Theta_F _ of _].
 have [/= -[_ k2] /andP[/= _ ?] /near_andP[_ ?]] := bigThetaP [bigTheta of T1].
-apply/eqOFP; by exists k2.
+apply/eqO_exP; by exists k2.
 Qed.
 
 Lemma idTheta (F : filter_on T) (f : T -> V) : f =Theta_F f.
@@ -1454,7 +1458,7 @@ rewrite -eqOmegaE; apply: addOmega.
 - by move=> ?; rewrite /the_bigO val_insubd /=; case: ifP.
 - rewrite eqOmegaE eqOmegaO. set T1 := [Theta_F _ of _].
   have [/= -[k1 _] /= /andP[? _] /near_andP[? _]] := bigThetaP [bigTheta of T1].
-  rewrite bigOE //; apply/bigOFP; exists k1^-1 => //; first by rewrite invr_gt0.
+  rewrite bigOE //; apply/bigO_exP; exists k1^-1 => //; first by rewrite invr_gt0.
   by near=> x; rewrite ler_pdivl_mull //; near: x.
 Grab Existential Variables. all: end_near. Qed.
 

--- a/topology.v
+++ b/topology.v
@@ -646,14 +646,6 @@ Proof.
 by move=> FF P Q subPQ FP; near=> x; suff: P x; near: x.
 Grab Existential Variables. by end_near. Qed.
 
-Lemma near_app (T U : Type) (F : set (set T)) (G : set (set U))
-  (GF : Filter G) (P : T -> set U) (Q : set U)
-  (FGP : \forall t \near F, \forall u \near G, P t u) (t : T) :
-  prop_of (InFilter FGP) t -> (\forall u \near G, P t u -> Q u) ->
-  \forall u \near G, Q u.
-Proof. by move=> GPt ?; apply: filter_app (near FGP t GPt). Qed.
-Arguments near_app {T U F G GF P Q} FGP t.
-
 Lemma filter_app2 (T : Type) (F : set (set T)) :
   Filter F -> forall P Q R : set T,  F (fun x => P x -> Q x -> R x) ->
   F P -> F Q -> F R.

--- a/topology.v
+++ b/topology.v
@@ -511,6 +511,15 @@ Proof. by case: F. Qed.
 Global Instance pfilter_on_ProperFilter T (F : pfilter_on T) : ProperFilter F.
 Proof. by case: F. Qed.
 
+Lemma locally_filter_onE T (F : filter_on T) : locally F = locally (filter F).
+Proof. by []. Qed.
+Definition locally_simpl := (@locally_simpl, @locally_filter_onE).
+
+Lemma near_filter_onE T (F : filter_on T) (P : set T) :
+  (\forall x \near F, P x) = \forall x \near filter F, P x.
+Proof. by []. Qed.
+Definition near_simpl := (@near_simpl, @near_filter_onE).
+
 Program Definition trivial_filter_on T := FilterType [set setT : set T] _.
 Next Obligation.
 split=> // [_ _ -> ->|Q R sQR QT]; first by rewrite setIT.


### PR DESCRIPTION
This PR:
- removes `bigOW`, which has no use: use `bigO` for proofs and switch to `bigOF` when using a `bigO` hypothesis
- removes the `littleo`/`bigO`/`bigOmega`/`bigTheta` definitions: the user should always use the equational notations and use the views `eqoP`, `eqaddOP`, etc, to go back to filter reasoning when needed.

There is something I don't truly understand: I had to add occurrences of `is_true` in the definitions of `littleo`, `bigO`, etc, in order for the hints related to `littleoP`, `bigOP`, etc, to work.