### PR TITLE
Revise the use of scopes

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,7 +4,7 @@
   sha256 = "0jsisiw8yckq96r5rgdmkrl3a7y9vg9ivpw12h11m8w6rxsfn5m5";
 }),
 coq-version ? "8.9",
-mc ? {url = "https://github.com/math-comp/math-comp"; ref = "experiment/order";},
+mc ? {url = "https://github.com/math-comp/math-comp"; ref = "master";},
 print-env ? false
 }:
 let

--- a/shell.nix
+++ b/shell.nix
@@ -4,7 +4,7 @@
   sha256 = "0jsisiw8yckq96r5rgdmkrl3a7y9vg9ivpw12h11m8w6rxsfn5m5";
 }),
 coq-version ? "8.9",
-mc ? {url = "https://github.com/math-comp/math-comp"; ref = "experiment/order";},
+mc ? {url = "https://github.com/math-comp/math-comp"; ref = "master";},
 print-env ? false
 }:
 let

--- a/theories/Rbar.v
+++ b/theories/Rbar.v
@@ -57,7 +57,7 @@ Definition Rbar_lt (x y : Rbar) : bool :=
   match x, y with
     | p_infty, _ | _, m_infty => false
     | m_infty, _ | _, p_infty => true
-    | Finite x, Finite y => (x < y)%R
+    | Finite x, Finite y => x < y
   end.
 
 Definition Rbar_le (x y : Rbar) : bool :=
@@ -135,7 +135,6 @@ Definition Rbar_inv (x : Rbar) : Rbar :=
     | _ => Finite 0
   end.
 
-Local Open Scope ring_scope.
 Definition Rbar_mult' (x y : Rbar) : option Rbar :=
   match x, y with
     | Finite x, Finite y => Some (Finite (x * y))

--- a/theories/altreals/realseq.v
+++ b/theories/altreals/realseq.v
@@ -109,7 +109,7 @@ Definition B {R : realType} (x e : R) :=
 
 (* -------------------------------------------------------------------- *)
 Lemma separable_le {R : realType} (l1 l2 : {ereal R}) :
-  (l1 < l2)%O -> exists (v1 : nbh l1) (v2 : nbh l2),
+  (l1 < l2)%E -> exists (v1 : nbh l1) (v2 : nbh l2),
     forall x y, x \in v1 -> y \in v2 -> x < y.
 Proof.
 case: l1 l2 => [l1||] [l2||] //= lt_l12; last first.
@@ -134,8 +134,8 @@ Lemma separable {R : realType} (l1 l2 : {ereal R}) :
   l1 != l2 -> exists (v1 : nbh l1) (v2 : nbh l2),
     forall x, x \notin [predI v1 & v2].
 Proof.
-wlog: l1 l2 / (l1 < l2)%O => [wlog ne_l12|le_l12 _].
-  case/boolP: (l1 < l2)%O => [/wlog/(_ ne_l12)//|].
+wlog: l1 l2 / (l1 < l2)%E => [wlog ne_l12|le_l12 _].
+  case/boolP: (l1 < l2)%E => [/wlog/(_ ne_l12)//|].
   rewrite -leNgt le_eqVlt eq_sym (negbTE ne_l12) /=.
   case/wlog=> [|x [y h]]; first by rewrite eq_sym.
   by exists y, x=> z; rewrite inE andbC /= (h z).
@@ -197,7 +197,7 @@ Lemma ncvg_eq v u l : u =1 v -> ncvg v l -> ncvg u l.
 Proof. by move=> eq; apply: (@ncvg_eq_from 0). Qed.
 
 Lemma ncvg_le_from K v u (lv lu : {ereal R}) :
-  (forall n, (K <= n)%N -> u n <= v n) -> ncvg v lv -> ncvg u lu -> (lu <= lv)%O.
+  (forall n, (K <= n)%N -> u n <= v n) -> ncvg v lv -> ncvg u lu -> (lu <= lv)%E.
 Proof.
 move=> le_uv cv cu; rewrite leNgt; apply/negP=> /separable_le.
 case=> [v1] [v2] h; have [] := (cv v1, cu v2).
@@ -207,7 +207,7 @@ by move=> le h1 h2; have := h _ _ h1 h2; rewrite ltNge le.
 Qed.
 
 Lemma ncvg_le v u (lv lu : {ereal R}) :
-  u <=1 v -> ncvg v lv -> ncvg u lu -> (lu <= lv)%O.
+  u <=1 v -> ncvg v lv -> ncvg u lu -> (lu <= lv)%E.
 Proof. by move=> le_uv; apply/(@ncvg_le_from 0). Qed.
 
 Lemma ncvg_nbounded u x : ncvg u x%:E -> nbounded u.
@@ -322,11 +322,11 @@ Lemma ncvgZ c u lu : ncvg u lu%:E -> ncvg (c \*o u) (c * lu)%:E.
 Proof. by move=> cu; apply/ncvgM => //; apply/ncvgC. Qed.
 
 Lemma ncvg_leC c u (lu : {ereal R}) :
-  (forall n, u n <= c) -> ncvg u lu -> (lu <= c%:E)%O.
+  (forall n, u n <= c) -> ncvg u lu -> (lu <= c%:E)%E.
 Proof. by move=> le cu; apply/(@ncvg_le c%:S u)=> //; apply/ncvgC. Qed.
 
 Lemma ncvg_geC c u (lu : {ereal R}) :
-  (forall n, c <= u n) -> ncvg u lu -> (c%:E <= lu)%O.
+  (forall n, c <= u n) -> ncvg u lu -> (c%:E <= lu)%E.
 Proof. by move=> le cu; apply/(@ncvg_le u c%:S)=> //; apply/ncvgC. Qed.
 
 Lemma iscvgC c : iscvg c%:S.
@@ -382,8 +382,8 @@ Lemma iscvg_shift k (u : nat -> R) :
 Proof. by split=> -[l h]; exists l; apply/(ncvg_shift _ u). Qed.
 
 Lemma ncvg_gt (u : nat -> R) (l1 l2 : {ereal R}) :
-  (l1 < l2)%O -> ncvg u l2 ->
-    exists K, forall n, (K <= n)%N -> (l1 < (u n)%:E)%O.
+  (l1 < l2)%E -> ncvg u l2 ->
+    exists K, forall n, (K <= n)%N -> (l1 < (u n)%:E)%E.
 Proof.
 case: l1 l2 => [l1||] [l2||] //=; first last.
 + by move=> _ _; exists 0%N. + by move=> _ _; exists 0%N.
@@ -395,8 +395,8 @@ by rewrite {cv}/e opprB addrCA subrr addr0.
 Qed.
 
 Lemma ncvg_lt (u : nat -> R) (l1 l2 : {ereal R}) :
-  (l1 < l2)%O -> ncvg u l1 ->
-    exists K, forall n, (K <= n)%N -> ((u n)%:E < l2)%O.
+  (l1 < l2)%E -> ncvg u l1 ->
+    exists K, forall n, (K <= n)%N -> ((u n)%:E < l2)%E.
 Proof.
 move=> lt_12 cv_u_l1; case: (@ncvg_gt (\- u) (-l2) (-l1)).
   by rewrite lte_opp2. by apply/ncvgN.
@@ -405,7 +405,7 @@ Qed.
 
 Lemma ncvg_homo_lt (u : nat -> R) (l1 l2 : {ereal R}) :
     (forall m n, (m <= n)%N -> u m <= u n)
-  -> (l1 < l2)%O -> ncvg u l1 -> forall n, ((u n)%:E < l2)%O.
+  -> (l1 < l2)%E -> ncvg u l1 -> forall n, ((u n)%:E < l2)%E.
 Proof.
 move=> homo_u lt_12 cvu n; have [K {cvu}cv] := ncvg_lt lt_12 cvu.
 case: (leqP n K) => [/homo_u|/ltnW /cv //].
@@ -414,10 +414,10 @@ Qed.
 
 Lemma ncvg_homo_le (u : nat -> R) (l : {ereal R}) :
     (forall m n, (m <= n)%N -> u m <= u n)
-  -> ncvg u l -> forall n, ((u n)%:E <= l)%O.
+  -> ncvg u l -> forall n, ((u n)%:E <= l)%E.
 Proof.
-move=> homo_u cvu n; case/boolP: (_ <= _)%O => //; rewrite -ltNge.
-by move/ncvg_homo_lt/(_ cvu) => -/(_ homo_u n); rewrite ltxx.
+move=> homo_u cvu n; rewrite leNgt.
+by apply/negP => /ncvg_homo_lt /(_ cvu) -/(_ homo_u n); rewrite ltxx.
 Qed.
 End SeqLimTh.
 

--- a/theories/altreals/realsum.v
+++ b/theories/altreals/realsum.v
@@ -169,7 +169,7 @@ Context {R : realType}.
 Lemma ncvg_mono (u : nat -> R) :
     (* {mono u : x y / (x <= y)%N >-> u x <= u y *)
     (forall x y, (x <= y)%N -> u x <= u y)
-  -> exists2 l, (-oo < l)%O & ncvg u l.
+  -> exists2 l, (-oo < l)%E & ncvg u l.
 Proof.
 move=> mono_u; pose E := [pred x | `[exists n, x == u n]].
 have nzE: nonempty E by exists (u 0%N); apply/imsetbP; exists 0%N.
@@ -442,7 +442,7 @@ Qed.
 
 Lemma psummable_ptbounded : nbounded (fun n => \sum_(i < n) S i).
 Proof.
-apply/asboolP/nboundedP; exists (psum S + 1)%R.
+apply/asboolP/nboundedP; exists (psum S + 1).
   rewrite ltr_spaddr ?ltr01 1?(le_trans (normr_ge0 (S 0%N))) //.
   by apply/ger1_psum.
 move=> n; rewrite ltr_spaddr ?ltr01 // ger0_norm ?sumr_ge0 //.
@@ -554,7 +554,7 @@ Proof. by exists 0 => J; rewrite big1 ?normr0. Qed.
 Lemma summableD (S1 S2 : T -> R) :
   summable S1 -> summable S2 -> summable (S1 \+ S2).
 Proof.
-case=> [M1 h1] [M2 h2]; exists (M1 + M2)%R => J /=.
+case=> [M1 h1] [M2 h2]; exists (M1 + M2) => J /=.
 pose M := \sum_(x : J) (`|S1 (val x)| + `|S2 (val x)|).
 rewrite (@le_trans _ _ M) // ?ler_sum // => [K _|].
   by rewrite ler_norm_add.
@@ -789,7 +789,7 @@ Qed.
 Lemma psumD S1 S2 :
     (forall x, 0 <= S1 x) -> (forall x, 0 <= S2 x)
   -> summable S1 -> summable S2
-  -> psum (S1 \+ S2) = (psum S1 + psum S2)%R.
+  -> psum (S1 \+ S2) = (psum S1 + psum S2).
 Proof.
 move=> ge0_S1 ge0_S2 smS1 smS2; have smD := summableD smS1 smS2.
 have ge0D: forall x, 0 <= S1 x + S2 x by move=> x; rewrite addr_ge0.
@@ -816,7 +816,7 @@ Qed.
 (* -------------------------------------------------------------------- *)
 Lemma psumB S1 S2 :
     (forall x, 0 <= S2 x <= S1 x) -> summable S1
-  -> psum (S1 \- S2) = (psum S1 - psum S2)%R.
+  -> psum (S1 \- S2) = (psum S1 - psum S2).
 Proof using Type. Admitted.
 
 (* -------------------------------------------------------------------- *)

--- a/theories/altreals/xfinmap.v
+++ b/theories/altreals/xfinmap.v
@@ -120,7 +120,7 @@ Section BigFSetOrder.
 Variable (R : realDomainType) (T : choiceType).
 
 Lemma big_fset_subset (I J : {fset T}) (F : T -> R) :
-  (forall x, (0 <= F x)%R) -> {subset I <= J} ->
+  (forall x, 0 <= F x) -> {subset I <= J} ->
     \sum_(i : I) F (val i) <= \sum_(j : J) F (val j).
 Proof.
 move=> ge0_F le_IJ; rewrite !big_fset_seq /=.

--- a/theories/ereal.v
+++ b/theories/ereal.v
@@ -23,8 +23,10 @@ Section ExtendedReals.
 Variable (R : numDomainType).
 
 Coercion real_of_er x : R :=
-  if x is ERFin v then v else 0%R.
+  if x is ERFin v then v else 0.
 End ExtendedReals.
+
+(* TODO: the following notations should have scopes. *)
 
 (*Notation "\+inf" := (@ERPInf _).*)
 Notation "+oo" := (@ERPInf _).
@@ -100,7 +102,7 @@ Definition le_ereal x1 x2 :=
   | -oo, _ | _, +oo => true
   | +oo, _ | _, -oo => false
 
-  | x1%:E, x2%:E => (x1 <= x2)%O
+  | x1%:E, x2%:E => x1 <= x2
   end.
 
 Definition lt_ereal x1 x2 :=
@@ -109,7 +111,7 @@ Definition lt_ereal x1 x2 :=
   | -oo, _   | _  , +oo => true
   | +oo, _   | _  , -oo => false
 
-  | x1%:E, x2%:E => (x1 < x2)%O
+  | x1%:E, x2%:E => x1 < x2
   end.
 
 Lemma lt_def_ereal x y : lt_ereal x y = (y != x) && le_ereal x y.
@@ -149,10 +151,10 @@ Notation "x < y <= z"  := ((lte x y) && (lee y z)) : ereal_scope.
 Notation "x <= y < z"  := ((lee x y) && (lte y z)) : ereal_scope.
 Notation "x < y < z"   := ((lte x y) && (lte y z)) : ereal_scope.
 
-Lemma lee_fin (R : numDomainType) (x y : R) : (x%:E <= y%:E)%E = (x <= y)%R.
+Lemma lee_fin (R : numDomainType) (x y : R) : (x%:E <= y%:E)%E = (x <= y).
 Proof. by []. Qed.
 
-Lemma lte_fin (R : numDomainType) (x y : R) : (x%:E < y%:E)%E = (x < y)%R.
+Lemma lte_fin (R : numDomainType) (x y : R) : (x%:E < y%:E)%E = (x < y).
 Proof. by []. Qed.
 
 Section ERealOrder_realDomainType.
@@ -273,7 +275,6 @@ Notation "\sum_ ( i 'in' A ) F" :=
   (\big[+%E/0%:E]_(i in A) F%R) : ereal_scope.
 
 Section ERealArithTh.
-Local Open Scope ereal_scope.
 
 Context {R : numDomainType}.
 
@@ -294,7 +295,7 @@ Proof. by case=> [x||] [y||] [z||] //=; rewrite addrA. Qed.
 Canonical adde_monoid := Monoid.Law addeA add0e adde0.
 Canonical adde_comoid := Monoid.ComLaw addeC.
 
-Lemma oppe0 : - (0%:E) = 0%:E :> {ereal R}.
+Lemma oppe0 : (- 0%:E)%E = 0%:E :> {ereal R}.
 Proof. by rewrite /= oppr0. Qed.
 
 Lemma oppeK : involutive (A := {ereal R}) -%E.

--- a/theories/forms.v
+++ b/theories/forms.v
@@ -289,7 +289,7 @@ Implicit Types (a b : R) (u v : 'rV[R]_n) (N P Q : 'M[R]_n).
 Definition form u v := (u *m M *m (v ^t theta)) 0 0.
 
 Local Notation "''[' u , v ]" := (form u%R v%R) : ring_scope.
-Local Notation "''[' u ]" := '[u, u]%R : ring_scope.
+Local Notation "''[' u ]" := '[u, u] : ring_scope.
 
 Lemma form0l u : '[0, u] = 0.
 Proof. by rewrite /form !mul0mx mxE. Qed.
@@ -348,7 +348,7 @@ Local Notation "eps_theta .-sesqui" := (sesqui eps_theta).
 Variables (eps : bool) (theta : {rmorphism R -> R}).
 Variables (M : 'M[R]_n).
 Local Notation "''[' u , v ]" := (form theta M u%R v%R) : ring_scope.
-Local Notation "''[' u ]" := '[u%R, u%R]%R : ring_scope.
+Local Notation "''[' u ]" := '[u, u] : ring_scope.
 
 Lemma sesquiE : (M \is (eps,theta).-sesqui) = (M == (-1) ^+ eps *: M ^t theta).
 Proof. by rewrite qualifE. Qed.

--- a/theories/landau.v
+++ b/theories/landau.v
@@ -278,7 +278,6 @@ Reserved Notation "f '=Theta_' F h"
 
 Delimit Scope R_scope with coqR.
 Delimit Scope real_scope with real.
-Local Close Scope R_scope.
 Local Open Scope ring_scope.
 Local Open Scope real_scope.
 Local Open Scope classical_set_scope.

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -425,14 +425,14 @@ Let R_topologicalType := [topologicalType of R^o].
 Definition ereal_locally' (a : {ereal R}) (P : R -> Prop) :=
   match a with
     | a%:E => @locally' R_topologicalType a P
-    | +oo => exists M, M \is Num.real /\ forall x, (M < x)%O -> P x
-    | -oo => exists M, M \is Num.real /\ forall x, (x < M)%O -> P x
+    | +oo => exists M, M \is Num.real /\ forall x, M < x -> P x
+    | -oo => exists M, M \is Num.real /\ forall x, x < M -> P x
   end.
 Definition ereal_locally (a : {ereal R}) (P : R -> Prop) :=
   match a with
     | a%:E => @locally _ R_topologicalType a P
-    | +oo => exists M, M \is Num.real /\ forall x, (M < x)%O -> P x
-    | -oo => exists M, M \is Num.real /\ forall x, (x < M)%O -> P x
+    | +oo => exists M, M \is Num.real /\ forall x, M < x -> P x
+    | -oo => exists M, M \is Num.real /\ forall x, x < M -> P x
   end.
 
 (*Canonical Rbar_choiceType := ChoiceType Rbar gen_choiceMixin.*)
@@ -2156,18 +2156,16 @@ Grab Existential Variables. all: end_near. Qed.
 
 (** Local properties in [R] *)
 
-Local Open Scope order_scope.
-
 (* TODO: generalize to numFieldType? *)
 Lemma lt_ereal_locally (R : realFieldType) (a b : {ereal R}) (x : R) :
-  a < x%:E -> x%:E < b ->
+  (a < x%:E)%E -> (x%:E < b)%E ->
   exists delta : {posnum R},
-    forall y, `|y - x| < delta%:num -> (a < y%:E) && (y%:E < b).
+    forall y, `|y - x| < delta%:num -> ((a < y%:E) && (y%:E < b))%E.
 Proof.
 move=> [:wlog]; case: a b => [a||] [b||] //= ltax ltxb.
 - move: a b ltax ltxb; abstract: wlog. (*BUG*)
   move=> {a b} a b ltxa ltxb.
-  have m_gt0 : (minr ((x - a) / 2) ((b - x) / 2) > 0)%R.
+  have m_gt0 : (minr ((x - a) / 2) ((b - x) / 2) > 0).
     by rewrite ltxI !divr_gt0 // ?subr_gt0.
   exists (PosNum m_gt0) => y //=; rewrite ltxI !ltr_distl.
   move=> /andP[/andP[ay _] /andP[_ yb]].
@@ -2178,21 +2176,19 @@ move=> [:wlog]; case: a b => [a||] [b||] //= ltax ltxb.
   by exists d => y /dP /andP[->].
 - have [//||d dP] := wlog (x - 1) b; rewrite ?lte_fin ?gtr_addl ?ltrN10 //.
   by exists d => y /dP /andP[_ ->].
-- by exists 1%:pos%R.
+- by exists 1%:pos.
 Qed.
 
 (* TODO: generalize to numFieldType? *)
 Lemma locally_interval (R : realFieldType) (P : R -> Prop) (x : R^o) (a b : {ereal R}) :
-  a < x%:E -> x%:E < b ->
-  (forall y : R, a < y%:E -> y%:E < b -> P y) ->
+  (a < x%:E)%E -> (x%:E < b)%E ->
+  (forall y : R, a < y%:E -> y%:E < b -> P y)%E ->
   locally x P.
 Proof.
 move => Hax Hxb Hp; case: (lt_ereal_locally Hax Hxb) => d Hd.
 exists d%:num => //= y; rewrite /= distrC.
 by move=> /Hd /andP[??]; apply: Hp.
 Qed.
-
-Local Close Scope order_scope.
 
 (** * Topology on [R]² *)
 
@@ -2461,9 +2457,7 @@ Qed.
 
 Variable R : realFieldType (* TODO: generalize to numFieldType? *).
 
-Local Open Scope order_scope.
-
-Lemma open_ereal_lt (y : {ereal R}) : open [set u : R^o | u%:E < y].
+Lemma open_ereal_lt (y : {ereal R}) : open [set u : R^o | u%:E < y]%E.
 Proof.
 case: y => [y||] /=; first exact: open_lt.
 rewrite [X in open X](_ : _ = setT); first exact: openT.
@@ -2472,7 +2466,7 @@ rewrite [X in open X](_ : _ = set0); first exact: open0.
 by rewrite funeqE => ?; rewrite falseE.
 Qed.
 
-Lemma open_ereal_gt y : open [set u : R^o | y < u%:E].
+Lemma open_ereal_gt y : open [set u : R^o | y < u%:E]%E.
 Proof.
 case: y => [y||] /=; first exact: open_gt.
 rewrite [X in open X](_ : _ = set0); first exact: open0.
@@ -2481,27 +2475,25 @@ rewrite [X in open X](_ : _ = setT); first exact: openT.
 by rewrite funeqE => ?; rewrite trueE.
 Qed.
 
-Lemma open_ereal_lt' (x y : {ereal R}) : x < y ->
-  ereal_locally x (fun u : R => u%:E < y).
+Lemma open_ereal_lt' (x y : {ereal R}) : (x < y)%E ->
+  ereal_locally x (fun u : R => u%:E < y)%E.
 Proof.
 case: x => [x|//|] xy; first exact: open_ereal_lt.
 case: y => [y||//] /= in xy *.
 exists y; rewrite num_real; split => //= x ? //.
-by exists 0%R.
+by exists 0.
 case: y => [y||//] /= in xy *.
 exists y; rewrite num_real; split => //= x ? //.
-by exists 0%R; rewrite real0.
+by exists 0; rewrite real0.
 Qed.
 
-Lemma open_ereal_gt' (x y : {ereal R}) : y < x ->
-  ereal_locally x (fun u : R => y < u%:E).
+Lemma open_ereal_gt' (x y : {ereal R}) : (y < x)%E ->
+  ereal_locally x (fun u : R => y < u%:E)%E.
 Proof.
 case: x => [x||] //=; do ?[exact: open_ereal_gt];
-  case: y => [y||] //=; do ?by exists 0%R; rewrite real0.
+  case: y => [y||] //=; do ?by exists 0; rewrite real0.
 by exists y; rewrite num_real.
 Qed.
-
-Local Close Scope order_scope.
 
 End open_sets_in_Rbar.
 

--- a/theories/posnum.v
+++ b/theories/posnum.v
@@ -43,7 +43,6 @@ Import Order.TTheory Order.Syntax GRing.Theory Num.Theory.
 
 Delimit Scope R_scope with coqR.
 Delimit Scope real_scope with real.
-Close Scope R_scope.
 Local Open Scope ring_scope.
 Local Open Scope real_scope.
 Bind Scope ring_scope with R.
@@ -64,7 +63,7 @@ Record posnum_of (R : numDomainType) (phR : phant R) := PosNumDef {
   posnum_gt0 :> num_of_pos > 0
 }.
 Hint Resolve posnum_gt0 : core.
-Hint Extern 0 ((0%R < _)%O = true) => exact: posnum_gt0 : core.
+Hint Extern 0 ((0 < _)%R = true) => exact: posnum_gt0 : core.
 Notation "'{posnum' R }" := (posnum_of (@Phant R)).
 Definition PosNum (R : numDomainType) x x_gt0 : {posnum R} :=
   @PosNumDef _ (Phant R) x x_gt0.
@@ -144,8 +143,8 @@ by rewrite andb_idl // => /lt_le_trans; apply.
 Qed.
 
 End PosNum.
-Hint Extern 0 ((0%R <= _)%O = true) => exact: posnum_ge0 : core.
-Hint Extern 0 ((_ != 0%R)%O = true) => exact: posnum_neq0 : core.
+Hint Extern 0 ((0 <= _)%R = true) => exact: posnum_ge0 : core.
+Hint Extern 0 ((_ != 0)%R = true) => exact: posnum_neq0 : core.
 
 Section PosNumReal.
 Context {R : realDomainType}.

--- a/theories/prodnormedzmodule.v
+++ b/theories/prodnormedzmodule.v
@@ -6,7 +6,6 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Local Open Scope order_scope.
 Local Open Scope ring_scope.
 Import Order.TTheory GRing.Theory Num.Theory.
 
@@ -24,7 +23,7 @@ Record nngnum_of (R : numDomainType) (phR : phant R) := NngNumDef {
   nngnum_ge0 :> num_of_nng >= 0
 }.
 Hint Resolve nngnum_ge0 : core.
-Hint Extern 0 ((0%R <= _)%O = true) => exact: nngnum_ge0 : core.
+Hint Extern 0 ((0 <= _)%R = true) => exact: nngnum_ge0 : core.
 Local Notation "'{nonneg' R }" := (nngnum_of (@Phant R)).
 Definition NngNum (R : numDomainType) x x_ge0 : {nonneg R} :=
   @NngNumDef _ (Phant R) x x_ge0.
@@ -61,7 +60,7 @@ Module Exports.
 Arguments NngNum {R}.
 Notation "'{nonneg' R }" := (nngnum_of (@Phant R)) : type_scope.
 Notation "x %:nngnum" := (num_of_nng x) : ring_scope.
-Hint Extern 0 ((0%R <= _)%O = true) => exact: nngnum_ge0 : core.
+Hint Extern 0 ((0 <= _)%R = true) => exact: nngnum_ge0 : core.
 Notation "x %:nng" := (nng_of_num (Phantom _ x)) : ring_scope.
 Canonical nngnum_subType.
 Canonical nngnum_eqType.

--- a/theories/reals.v
+++ b/theories/reals.v
@@ -561,7 +561,7 @@ Lemma range1z_inj (x : R) (m1 m2 : int) :
   x \in range1 m1%:~R -> x \in range1 m2%:~R -> m1 = m2.
 Proof.
 move=> /andP[m1x x_m1] /andP[m2x x_m2].
-wlog suffices: m1 m2 m1x {x_m1 m2x} x_m2 / (m1 <= m2)%R.
+wlog suffices: m1 m2 m1x {x_m1 m2x} x_m2 / (m1 <= m2).
   by move=> ih; apply/eqP; rewrite eq_le !ih.
 rewrite -(ler_add2r 1) lez_addr1 -(@ltr_int R) intrD.
 by apply/(le_lt_trans m1x).
@@ -745,15 +745,10 @@ Qed.
 
 End Sup.
 
-Local Open Scope ereal_scope.
-
 (* -------------------------------------------------------------------- *)
 (* TODO: There are many duplications with `order.v`. Remove them.       *)
 Section ERealOrderTheory.
 Context {R : realDomainType}.
-
-Local Open Scope ring_scope.
-Local Open Scope ereal_scope.
 
 Implicit Types x y z : {ereal R}.
 
@@ -766,18 +761,19 @@ Local Tactic Notation "elift" constr(lm) ":" ident(x) ident(y) :=
 Local Tactic Notation "elift" constr(lm) ":" ident(x) ident(y) ident(z) :=
   by case: x y z => [?||] [?||] [?||]; first by rewrite ?eqe; apply: lm.
 
-Lemma le0R (l : {ereal R}) : 0%:E <= l -> (0%R <= real_of_er(*TODO: coercion broken*) l :> R).
+Lemma le0R (l : {ereal R}) : (0%:E <= l)%E -> (0 <= real_of_er(*TODO: coercion broken*) l).
 Proof. by case: l. Qed.
 
-Lemma lee_tofin (x y : R) : (x <= y)%R -> (x%:E <= y%:E).
+Lemma lee_tofin (x y : R) : x <= y -> (x%:E <= y%:E)%E.
 Proof. by []. Qed.
 
-Lemma lte_tofin (x y : R) : (x < y)%R -> (x%:E < y%:E).
+Lemma lte_tofin (x y : R) : x < y -> (x%:E < y%:E)%E.
 Proof. by []. Qed.
 
-Lemma lee_opp2 : {mono @eopp R : x y /~ (x <= y)}.
+Lemma lee_opp2 : {mono @eopp R : x y /~ (x <= y)%E}.
 Proof. by move=> x y; elift ler_opp2 : x y. Qed.
 
-Lemma lte_opp2 : {mono @eopp R : x y /~ (x < y)}.
+Lemma lte_opp2 : {mono @eopp R : x y /~ (x < y)%E}.
 Proof. by move=> x y; elift ltr_opp2 : x y. Qed.
+
 End ERealOrderTheory.

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -2471,14 +2471,14 @@ Hint Resolve ball_center : core.
 Section uniformType_numDomainType.
 Context {R : numDomainType} {M : uniformType R}.
 
-Lemma ballxx (x : M) (e : R) : (0 < e)%R -> ball x e x.
+Lemma ballxx (x : M) (e : R) : 0 < e -> ball x e x.
 Proof. by move=> e_gt0; apply: ball_center (PosNum e_gt0). Qed.
 
 Lemma ball_sym (x y : M) (e : R) : ball x e y -> ball y e x.
 Proof. exact: Uniform.ax2. Qed.
 
 Lemma ball_triangle (y x z : M) (e1 e2 : R) :
-  ball x e1 y -> ball y e2 z -> ball x (e1 + e2)%R z.
+  ball x e1 y -> ball y e2 z -> ball x (e1 + e2) z.
 Proof. exact: Uniform.ax3. Qed.
 
 Lemma locally_ball (x : M) (eps : {posnum R}) : locally x (ball x eps%:num).
@@ -2574,11 +2574,11 @@ Section uniformType_numFieldType.
 Context {R : numFieldType} {M : uniformType R}.
 
 Lemma ball_split (z x y : M) (e : R) :
-  ball x (e / 2)%R z -> ball z (e / 2)%R y -> ball x e y.
+  ball x (e / 2) z -> ball z (e / 2) y -> ball x e y.
 Proof. by move=> /ball_triangle h /h; rewrite -splitr. Qed.
 
 Lemma ball_splitr (z x y : M) (e : R) :
-  ball z (e / 2)%R x -> ball z (e / 2)%R y -> ball x e y.
+  ball z (e / 2) x -> ball z (e / 2) y -> ball x e y.
 Proof. by move=> /ball_sym /ball_split; apply. Qed.
 
 Lemma ball_splitl (z x y : M) (e : R) :


### PR DESCRIPTION
- As I suggested in https://github.com/math-comp/analysis/pull/163#issuecomment-561187282, it is better to do not use `order_scope`.
- Both `ring_scope` and `ereal_scope` have the ordering notations, thus they should not be opened simultaneously.

cc: @affeldt-aist 