### PR TITLE
WIP Clean-up of lower classical layers

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -2,10 +2,12 @@
 -arg -parsing
 -arg -w -arg -duplicate-clear
 
+
 theories/boolp.v
 theories/reals.v
 theories/posnum.v
 theories/landau.v
+theories/classical_preds.v
 theories/classical_sets.v
 theories/Rstruct.v
 theories/Rbar.v

--- a/theories/altreals/realseq.v
+++ b/theories/altreals/realseq.v
@@ -5,7 +5,7 @@
 
 (* -------------------------------------------------------------------- *)
 From mathcomp Require Import all_ssreflect all_algebra.
-Require Import mathcomp.bigenough.bigenough.
+From mathcomp Require Import bigenough.
 Require Import xfinmap boolp reals discrete.
 
 Set Implicit Arguments.

--- a/theories/boolp.v
+++ b/theories/boolp.v
@@ -19,6 +19,14 @@ Arguments PredType [T pT] toP.
 
 Local Notation predOfType T := (pred_of_simpl (@pred_of_argType T)).
 
+
+(* -------------------------------------------------------------------- *)
+(* Misc. *)
+Lemma forall_congr T (P Q : T -> Prop) : 
+ (forall t, P t <-> Q t) -> ((forall t, P t) <-> (forall t, Q t)).
+Proof. by move=> hequiv; split=> h t; apply/hequiv. Qed.
+
+
 (* -------------------------------------------------------------------- *)
 
 Axiom functional_extensionality_dep :
@@ -30,28 +38,19 @@ Axiom propositional_extensionality :
 Axiom constructive_indefinite_description :
   forall (A : Type) (P : A -> Prop),
   (exists x : A, P x) -> {x : A | P x}.
-Notation cid := constructive_indefinite_description.
+Local Notation cid := constructive_indefinite_description.
 
 (* -------------------------------------------------------------------- *)
-Record mextentionality := {
-  _ : forall (P Q : Prop), (P <-> Q) -> (P = Q);
-  _ : forall {T U : Type} (f g : T -> U),
-        (forall x, f x = g x) -> f = g;
-}.
-
-Fact extentionality : mextentionality.
-Proof.
-split.
-- exact: propositional_extensionality.
-- by move=> T U f g; apply: functional_extensionality_dep.
-Qed.
-
-Lemma propext (P Q : Prop) : (P <-> Q) -> (P = Q).
-Proof. by have [propext _] := extentionality; apply: propext. Qed.
+(* Functional extensionality *)
 
 Lemma funext {T U : Type} (f g : T -> U) : (f =1 g) -> f = g.
-Proof. by case: extentionality=> _; apply. Qed.
+Proof. exact: functional_extensionality_dep. Qed.
 
+(* -------------------------------------------------------------------- *)
+(* Propositional extensionality *)
+
+Lemma propext (P Q : Prop) : (P <-> Q) -> (P = Q).
+Proof. exact: propositional_extensionality. Qed.
 Lemma propeqE (P Q : Prop) : (P = Q) = (P <-> Q).
 Proof. by apply: propext; split=> [->|/propext]. Qed.
 
@@ -90,18 +89,51 @@ Qed.
 Lemma propT (P : Prop) : P -> P = True.
 Proof. by move=> p; rewrite propeqE; tauto. Qed.
 
+Lemma propF (P : Prop) : ~ P -> P = False.
+Proof. by move=> p; rewrite propeqE; tauto. Qed.
+
+
+Lemma trueE : true = True :> Prop.
+Proof. by rewrite propeqE; split. Qed.
+
+Lemma falseE : false = False :> Prop.
+Proof. by rewrite propeqE; split. Qed.
+
+Lemma eq_forall T (U V : T -> Prop) :
+  (forall x : T, U x = V x) -> (forall x, U x) = (forall x, V x).
+Proof. by move=> e; rewrite propeqE; split=> ??; rewrite (e,=^~e). Qed.
+
+Lemma eq_exists T (U V : T -> Prop) :
+  (forall x : T, U x = V x) -> (exists x, U x) = (exists x, V x).
+Proof.
+by move=> e; rewrite propeqE; split=> - [] x ?; exists x; rewrite (e,=^~e).
+Qed.
+
+Lemma reflect_eq (P : Prop) (b : bool) : reflect P b -> P = b.
+Proof. by rewrite propeqE; exact: rwP. Qed.
+
+Lemma notb (b : bool) : (~ b) = ~~ b.
+Proof. apply: reflect_eq; exact: negP. Qed.
+
 Lemma Prop_irrelevance (P : Prop) (x y : P) : x = y.
 Proof. by move: x (x) y => /propT-> [] []. Qed.
 
+Lemma exist_congr T (U : T -> Prop) (s t : T) (p : U s) (q : U t) :
+  s = t -> exist U s p = exist U t q.
+Proof. by move=> st; case: _ / st in q *; apply/congr1/Prop_irrelevance. Qed.
+
 (* -------------------------------------------------------------------- *)
-Record mclassic := {
-  _ : forall (P : Prop), {P} + {~P};
-  _ : forall T, Choice.mixin_of T
-}.
+
+(* Informative excluded middle *)
+
+(* Record mclassic := { *)
+(*   _ : forall (P : Prop), {P} + {~P}; *)
+(*   _ : forall T, Choice.mixin_of T *)
+(* }. *)
 
 Lemma choice X Y (P : X -> Y -> Prop) :
   (forall x, exists y, P x y) -> {f & forall x, P x (f x)}.
-Proof. by move=> /(_ _)/constructive_indefinite_description -/all_tag. Qed.
+Proof. by move=> /(_ _)/cid -/all_tag. Qed.
 
 (* Diaconescu Theorem *)
 Theorem EM P : P \/ ~ P.
@@ -121,526 +153,568 @@ Qed.
 
 Lemma pselect (P : Prop): {P} + {~P}.
 Proof.
-have : exists b, if b then P else ~ P.
-  by case: (EM P); [exists true|exists false].
+have : exists b, if b then P else ~ P by case: (EM P); [exists true|exists false].
 by move=> /cid [[]]; [left|right].
 Qed.
-
-Lemma classic : mclassic.
-Proof.
-split=> [|T]; first exact: pselect.
-exists (fun (P : pred T) (n : nat) =>
-  if pselect (exists x, P x) isn't left ex then None
-  else Some (projT1 (cid ex)))
-  => [P n x|P [x Px]|P Q /funext -> //].
-  by case: pselect => // ex [<- ]; case: cid.
-by exists 0; case: pselect => // -[]; exists x.
-Qed.
-
-Lemma gen_choiceMixin {T : Type} : Choice.mixin_of T.
-Proof. by case: classic. Qed.
-
-
-Lemma pdegen (P : Prop): P = True \/ P = False.
-Proof. by have [p|Np] := pselect P; [left|right]; rewrite propeqE. Qed.
 
 Lemma lem (P : Prop): P \/ ~P.
 Proof. by case: (pselect P); tauto. Qed.
 
-(* -------------------------------------------------------------------- *)
-Lemma trueE : true = True :> Prop.
-Proof. by rewrite propeqE; split. Qed.
-
-Lemma falseE : false = False :> Prop.
-Proof. by rewrite propeqE; split. Qed.
-
-Lemma propF (P : Prop) : ~ P -> P = False.
-Proof. by move=> p; rewrite propeqE; tauto. Qed.
-
-Lemma eq_forall T (U V : T -> Prop) :
-  (forall x : T, U x = V x) -> (forall x, U x) = (forall x, V x).
-Proof. by move=> e; rewrite propeqE; split=> ??; rewrite (e,=^~e). Qed.
-
-Lemma eq_exists T (U V : T -> Prop) :
-  (forall x : T, U x = V x) -> (exists x, U x) = (exists x, V x).
-Proof.
-by move=> e; rewrite propeqE; split=> - [] x ?; exists x; rewrite (e,=^~e).
-Qed.
-
-Lemma reflect_eq (P : Prop) (b : bool) : reflect P b -> P = b.
-Proof. by rewrite propeqE; exact: rwP. Qed.
+Lemma pdegen (P : Prop): P = True \/ P = False.
+Proof. by have [p|Np] := pselect P; [left|right]; rewrite propeqE. Qed.
 
 Definition asbool (P : Prop) :=
   if pselect P then true else false.
 
 Notation "`[< P >]" := (asbool P) : bool_scope.
 
-Lemma asboolE (P : Prop) : `[<P>] = P :> Prop.
+Lemma asboolE (P : Prop) : `[< P >] = P :> Prop.
 Proof. by rewrite propeqE /asbool; case: pselect; split. Qed.
 
-Lemma asboolP (P : Prop) : reflect P `[<P>].
+(* todo: this is rwP of the other *)
+Lemma asboolP (P : Prop) : reflect P `[< P >].
 Proof. by apply: (equivP idP); rewrite asboolE. Qed.
 
-Lemma asboolPn (P : Prop) : reflect (~ P) (~~ `[<P>]).
-Proof. by rewrite /asbool; case: pselect=> h; constructor. Qed.
+(* -------------------------------------------------------------------- *)
+(* Not sure all this is usefull after all. Commenting to avoid pollution. *)
 
-Lemma asboolW (P : Prop) : `[<P>] -> P.
-Proof. by case: asboolP. Qed.
+(* Lemma asboolPn (P : Prop) : reflect (~ P) (~~ `[<P>]). *)
+(* Proof. by rewrite /asbool; case: pselect=> h; constructor. Qed. *)
 
-(* Shall this be a coercion ?*)
-Lemma asboolT (P : Prop) : P -> `[<P>].
-Proof. by case: asboolP. Qed.
+(* Lemma asboolW (P : Prop) : `[<P>] -> P. *)
+(* Proof. by case: asboolP. Qed. *)
 
-Lemma asboolF (P : Prop) : ~ P -> `[<P>] = false.
-Proof. by apply/introF/asboolP. Qed.
+(* (* Shall this be a coercion ?*) *)
+(* Lemma asboolT (P : Prop) : P -> `[<P>]. *)
+(* Proof. by case: asboolP. Qed. *)
 
-Lemma is_true_inj : injective is_true.
-Proof. by move=> [] []; rewrite ?(trueE, falseE) ?propeqE; tauto. Qed.
+(* Lemma asboolF (P : Prop) : ~ P -> `[<P>] = false. *)
+(* Proof. by apply/introF/asboolP. Qed. *)
+
+(* Lemma is_true_inj : injective is_true. *)
+(* Proof. by move=> [] []; rewrite ?(trueE, falseE) ?propeqE; tauto. Qed. *)
+
+
+(* Lemma asbool_equiv_eq {P Q : Prop} : (P <-> Q) -> `[<P>] = `[<Q>]. *)
+(* Proof. by rewrite -propeqE => ->. Qed. *)
+
+(* Lemma asbool_equiv_eqP {P Q : Prop} QQ : reflect Q QQ -> (P <-> Q) -> `[<P>] = QQ. *)
+(* Proof. *)
+(* move=> Q_QQ [hPQ hQP]; apply/idP/Q_QQ=> [/asboolP//|]. *)
+(* by move=> hQ; apply/asboolP/hQP. *)
+(* Qed. *)
+
+(* Lemma asbool_equiv {P Q : Prop} : (P <-> Q) -> (`[<P>] <-> `[<Q>]). *)
+(* Proof. by move/asbool_equiv_eq->. Qed. *)
+
+(* Lemma asbool_eq_equiv {P Q : Prop} : `[<P>] = `[<Q>] -> (P <-> Q). *)
+(* Proof. *)
+(* by move=> eq; split=> /asboolP; rewrite (eq, =^~ eq) => /asboolP. *)
+(* Qed. *)
+
+(* (* -------------------------------------------------------------------- *) *)
+(* Lemma and_asboolP (P Q : Prop) : reflect (P /\ Q) (`[<P>] && `[<Q>]). *)
+(* Proof. *)
+(* apply: (iffP idP); first by case/andP=> /asboolP hP /asboolP hQ. *)
+(* by case=> /asboolP-> /asboolP->. *)
+(* Qed. *)
+
+(* Lemma or_asboolP (P Q : Prop) : reflect (P \/ Q) (`[<P>] || `[<Q>]). *)
+(* Proof. *)
+(* apply: (iffP idP); first by case/orP=> /asboolP; [left | right]. *)
+(* by case=> /asboolP-> //=; rewrite orbT. *)
+(* Qed. *)
+
+(* Lemma asbool_neg {P : Prop} : `[<~ P>] = ~~ `[<P>]. *)
+(* Proof. by apply/idP/asboolPn=> [/asboolP|/asboolT]. Qed. *)
+
+(* Lemma asbool_or {P Q : Prop} : `[<P \/ Q>] = `[<P>] || `[<Q>]. *)
+(* Proof. exact: (asbool_equiv_eqP (or_asboolP _ _)). Qed. *)
+
+(* Lemma asbool_and {P Q : Prop} : `[<P /\ Q>] = `[<P>] && `[<Q>]. *)
+(* Proof. exact: (asbool_equiv_eqP (and_asboolP _ _)). Qed. *)
+
+(* (* -------------------------------------------------------------------- *) *)
+(* Lemma imply_asboolP {P Q : Prop} : reflect (P -> Q) (`[<P>] ==> `[<Q>]). *)
+(* Proof. *)
+(* apply: (iffP implyP)=> [PQb /asboolP/PQb/asboolW //|]. *)
+(* by move=> PQ /asboolP/PQ/asboolT. *)
+(* Qed. *)
+
+(* Lemma asbool_imply {P Q : Prop} : `[<P -> Q>] = `[<P>] ==> `[<Q>]. *)
+(* Proof. exact: (asbool_equiv_eqP imply_asboolP). Qed. *)
+
+(* Lemma imply_asboolPn (P Q : Prop) : reflect (P /\ ~ Q) (~~ `[<P -> Q>]). *)
+(* Proof. *)
+(* apply: (iffP idP). *)
+(* by rewrite asbool_imply negb_imply -asbool_neg => /and_asboolP. *)
+(* by move/and_asboolP; rewrite asbool_neg -negb_imply asbool_imply. *)
+(* Qed. *)
+
+(* (* -------------------------------------------------------------------- *) *)
+(* Lemma forall_asboolP {T : Type} (P : T -> Prop) : *)
+(*   reflect (forall x, `[<P x>]) (`[<forall x, P x>]). *)
+(* Proof. *)
+(* apply: (iffP idP); first by move/asboolP=> Px x; apply/asboolP. *)
+(* by move=> Px; apply/asboolP=> x; apply/asboolP. *)
+(* Qed. *)
+
+(* Lemma exists_asboolP {T : Type} (P : T -> Prop) : *)
+(*   reflect (exists x, `[<P x>]) (`[<exists x, P x>]). *)
+(* Proof. *)
+(* apply: (iffP idP); first by case/asboolP=> x Px; exists x; apply/asboolP. *)
+(* by case=> x bPx; apply/asboolP; exists x; apply/asboolP. *)
+(* Qed. *)
 
 (* -------------------------------------------------------------------- *)
-Lemma asbool_equiv_eq {P Q : Prop} : (P <-> Q) -> `[<P>] = `[<Q>].
-Proof. by rewrite -propeqE => ->. Qed.
+(* Contraposition and friends. *)
 
-Lemma asbool_equiv_eqP {P Q : Prop} QQ : reflect Q QQ -> (P <-> Q) -> `[<P>] = QQ.
-Proof.
-move=> Q_QQ [hPQ hQP]; apply/idP/Q_QQ=> [/asboolP//|].
-by move=> hQ; apply/asboolP/hQP.
-Qed.
-
-Lemma asbool_equiv {P Q : Prop} : (P <-> Q) -> (`[<P>] <-> `[<Q>]).
-Proof. by move/asbool_equiv_eq->. Qed.
-
-Lemma asbool_eq_equiv {P Q : Prop} : `[<P>] = `[<Q>] -> (P <-> Q).
-Proof.
-by move=> eq; split=> /asboolP; rewrite (eq, =^~ eq) => /asboolP.
-Qed.
-
-(* -------------------------------------------------------------------- *)
-Lemma and_asboolP (P Q : Prop) : reflect (P /\ Q) (`[<P>] && `[<Q>]).
-Proof.
-apply: (iffP idP); first by case/andP=> /asboolP hP /asboolP hQ.
-by case=> /asboolP-> /asboolP->.
-Qed.
-
-Lemma or_asboolP (P Q : Prop) : reflect (P \/ Q) (`[<P>] || `[<Q>]).
-Proof.
-apply: (iffP idP); first by case/orP=> /asboolP; [left | right].
-by case=> /asboolP-> //=; rewrite orbT.
-Qed.
-
-Lemma asbool_neg {P : Prop} : `[<~ P>] = ~~ `[<P>].
-Proof. by apply/idP/asboolPn=> [/asboolP|/asboolT]. Qed.
-
-Lemma asbool_or {P Q : Prop} : `[<P \/ Q>] = `[<P>] || `[<Q>].
-Proof. exact: (asbool_equiv_eqP (or_asboolP _ _)). Qed.
-
-Lemma asbool_and {P Q : Prop} : `[<P /\ Q>] = `[<P>] && `[<Q>].
-Proof. exact: (asbool_equiv_eqP (and_asboolP _ _)). Qed.
-
-(* -------------------------------------------------------------------- *)
-Lemma imply_asboolP {P Q : Prop} : reflect (P -> Q) (`[<P>] ==> `[<Q>]).
-Proof.
-apply: (iffP implyP)=> [PQb /asboolP/PQb/asboolW //|].
-by move=> PQ /asboolP/PQ/asboolT.
-Qed.
-
-Lemma asbool_imply {P Q : Prop} : `[<P -> Q>] = `[<P>] ==> `[<Q>].
-Proof. exact: (asbool_equiv_eqP imply_asboolP). Qed.
-
-Lemma imply_asboolPn (P Q : Prop) : reflect (P /\ ~ Q) (~~ `[<P -> Q>]).
-Proof.
-apply: (iffP idP).
-by rewrite asbool_imply negb_imply -asbool_neg => /and_asboolP.
-by move/and_asboolP; rewrite asbool_neg -negb_imply asbool_imply.
-Qed.
-
-(* -------------------------------------------------------------------- *)
-Lemma forall_asboolP {T : Type} (P : T -> Prop) :
-  reflect (forall x, `[<P x>]) (`[<forall x, P x>]).
-Proof.
-apply: (iffP idP); first by move/asboolP=> Px x; apply/asboolP.
-by move=> Px; apply/asboolP=> x; apply/asboolP.
-Qed.
-
-Lemma exists_asboolP {T : Type} (P : T -> Prop) :
-  reflect (exists x, `[<P x>]) (`[<exists x, P x>]).
-Proof.
-apply: (iffP idP); first by case/asboolP=> x Px; exists x; apply/asboolP.
-by case=> x bPx; apply/asboolP; exists x; apply/asboolP.
-Qed.
-
-(* -------------------------------------------------------------------- *)
+(* This one is constructive *)
 Lemma contrap (Q P : Prop) : (Q -> P) -> ~ P -> ~ Q.
-Proof.
-move=> cb /asboolPn nb; apply/asboolPn.
-by apply: contra nb => /asboolP /cb /asboolP.
-Qed.
+Proof. by move=> QP nP hQ; apply/nP/QP. Qed.
 
-Definition contrapNN := contra.
-
+(* This one is constructive *)
 Lemma contrapL (Q P : Prop) : (Q -> ~ P) -> P -> ~ Q.
-Proof.
-move=> cb /asboolP hb; apply/asboolPn.
-by apply: contraL hb => /asboolP /cb /asboolPn.
-Qed.
-
-Definition contrapTN := contrapL.
+Proof. by move=> QnP hP hQ; move: hP; apply: QnP. Qed.
 
 Lemma contrapR (Q P : Prop) : (~ Q -> P) -> ~ P -> Q.
-Proof.
-move=> cb /asboolPn nb; apply/asboolP.
-by apply: contraR nb => /asboolP /cb /asboolP.
-Qed.
-
-Definition contrapNT := contrapR.
+Proof. by move=> nQP nP; case: (lem Q)=> // /nQP. Qed.
 
 Lemma contrapLR (Q P : Prop) : (~ Q -> ~ P) -> P -> Q.
-Proof.
-move=> cb /asboolP hb; apply/asboolP.
-by apply: contraLR hb => /asboolP /cb /asboolPn.
-Qed.
-
-Definition contrapTT := contrapLR.
+Proof. by move=> nQnP hP; case: (lem Q)=> // /nQnP. Qed.
 
 Lemma contrapT P : ~ ~ P -> P.
-Proof.
-by move/asboolPn=> nnb; apply/asboolP; apply: contraR nnb => /asboolPn /asboolP.
-Qed.
+Proof. by move=> nnP; case: (lem P). Qed.
 
+(* cf X. Leroy's talk for the historical name *)
 Lemma wlog_neg P : (~ P -> P) -> P.
 Proof. by move=> ?; case: (pselect P). Qed.
 
 Lemma notT (P : Prop) : P = False -> ~ P. Proof. by move->. Qed.
 
 Lemma notTE (P : Prop) : (~ P) -> P = False. Proof. by case: (pdegen P)=> ->. Qed.
-Lemma notFE (P : Prop) : (~ P) = False -> P.
-Proof. move/notT; exact: contrapT. Qed.
+
+Lemma notFE (P : Prop) : (~ P) = False -> P. Proof. move/notT; exact: contrapT. Qed.
 
 Lemma notK : involutive not.
-Proof.
-move=> P; case: (pdegen P)=> ->; last by apply: notTE; intuition.
-by rewrite [~ True]notTE //; case: (pdegen (~ False)) => // /notFE.
-Qed.
+Proof. move=> P; rewrite propeqE; split=> [| ? ? //]; exact: contrapT. Qed.
+
 
 Lemma not_inj : injective not. Proof. exact: can_inj notK. Qed.
+
 Lemma notLR P Q : (P = ~ Q) -> (~ P) = Q. Proof. exact: canLR notK. Qed.
 
 Lemma notRL P Q : (~ P) = Q -> P = ~ Q. Proof. exact: canRL notK. Qed.
-
 (* -------------------------------------------------------------------- *)
-(* assia : let's see if we need the simplpred machinery. In any case, we sould
-   first try definitions + appropriate Arguments setting to see whether these
-   can replace the canonical structures machinery. *)
+(* De Morgan laws for quantifiers *)
 
-Definition predp T := T -> Prop.
-
-Identity Coercion fun_of_pred : predp >-> Funclass.
-
-Definition relp T := T -> predp T.
-
-Identity Coercion fun_of_rel : rel >-> Funclass.
-
-Notation xpredp0 := (fun _ => False).
-Notation xpredpT := (fun _ => True).
-Notation xpredpI := (fun (p1 p2 : predp _) x => p1 x /\ p2 x).
-Notation xpredpU := (fun (p1 p2 : predp _) x => p1 x \/ p2 x).
-Notation xpredpC := (fun (p : predp _) x => ~ p x).
-Notation xpredpD := (fun (p1 p2 : predp _) x => ~ p2 x /\ p1 x).
-Notation xpreimp := (fun f (p : predp _) x => p (f x)).
-Notation xrelpU := (fun (r1 r2 : relp _) x y => r1 x y \/ r2 x y).
-
-(* -------------------------------------------------------------------- *)
-Definition pred0p (T : Type) (P : predp T) : bool := `[<P =1 xpredp0>].
-Prenex Implicits pred0p.
-
-Lemma pred0pP  (T : Type) (P : predp T) : reflect (P =1 xpredp0) (pred0p P).
-Proof. by apply: (iffP (asboolP _)). Qed.
-
-(* -------------------------------------------------------------------- *)
-Module BoolQuant.
-
-Inductive box := Box of bool.
-
-Bind    Scope box_scope with box.
-Delimit Scope box_scope with P.
-
-Definition idbox {T : Type} (B : box) := fun (x : T) => B.
-
-Definition unbox {T : Type} (B : T -> box) : bool :=
-  asbool (forall x : T, let: Box b := B x in b).
-
-Notation "F ^*" := (Box F) (at level 2).
-Notation "F ^~" := (~~ F) (at level 2).
-
-Section Definitions.
-
-Variable T : Type.
-Implicit Types (B : box) (x y : T).
-
-Definition quant0p Bp := pred0p (fun x : T => let: F^* := Bp x x in F).
-(* The first redundant argument protects the notation from  Coq's K-term      *)
-(* display kludge; the second protects it from simpl and /=.                  *)
-Definition ex B x y := B.
-(* Binding the predicate value rather than projecting it prevents spurious    *)
-(* unfolding of the boolean connectives by unification.                       *)
-Definition all B x y := let: F^* := B in F^~^*.
-Definition all_in C B x y := let: F^* := B in (C ==> F)^~^*.
-Definition ex_in C B x y :=  let: F^* := B in (C && F)^*.
-
-End Definitions.
-
-
-Notation "`[ x | B ]" := (quant0p (fun x => B x)) (at level 0, x ident).
-Notation "`[ x : T | B ]" := (quant0p (fun x : T => B x)) (at level 0, x ident).
-
-Module Exports.
-
-Delimit Scope quant_scope with Q. (* Bogus, only used to declare scope. *)
-Bind Scope quant_scope with box.
-
-Notation ", F" := F^* (at level 200, format ", '/ '  F") : quant_scope.
-
-Notation "`[ 'forall' x B ]" := `[x | all B]
-  (at level 0, x at level 99, B at level 200,
-   format "`[ '[hv' 'forall'  x B ] ']'") : bool_scope.
-
-Notation "`[ 'forall' x : T B ]" := `[x : T | all B]
-  (at level 0, x at level 99, B at level 200, only parsing) : bool_scope.
-Notation "`[ 'forall' ( x | C ) B ]" := `[x | all_in C B]
-  (at level 0, x at level 99, B at level 200,
-   format "`[ '[hv' '[' 'forall'  ( x '/  '  |  C ) ']' B ] ']'") : bool_scope.
-Notation "`[ 'forall' ( x : T | C ) B ]" := `[x : T | all_in C B]
-  (at level 0, x at level 99, B at level 200, only parsing) : bool_scope.
-Notation "`[ 'forall' x 'in' A B ]" := `[x | all_in (x \in A) B]
-  (at level 0, x at level 99, B at level 200,
-   format "`[ '[hv' '[' 'forall'  x '/  '  'in'  A ']' B ] ']'") : bool_scope.
-Notation "`[ 'forall' x : T 'in' A B ]" := `[x : T | all_in (x \in A) B]
-  (at level 0, x at level 99, B at level 200, only parsing) : bool_scope.
-Notation ", 'forall' x B" := `[x | all B]^*
-  (at level 200, x at level 99, B at level 200,
-   format ", '/ '  'forall'  x B") : quant_scope.
-Notation ", 'forall' x : T B" := `[x : T | all B]^*
-  (at level 200, x at level 99, B at level 200, only parsing) : quant_scope.
-Notation ", 'forall' ( x | C ) B" := `[x | all_in C B]^*
-  (at level 200, x at level 99, B at level 200,
-   format ", '/ '  '[' 'forall'  ( x '/  '  |  C ) ']' B") : quant_scope.
-Notation ", 'forall' ( x : T | C ) B" := `[x : T | all_in C B]^*
-  (at level 200, x at level 99, B at level 200, only parsing) : quant_scope.
-Notation ", 'forall' x 'in' A B" := `[x | all_in (x \in A) B]^*
-  (at level 200, x at level 99, B at level 200,
-   format ", '/ '  '[' 'forall'  x '/  '  'in'  A ']' B") : bool_scope.
-Notation ", 'forall' x : T 'in' A B" := `[x : T | all_in (x \in A) B]^*
-  (at level 200, x at level 99, B at level 200, only parsing) : bool_scope.
-
-Notation "`[ 'exists' x B ]" := `[x | ex B]^~
-  (at level 0, x at level 99, B at level 200,
-   format "`[ '[hv' 'exists'  x B ] ']'") : bool_scope.
-Notation "`[ 'exists' x : T B ]" := `[x : T | ex B]^~
-  (at level 0, x at level 99, B at level 200, only parsing) : bool_scope.
-Notation "`[ 'exists' ( x | C ) B ]" := `[x | ex_in C B]^~
-  (at level 0, x at level 99, B at level 200,
-   format "`[ '[hv' '[' 'exists'  ( x '/  '  |  C ) ']' B ] ']'") : bool_scope.
-Notation "`[ 'exists' ( x : T | C ) B ]" := `[x : T | ex_in C B]^~
-  (at level 0, x at level 99, B at level 200, only parsing) : bool_scope.
-Notation "`[ 'exists' x 'in' A B ]" := `[x | ex_in (x \in A) B]^~
-  (at level 0, x at level 99, B at level 200,
-   format "`[ '[hv' '[' 'exists'  x '/  '  'in'  A ']' B ] ']'") : bool_scope.
-Notation "`[ 'exists' x : T 'in' A B ]" := `[x : T | ex_in (x \in A) B]^~
-  (at level 0, x at level 99, B at level 200, only parsing) : bool_scope.
-Notation ", 'exists' x B" := `[x | ex B]^~^*
-  (at level 200, x at level 99, B at level 200,
-   format ", '/ '  'exists'  x B") : quant_scope.
-Notation ", 'exists' x : T B" := `[x : T | ex B]^~^*
-  (at level 200, x at level 99, B at level 200, only parsing) : quant_scope.
-Notation ", 'exists' ( x | C ) B" := `[x | ex_in C B]^~^*
-  (at level 200, x at level 99, B at level 200,
-   format ", '/ '  '[' 'exists'  ( x '/  '  |  C ) ']' B") : quant_scope.
-Notation ", 'exists' ( x : T | C ) B" := `[x : T | ex_in C B]^~^*
-  (at level 200, x at level 99, B at level 200, only parsing) : quant_scope.
-Notation ", 'exists' x 'in' A B" := `[x | ex_in (x \in A) B]^~^*
-  (at level 200, x at level 99, B at level 200,
-   format ", '/ '  '[' 'exists'  x '/  '  'in'  A ']' B") : bool_scope.
-Notation ", 'exists' x : T 'in' A B" := `[x : T | ex_in (x \in A) B]^~^*
-  (at level 200, x at level 99, B at level 200, only parsing) : bool_scope.
-
-End Exports.
-
-End BoolQuant.
-Export BoolQuant.Exports.
-
-Open Scope quant_scope.
-
-(* -------------------------------------------------------------------- *)
-Section QuantifierCombinators.
-
-Variables (T : Type) (P : pred T) (PP : predp T).
-Hypothesis viewP : forall x, reflect (PP x) (P x).
-
-Lemma existsPP : reflect (exists x, PP x) `[exists x, P x].
+Lemma not_forall {T} (P : T -> Prop) : (~ forall x, P x) = exists y, ~ P y.
 Proof.
-apply: (iffP idP).
-  move/asboolP; (* oops notation! *) apply: contrapR => nh x /=; apply: notTE.
-  by apply: contrap nh => /viewP Px; exists x.
-case=> x PPx; apply/asboolP=> /(_ x) /notT /=; rewrite -/(not (~ P x)) notK.
-exact/viewP.
+rewrite propeqE; split; last by case=> x Px allP; apply: Px.
+by apply: contrapR=> /contrapR nexP x; apply: nexP => nPx; exists x.
 Qed.
 
-Lemma forallPP : reflect (forall x, PP x) `[forall x, P x].
+Lemma not_forallN  {T} (P : T -> Prop) : (~ forall x, ~ P x) = exists y, P y.
+Proof. rewrite not_forall; apply: eq_exists => x; exact: notK. Qed.
+
+Lemma not_exists {T} (P : T -> Prop) : (~ exists x, P x) = forall x, ~ P x.
 Proof.
-apply: (iffP idP).
-  by move/asboolP=> h x; move/notT: (h x)=> /= /negP; rewrite negbK => /viewP.
-move=> h; apply/asboolP=> x; apply/notTE/negP; rewrite negbK; exact/viewP.
+by apply: notLR; rewrite not_forall; apply: eq_exists => x; rewrite notK.
 Qed.
 
-End QuantifierCombinators.
+Lemma not_existsN {T} (P : T -> Prop) : (~ exists x, ~ P x) = forall x, P x.
+Proof. by apply: notLR; rewrite not_forall; apply: eq_exists=> x. Qed.
 
-Section PredQuantifierCombinators.
-
-Variables (T : Type) (P : pred T).
-
-Lemma existsbP : reflect (exists x, P x) `[exists x, P x].
-Proof. exact: existsPP (fun x => @idP (P x)). Qed.
-
-Lemma existsbE : `[exists x, P x] = `[<exists x, P x>].
-Proof.
-apply/esym/is_true_inj; rewrite asboolE propeqE; apply: rwP; exact: existsbP.
+Lemma not_exists2 {T} (P Q : T -> Prop) :
+  (~ exists2 x, P x & Q x) = forall x, P x -> ~ Q x.
+Proof. (* too long says py *)
+apply: notLR; rewrite not_forall; rewrite propeqE; split; case=> x.
+  by move=> Px Qx; exists x; apply: contrapL Qx; apply.
+move=> hx; exists x; first exact: contrapR hx.
+exact: contrapR hx.
 Qed.
 
-Lemma forallbP : reflect (forall x, P x) `[forall x, P x].
-Proof. exact: forallPP (fun x => @idP (P x)). Qed.
-
-Lemma forallbE : `[forall x, P x] = `[<forall x, P x>].
+Lemma lem_forall U (P : U -> Prop) : (forall u, P u) \/ (exists u, ~ P u).
 Proof.
-apply/esym/is_true_inj; rewrite asboolE propeqE; apply: rwP; exact: forallbP.
+case: (pselect (forall u : U, P u)) => h; first by left.
+by right; move: h; rewrite not_forall.
 Qed.
 
-End PredQuantifierCombinators.
-
-(* -------------------------------------------------------------------- *)
-Lemma existsp_asboolP {T} {P : T -> Prop} :
-  reflect (exists x : T, P x) `[exists x : T, `[<P x>]].
-Proof. exact: existsPP (fun x => @asboolP (P x)). Qed.
-
-Lemma forallp_asboolP {T} {P : T -> Prop} :
-  reflect (forall x : T, P x) `[forall x : T, `[<P x>]].
-Proof. exact: forallPP (fun x => @asboolP (P x)). Qed.
-
-Lemma forallp_asboolPn {T} {P : T -> Prop} :
-  reflect (forall x : T, ~ P x) (~~ `[<exists x : T, P x>]).
+Lemma lem_exists U (P : U -> Prop) : (exists u, P u) \/ (forall u, ~ P u).
 Proof.
-apply: (iffP idP)=> [/asboolPn NP x Px|NP].
-by apply/NP; exists x. by apply/asboolP=> -[x]; apply/NP.
-Qed.
-
-Lemma existsp_asboolPn {T} {P : T -> Prop} :
-  reflect (exists x : T, ~ P x) (~~ `[<forall x : T, P x>]).
-Proof.
-apply: (iffP idP); last by case=> x NPx; apply/asboolPn=> /(_ x).
-move/asboolPn=> NP; apply/asboolP/negbNE/asboolPn=> h.
-by apply/NP=> x; apply/asboolP/negbNE/asboolPn=> NPx; apply/h; exists x.
-Qed.
-
-Lemma asbool_forallNb {T : Type} (P : pred T) :
-  `[< forall x : T, ~~ (P x) >] = ~~ `[< exists x : T, P x >].
-Proof.
-apply: (asbool_equiv_eqP forallp_asboolPn);
-  by split=> h x; apply/negP/h.
-Qed.
-
-Lemma asbool_existsNb {T : Type} (P : pred T) :
-  `[< exists x : T, ~~ (P x) >] = ~~ `[< forall x : T, P x >].
-Proof.
-apply: (asbool_equiv_eqP existsp_asboolPn);
-  by split=> -[x h]; exists x; apply/negP.
+case: (pselect (exists u : U, P u)) => h; first by left.
+by right; move: h; rewrite not_exists.
 Qed.
 
 (* -------------------------------------------------------------------- *)
-Definition xchooseb {T : choiceType} (P : pred T) (h : `[exists x, P x]) :=
-  xchoose (existsbP P h).
+(* More de Morgan like lemmas *)
 
-Lemma xchoosebP {T : choiceType} (P : pred T) (h : `[exists x, P x]) :
-  P (xchooseb h).
-Proof. exact/xchooseP. Qed.
+Lemma not_imply (A B : Prop) : (~ (A -> B)) = (A /\ ~ B).
+Proof.
+rewrite propeqE; split; last by case=> hA hnB iAB; intuition.
+by move=> niAB; case: (lem A) => [hA | hnA]; intuition.
+Qed.
+
+Lemma not_and (A B : Prop) : (~ (A /\ B)) = ((~ A) \/ (~ B)).
+Proof.
+rewrite propeqE; split => [nAB |]; last by case; tauto.
+case: (lem A)=> ?; last by left. 
+case: (lem B)=> ?; last by right.
+tauto.
+Qed.
+
+Lemma not_or (A B : Prop) : (~ (A \/ B)) = ((~ A) /\ (~ B)).
+Proof.
+rewrite propeqE; split=> [nAoB | [nA nB]]; last by case. 
+by split=> ?; apply: nAoB; [left | right]. 
+Qed.
 
 (* -------------------------------------------------------------------- *)
-(* Notation "'exists_ view" := (existsPP (fun _ => view)) *)
-(*   (at level 4, right associativity, format "''exists_' view"). *)
-(* Notation "'forall_ view" := (forallPP (fun _ => view)) *)
-(*   (at level 4, right associativity, format "''forall_' view"). *)
+(* Generic mixins *)
 
 
-(* Section Quantifiers. *)
+(* Any type can be equipped with an eqType structure. *)
+Definition gen_eq (T : Type) (u v : T) := `[< u = v >].
+Lemma gen_eqP (T : Type) : Equality.axiom (@gen_eq T).
+Proof. by move=> x y; apply: (iffP (asboolP _)). Qed.
+Definition gen_eqMixin {T : Type} := EqMixin (@gen_eqP T).
 
-(* Variables (T : Type) (rT : T -> eqType). *)
-(* Implicit Type (D P : rset T) (f : forall x, rT x). *)
+(* Any type can be equipped with a choiceType structure.*)
+Lemma gen_choiceMixin {T : Type} : Choice.mixin_of T.
+Proof.
+pose eps (P : pred T) (n : nat) :=
+  if pselect (exists x, P x) isn't left ex then None
+  else Some (projT1 (cid ex)).
+exists eps => [P n x|P [x Px]|P Q /funext -> //].
+  by rewrite /eps; case: pselect => // ex [<- ]; case: cid.
+by exists 0; rewrite /eps; case: pselect => // -[]; exists x.
+Qed.
 
-(* Lemma forallP P : reflect (forall x, P x) [forall x, P x]. *)
+
+Definition dep_arrow_eqType (T : Type) (T' : T -> eqType) :=
+  EqType (forall x : T, T' x) gen_eqMixin.
+Canonical arrow_eqType (T : Type) (T' : eqType) :=
+  EqType (T -> T') gen_eqMixin.
+Canonical arrow_choiceType (T : Type) (T' : choiceType) :=
+  ChoiceType (T -> T') gen_choiceMixin.
+
+Canonical Prop_eqType := EqType Prop gen_eqMixin.
+Canonical Prop_choiceType := ChoiceType Prop gen_choiceMixin.
+
+
+(* (* assia : let's see if we need the simplpred machinery. In any case, we sould *)
+(*    first try definitions + appropriate Arguments setting to see whether these *)
+(*    can replace the canonical structures machinery. *) *)
+
+(* Definition predp T := T -> Prop. *)
+
+(* Identity Coercion fun_of_pred : predp >-> Funclass. *)
+
+(* Definition relp T := T -> predp T. *)
+
+(* Identity Coercion fun_of_rel : rel >-> Funclass. *)
+
+(* Notation xpredp0 := (fun _ => False). *)
+(* Notation xpredpT := (fun _ => True). *)
+(* Notation xpredpI := (fun (p1 p2 : predp _) x => p1 x /\ p2 x). *)
+(* Notation xpredpU := (fun (p1 p2 : predp _) x => p1 x \/ p2 x). *)
+(* Notation xpredpC := (fun (p : predp _) x => ~ p x). *)
+(* Notation xpredpD := (fun (p1 p2 : predp _) x => ~ p2 x /\ p1 x). *)
+(* Notation xpreimp := (fun f (p : predp _) x => p (f x)). *)
+(* Notation xrelpU := (fun (r1 r2 : relp _) x y => r1 x y \/ r2 x y). *)
+
+(* (* -------------------------------------------------------------------- *) *)
+(* Definition pred0p (T : Type) (P : predp T) : bool := `[<P =1 xpredp0>]. *)
+(* Prenex Implicits pred0p. *)
+
+(* Lemma pred0pP  (T : Type) (P : predp T) : reflect (P =1 xpredp0) (pred0p P). *)
+(* Proof. by apply: (iffP (asboolP _)). Qed. *)
+
+(* (* -------------------------------------------------------------------- *) *)
+(* Module BoolQuant. *)
+
+(* Inductive box := Box of bool. *)
+
+(* Bind    Scope box_scope with box. *)
+(* Delimit Scope box_scope with P. *)
+
+(* Definition idbox {T : Type} (B : box) := fun (x : T) => B. *)
+
+(* Definition unbox {T : Type} (B : T -> box) : bool := *)
+(*   asbool (forall x : T, let: Box b := B x in b). *)
+
+(* Notation "F ^*" := (Box F) (at level 2). *)
+(* Notation "F ^~" := (~~ F) (at level 2). *)
+
+(* Section Definitions. *)
+
+(* Variable T : Type. *)
+(* Implicit Types (B : box) (x y : T). *)
+
+(* Definition quant0p Bp := pred0p (fun x : T => let: F^* := Bp x x in F). *)
+(* (* The first redundant argument protects the notation from  Coq's K-term      *) *)
+(* (* display kludge; the second protects it from simpl and /=.                  *) *)
+(* Definition ex B x y := B. *)
+(* (* Binding the predicate value rather than projecting it prevents spurious    *) *)
+(* (* unfolding of the boolean connectives by unification.                       *) *)
+(* Definition all B x y := let: F^* := B in F^~^*. *)
+(* Definition all_in C B x y := let: F^* := B in (C ==> F)^~^*. *)
+(* Definition ex_in C B x y :=  let: F^* := B in (C && F)^*. *)
+
+(* End Definitions. *)
+
+
+(* Notation "`[ x | B ]" := (quant0p (fun x => B x)) (at level 0, x ident). *)
+(* Notation "`[ x : T | B ]" := (quant0p (fun x : T => B x)) (at level 0, x ident). *)
+
+(* Module Exports. *)
+
+(* Delimit Scope quant_scope with Q. (* Bogus, only used to declare scope. *) *)
+(* Bind Scope quant_scope with box. *)
+
+(* Notation ", F" := F^* (at level 200, format ", '/ '  F") : quant_scope. *)
+
+(* Notation "`[ 'forall' x B ]" := `[x | all B] *)
+(*   (at level 0, x at level 99, B at level 200, *)
+(*    format "`[ '[hv' 'forall'  x B ] ']'") : bool_scope. *)
+
+(* Notation "`[ 'forall' x : T B ]" := `[x : T | all B] *)
+(*   (at level 0, x at level 99, B at level 200, only parsing) : bool_scope. *)
+(* Notation "`[ 'forall' ( x | C ) B ]" := `[x | all_in C B] *)
+(*   (at level 0, x at level 99, B at level 200, *)
+(*    format "`[ '[hv' '[' 'forall'  ( x '/  '  |  C ) ']' B ] ']'") : bool_scope. *)
+(* Notation "`[ 'forall' ( x : T | C ) B ]" := `[x : T | all_in C B] *)
+(*   (at level 0, x at level 99, B at level 200, only parsing) : bool_scope. *)
+(* Notation "`[ 'forall' x 'in' A B ]" := `[x | all_in (x \in A) B] *)
+(*   (at level 0, x at level 99, B at level 200, *)
+(*    format "`[ '[hv' '[' 'forall'  x '/  '  'in'  A ']' B ] ']'") : bool_scope. *)
+(* Notation "`[ 'forall' x : T 'in' A B ]" := `[x : T | all_in (x \in A) B] *)
+(*   (at level 0, x at level 99, B at level 200, only parsing) : bool_scope. *)
+(* Notation ", 'forall' x B" := `[x | all B]^* *)
+(*   (at level 200, x at level 99, B at level 200, *)
+(*    format ", '/ '  'forall'  x B") : quant_scope. *)
+(* Notation ", 'forall' x : T B" := `[x : T | all B]^* *)
+(*   (at level 200, x at level 99, B at level 200, only parsing) : quant_scope. *)
+(* Notation ", 'forall' ( x | C ) B" := `[x | all_in C B]^* *)
+(*   (at level 200, x at level 99, B at level 200, *)
+(*    format ", '/ '  '[' 'forall'  ( x '/  '  |  C ) ']' B") : quant_scope. *)
+(* Notation ", 'forall' ( x : T | C ) B" := `[x : T | all_in C B]^* *)
+(*   (at level 200, x at level 99, B at level 200, only parsing) : quant_scope. *)
+(* Notation ", 'forall' x 'in' A B" := `[x | all_in (x \in A) B]^* *)
+(*   (at level 200, x at level 99, B at level 200, *)
+(*    format ", '/ '  '[' 'forall'  x '/  '  'in'  A ']' B") : bool_scope. *)
+(* Notation ", 'forall' x : T 'in' A B" := `[x : T | all_in (x \in A) B]^* *)
+(*   (at level 200, x at level 99, B at level 200, only parsing) : bool_scope. *)
+
+(* Notation "`[ 'exists' x B ]" := `[x | ex B]^~ *)
+(*   (at level 0, x at level 99, B at level 200, *)
+(*    format "`[ '[hv' 'exists'  x B ] ']'") : bool_scope. *)
+(* Notation "`[ 'exists' x : T B ]" := `[x : T | ex B]^~ *)
+(*   (at level 0, x at level 99, B at level 200, only parsing) : bool_scope. *)
+(* Notation "`[ 'exists' ( x | C ) B ]" := `[x | ex_in C B]^~ *)
+(*   (at level 0, x at level 99, B at level 200, *)
+(*    format "`[ '[hv' '[' 'exists'  ( x '/  '  |  C ) ']' B ] ']'") : bool_scope. *)
+(* Notation "`[ 'exists' ( x : T | C ) B ]" := `[x : T | ex_in C B]^~ *)
+(*   (at level 0, x at level 99, B at level 200, only parsing) : bool_scope. *)
+(* Notation "`[ 'exists' x 'in' A B ]" := `[x | ex_in (x \in A) B]^~ *)
+(*   (at level 0, x at level 99, B at level 200, *)
+(*    format "`[ '[hv' '[' 'exists'  x '/  '  'in'  A ']' B ] ']'") : bool_scope. *)
+(* Notation "`[ 'exists' x : T 'in' A B ]" := `[x : T | ex_in (x \in A) B]^~ *)
+(*   (at level 0, x at level 99, B at level 200, only parsing) : bool_scope. *)
+(* Notation ", 'exists' x B" := `[x | ex B]^~^* *)
+(*   (at level 200, x at level 99, B at level 200, *)
+(*    format ", '/ '  'exists'  x B") : quant_scope. *)
+(* Notation ", 'exists' x : T B" := `[x : T | ex B]^~^* *)
+(*   (at level 200, x at level 99, B at level 200, only parsing) : quant_scope. *)
+(* Notation ", 'exists' ( x | C ) B" := `[x | ex_in C B]^~^* *)
+(*   (at level 200, x at level 99, B at level 200, *)
+(*    format ", '/ '  '[' 'exists'  ( x '/  '  |  C ) ']' B") : quant_scope. *)
+(* Notation ", 'exists' ( x : T | C ) B" := `[x : T | ex_in C B]^~^* *)
+(*   (at level 200, x at level 99, B at level 200, only parsing) : quant_scope. *)
+(* Notation ", 'exists' x 'in' A B" := `[x | ex_in (x \in A) B]^~^* *)
+(*   (at level 200, x at level 99, B at level 200, *)
+(*    format ", '/ '  '[' 'exists'  x '/  '  'in'  A ']' B") : bool_scope. *)
+(* Notation ", 'exists' x : T 'in' A B" := `[x : T | ex_in (x \in A) B]^~^* *)
+(*   (at level 200, x at level 99, B at level 200, only parsing) : bool_scope. *)
+
+(* End Exports. *)
+
+(* End BoolQuant. *)
+(* Export BoolQuant.Exports. *)
+
+(* Open Scope quant_scope. *)
+
+(* (* -------------------------------------------------------------------- *) *)
+(* Section QuantifierCombinators. *)
+
+(* Variables (T : Type) (P : pred T) (PP : predp T). *)
+(* Hypothesis viewP : forall x, reflect (PP x) (P x). *)
+
+(* Lemma existsPP : reflect (exists x, PP x) `[exists x, P x]. *)
 (* Proof. *)
-(* About forallPP. *)
-(* have:= (forallPP (fun x => (asboolP (P x)))). *)
-(* exact: 'forall_asboolP. Qed. *)
-
-(* Lemma eqfunP f1 f2 : reflect (forall x, f1 x = f2 x) [forall x, f1 x == f2 x]. *)
-(* Proof. exact: 'forall_eqP. Qed. *)
-
-(* Lemma forall_inP D P : reflect (forall x, D x -> P x) [forall (x | D x), P x]. *)
-(* Proof. exact: 'forall_implyP. Qed. *)
-
-(* Lemma eqfun_inP D f1 f2 : *)
-(*   reflect {in D, forall x, f1 x = f2 x} [forall (x | x \in D), f1 x == f2 x]. *)
-(* Proof. by apply: (iffP 'forall_implyP) => eq_f12 x Dx; apply/eqP/eq_f12. Qed. *)
-
-(* Lemma existsP P : reflect (exists x, P x) [exists x, P x]. *)
-(* Proof. exact: 'exists_idP. Qed. *)
-
-(* Lemma exists_eqP f1 f2 : *)
-(*   reflect (exists x, f1 x = f2 x) [exists x, f1 x == f2 x]. *)
-
-(* Proof. exact: 'exists_eqP. Qed. *)
-
-(* Lemma exists_inP D P : reflect (exists2 x, D x & P x) [exists (x | D x), P x]. *)
-(* Proof. by apply: (iffP 'exists_andP) => [[x []] | [x]]; exists x. Qed. *)
-
-(* Lemma exists_eq_inP D f1 f2 : *)
-(*   reflect (exists2 x, D x & f1 x = f2 x) [exists (x | D x), f1 x == f2 x]. *)
-(* Proof. by apply: (iffP (exists_inP _ _)) => [] [x Dx /eqP]; exists x. Qed. *)
-
-(* Lemma eq_existsb P1 P2 : P1 =1 P2 -> [exists x, P1 x] = [exists x, P2 x]. *)
-(* Proof. by move=> eqP12; congr (_ != 0); apply: eq_card. Qed. *)
-
-(* Lemma eq_existsb_in D P1 P2 : *)
-(*     (forall x, D x -> P1 x = P2 x) -> *)
-(*   [exists (x | D x), P1 x] = [exists (x | D x), P2 x]. *)
-(* Proof. by move=> eqP12; apply: eq_existsb => x; apply: andb_id2l => /eqP12. Qed. *)
-
-(* Lemma eq_forallb P1 P2 : P1 =1 P2 -> [forall x, P1 x] = [forall x, P2 x]. *)
-(* Proof. by move=> eqP12; apply/negb_inj/eq_existsb=> /= x; rewrite eqP12. Qed. *)
-
-(* Lemma eq_forallb_in D P1 P2 : *)
-(*     (forall x, D x -> P1 x = P2 x) -> *)
-(*   [forall (x | D x), P1 x] = [forall (x | D x), P2 x]. *)
-(* Proof. *)
-(* by move=> eqP12; apply: eq_forallb => i; case Di: (D i); rewrite // eqP12. *)
+(* apply: (iffP idP). *)
+(*   move/asboolP; (* oops notation! *) apply: contrapR => nh x /=; apply: notTE. *)
+(*   by apply: contrap nh => /viewP Px; exists x. *)
+(* case=> x PPx; apply/asboolP=> /(_ x) /notT /=; rewrite -/(not (~ P x)) notK. *)
+(* exact/viewP. *)
 (* Qed. *)
 
-(* Lemma negb_forall P : ~~ [forall x, P x] = [exists x, ~~ P x]. *)
-(* Proof. by []. Qed. *)
+(* Lemma forallPP : reflect (forall x, PP x) `[forall x, P x]. *)
+(* Proof. *)
+(* apply: (iffP idP). *)
+(*   by move/asboolP=> h x; move/notT: (h x)=> /= /negP; rewrite negbK => /viewP. *)
+(* move=> h; apply/asboolP=> x; apply/notTE/negP; rewrite negbK; exact/viewP. *)
+(* Qed. *)
 
-(* Lemma negb_forall_in D P : *)
-(*   ~~ [forall (x | D x), P x] = [exists (x | D x), ~~ P x]. *)
-(* Proof. by apply: eq_existsb => x; rewrite negb_imply. Qed. *)
+(* End QuantifierCombinators. *)
 
-(* Lemma negb_exists P : ~~ [exists x, P x] = [forall x, ~~ P x]. *)
-(* Proof. by apply/negbLR/esym/eq_existsb=> x; apply: negbK. Qed. *)
+(* Section PredQuantifierCombinators. *)
 
-(* Lemma negb_exists_in D P : *)
-(*   ~~ [exists (x | D x), P x] = [forall (x | D x), ~~ P x]. *)
-(* Proof. by rewrite negb_exists; apply/eq_forallb => x; rewrite [~~ _]fun_if. Qed. *)
+(* Variables (T : Type) (P : pred T). *)
+
+(* Lemma existsbP : reflect (exists x, P x) `[exists x, P x]. *)
+(* Proof. exact: existsPP (fun x => @idP (P x)). Qed. *)
+
+(* Lemma existsbE : `[exists x, P x] = `[<exists x, P x>]. *)
+(* Proof. *)
+(* apply/esym/is_true_inj; rewrite asboolE propeqE; apply: rwP; exact: existsbP. *)
+(* Qed. *)
+
+(* Lemma forallbP : reflect (forall x, P x) `[forall x, P x]. *)
+(* Proof. exact: forallPP (fun x => @idP (P x)). Qed. *)
+
+(* Lemma forallbE : `[forall x, P x] = `[<forall x, P x>]. *)
+(* Proof. *)
+(* apply/esym/is_true_inj; rewrite asboolE propeqE; apply: rwP; exact: forallbP. *)
+(* Qed. *)
+
+(* End PredQuantifierCombinators. *)
+
+(* (* -------------------------------------------------------------------- *) *)
+(* Lemma existsp_asboolP {T} {P : T -> Prop} : *)
+(*   reflect (exists x : T, P x) `[exists x : T, `[<P x>]]. *)
+(* Proof. exact: existsPP (fun x => @asboolP (P x)). Qed. *)
+
+(* Lemma forallp_asboolP {T} {P : T -> Prop} : *)
+(*   reflect (forall x : T, P x) `[forall x : T, `[<P x>]]. *)
+(* Proof. exact: forallPP (fun x => @asboolP (P x)). Qed. *)
+
+(* Lemma forallp_asboolPn {T} {P : T -> Prop} : *)
+(*   reflect (forall x : T, ~ P x) (~~ `[<exists x : T, P x>]). *)
+(* Proof. *)
+(* apply: (iffP idP)=> [/asboolPn NP x Px|NP]. *)
+(* by apply/NP; exists x. by apply/asboolP=> -[x]; apply/NP. *)
+(* Qed. *)
+
+(* Lemma existsp_asboolPn {T} {P : T -> Prop} : *)
+(*   reflect (exists x : T, ~ P x) (~~ `[<forall x : T, P x>]). *)
+(* Proof. *)
+(* apply: (iffP idP); last by case=> x NPx; apply/asboolPn=> /(_ x). *)
+(* move/asboolPn=> NP; apply/asboolP/negbNE/asboolPn=> h. *)
+(* by apply/NP=> x; apply/asboolP/negbNE/asboolPn=> NPx; apply/h; exists x. *)
+(* Qed. *)
+
+(* Lemma asbool_forallNb {T : Type} (P : pred T) : *)
+(*   `[< forall x : T, ~~ (P x) >] = ~~ `[< exists x : T, P x >]. *)
+(* Proof. *)
+(* apply: (asbool_equiv_eqP forallp_asboolPn); *)
+(*   by split=> h x; apply/negP/h. *)
+(* Qed. *)
+
+(* Lemma asbool_existsNb {T : Type} (P : pred T) : *)
+(*   `[< exists x : T, ~~ (P x) >] = ~~ `[< forall x : T, P x >]. *)
+(* Proof. *)
+(* apply: (asbool_equiv_eqP existsp_asboolPn); *)
+(*   by split=> -[x h]; exists x; apply/negP. *)
+(* Qed. *)
+
+(* (* -------------------------------------------------------------------- *) *)
+(* Definition xchooseb {T : choiceType} (P : pred T) (h : `[exists x, P x]) := *)
+(*   xchoose (existsbP P h). *)
+
+(* Lemma xchoosebP {T : choiceType} (P : pred T) (h : `[exists x, P x]) : *)
+(*   P (xchooseb h). *)
+(* Proof. exact/xchooseP. Qed. *)
+
+(* (* -------------------------------------------------------------------- *) *)
+(* (* Notation "'exists_ view" := (existsPP (fun _ => view)) *) *)
+(* (*   (at level 4, right associativity, format "''exists_' view"). *) *)
+(* (* Notation "'forall_ view" := (forallPP (fun _ => view)) *) *)
+(* (*   (at level 4, right associativity, format "''forall_' view"). *) *)
+
+
+(* (* Section Quantifiers. *) *)
+
+(* (* Variables (T : Type) (rT : T -> eqType). *) *)
+(* (* Implicit Type (D P : rset T) (f : forall x, rT x). *) *)
+
+(* (* Lemma forallP P : reflect (forall x, P x) [forall x, P x]. *) *)
+(* (* Proof. *) *)
+(* (* About forallPP. *) *)
+(* (* have:= (forallPP (fun x => (asboolP (P x)))). *) *)
+(* (* exact: 'forall_asboolP. Qed. *) *)
+
+(* (* Lemma eqfunP f1 f2 : reflect (forall x, f1 x = f2 x) [forall x, f1 x == f2 x]. *) *)
+(* (* Proof. exact: 'forall_eqP. Qed. *) *)
+
+(* (* Lemma forall_inP D P : reflect (forall x, D x -> P x) [forall (x | D x), P x]. *) *)
+(* (* Proof. exact: 'forall_implyP. Qed. *) *)
+
+(* (* Lemma eqfun_inP D f1 f2 : *) *)
+(* (*   reflect {in D, forall x, f1 x = f2 x} [forall (x | x \in D), f1 x == f2 x]. *) *)
+(* (* Proof. by apply: (iffP 'forall_implyP) => eq_f12 x Dx; apply/eqP/eq_f12. Qed. *) *)
+
+(* (* Lemma existsP P : reflect (exists x, P x) [exists x, P x]. *) *)
+(* (* Proof. exact: 'exists_idP. Qed. *) *)
+
+(* (* Lemma exists_eqP f1 f2 : *) *)
+(* (*   reflect (exists x, f1 x = f2 x) [exists x, f1 x == f2 x]. *) *)
+
+(* (* Proof. exact: 'exists_eqP. Qed. *) *)
+
+(* (* Lemma exists_inP D P : reflect (exists2 x, D x & P x) [exists (x | D x), P x]. *) *)
+(* (* Proof. by apply: (iffP 'exists_andP) => [[x []] | [x]]; exists x. Qed. *) *)
+
+(* (* Lemma exists_eq_inP D f1 f2 : *) *)
+(* (*   reflect (exists2 x, D x & f1 x = f2 x) [exists (x | D x), f1 x == f2 x]. *) *)
+(* (* Proof. by apply: (iffP (exists_inP _ _)) => [] [x Dx /eqP]; exists x. Qed. *) *)
+
+(* (* Lemma eq_existsb P1 P2 : P1 =1 P2 -> [exists x, P1 x] = [exists x, P2 x]. *) *)
+(* (* Proof. by move=> eqP12; congr (_ != 0); apply: eq_card. Qed. *) *)
+
+(* (* Lemma eq_existsb_in D P1 P2 : *) *)
+(* (*     (forall x, D x -> P1 x = P2 x) -> *) *)
+(* (*   [exists (x | D x), P1 x] = [exists (x | D x), P2 x]. *) *)
+(* (* Proof. by move=> eqP12; apply: eq_existsb => x; apply: andb_id2l => /eqP12. Qed. *) *)
+
+(* (* Lemma eq_forallb P1 P2 : P1 =1 P2 -> [forall x, P1 x] = [forall x, P2 x]. *) *)
+(* (* Proof. by move=> eqP12; apply/negb_inj/eq_existsb=> /= x; rewrite eqP12. Qed. *) *)
+
+(* (* Lemma eq_forallb_in D P1 P2 : *) *)
+(* (*     (forall x, D x -> P1 x = P2 x) -> *) *)
+(* (*   [forall (x | D x), P1 x] = [forall (x | D x), P2 x]. *) *)
+(* (* Proof. *) *)
+(* (* by move=> eqP12; apply: eq_forallb => i; case Di: (D i); rewrite // eqP12. *) *)
+(* (* Qed. *) *)
+
+(* (* Lemma negb_forall P : ~~ [forall x, P x] = [exists x, ~~ P x]. *) *)
+(* (* Proof. by []. Qed. *) *)
+
+(* (* Lemma negb_forall_in D P : *) *)
+(* (*   ~~ [forall (x | D x), P x] = [exists (x | D x), ~~ P x]. *) *)
+(* (* Proof. by apply: eq_existsb => x; rewrite negb_imply. Qed. *) *)
+
+(* (* Lemma negb_exists P : ~~ [exists x, P x] = [forall x, ~~ P x]. *) *)
+(* (* Proof. by apply/negbLR/esym/eq_existsb=> x; apply: negbK. Qed. *) *)
+
+(* (* Lemma negb_exists_in D P : *) *)
+(* (*   ~~ [exists (x | D x), P x] = [forall (x | D x), ~~ P x]. *) *)
+(* (* Proof. by rewrite negb_exists; apply/eq_forallb => x; rewrite [~~ _]fun_if. Qed. *) *)
 
 (* End Quantifiers. *)
 
 (* -------------------------------------------------------------------- *)
 (* FIXME: to be moved                                                   *)
-Lemma imsetbP (T : Type) (U : eqType) (f : T -> U) v :
-  reflect (exists x, v = f x) (v \in [pred y | `[exists x, y == f x]]).
-Proof. by apply: (iffP (existsbP _))=> -[x] => [/eqP|] ->; exists x. Qed.
+(* Lemma imsetbP (T : Type) (U : eqType) (f : T -> U) v : *)
+(*   reflect (exists x, v = f x) (v \in [pred y | `[exists x, y == f x]]). *)
+(* Proof. by apply: (iffP (existsbP _))=> -[x] => [/eqP|] ->; exists x. Qed. *)

--- a/theories/classical_preds.v
+++ b/theories/classical_preds.v
@@ -204,3 +204,4 @@ Notation "[ 'prel' x y 'in' A ]" := [prel x y in A & A]
 (* skipping the keyed predicates *)
 
 (* skipping ... *) 
+

--- a/theories/classical_preds.v
+++ b/theories/classical_preds.v
@@ -1,0 +1,206 @@
+From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype choice.
+Require Import boolp.
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+Set Warnings "-projection-no-head-constant".
+
+
+(* todo: define classical predtypes, named sets, so as to have an infix \in in Prop, in scope classical_stuff *)
+(* possible pb: clash with mathcomp..., and painful duplication. *)
+
+
+(******************************************************************************)
+(* Predicates, i.e., packaged functions to Prop.                              *)
+(* - ppred T, the basic type for predicates over a type T, is simply an alias *)
+(* for T -> Prop.                                                             *)
+(* See ssrbool for more comment: we are just trying to duplicate the various  *)
+(* machineries here.                                                          *)
+(******************************************************************************)
+Definition ppred T := T -> Prop.
+
+Identity Coercion fun_of_ppred : ppred >-> Funclass.
+
+Definition prel T := T -> ppred T.
+
+Identity Coercion fun_of_prel : prel >-> Funclass.
+
+Notation xppred0 := (fun _ => False).
+Notation xppredT := (fun _ => True).
+Notation xppredI := (fun (p1 p2 : ppred _) x => p1 x /\ p2 x).
+Notation xppredU := (fun (p1 p2 : ppred _) x => p1 x \/ p2 x).
+Notation xppredC := (fun (p : ppred _) x => ~ p x).
+Notation xppredD := (fun (p1 p2 : ppred _) x => ~ p2 x /\ p1 x).
+Notation xpreim := (fun f (p : ppred _) x => p (f x)).
+Notation xprelU := (fun (r1 r2 : prel _) x y => r1 x y \/ r2 x y).
+
+
+(* First, the applicative and collective versions, and the related notations *)
+Section PropPredicates.
+
+Variables T : Type.
+
+Definition subppred (p1 p2 : ppred T) := forall x, p1 x -> p2 x.
+
+Definition subprel (r1 r2 : prel T) := forall x y, r1 x y -> r2 x y.
+
+Definition simpl_ppred := simpl_fun T Prop.
+Definition applicative_ppred := ppred T.
+Definition collective_ppred := ppred T.
+
+Definition SimplPpred (p : ppred T) : simpl_ppred := SimplFun p.
+
+Coercion ppred_of_simpl (p : simpl_ppred) : ppred T := fun_of_simpl p.
+Coercion applicative_ppred_of_simpl (p : simpl_ppred) : applicative_ppred :=
+  fun_of_simpl p.
+Coercion collective_ppred_of_simpl (p : simpl_ppred) : collective_ppred :=
+  fun x => (let: SimplFun f := p in fun _ => f x) x.
+(* Note: applicative_of_simpl is convertible to ppred_of_simpl, while *)
+(* collective_of_simpl is not. *)
+
+Definition ppred0 := SimplPpred xppred0.
+Definition ppredT := SimplPpred xppredT.
+Definition ppredI p1 p2 := SimplPpred (xppredI p1 p2).
+Definition ppredU p1 p2 := SimplPpred (xppredU p1 p2).
+Definition ppredC p := SimplPpred (xppredC p).
+Definition ppredD p1 p2 := SimplPpred (xppredD p1 p2).
+Definition ppreim rT f (d : ppred rT) := SimplPpred (xpreim f d).
+
+Definition simpl_prel := simpl_fun T (ppred T).
+
+Definition SimplPrel (r : prel T) : simpl_prel := [fun x => r x].
+
+Coercion prel_of_simpl_prel (r : simpl_prel) : prel T := fun x y => r x y.
+
+Definition prelU r1 r2 := SimplPrel (xprelU r1 r2).
+
+Lemma subprelUl r1 r2 : subprel r1 (prelU r1 r2).
+Proof. by move=> *; left. Qed.
+
+Lemma subprelUr r1 r2 : subprel r2 (prelU r1 r2).
+Proof. by move=> *; right. Qed.
+
+Variant mem_ppred := Mem of ppred T.
+
+Definition isMem pT toppred mem := mem = (fun p : pT => Mem [eta toppred p]).
+
+Structure ppredType := PpredType {
+  ppred_sort :> Type;
+  toppred : ppred_sort -> ppred T;
+  _ : {mem | isMem toppred mem}
+}.
+
+Definition mkPpredType pT toP := PpredType (exist (@isMem pT toP) _ (erefl _)).
+
+Canonical ppredPpredType := Eval hnf in @mkPpredType (ppred T) id.
+Canonical simplPpredType := Eval hnf in mkPpredType ppred_of_simpl.
+Canonical PropfunPpredType := Eval hnf in @mkPpredType (T -> Prop) id.
+
+Coercion ppred_of_mem mp : ppred_sort ppredPpredType := let: Mem p := mp in [eta p].
+Canonical memPpredType := Eval hnf in mkPpredType ppred_of_mem.
+
+Definition clone_ppred U :=
+  fun pT & ppred_sort pT -> U =>
+  fun a mP (pT' := @PpredType U a mP) & phant_id pT' pT => pT'.
+
+End PropPredicates.
+
+Arguments ppred0 [T].
+Arguments ppredT [T].
+Prenex Implicits ppred0 ppredT ppredI ppredU ppredC ppredD ppreim prelU.
+
+(* Short delimiter for Prop, but we cannot bind?*)
+Delimit Scope prop_scope with P.
+Open Scope prop_scope.
+
+Notation "[ 'ppred' : T | E ]" := (SimplPpred ((fun _ : T => E) : ppred T))
+  (at level 0, format "[ 'ppred' :  T  |  E ]") : fun_scope.
+Notation "[ 'ppred' x | E ]" := (SimplPpred ((fun x => E) : ppred _))
+  (at level 0, x ident, format "[ 'ppred'  x  |  E ]") : fun_scope.
+
+Notation "[ 'ppred' x | E1 & E2 ]" := [ppred x | E1 /\ E2 ]
+  (at level 0, x ident, format "[ 'ppred'  x  |  E1  &  E2 ]") : fun_scope.
+Notation "[ 'ppred' x : T | E ]" := (SimplPpred ((fun x : T => E) : ppred T))
+  (at level 0, x ident, only parsing) : fun_scope.
+Notation "[ 'ppred' x : T | E1 /\ E2 ]" := [ppred x : T | E1 /\ E2 ]
+  (at level 0, x ident, only parsing) : fun_scope.
+Notation "[ 'prel' x y | E ]" := (SimplPrel ((fun x y => E) : prel _))
+  (at level 0, x ident, y ident, format "[ 'prel'  x  y  |  E ]") : fun_scope.
+
+Notation "[ 'prel' x y : T | E ]" := (SimplPrel ((fun x y : T => E) : prel T))
+  (at level 0, x ident, y ident, only parsing) : fun_scope.
+
+Notation "[ 'ppredType' 'of' T ]" := (@clone_ppred _ T _ id _ _ id)
+  (at level 0, format "[ 'ppredType'  'of'  T ]") : form_scope.
+
+(* Skiping the trick to use types as a synonym for their collective predicates.*)
+
+(* These must be defined outside a Section because "cooking" kills the        *)
+(* nosimpl tag.                                                               *)
+Definition pmem T (pT : ppredType T) : pT -> mem_ppred T :=
+  nosimpl (let: @PpredType _ _ _ (exist mem _) := pT return pT -> _ in mem).
+Definition in_pmem T x mp := nosimpl ppred_of_mem T mp x.
+
+Prenex Implicits pmem.
+
+Coercion ppred_of_pmem_pred T mp := [ppred x : T | in_pmem x mp].
+
+
+Definition eq_pmem T p1 p2 := forall x : T, in_pmem x p1 = in_pmem x p2.
+Definition sub_pmem T p1 p2 := forall x : T, in_pmem x p1 -> in_pmem x p2.
+
+(* why this? *)
+Typeclasses Opaque eq_pmem.
+
+Lemma sub_prefl T (p : mem_ppred T) : sub_pmem p p. Proof. by []. Qed.
+Arguments sub_prefl {T p}.
+
+Notation "x \in A" := (in_pmem x (pmem A)) : prop_scope.
+Notation "x \in A" := (in_pmem x (pmem A)) : prop_scope.
+Notation "x \notin A" := (~ (x \in A)) : prop_scope.
+Notation "A =i B" := (eq_pmem (pmem A) (pmem B)) : type_scope.
+Notation "{ 'subset' A <= B }" := (sub_pmem (pmem A) (pmem B))
+  (at level 0, A, B at level 69,
+   format "{ '[hv' 'subset'  A '/   '  <=  B ']' }") : type_scope.
+Notation "[ 'pmem' A ]" := (ppred_of_simpl (ppred_of_pmem_pred (pmem A)))
+  (at level 0, only parsing) : fun_scope.
+Notation "[ 'prel' 'of' fA ]" := (fun x => [pmem (fA x)])
+  (at level 0, format "[ 'prel'  'of'  fA ]") : fun_scope.
+Notation "[ 'ppredI' A & B ]" := (ppredI [pmem A] [pmem B])
+  (at level 0, format "[ 'ppredI'  A  &  B ]") : fun_scope.
+Notation "[ 'ppredU' A & B ]" := (ppredU [pmem A] [pmem B])
+  (at level 0, format "[ 'ppredU'  A  &  B ]") : fun_scope.
+Notation "[ 'ppredD' A & B ]" := (ppredD [pmem A] [pmem B])
+  (at level 0, format "[ 'ppredD'  A  &  B ]") : fun_scope.
+Notation "[ 'ppredC' A ]" := (ppredC [pmem A])
+  (at level 0, format "[ 'ppredC'  A ]") : fun_scope.
+Notation "[ 'preim' f 'of' A ]" := (preim f [pmem A])
+  (at level 0, format "[ 'preim'  f  'of'  A ]") : fun_scope.
+
+Notation "[ 'ppred' x 'in' A ]" := [ppred x | x \in A]
+  (at level 0, x ident, format "[ 'ppred'  x  'in'  A ]") : fun_scope.
+Notation "[ 'ppred' x 'in' A | E ]" := [ppred x | x \in A & E]
+  (at level 0, x ident, format "[ 'ppred'  x  'in'  A  |  E ]") : fun_scope.
+Notation "[ 'ppred' x 'in' A | E1 & E2 ]" := [ppred x | x \in A & E1 && E2 ]
+  (at level 0, x ident,
+   format "[ 'ppred'  x  'in'  A  |  E1  &  E2 ]") : fun_scope.
+Notation "[ 'prel' x y 'in' A & B | E ]" :=
+  [prel x y | (x \in A) && (y \in B) && E]
+  (at level 0, x ident, y ident,
+   format "[ 'prel'  x  y  'in'  A  &  B  |  E ]") : fun_scope.
+Notation "[ 'prel' x y 'in' A & B ]" := [prel x y | (x \in A) && (y \in B)]
+  (at level 0, x ident, y ident,
+   format "[ 'prel'  x  y  'in'  A  &  B ]") : fun_scope.
+Notation "[ 'prel' x y 'in' A | E ]" := [prel x y in A & A | E]
+  (at level 0, x ident, y ident,
+   format "[ 'prel'  x  y  'in'  A  |  E ]") : fun_scope.
+Notation "[ 'prel' x y 'in' A ]" := [prel x y in A & A]
+  (at level 0, x ident, y ident,
+   format "[ 'prel'  x  y  'in'  A ]") : fun_scope.
+
+(* skipping the finer-grained control machineries (manifest, etc.) for now. *)
+
+(* skipping the keyed predicates *)
+
+(* skipping ... *) 

--- a/theories/classical_sets.v
+++ b/theories/classical_sets.v
@@ -102,7 +102,10 @@ Reserved Notation "A `\ b" (at level 50, left associativity).
 
 Definition set A := A -> Prop.
 Definition in_set T (P : set T) : ppred T := [ppred x | P x].
-Canonical set_predType T := @mkPpredType T (set T) (@in_set T).
+Canonical set_ppredType T := @mkPpredType T (set T) (@in_set T).
+
+Definition bin_set T (P : set T) : pred T := [pred x | asbool (P x)].
+Canonical set_predType T := @mkPredType T (set T) (@bin_set T).
 
 Lemma in_setE T (P : set T) x : x \in P = P x :> Prop.
 Proof. by []. Qed.
@@ -443,8 +446,8 @@ Canonical Prop_pointedType := PointedType Prop False.
 Canonical nat_pointedType := PointedType nat 0%N.
 Canonical prod_pointedType (T T' : pointedType) :=
   PointedType (T * T') (point, point).
-(* Canonical matrix_pointedType m n (T : pointedType) := *)
-(*   PointedType 'M[T]_(m, n) (\matrix_(_, _) point)%R. *)
+Canonical matrix_pointedType m n (T : pointedType) :=
+  PointedType 'M[T]_(m, n) (\matrix_(_, _) point)%R.
 
 Notation get := (xget point).
 
@@ -540,10 +543,6 @@ Qed.
 
 End ZL.
 
-Lemma exist_congr T (P : T -> Prop) (s t : T) (p : P s) (q : P t) :
-  s = t -> exist P s p = exist P t q.
-Proof. by move=> st; case: _ / st in q *; apply/congr1/Prop_irrelevance. Qed.
-
 Lemma Zorn T (R : T -> T -> Prop) :
   (forall t, R t t) -> (forall r s t, R r s -> R s t -> R r t) ->
   (forall s t, R s t -> R t s -> s = t) ->
@@ -571,7 +570,8 @@ have R'tot_lub A : total_on A R' -> exists t, (forall s, A s -> R' s t) /\
   by move=> B Bub ? /= [? /Bub]; apply.
 have tot0 : total_on set0 R by []. 
 apply: contrapT => nomax.
-apply: (ZL' (exist _ set0 tot0)) R'tot_lub _ => // A.                                have {nomax} nomax t : exists s, R t s /\ s <> t.
+apply: (ZL' (exist _ set0 tot0)) R'tot_lub _ => // A.
+have {nomax} nomax t : exists s, R t s /\ s <> t.
   move: nomax; rewrite not_exists => /(_ t); rewrite not_forall => - [s].
   by rewrite not_imply => ?; exists s.
 have /Rtot_max [t tub] := svalP A; have [s [Rts snet]] := nomax t.

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -1424,11 +1424,22 @@ Lemma continuous_comp (R S T : topologicalType) (f : R -> S) (g : S -> T) x :
   {for x, continuous (g \o f)}.
 Proof. exact: flim_comp. Qed.
 
+About prop_pin1.
+
+Notation "{ 'in' d , P }" :=
+  (prop_pin1 (pmem d) (inPhantom P))
+  (at level 0, format "{ 'in'  d ,  P }") : classical_scope.
+
 Lemma open_comp  {T U : topologicalType} (f : T -> U) (D : set U) :
   ({in f @^-1` D, continuous f})%classic -> open D -> open (f @^-1` D).
-Proof.
-rewrite !openE => fcont Dop x /= Dfx.
+Proof. Unset Printing Notations.
+
+
+ewrite !openE => fcont Dop x /= Dfx. Locate "{ in _ , _ }". Locate prop_in1.
+apply: fcont; last exact: Dop. Locate "{ in _ , _ }".
+Locate prop_in1.
 by apply: fcont; [rewrite in_setE|apply: Dop].
+
 Qed.
 
 Lemma is_filter_lim_filtermap {T: topologicalType} {U : topologicalType}


### PR DESCRIPTION
- [ ]  ~~Obtain axioms from the std library~~ Keep the explicit list of additional axioms, and derive their standard consequences.
- [x] Remove ugly notation for `asbool`
- [x] Minimize the use of bool, and restrict it to plumbing with mathcomp. In particular, add better support for Prop predicates.
- [ ] Reorganize and complete the corpus of lemmas, in particular rewrite rules. 
 - [ ] Collect lemmas presently in other libraries, e.g. [this ones in hierarchy](https://github.com/amahboubi/analysis/blob/e135998d7130224228748cdd004051d91431985c/hierarchy.v#L612)
- [ ] Clean up the proof of Zorn-related lemmas
- [x] Move the generic choice mixin from `set.v` to boolp.

Several items in this list were already addressed or in progress [elsewhere](https://github.com/amahboubi/analysis/tree/clean-boolp), so the present branch will incorporate the relevant material.