### PR TITLE
remove: line not necessary with opam 2; loosen up restriction about mathcomp's version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,11 @@ env:
   matrix:
   - DOCKERIMAGE="mathcomp/mathcomp:1.8.0-coq-8.8"
   - DOCKERIMAGE="mathcomp/mathcomp:1.8.0-coq-8.9"
-  - DOCKERIMAGE="mathcomp/mathcomp:1.8.0-coq-dev"
+  - DOCKERIMAGE="mathcomp/mathcomp:1.9.0-coq-8.8"
+  - DOCKERIMAGE="mathcomp/mathcomp:1.9.0-coq-8.9"
+  - DOCKERIMAGE="mathcomp/mathcomp:1.9.0-coq-8.10"
+
+
 
 install: |
   # Prepare the COQ container

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,32 +1,28 @@
 # Installing
 
 ## Requirements
-- [The Coq Proof Assistant version ≥ 8.7](https://coq.inria.fr)
-- [Mathematical Components version 1.7.0](https://github.com/math-comp/math-comp)
+- [The Coq Proof Assistant version ≥ 8.8](https://coq.inria.fr)
+- [Mathematical Components version ≥ 1.8.0](https://github.com/math-comp/math-comp)
 - [Bigenough version 1.0.0](https://github.com/math-comp/bigenough)
-- [Finmap library version 1.1.0](https://github.com/math-comp/finmap)
+- [Finmap library version 1.2.0](https://github.com/math-comp/finmap)
 
-These requirements can be installed in a custom way or through [opam 1.2](https://opam.ocaml.org/) using the repository https://coq.inria.fr/opam/extra-dev, which you can add by typing `opam repo add coq-extra-dev https://coq.inria.fr/opam/extra-dev`.
+These requirements can be installed in a custom way or through [opam 2](https://opam.ocaml.org/) using the repository https://coq.inria.fr/opam/released, which you can add by typing `opam repo add coq-released https://coq.inria.fr/opam/released`.
 
 Detailed instructions for possible installations of Mathematical Components are located [here](https://github.com/math-comp/math-comp/blob/master/INSTALL.md).
 
 ## Short Instructions
-- Custom (assuming Coq ≥ 8.7, Mathematical Components version 1.7.0, Bigenough version 1.0.0 and Finmap version 1.1.0 have been installed):
+- Custom (assuming Coq ≥ 8.8, Mathematical Components version ≥ 1.8.0, Bigenough version 1.0.0 and Finmap version 1.2.0 have been installed):
   + Type `make` to use the provided `Makefile`.
 - Through opam:
   + Type `opam install coq-mathcomp-analysis`
-  (all the dependencies should be automatically installed, assuming `opam` has been properly configured and `extra-dev` repository is added)
+  (all the dependencies should be automatically installed, assuming `opam` has been properly configured and `coq-released` repository is added)
 
 ## From scratch instructions
 ### How to install as a package
 1. Install opam
-- with Debian/Ubuntu:
-```
-$ sudo apt-get install opam
-```
 - any linux system:
 ```
-$ wget https://raw.github.com/ocaml/opam/master/shell/opam_installer.sh -O - | sh -s /usr/local/bin
+$ sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)
 ```
 
 2. Configure opam
@@ -34,7 +30,7 @@ $ wget https://raw.github.com/ocaml/opam/master/shell/opam_installer.sh -O - | s
 $ export OPAMROOT=~/.opam_mathcomp_analysis
 $ opam init -j4 # adapt to the number of cores you have
 $ eval `opam config env`
-$ opam repo add coq-extra-dev https://coq.inria.fr/opam/extra-dev
+$ opam repo add coq-released https://coq.inria.fr/opam/released
 ```
 3. Install our package (and all its dependencies)
 ```
@@ -57,22 +53,22 @@ $ make
 You may then browse the files using `coqide` (you might want to `opam install coqide`) or using [proof general for emacs](https://github.com/ProofGeneral/PG)
 
 ## Break-down of phase 3 of the installation procedure step by step
-1. Install Coq 8.8.1
+1. Install Coq 8.9.1
 ```
-$ opam install coq.8.8.1
+$ opam install coq.8.9.1
 ```
 2. Install Mathematical Components development version 
 ```
-$ opam install coq-mathcomp-ssreflect.1.7.0
-$ opam install coq-mathcomp-fingroup.1.7.0
-$ opam install coq-mathcomp-algebra.1.7.0
-$ opam install coq-mathcomp-solvable.1.7.0
-$ opam install coq-mathcomp-field.1.7.0
+$ opam install coq-mathcomp-ssreflect.1.8.0
+$ opam install coq-mathcomp-fingroup.1.8.0
+$ opam install coq-mathcomp-algebra.1.8.0
+$ opam install coq-mathcomp-solvable.1.8.0
+$ opam install coq-mathcomp-field.1.8.0
 $ opam install coq-mathcomp-bigenough.1.0.0
 ```
 3. Install Finite maps library
 ```
-$ opam install coq-mathcomp-finmap.1.1.0
+$ opam install coq-mathcomp-finmap.1.2.0
 ```
 4. Download and compile `coq-mathcomp-analysis` without installing
 ```

--- a/opam
+++ b/opam
@@ -22,7 +22,7 @@ depends: [
   "coq" { ((>= "8.8" & < "8.11~") | = "dev") }
   "coq-mathcomp-field"       {(>= "1.8.0" & < "1.10~")}
   "coq-mathcomp-bigenough"   {(>= "1.0.0" & < "1.1~")}
-  "coq-mathcomp-finmap"      {(>= "1.2.0" & < "1.3~")}
+  "coq-mathcomp-finmap"      {(>= "1.2.0" & < "1.4~")}
 ]
 synopsis: "An analysis library for mathematical components"
 description: """

--- a/opam
+++ b/opam
@@ -19,10 +19,10 @@ install: [
   [make "install"]
 ]
 depends: [
-  "coq" { (>= "8.8" | = "dev") }
-  "coq-mathcomp-field"       {(>= "1.8.0" & < "1.10.0~")}
-  "coq-mathcomp-bigenough"   {(>= "1.0.0" & < "1.1.0~")}
-  "coq-mathcomp-finmap"      {(>= "1.2.0" & < "1.3.0~")}
+  "coq" { ((>= "8.8" & < "8.11~") | = "dev") }
+  "coq-mathcomp-field"       {(>= "1.8.0" & < "1.10~")}
+  "coq-mathcomp-bigenough"   {(>= "1.0.0" & < "1.1~")}
+  "coq-mathcomp-finmap"      {(>= "1.2.0" & < "1.3~")}
 ]
 synopsis: "An analysis library for mathematical components"
 description: """

--- a/opam
+++ b/opam
@@ -18,10 +18,9 @@ build: [
 install: [
   [make "install"]
 ]
-remove: ["rm" "-R" "%{lib}%/coq/user-contrib/mathcomp/analysis"]
 depends: [
   "coq" { (>= "8.8" | = "dev") }
-  "coq-mathcomp-field"       {(>= "1.8.0" & < "1.9.0~")}
+  "coq-mathcomp-field"       {(>= "1.8.0" & < "1.10.0~")}
   "coq-mathcomp-bigenough"   {(>= "1.0.0" & < "1.1.0~")}
   "coq-mathcomp-finmap"      {(>= "1.2.0" & < "1.3.0~")}
 ]


### PR DESCRIPTION
This the same PR as #146 but recreated to trigger the CI.
Closes #150 and closes #148.