### PR TITLE
Mathcomp master hausdorff close

### DIFF
--- a/theories/altreals/distr.v
+++ b/theories/altreals/distr.v
@@ -1220,7 +1220,7 @@ set c1 : R := _ / _; set c2 : R := _ / _; have eqc2: c2 = 1 - c1.
 set c := (li + l j); pose z := (c * c1 * f xi + c * c2 * f (x j)).
 apply/(@le_trans _ _ z); last by rewrite /z ![_*(_/_)]mulrC !mulfVK.
 rewrite {}/z -![c * _ * _]mulrA -mulrDr ler_wpmul2l ?addr_ge0 //.
-rewrite eqc2 cvx_f // divr_ge0 ?addr_ge0 //=.
+rewrite eqc2 cvx_f // ?lee_ninfty ?lee_pinfty // divr_ge0 ?addr_ge0 //=.
 by rewrite ler_pdivr_mulr ?mul1r ?ler_addl ?ltr_paddl.
 Qed.
 End Jensen.

--- a/theories/altreals/realseq.v
+++ b/theories/altreals/realseq.v
@@ -386,7 +386,8 @@ Lemma ncvg_gt (u : nat -> R) (l1 l2 : {ereal R}) :
     exists K, forall n, (K <= n)%N -> (l1 < (u n)%:E)%E.
 Proof.
 case: l1 l2 => [l1||] [l2||] //=; first last.
-+ by move=> _ _; exists 0%N. + by move=> _ _; exists 0%N.
++ by move=> _ _; exists 0%N => ? ?; exact: lte_ninfty.
++ by move=> _ _; exists 0%N => ? ?; exact: lte_ninfty.
 + by move=> _ /(_ (NPInf l1)) [K cv]; exists K => n /cv.
 move=> lt_12; pose e := l2 - l1 => /(_ (B l2 e)).
 case=> K cv; exists K => n /cv; rewrite !inE eclamp_id ?subr_gt0 //.

--- a/theories/altreals/realseq.v
+++ b/theories/altreals/realseq.v
@@ -75,14 +75,14 @@ Qed.
 Lemma nbh_pinfW (P : forall x, nbh x -> Prop) :
   (forall M, P _ (@NPInf R M)) -> forall (v : nbh +oo), P _ v.
 Proof.
-move=> ih ; move: {-2}+oo (erefl (@ERPInf R)).
+move=> ih; move: {-2}+oo%E (erefl (@ERPInf R)).
 by move=> e eE v; case: v eE => // c' e' h [->].
 Qed.
 
 Lemma nbh_ninfW (P : forall x, nbh x -> Prop) :
   (forall M, P _ (@NNInf R M)) -> forall (v : nbh -oo), P _ v.
 Proof.
-move=> ih ; move: {-2}-oo (erefl (@ERNInf R)).
+move=> ih ; move: {-2}-oo%E (erefl (@ERNInf R)).
 by move=> e eE v; case: v eE => // c' e' h [->].
 Qed.
 End NbhElim.
@@ -439,7 +439,7 @@ move=> p; rewrite -[xchooseb _](ncvg_uniq cv_u_l) //.
 by apply/asboolP/(xchoosebP p).
 Qed.
 
-Lemma nlim_out u : ~ (exists l, ncvg u l) -> nlim u = -oo.
+Lemma nlim_out u : ~ (exists l, ncvg u l) -> nlim u = -oo%E.
 Proof.
 move=> h; rewrite /nlim; case: {-}_ / idP => // p.
 by case: h; case/existsbP: p => l /asboolP; exists l.

--- a/theories/altreals/realsum.v
+++ b/theories/altreals/realsum.v
@@ -174,7 +174,7 @@ Proof.
 move=> mono_u; pose E := [pred x | `[exists n, x == u n]].
 have nzE: nonempty E by exists (u 0%N); apply/imsetbP; exists 0%N.
 case/boolP: `[< has_sup E >] => /asboolP; last first.
-  move/has_supPn=> -/(_ nzE) h; exists +oo => //; elim/nbh_pinfW => M /=.
+  move/has_supPn=> -/(_ nzE) h; exists +oo%E => //; elim/nbh_pinfW => M /=.
   case/(_ M): h=> x /imsetbP[K -> lt_MuK]; exists K=> n le_Kn; rewrite inE.
   by apply/(lt_le_trans lt_MuK)/mono_u.
 move=> supE; exists (sup E)%:E => //; elim/nbh_finW=>e /= gt0_e.

--- a/theories/altreals/realsum.v
+++ b/theories/altreals/realsum.v
@@ -177,7 +177,8 @@ case/boolP: `[< has_sup E >] => /asboolP; last first.
   move/has_supPn=> -/(_ nzE) h; exists +oo%E => //; elim/nbh_pinfW => M /=.
   case/(_ M): h=> x /imsetbP[K -> lt_MuK]; exists K=> n le_Kn; rewrite inE.
   by apply/(lt_le_trans lt_MuK)/mono_u.
-move=> supE; exists (sup E)%:E => //; elim/nbh_finW=>e /= gt0_e.
+move=> supE; exists (sup E)%:E => //; first exact: lte_ninfty.
+elim/nbh_finW=>e /= gt0_e.
 case: (sup_adherent supE gt0_e)=> x /imsetbP[K ->] lt_uK.
 exists K=> n le_Kn; rewrite inE distrC ger0_norm ?subr_ge0.
   by apply/sup_upper_bound/imsetbP=> //; exists n.

--- a/theories/classical_sets.v
+++ b/theories/classical_sets.v
@@ -349,6 +349,14 @@ Qed.
 Lemma subIset {A} (X Y Z : set A) : X `<=` Z \/ Y `<=` Z -> X `&` Y `<=` Z.
 Proof. case => H a; by [move=> [/H] | move=> [_ /H]]. Qed.
 
+Lemma subsetI_neq0 T (A B C D : set T) :
+  A `<=` B -> C `<=` D -> A `&` C !=set0 -> B `&` D !=set0.
+Proof. by move=> AB CD [x [/AB Bx /CD Dx]]; exists x. Qed.
+
+Lemma subsetI_eq0 T (A B C D : set T) :
+  A `<=` B -> C `<=` D -> B `&` D = set0 -> A `&` C = set0.
+Proof. by move=> AB /(subsetI_neq0 AB); rewrite -!set0P => /contra_eq. Qed.
+
 Lemma setD_eq0 A (X Y : set A) : (X `\` Y = set0) = (X `<=` Y).
 Proof.
 rewrite propeqE; split=> [XDY0 a|sXY].

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -108,10 +108,10 @@ Lemma diff_locallyxP (x : V) (f : V -> W) :
 Proof.
 split=> [dxf|[dfc dxf]].
   split => //; apply: eqaddoEx => h; have /diffE -> := dxf.
-  rewrite lim_id addrK; congr (_ + _); rewrite littleo_center0 /= addrK.
+  rewrite lim_id // addrK; congr (_ + _); rewrite littleo_center0 /= addrK.
   by congr ('o); rewrite funeqE => k /=; rewrite addrK.
 apply/diffP; split=> //; apply: eqaddoEx; move=> y.
-rewrite lim_id -[in LHS](subrK x y) dxf; congr (_ + _).
+rewrite lim_id // -[in LHS](subrK x y) dxf; congr (_ + _).
 rewrite -(comp_centerK x id) -[X in the_littleo _ _ _ X](comp_centerK x).
 by rewrite -[_ (y - x)]/((_ \o (center x)) y) -littleo_center0.
 Qed.
@@ -297,7 +297,7 @@ rewrite /derive => /diff_locally -> /=; set k := 'o _.
 evar (g : R -> W); rewrite [X in X @ _](_ : _ = g) /=; last first.
   rewrite funeqE=> h; rewrite !scalerDr scalerN /cst /=.
   by rewrite addrC !addrA addNr add0r linearZ /= scalerA /g.
-apply: cvg_map_lim.
+apply: cvg_map_lim => //.
 pose g1 : R -> W := fun h => (h^-1 * h) *: 'd f a v.
 pose g2 : R -> W := fun h : R => h^-1 *: k (h *: v ).
 rewrite (_ : g = g1 + g2) ?funeqE // -(addr0 (_ _ v)); apply: (@cvgD _ _ [topologicalType of R^o]).
@@ -525,7 +525,7 @@ suff /diff_locally /hdf -> : differentiable f x.
 apply/diffP; apply: (@getPex _ (fun (df : {linear V -> W}) => continuous df /\
   forall y, f y = f (lim x) + df (y - lim x) +o_(y \near x) (y - lim x))).
 exists df; split=> //; apply: eqaddoEx => z.
-rewrite (hdf _ dxf) !addrA lim_id /(_ \o _) /= subrK [f _ + _]addrC addrK.
+rewrite (hdf _ dxf) !addrA lim_id // /(_ \o _) /= subrK [f _ + _]addrC addrK.
 rewrite -addrA -[LHS]addr0; congr (_ + _).
 apply/eqP; rewrite eq_sym addrC addr_eq0 oppox; apply/eqP.
 by rewrite littleo_center0 (comp_centerK x id) -[- _ in RHS](comp_centerK x).
@@ -1376,7 +1376,7 @@ Proof.
 move=> cvfx; apply/Logic.eq_sym.
 (* should be inferred *)
 have atrF := at_right_proper_filter x.
-apply: (@cvg_map_lim _ _ _ (at_right _)) => A /cvfx /locallyP [_ /posnumP[e] xe_A].
+apply: (@cvg_map_lim _ _ _ (at_right _)) => // A /cvfx /locallyP [_ /posnumP[e] xe_A].
 by exists e%:num => // y xe_y; rewrite lt_def => /andP [xney _]; apply: xe_A.
 Qed.
 
@@ -1386,7 +1386,7 @@ Proof.
 move=> cvfx; apply/Logic.eq_sym.
 (* should be inferred *)
 have atrF := at_left_proper_filter x.
-apply: (@cvg_map_lim _ _ _ (at_left _)) => A /cvfx /locallyP [_ /posnumP[e] xe_A].
+apply: (@cvg_map_lim _ _ _ (at_left _)) => // A /cvfx /locallyP [_ /posnumP[e] xe_A].
 exists e%:num => // y xe_y; rewrite lt_def => /andP [xney _].
 by apply: xe_A => //; rewrite eq_sym.
 Qed.
@@ -1411,7 +1411,7 @@ Lemma ler0_cvg_map (R : realFieldType) (T : topologicalType) (F : set (set T))
 Proof.
 move=> fle0 fcv; rewrite -oppr_ge0.
 have limopp : - lim (f @ F) = lim (- f @ F).
-  by apply: Logic.eq_sym; apply: cvg_map_lim; apply: cvgN.
+  by apply: Logic.eq_sym; apply: cvg_map_lim => //; apply: cvgN.
 rewrite limopp; apply: le0r_cvg_map; last by rewrite -limopp; apply: cvgN.
 by move: fle0; apply: filterS => x; rewrite oppr_ge0.
 Qed.
@@ -1423,7 +1423,7 @@ Lemma ler_cvg_map (R : realFieldType) (T : topologicalType) (F : set (set T)) (F
 Proof.
 move=> lefg fcv gcv; rewrite -subr_ge0.
 have eqlim : lim (g @ F) - lim (f @ F) = lim ((g - f) @ F).
-  by apply: Logic.eq_sym; apply: cvg_map_lim; apply: cvgD => //; apply: cvgN.
+  by apply/esym; apply: cvg_map_lim => //; apply: cvgD => //; apply: cvgN.
 rewrite eqlim; apply: le0r_cvg_map; last first.
   by rewrite /(cvg _) -eqlim /=; apply: cvgD => //; apply: cvgN.
 by move: lefg; apply: filterS => x; rewrite subr_ge0.

--- a/theories/ereal.v
+++ b/theories/ereal.v
@@ -166,14 +166,14 @@ Proof. by []. Qed.
 Lemma lte_pinfty (R : realDomainType) (x : R) : (x%:E < +oo).
 Proof. exact: num_real. Qed.
 
-Lemma lee_pinfty (R : realDomainType) (x : R) : (x%:E <= +oo).
-Proof. by rewrite ltW // lte_pinfty. Qed.
+Lemma lee_pinfty (R : realDomainType) (x : {ereal R}) : (x <= +oo).
+Proof. case: x => //= r; exact: num_real. Qed.
 
 Lemma lte_ninfty (R : realDomainType) (x : R) : (-oo < x%:E).
 Proof. exact: num_real. Qed.
 
-Lemma lee_ninfty (R : realDomainType) (x : R) : (-oo <= x%:E).
-Proof. by rewrite ltW // lte_ninfty. Qed.
+Lemma lee_ninfty (R : realDomainType) (x : {ereal R}) : (-oo <= x).
+Proof. case: x => //= r; exact: num_real. Qed.
 
 Section ERealOrder_realDomainType.
 Context {R : realDomainType}.

--- a/theories/ereal.v
+++ b/theories/ereal.v
@@ -29,15 +29,17 @@ End ExtendedReals.
 (* TODO: the following notations should have scopes. *)
 
 (*Notation "\+inf" := (@ERPInf _).*)
-Notation "+oo" := (@ERPInf _).
+Notation "+oo" := (@ERPInf _) : ereal_scope.
 (*Notation "\-inf" := (@ERNInf _).*)
-Notation "-oo" := (@ERNInf _).
+Notation "-oo" := (@ERNInf _) : ereal_scope.
 Notation "x %:E" := (@ERFin _ x) (at level 2, format "x %:E").
 
 Notation "{ 'ereal' R }" := (er R) (format "{ 'ereal'  R }").
 
 Bind    Scope ereal_scope with er.
 Delimit Scope ereal_scope with E.
+
+Local Open Scope ereal_scope.
 
 Section EqEReal.
 Variable (R : eqType).
@@ -65,7 +67,7 @@ Variable (R : choiceType).
 
 Definition code (x : {ereal R}) :=
   match x with
-  | x%:E  => GenTree.Node 0 [:: GenTree.Leaf x]
+  | x%:E => GenTree.Node 0 [:: GenTree.Leaf x]
   | +oo => GenTree.Node 1 [::]
   | -oo => GenTree.Node 2 [::]
   end.
@@ -151,10 +153,10 @@ Notation "x < y <= z"  := ((lte x y) && (lee y z)) : ereal_scope.
 Notation "x <= y < z"  := ((lee x y) && (lte y z)) : ereal_scope.
 Notation "x < y < z"   := ((lte x y) && (lte y z)) : ereal_scope.
 
-Lemma lee_fin (R : numDomainType) (x y : R) : (x%:E <= y%:E)%E = (x <= y).
+Lemma lee_fin (R : numDomainType) (x y : R) : (x%:E <= y%:E)%E = (x <= y)%O.
 Proof. by []. Qed.
 
-Lemma lte_fin (R : numDomainType) (x y : R) : (x%:E < y%:E)%E = (x < y).
+Lemma lte_fin (R : numDomainType) (x y : R) : (x%:E < y%:E)%E = (x < y)%O.
 Proof. by []. Qed.
 
 Section ERealOrder_realDomainType.

--- a/theories/landau.v
+++ b/theories/landau.v
@@ -1139,7 +1139,7 @@ Hypothesis (normm_s : forall k x, `|s k x| = `|k| * `|x|).
 (* - locally lipschitz => continuous at a point *)
 (* - lipschitz => uniformly continous *)
 
-Local Notation "'+oo'" := (@ERPInf R).
+Local Notation "'+oo'" := (@pinfty_locally R).
 
 Lemma linear_for_continuous (f : {linear U -> V | GRing.Scale.op s_law}) :
   (f : _ -> _) =O_ (0 : U) (cst (1 : R^o)) -> continuous f.

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -958,28 +958,6 @@ by move: (ball_splitl av bv); rewrite -ball_normE /ball_ ltxx.
 Qed.
 Hint Extern 0 (separated _) => exact: normedModType_separated.*)
 
-(*Lemma cvg_unique {F} {FF : ProperFilter F} :
-  is_prop [set x : V | F --> x].
-Proof. by move=> Fx Fy; rewrite -closeE; apply: cvg_close. Qed.*)
-
-Lemma locally_cvg_unique (x y : V) : x --> y -> x = y.
-Proof. by rewrite -closeE //; apply: cvg_close. Qed.
-
-Lemma lim_id (x : V) : lim x = x.
-Proof. by symmetry; apply: locally_cvg_unique; apply/cvg_ex; exists x. Qed.
-
-(*Lemma cvg_lim {F} {FF : ProperFilter F} (l : V) :
-  F --> l -> lim F = l.
-Proof. by move=> Fl; have Fcv := cvgP Fl; apply: (@cvg_unique F). Qed.*)
-
-Lemma cvg_map_lim {T : Type} {F} {FF : ProperFilter F} (f : T -> V) (l : V) :
-  f @ F --> l -> lim (f @ F) = l.
-Proof. exact: cvg_lim. Qed.
-
-Lemma cvgi_unique {T : Type} {F} {FF : ProperFilter F} (f : T -> set V) :
-  {near F, is_fun f} -> is_prop [set x : V | f `@ F --> x].
-Proof. by move=> ffun fx fy; rewrite -closeE //; apply: cvgi_close. Qed.
-
 Lemma cvg_normW {F : set (set V)} {FF : Filter F} (y : V) :
   (forall eps, 0 < eps -> \forall y' \near F, `|y - y'| <= eps) ->
   F --> y.
@@ -987,14 +965,6 @@ Proof.
 move=> cv; apply/cvg_normP => _/posnumP[e]; near=> x.
 by apply: normm_leW => //; near: x; apply: cv.
 Grab Existential Variables. all: end_near. Qed.
-
-Lemma cvgi_map_lim {T} {F} {FF : ProperFilter F} (f : T -> V -> Prop) (l : V) :
-  F (fun x : T => is_prop (f x)) ->
-  f `@ F --> l -> lim (f `@ F) = l.
-Proof.
-move=> f_prop f_l; apply: get_unique => // l' f_l'.
-exact: cvgi_unique _ f_l' f_l.
-Qed.
 
 Lemma cvg_bounded_real {F : set (set V)} {FF : Filter F} (y : V) :
   F --> y ->

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -937,36 +937,19 @@ Proof. by move=> /cvg_normP. Qed.
 Lemma locally_norm_ball x (eps : {posnum R}) : locally_norm x (ball x eps%:num).
 Proof. rewrite locally_locally_norm; by apply: locally_ball. Qed.
 
-(* TODO: commented out on 2020-03-10, prove me *)
-(*
-Lemma closeE (x y : V) : close x y = (x = y).
-Proof.
-rewrite propeqE; split => [cl_xy|->//]; have [//|neq_xy] := eqVneq x y.
-have dxy_gt0 : `|x - y| > 0.
-  by rewrite normr_gt0 subr_eq0.
-have dxy_ge0 := ltW dxy_gt0.
-have := cl_xy (PosNum dxy_gt0).
-by rewrite -ball_normE /= ltxx.
-Qed.
-
-Lemma eq_close (x y : V) : close x y -> x = y. by rewrite closeE. Qed.
-
-Lemma norm_close x y : close x y = (forall eps : {posnum R}, ball_norm x eps%:num y).
-Proof. by rewrite propeqE ball_normE. Qed.
-*)
-
 End NormedModule_numDomainType.
 Hint Resolve normr_ge0 : core.
 Arguments cvg_norm {_ _ F FF}.
 
 Section NormedModule_numFieldType.
 Variables (R : numFieldType) (V : normedModType R).
+Implicit Types (x y z : V).
 
 Local Notation ball_norm := (ball_ (@normr R V)).
 
 Local Notation locally_norm := (locally_ ball_norm).
 
-Lemma normedModType_hausdorff : hausdorff V.
+Lemma norm_hausdorff : hausdorff V.
 Proof.
 rewrite ball_hausdorff => a b ab.
 have ab2 : 0 < `|a - b| / 2 by apply divr_gt0 => //; rewrite normr_gt0 subr_eq0.
@@ -977,7 +960,32 @@ move: (ltr_add acr bcr); rewrite -r22 (distrC b c).
 move/(le_lt_trans (ler_dist_add c a b)).
 by rewrite -mulrA mulVr ?mulr1 ?ltxx // unitfE.
 Qed.
-Hint Extern 0 (hausdorff _) => exact: normedModType_hausdorff.
+Hint Extern 0 (hausdorff _) => solve[apply: norm_hausdorff] : core.
+
+(* TODO: check if the following lemma are indeed useless *)
+(*       i.e. where the generic lemma is applied, *)
+(*            check that norm_hausdorff is not used in a hard way *)
+
+Lemma norm_closeE x y : close x y = (x = y). Proof. exact: closeE. Qed.
+Lemma norm_close_eq x y : close x y -> x = y. Proof. exact: close_eq. Qed.
+
+Lemma norm_cvg_unique {F} {FF : ProperFilter F} : is_subset1 [set x : V | F --> x].
+Proof. exact: cvg_unique. Qed.
+
+Lemma norm_cvg_eq x y : x --> y -> x = y. Proof. exact: cvg_eq. Qed.
+Lemma norm_lim_id x : lim x = x. Proof. exact: lim_id. Qed.
+
+Lemma norm_cvg_lim {F} {FF : ProperFilter F} (l : V) : F --> l -> lim F = l.
+Proof. exact: cvg_lim. Qed.
+
+Lemma norm_cvgi_unique {U : Type} {F} {FF : ProperFilter F} (f : U -> set V) :
+  {near F, is_fun f} -> is_subset1 [set x : V | f `@ F --> x].
+Proof. exact: cvgi_unique. Qed.
+
+Lemma norm_cvgi_map_lim {U} {F} {FF : ProperFilter F} (f : U -> V -> Prop) (l : V) :
+  F (fun x : U => is_subset1 (f x)) ->
+  f `@ F --> l -> lim (f `@ F) = l.
+Proof. exact: cvgi_map_lim. Qed.
 
 Lemma distm_lt_split (z x y : V) (e : R) :
   `|x - z| < e / 2 -> `|z - y| < e / 2 -> `|x - y| < e.
@@ -1033,7 +1041,7 @@ Proof. move/cvg_bounded_real; by apply: filterS => x []. Qed.
 
 End NormedModule_numFieldType.
 Arguments cvg_bounded {_ _ F FF}.
-Hint Extern 0 (hausdorff _) => exact: normedModType_hausdorff : core.
+Hint Extern 0 (hausdorff _) => solve[apply: norm_hausdorff] : core.
 
 Module Export LocallyNorm.
 Definition locally_simpl :=

--- a/theories/reals.v
+++ b/theories/reals.v
@@ -254,7 +254,7 @@ Proof. by case: R E => ? [? ? []]. Qed.
 
 (* -------------------------------------------------------------------- *)
 Section IsInt.
-Context {R : realType}.
+Context {R : realFieldType}.
 
 Definition Rint := [qualify a x : R | `[exists z, x == z%:~R]].
 Fact Rint_key : pred_key Rint. Proof. by []. Qed.
@@ -773,9 +773,17 @@ Lemma lte_tofin (x y : R) : x < y -> (x%:E < y%:E)%E.
 Proof. by []. Qed.
 
 Lemma lee_opp2 : {mono @eopp R : x y /~ (x <= y)%E}.
-Proof. by move=> x y; elift ler_opp2 : x y. Qed.
+Proof.
+move=> x y; case: x y => [?||] [?||] //; first by rewrite !lee_fin !ler_opp2.
+by rewrite lee_ninfty /Order.le /= realN num_real.
+by rewrite lee_pinfty /Order.le /= realN num_real.
+Qed.
 
 Lemma lte_opp2 : {mono @eopp R : x y /~ (x < y)%E}.
-Proof. by move=> x y; elift ltr_opp2 : x y. Qed.
+Proof.
+move=> x y; case: x y => [?||] [?||] //; first by rewrite !lte_fin !ltr_opp2.
+by rewrite lte_ninfty /Order.lt /= realN num_real.
+by rewrite lte_pinfty /Order.lt /= realN num_real.
+Qed.
 
 End ERealOrderTheory.

--- a/theories/summability.v
+++ b/theories/summability.v
@@ -44,7 +44,7 @@ Definition sum (I : choiceType) {K : numDomainType} {R : normedModType K}
 
 Definition summable (I : choiceType) {K : realType} {R : normedModType K}
    (x : I -> R) :=
-   \forall M \near +oo, \forall J \near totally,
+   \forall M \near +oo%R, \forall J \near totally,
    (partial_sum (fun i => `|x i|) J <= M)%R.
 
 End totally.

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -2458,14 +2458,17 @@ apply: sep => A B; rewrite !locallyE => - [oA [xoA oAA]] [oB [xoB oBB]].
 exact: subsetI_neq0 oAA oBB (cxy _ _ _ _).
 Qed.
 
+Lemma close_eq (y x : T) : close x y -> x = y.
+Proof. by rewrite closeE. Qed.
+
 Lemma cvg_unique {F} {FF : ProperFilter F} : is_subset1 [set x : T | F --> x].
 Proof. move=> Fx Fy; rewrite -closeE //; exact: (@cvg_close F). Qed.
 
-Lemma locally_cvg_unique (x y : T) : x --> y -> x = y.
+Lemma cvg_eq (x y : T) : x --> y -> x = y.
 Proof. by rewrite -closeE //; apply: cvg_close. Qed.
 
 Lemma lim_id (x : T) : lim x = x.
-Proof. by apply/esym/locally_cvg_unique/cvg_ex; exists x. Qed.
+Proof. by apply/esym/cvg_eq/cvg_ex; exists x. Qed.
 
 Lemma cvg_lim {F} {FF : ProperFilter F} (l : T) : F --> l -> lim F = l.
 Proof. by move=> Fl; have Fcv := cvgP Fl; apply: (@cvg_unique F). Qed.

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -338,6 +338,17 @@ Canonical linear_pointedType := PointedType {linear U -> V | GRing.Scale.op s_la
                                             (@GRing.null_fun_linear R U V s s_law).
 End Linear2.
 
+
+(* TODO: move to classical_sets *)
+Lemma subsetI_neq0 (T : Type) (A B C D : set T) :
+  A `<=` B -> C `<=` D -> A `&` C !=set0 -> B `&` D !=set0.
+Proof. by move=> AB CD [x [/AB Bx /CD Dx]]; exists x. Qed.
+
+Lemma subsetI_eq0 (T : Type) (A B C D : set T) :
+  A `<=` B -> C `<=` D -> B `&` D = set0 -> A `&` C = set0.
+Proof. by move=> AB /(subsetI_neq0 AB); rewrite -!set0P => /contra_eq. Qed.
+
+
 Module Filtered.
 
 (* Index a family of filters on a type, one for each element of the type *)
@@ -2348,50 +2359,95 @@ End Covers.
 
 Section separated_topologicalType.
 Variable (T : topologicalType).
-Local Open Scope classical_set_scope.
-Definition T2separated (O : set (set T)) := forall x y, x != y ->
-  exists2 AB, (x \in AB.1 /\ y \in AB.2) &
-              [/\ O AB.1, O AB.2 & AB.1 `&` AB.2 == set0].
-End separated_topologicalType.
 
-Definition closeness (T : topologicalType) (x : T) (A : set T) : Prop :=
+Local Open Scope classical_set_scope.
+
+Definition close_to (x : T) (A : set T) : Prop :=
   forall N, neigh x N -> N `&` A !=set0.
 
-Definition close_points (T : topologicalType) (x y : T) : Prop :=
-  forall M, neigh y M -> closeness x M.
+Definition close (x y : T) : Prop :=
+  forall M, neigh y M -> close_to x M.
 
-Lemma close_points_sym (T : topologicalType) (x y : T) :
-  close_points x y -> close_points y x.
+Lemma close_refl (t : T) : close t t.
+Proof. by move=> M [? ?] N [? ?]; exists t; split. Qed.
+Hint Resolve close_refl : core.
+
+Lemma close_sym (x y : T) : close x y -> close y x.
 Proof.
-rewrite /close_points /closeness => xy N xN M yM.
+rewrite /close /close_to => xy N xN M yM.
 rewrite setIC; apply xy => //; by case yM.
 Qed.
 
-Lemma close_points_refl (T : topologicalType) (t : T) : close_points t t.
-Proof. by move=> M [? ?] N [? ?]; exists t; split. Qed.
-Hint Resolve close_points_refl : core.
-
-Lemma cvg_close (T : topologicalType) {F} {FF : ProperFilter F} (x y : T) :
-  F --> x -> F --> y -> close_points x y.
+Lemma cvg_close {F} {FF : ProperFilter F} (x y : T) :
+  F --> x -> F --> y -> close x y.
 Proof.
 move=> Fx Fy N yN M xM; near F => z; exists z; split.
 - near: z; by apply/Fx; rewrite /filter_of locallyE; exists M; split.
 - near: z; by apply/Fy; rewrite /filter_of locallyE; exists N; split.
 Grab Existential Variables. all: end_near. Qed.
 
-Section separated_numDomainType.
-Variables (T : topologicalType).
-Hypothesis sep : T2separated (@open T).
-Lemma closeE (x y : T) : close_points x y = (x = y).
+
+Lemma close_cvg (F1 F2 : set (set T)) {FF2 : ProperFilter F2} :
+  F1 --> F2 -> F2 --> F1 -> close (lim F1) (lim F2).
+Proof.
+move=> F12 F21.
+have [/(cvg_trans F21) F2l|dvgF1] := pselect (cvg F1).
+  by apply: (@cvg_close F2) => //; apply: cvgP F2l.
+have [/(cvg_trans F12)/cvgP//|dvgF2] := pselect (cvg F2).
+rewrite dvgP // dvgP //; exact/close_refl.
+Qed.
+
+Lemma cvgx_close (x y : T) : x --> y -> close x y.
+Proof. exact: cvg_close. Qed.
+
+Lemma cvgi_close T' {F} {FF: ProperFilter F} (f : T' -> set T) (l l' : T) :
+  {near F, is_fun f} -> f `@ F --> l -> f `@ F --> l' -> close l l'.
+Proof.
+move=> f_prop fFl fFl'.
+suff f_totalfun: infer {near F, is_totalfun f} by exact: cvg_close fFl fFl'.
+apply: filter_app f_prop; near=> x; split=> //=; near: x.
+have: (f `@ F) setT by apply: fFl; apply: filterT.
+by rewrite fmapiE; apply: filterS => x [y []]; exists y.
+Grab Existential Variables. all: end_near. Qed.
+Definition cvg_toi_locally_close := @cvgi_close.
+
+Lemma open_hausdorff : hausdorff T =
+  (forall x y : T, x != y ->
+    exists2 AB, (x \in AB.1 /\ y \in AB.2) &
+                [/\ open AB.1, open AB.2 & AB.1 `&` AB.2 == set0]).
+Proof.
+rewrite propeqE; split => [T_filterT2|T_openT2] x y.
+  have := contrap (T_filterT2 x y); rewrite (rwP eqP) (rwP negP) => cl /cl.
+  rewrite [cluster _ _](rwP forallp_asboolP) => /negP.
+  rewrite forallbE => /existsp_asboolPn/=[A]/negP/existsp_asboolPn/=[B].
+  rewrite [locally _ _ -> _](rwP imply_asboolP) => /negP.
+  rewrite asbool_imply !negb_imply => /andP[/asboolP xA] /andP[/asboolP yB].
+  move=> /asboolPn; rewrite -set0P => /negP; rewrite negbK => /eqP AIB_eq0.
+  move: xA yB; rewrite !locallyE.
+  move=> - [oA [[oA_open oAx] oAA]] [oB [[oB_open oBx] oBB]].
+  by exists (oA, oB); rewrite ?in_setE; split => //; apply: subsetI_eq0 AIB_eq0.
+apply: contrapTT => /eqP /T_openT2[[/=A B]].
+rewrite !in_setE => - [xA yB] [Aopen Bopen /eqP AIB_eq0].
+move=> /(_ A B (neigh_locally _) (neigh_locally _)).
+by rewrite -set0P => /(_ _ _)/negP; apply.
+Qed.
+
+Hypothesis sep : hausdorff T.
+
+Lemma closeE (x y : T) : close x y = (x = y).
 Proof.
 rewrite propeqE; split => [cxy|->//]; have [//|xdy] := eqVneq x y.
-case: (sep xdy) => -[/= r1 r2] [xr1 yr2] [or1 or2].
-move/eqP; rewrite funeqE => /(_ x)/notT/Classical_Prop.not_and_or => -[].
-by rewrite in_setE in xr1.
-rewrite in_setE in yr2.
-move: (cxy r2 (conj or2 yr2)); rewrite /closeness.
-Abort.
-End separated_numDomainType.
+apply: sep => A B; rewrite !locallyE => - [oA [xoA oAA]] [oB [xoB oBB]].
+exact: subsetI_neq0 oAA oBB (cxy _ _ _ _).
+Qed.
+
+Lemma cvg_unique {F} {FF : ProperFilter F} : is_subset1 [set x : T | F --> x].
+Proof. move=> Fx Fy; rewrite -closeE //; exact: (@cvg_close F). Qed.
+
+Lemma cvg_lim {F} {FF : ProperFilter F} (l : T) : F --> l -> lim F = l.
+Proof. by move=> Fl; have Fcv := cvgP Fl; apply: (@cvg_unique F). Qed.
+
+End separated_topologicalType.
 
 (* connected sets *)
 
@@ -2555,7 +2611,13 @@ Proof. exact: PseudoMetric.ax3. Qed.
 Lemma locally_ball (x : M) (eps : {posnum R}) : locally x (ball x eps%:num).
 Proof. by apply/locallyP; exists eps%:num. Qed.
 
-Definition close (x y : M) : Prop := forall eps : {posnum R}, ball x eps%:num y.
+Lemma neigh_ball (x : M) (eps : {posnum R}) : neigh x ((ball x eps%:num)^°).
+Proof.
+split; first exact: open_interior.
+apply: locally_singleton; apply: locally_interior.
+by apply/locallyP; exists eps%:num.
+Qed.
+
 
 Lemma ball_ler (x : M) (e1 e2 : R) : e1 <= e2 -> ball x e1 `<=` ball x e2.
 Proof.
@@ -2565,11 +2627,6 @@ Qed.
 
 Lemma ball_le (x : M) (e1 e2 : R) : (e1 <= e2) -> ball x e1 `<=` ball x e2.
 Proof. by move=> /ball_ler. Qed.
-
-Lemma close_refl (x : M) : close x x. Proof. by []. Qed.
-
-Lemma close_sym (x y : M) : close x y -> close y x.
-Proof. by move=> ??; apply: ball_sym. Qed.
 
 Definition entourages : set (set (M * M)):=
   filter_from [set eps : R | eps > 0]
@@ -2629,7 +2686,7 @@ Lemma cvg_const {T} {F : set (set T)}
    {FF : Filter F} (a : M) : a @[_ --> F] --> a.
 Proof.
 move=> P /locallyP[_ /posnumP[eps] subP]; rewrite !near_simpl /=.
-by apply: filterE=> ?; apply/subP/close_refl.
+by apply: filterE=> ?; apply/subP/ballxx.
 Qed.
 
 Definition ball_set (A : set M) e := \bigcup_(p in A) ball p e.
@@ -2640,6 +2697,7 @@ End pseudoMetricType_numDomainType.
 Hint Resolve locally_ball : core.
 Hint Resolve close_refl : core.
 Arguments cvg_const {R M T F FF} a.
+Arguments close_cvg {T} F1 F2 {FF2} _.
 
 Section pseudoMetricType_numFieldType.
 Context {R : numFieldType} {M : pseudoMetricType R}.
@@ -2656,97 +2714,59 @@ Lemma ball_splitl (z x y : M) (e : R) :
   ball x (e / 2) z -> ball y (e / 2) z -> ball x e y.
 Proof. by move=> bxz /ball_sym /(ball_split bxz). Qed.
 
-Lemma cvg_close {F} {FF : ProperFilter F} (x y : M) :
-  F --> x -> F --> y -> close x y.
+Lemma ball_close (x y : M) :
+  close x y = forall eps : {posnum R}, ball x eps%:num y.
 Proof.
-move=> Fx Fy e; near F => z; apply: (@ball_splitl z); near: z;
-by [apply/Fx/locally_ball|apply/Fy/locally_ball].
-Grab Existential Variables. all: end_near. Qed.
+rewrite propeqE; split => [cxy eps|cxy].
+  have [z [zx zy]] := cxy _ (neigh_ball _ (eps%:num/2)%:pos)
+                          _ (neigh_ball _ (eps%:num/2)%:pos).
+  by apply: (@ball_splitl z); apply: interior_subset.
+move=> B /neigh_locally/locallyP[_/posnumP[e2 e2B]].
+move=> A /neigh_locally/locallyP[_/posnumP[e1 e1A]].
+by exists y; split; [apply/e1A|apply/e2B/ballxx].
+Qed.
 
-Lemma close_trans (x y z : M) : close x y -> close y z -> close x z.
-Proof. by move=> cxy cyz eps; apply: ball_split (cxy _) (cyz _). Qed.
+Lemma close_trans (y x z : M) : close x y -> close y z -> close x z.
+Proof.
+by rewrite !ball_close  => cxy cyz eps; apply: ball_split (cxy _) (cyz _).
+Qed.
 
 Lemma close_cvgxx (x y : M) : close x y -> x --> y.
 Proof.
-move=> cxy P /= /locallyP /= [_/posnumP [eps] epsP].
+rewrite ball_close => cxy P /= /locallyP /= [_/posnumP [eps] epsP].
 apply/locallyP; exists (eps%:num / 2) => // z bxz.
 by apply: epsP; apply: ball_splitr (cxy _) bxz.
-Qed.
-
-Lemma cvgx_close (x y : M) : x --> y -> close x y.
-Proof. exact: cvg_close. Qed.
-
-Lemma cvgi_close T {F} {FF: ProperFilter F} (f : T -> set M) (l l' : M) :
-  {near F, is_fun f} -> f `@ F --> l -> f `@ F --> l' -> close l l'.
-Proof.
-move=> f_prop fFl fFl'.
-suff f_totalfun: infer {near F, is_totalfun f} by exact: cvg_close fFl fFl'.
-apply: filter_app f_prop; near=> x; split=> //=.
-by have [//|y [fxy _]] := near (cvgi_ball fFl [gt0 of 1]) x; exists y.
-Grab Existential Variables. all: end_near. Qed.
-Definition cvg_toi_locally_close := @cvgi_close.
-
-Lemma close_cvg (F1 F2 : set (set M)) {FF2 : ProperFilter F2} :
-  F1 --> F2 -> F2 --> F1 -> close (lim F1) (lim F2).
-Proof.
-move=> F12 F21; have [/(cvg_trans F21) F2l|dvgF1] := pselect (cvg F1).
-  by apply: (@cvg_close F2) => //; apply: cvgP F2l.
-have [/(cvg_trans F12)/cvgP//|dvgF2] := pselect (cvg F2).
-rewrite dvgP // dvgP //; exact/close_refl.
 Qed.
 
 Lemma cvg_closeP (F : set (set M)) (l : M) : ProperFilter F ->
   F --> l <-> ([cvg F in M] /\ close (lim F) l).
 Proof.
 move=> FF; split=> [Fl|[cvF]Cl].
-  by have /cvgP := Fl; split=> //; apply: (@cvg_close F).
+  by have /cvgP := Fl; split=> //; apply: (@cvg_close _ F).
 by apply: cvg_trans (close_cvgxx Cl).
 Qed.
 
 End pseudoMetricType_numFieldType.
-Arguments close_cvg {R M} F1 F2 {FF2} _.
 
-Section separated.
+Section ball_hausdorff.
 Variables (R : numDomainType) (T : pseudoMetricType R).
-Definition separated := forall (a b : T), a != b ->
+
+Lemma ball_hausdorff : hausdorff T =
+  forall (a b : T), a != b ->
   exists r : {posnum R} * {posnum R}, ball a r.1%:num `&` ball b r.2%:num == set0.
-Lemma T2separated_separated : T2separated (@open T) -> separated.
 Proof.
-move=> T2T a b ab; have [[A B] /=] := (@T2T a b ab).
-rewrite 2!in_setE => -[aA bB]; rewrite !openE /interior => -[].
-move/(_ _ aA); rewrite locallyE => -[A0 [[oA0 aA0] A0A]] => -[].
-move/(_ _ bB); rewrite locallyE => -[B0 [[oB0 bB0] B0B]] => AB0.
-move: oA0; rewrite openE => /(_ _ aA0).
-rewrite /interior => /locallyP; rewrite /locally_ => -[ra ra0 rA0].
-move: oB0; rewrite openE => /(_ _ bB0).
-rewrite /interior => /locallyP; rewrite /locally_ => -[rb rb0 rB0].
-exists (PosNum ra0, PosNum rb0) => /=; apply/negPn/negP => /set0P[t [ta tb]].
-by move: AB0; apply/negP/set0P; exists t; split; [apply/A0A/rA0 | apply/B0B/rB0].
+rewrite propeqE open_hausdorff; split => T2T a b /T2T[[/=]].
+  move=> A B; rewrite 2!in_setE => [[aA bB] [oA oB /eqP ABeq0]].
+  have /locallyP[_/posnumP[r] rA]: locally a A by apply: neigh_locally.
+  have /locallyP[_/posnumP[s] rB]: locally b B by apply: neigh_locally.
+  by exists (r, s) => /=; rewrite (subsetI_eq0 _ _ ABeq0).
+move=> r s /eqP brs_eq0; exists ((ball a r%:num)^°, (ball b s%:num)^°) => /=.
+  split; by rewrite in_setE; apply: locally_singleton; apply: locally_interior;
+            apply/locallyP; apply: in_filter_from.
+split; do ?by apply: open_interior.
+by rewrite (subsetI_eq0 _ _ brs_eq0)//; apply: interior_subset.
 Qed.
-End separated.
-
-Section separated_numDomainType.
-Variables (R : numDomainType) (T : pseudoMetricType R).
-Hypothesis sep : separated T.
-Lemma closeE (x y : T) : close x y = (x = y).
-Proof.
-rewrite propeqE; split => [cxy|->//]; have [//|xdy] := eqVneq x y.
-case: (sep xdy) => -[r1 r2] /=.
-move/eqP; rewrite funeqE => /(_ x)/notT/Classical_Prop.not_and_or => -[].
-by move/(_ (@ballxx _ _ _ _ (posnum_gt0 r1))).
-by move/ball_sym : (cxy r2).
-Qed.
-End separated_numDomainType.
-
-Section separated_numFieldType.
-Variables (R : numFieldType) (T : pseudoMetricType R).
-Hypothesis sep : separated T.
-Lemma cvg_unique {F} {FF : ProperFilter F} : is_subset1 [set x : T | F --> x].
-Proof. move=> Fx Fy; rewrite -closeE //; exact: (@cvg_close _ T F). Qed.
-
-Lemma cvg_lim {F} {FF : ProperFilter F} (l : T) : F --> l -> lim F = l.
-Proof. by move=> Fl; have Fcv := cvgP Fl; apply: (@cvg_unique F). Qed.
-End separated_numFieldType.
+End ball_hausdorff.
 
 Section entourages.
 Variable R : numDomainType.

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -2386,7 +2386,6 @@ move=> Fx Fy N yN M xM; near F => z; exists z; split.
 - near: z; by apply/Fy; rewrite /filter_of locallyE; exists N; split.
 Grab Existential Variables. all: end_near. Qed.
 
-
 Lemma close_cvg (F1 F2 : set (set T)) {FF2 : ProperFilter F2} :
   F1 --> F2 -> F2 --> F1 -> close (lim F1) (lim F2).
 Proof.
@@ -2400,7 +2399,7 @@ Qed.
 Lemma cvgx_close (x y : T) : x --> y -> close x y.
 Proof. exact: cvg_close. Qed.
 
-Lemma cvgi_close T' {F} {FF: ProperFilter F} (f : T' -> set T) (l l' : T) :
+Lemma cvgi_close T' {F} {FF : ProperFilter F} (f : T' -> set T) (l l' : T) :
   {near F, is_fun f} -> f `@ F --> l -> f `@ F --> l' -> close l l'.
 Proof.
 move=> f_prop fFl fFl'.
@@ -2444,8 +2443,29 @@ Qed.
 Lemma cvg_unique {F} {FF : ProperFilter F} : is_subset1 [set x : T | F --> x].
 Proof. move=> Fx Fy; rewrite -closeE //; exact: (@cvg_close F). Qed.
 
+Lemma locally_cvg_unique (x y : T) : x --> y -> x = y.
+Proof. by rewrite -closeE //; apply: cvg_close. Qed.
+
+Lemma lim_id (x : T) : lim x = x.
+Proof. by apply/esym/locally_cvg_unique/cvg_ex; exists x. Qed.
+
 Lemma cvg_lim {F} {FF : ProperFilter F} (l : T) : F --> l -> lim F = l.
 Proof. by move=> Fl; have Fcv := cvgP Fl; apply: (@cvg_unique F). Qed.
+
+Lemma cvg_map_lim {U : Type} {F} {FF : ProperFilter F} (f : U -> T) (l : T) :
+  f @ F --> l -> lim (f @ F) = l.
+Proof. exact: cvg_lim. Qed.
+
+Lemma cvgi_unique {U : Type} {F} {FF : ProperFilter F} (f : U -> set T) :
+  {near F, is_fun f} -> is_prop [set x : T | f `@ F --> x].
+Proof. by move=> ffun fx fy; rewrite -closeE //; exact: cvgi_close. Qed.
+
+Lemma cvgi_map_lim {U} {F} {FF : ProperFilter F} (f : U -> T -> Prop) (l : T) :
+  F (fun x : U => is_prop (f x)) ->
+  f `@ F --> l -> lim (f `@ F) = l.
+Proof.
+move=> f_prop fl; apply: get_unique => // l' fl'; exact: cvgi_unique _ fl' fl.
+Qed.
 
 End separated_topologicalType.
 
@@ -2767,6 +2787,20 @@ split; do ?by apply: open_interior.
 by rewrite (subsetI_eq0 _ _ brs_eq0)//; apply: interior_subset.
 Qed.
 End ball_hausdorff.
+
+Lemma close_cluster (R : numFieldType) (T : pseudoMetricType R) (x y : T) :
+  close x y = cluster (locally x) y.
+Proof.
+rewrite propeqE; split => xy.
+- move=> A B xA; rewrite -locally_ballE locally_E => -[_/posnumP[e] yeB].
+  exists x; split; first exact: locally_singleton.
+  by apply/yeB/ball_sym; move: e {yeB}; rewrite -ball_close.
+- rewrite ball_close => e.
+  have e20 : 0 < e%:num / 2 by apply: divr_gt0.
+  set e2  := PosNum e20.
+  case: (xy _ _ (locally_ball x e2) (locally_ball y e2)) => z [xz /ball_sym zy].
+  by rewrite (splitr e%:num); exact: (ball_triangle xz).
+Qed.
 
 Section entourages.
 Variable R : numDomainType.

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -344,17 +344,6 @@ Canonical linear_pointedType := PointedType {linear U -> V | GRing.Scale.op s_la
                                             (@GRing.null_fun_linear R U V s s_law).
 End Linear2.
 
-
-(* TODO: move to classical_sets *)
-Lemma subsetI_neq0 (T : Type) (A B C D : set T) :
-  A `<=` B -> C `<=` D -> A `&` C !=set0 -> B `&` D !=set0.
-Proof. by move=> AB CD [x [/AB Bx /CD Dx]]; exists x. Qed.
-
-Lemma subsetI_eq0 (T : Type) (A B C D : set T) :
-  A `<=` B -> C `<=` D -> B `&` D = set0 -> A `&` C = set0.
-Proof. by move=> AB /(subsetI_neq0 AB); rewrite -!set0P => /contra_eq. Qed.
-
-
 Module Filtered.
 
 (* Index a family of filters on a type, one for each element of the type *)


### PR DESCRIPTION
This PR:
- generalizes lemmas from `topology.v` and `normedtype.v` using the `hausdorff` predicate:
  + generalize the predicate `close x y` for two points of a topological space (was previously defined at the level of pseudometric spaces)
  + lemmas `flim_unique`, `locally_flim_unique`, `lim_id`, `flim_lim`, `flim_map_lim`, etc. are now defined at the level of topogical spaces
  + alternative definition of `hausdorff` for topological spaces (lemma `open_hausdorff`)
  + alternative definition of `hausdorff` for pseudometric spaces (lemma `ball_hausdorff`)
  + proof that normed modules are Hausdorff (lemma `normedModType_hausdorff`)
- fixes extended reals 
  + fix the definition of filters for extended reals (`ereal_locally`, `ereal_locally'`)
  + fix the definitions of inequalities
  + equip extended reals with a structure of topological space
  + proof that extended reals are Hausdorff

Start of this PR: 4 cherry-picked commits from the branch `mathcomp_master_integral_ereal`
ca4995dcdd835507bc37e58ef22da9b9ffd67d5c
87788a5670d3d13e96a3f04d90daff4b5806d148
42f184e428a1f4f1384c95de0ac1cb3cba153188
8dcc72a2ecf50ded58f8337137ee721a7e8f32d3
Add modifications introduced by commits
5e75df19fe7cacd6f19ac15aaaede249c3d620e1
d64953e35400f52eb86141be2f2732f31853067a
0d11d38d9cc6a3934abdf469b2f2429eadb5cfa3
29d807d7fc3fbcff1797da88670ab7edecb5e2f0
8f4c265681e03f8e014640ce13d604f3c97ab5f3
80f11f66164b519035b089611e61399d179de268
(Yet, the changes made to files specific to `mathcomp_master_integral_ereal` such as `integral.v` have not been reported here.)

Relation with PR #174: The contents of these 4 commits have been modified to be a superset of PR #174 (checked with @mkerjean):
- This PR provides proofs for `flimi_cluster` (now `flimi_close`) and `flim_clusterP` (now `flim_closeP`).
- `locally_flim_unique`, `lim_id`, `flim_map_lim`, `flimi_unique`, and `flimi_map_lim` have been generalized like they were in PR #174.