### PR TITLE
Add setICl (intersection of set with its complement)

### DIFF
--- a/theories/classical_sets.v
+++ b/theories/classical_sets.v
@@ -323,6 +323,9 @@ Qed.
 Lemma setDE {A} (X Y : set A) : X `\` Y = X `&` ~` Y.
 Proof. by []. Qed.
 
+Lemma nonsubset {A} (X Y:set A): ~ (X `<=` Y) -> X `&` ~` Y !=set0.
+Proof. by rewrite -setD_eq0 setDE -set0P => /eqP. Qed.
+
 Lemma setIid {A} (X : set A) : X `&` X = X.
 Proof. by rewrite predeqE => ?; split=> [[]|]. Qed.
 
@@ -337,6 +340,9 @@ Proof. by rewrite predeqE => ?; split=> [[]|]. Qed.
 
 Lemma set0I A (Y : set A) : set0 `&` Y = set0.
 Proof. by rewrite setIC setI0. Qed.
+
+Lemma setICl {A} (X : set A) : ~` X `&` X = set0.
+Proof. by rewrite predeqE => ?; split => // -[]. Qed.
 
 Lemma setIA {A} (X Y Z : set A) : X `&` (Y `&` Z) = X `&` Y `&` Z.
 Proof. by rewrite predeqE => ?; split=> [[? []]|[[]]]. Qed.


### PR DESCRIPTION
Hi,

I'd like to add two lemma to topology, closureC (closure of complement is complement of interior) and interiorC (complement of interior is closure of complement). For this I need these two intermediate lemma which I think may more generally be useful for anyone.

I'm still learning the naming convention of mathcomp, but there is a clash between C for Complement and C for Commutativity. So while setCC may fits mathcomp convention, I didn't know how to name the third lemma since setIC was already taken.