### PR TITLE
Mathcomp master PseudoMetricNormedZmod

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -91,6 +91,10 @@
     * `cvg_distW`
     * `continuous_cvg_dist`
     * `add_continuous`
+- moved from `normedtype.v` to `reals.v`:
+  + lemmas `inf_lb_strict`, `sup_ub_strict`
+- moved from `sequences.v` to `reals.v`:
+  + lemma `has_ub_image_norm`
 
 ### Renamed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -41,6 +41,17 @@
 
 ### Removed
 
+- in `classical_sets.v`
+  + lemmas `eq_set_inl`, `set_in_in`
+- from `topology.v`:
+  + lemmas `homoRL_in`, `homoLR_in`, `homo_mono_in`, `monoLR_in`,
+    `monoRL_in`, `can_mono_in`, `onW_can`, `onW_can_in`, `in_onW_can`,
+    `onT_can`, `onT_can_in`, `in_onT_can` (now in MathComp)
+- in `forms.v`:
+  + lemma `mxdirect_delta`, `row_mx_eq0`, `col_mx_eq0`, `map_mx_comp`
+- in `nngnum.v`:
+  + lemma `filter_andb`
+
 ### Infrastructure
 
 ### Misc

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -33,6 +33,64 @@
   + HB.mixin `Measurable_from_ringOfSets` changed to `Measurable_from_algebraOfSets`
   + HB.instance `T_isRingOfSets` becomes `T_isAlgebraOfSets` in HB.builders `isMeasurable`
   + lemma `measurableC` now applies to `algebraOfSetsType` instead of `measureableType`
+- in `normedtype.v`:
+  + lemma `cvg_bounded_real`
+  + lemma `pseudoMetricNormedZModType_hausdorff`
+
+### Changed
+
+- in `normedtype.v`:
+  + generalized from `normedModType` to `pseudoMetricNormedZmodType`:
+    * `nbhs_le_nbhs_norm`
+    * `nbhs_norm_le_nbhs`
+    * `nbhs_nbhs_norm`
+    * `nbhs_normP`
+    * `filter_from_norm_nbhs`
+    * `nbhs_normE`
+    * `filter_from_normE`
+    * `near_nbhs_norm`
+    * `nbhs_norm_ball_norm`
+    * `nbhs_ball_norm`
+    * `ball_norm_dec`
+    * `ball_norm_sym`
+    * `ball_norm_le`
+    * `cvg_distP`
+    * `cvg_dist`
+    * `nbhs_norm_ball`
+    * `dominated_by`
+    * `strictly_dominated_by`
+    * `sub_dominatedl`
+    * `sub_dominatedr`
+    * `dominated_by1`
+    * `strictly_dominated_by1`
+    * `ex_dom_bound`
+    * `ex_strict_dom_bound`
+    * `bounded_near`
+    * `boundedE`
+    * `sub_boundedr`
+    * `sub_boundedl`
+    * `ex_bound`
+    * `ex_strict_bound`
+    * `ex_strict_bound_gt0`
+    * `norm_hausdorff`
+    * `norm_closeE`
+    * `norm_close_eq`
+    * `norm_cvg_unique`
+    * `norm_cvg_eq`
+    * `norm_lim_id`
+    * `norm_cvg_lim`
+    * `norm_lim_near_cst`
+    * `norm_lim_cst`
+    * `norm_cvgi_unique`
+    * `norm_cvgi_map_lim`
+    * `distm_lt_split`
+    * `distm_lt_splitr`
+    * `distm_lt_splitl`
+    * `normm_leW`
+    * `normm_lt_split`
+    * `cvg_distW`
+    * `continuous_cvg_dist`
+    * `add_continuous`
 
 ### Renamed
 
@@ -41,14 +99,6 @@
 
 ### Removed
 
-- in `classical_sets.v`
-  + lemmas `eq_set_inl`, `set_in_in`
-- from `topology.v`:
-  + lemmas `homoRL_in`, `homoLR_in`, `homo_mono_in`, `monoLR_in`,
-    `monoRL_in`, `can_mono_in`, `onW_can`, `onW_can_in`, `in_onW_can`,
-    `onT_can`, `onT_can_in`, `in_onT_can` (now in MathComp)
-- in `forms.v`:
-  + lemma `mxdirect_delta`, `row_mx_eq0`, `col_mx_eq0`, `map_mx_comp`
 - in `nngnum.v`:
   + lemma `filter_andb`
 

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -1,4 +1,3 @@
-
 (* mathcomp analysis (c) 2017 Inria and AIST. License: CeCILL-C.              *)
 From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype choice.
 From mathcomp Require Import ssralg ssrnum fintype bigop order matrix interval.
@@ -625,7 +624,7 @@ move=> dfx; apply: DiffDef; first exact: differentiableZ.
 by rewrite diffZ // diff_val.
 Qed.
 
-Lemma diffZl (k : V -> R) (f : W) x : differentiable k x -> 
+Lemma diffZl (k : V -> R) (f : W) x : differentiable k x ->
   'd (fun z => k z *: f) x = (fun z => 'd k x z *: f) :> (_ -> _).
 Proof.
 move=> df; set g := RHS; have glin : linear g.
@@ -786,10 +785,9 @@ apply/eqoP=> _ /posnumP[e]; near=> x; rewrite (le_trans (fschwarz _ _))//.
 rewrite ler_pmul ?pmulr_rge0 //; last by rewrite nng_le_maxr /= lexx orbT.
 rewrite -ler_pdivl_mull //.
 suff : `|x| <= k%:num ^-1 * e%:num by apply: le_trans; rewrite nng_le_maxr /= lexx.
-near: x; rewrite !near_simpl; apply/(@nbhs_le_nbhs_norm R (@prod_normedModType R U V')).
-+(*tentative fix*)
-+by exists (k%:num ^-1 * e%:num) => // ? /=; rewrite -ball_normE /= distrC subr0 => /ltW.
-+Grab Existential Variables. all: end_near. Qed.
+near: x; rewrite !near_simpl; apply/nbhs_le_nbhs_norm.
+by exists (k%:num ^-1 * e%:num) => // ? /=; rewrite -ball_normE /= distrC subr0 => /ltW.
+Grab Existential Variables. all: end_near. Qed.
 
 Fact dbilin (U V' W' : normedModType R) (f : {bilinear U -> V' -> W'}) p :
   continuous (fun p => f p.1 p.2) ->

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -786,10 +786,10 @@ apply/eqoP=> _ /posnumP[e]; near=> x; rewrite (le_trans (fschwarz _ _))//.
 rewrite ler_pmul ?pmulr_rge0 //; last by rewrite nng_le_maxr /= lexx orbT.
 rewrite -ler_pdivl_mull //.
 suff : `|x| <= k%:num ^-1 * e%:num by apply: le_trans; rewrite nng_le_maxr /= lexx.
-near: x; rewrite !near_simpl. Fail apply/nbhs_le_nbhs_norm.
-(*by exists (k%:num ^-1 * e%:num) => // ? /=; rewrite -ball_normE /= distrC subr0 => /ltW.
-Grab Existential Variables. all: end_near. Qed.*)
-Admitted. 
+near: x; rewrite !near_simpl; apply/(@nbhs_le_nbhs_norm R (@prod_normedModType R U V')).
++(*tentative fix*)
++by exists (k%:num ^-1 * e%:num) => // ? /=; rewrite -ball_normE /= distrC subr0 => /ltW.
++Grab Existential Variables. all: end_near. Qed.
 
 Fact dbilin (U V' W' : normedModType R) (f : {bilinear U -> V' -> W'}) p :
   continuous (fun p => f p.1 p.2) ->

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -1,3 +1,4 @@
+
 (* mathcomp analysis (c) 2017 Inria and AIST. License: CeCILL-C.              *)
 From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype choice.
 From mathcomp Require Import ssralg ssrnum fintype bigop order matrix interval.
@@ -785,9 +786,10 @@ apply/eqoP=> _ /posnumP[e]; near=> x; rewrite (le_trans (fschwarz _ _))//.
 rewrite ler_pmul ?pmulr_rge0 //; last by rewrite nng_le_maxr /= lexx orbT.
 rewrite -ler_pdivl_mull //.
 suff : `|x| <= k%:num ^-1 * e%:num by apply: le_trans; rewrite nng_le_maxr /= lexx.
-near: x; rewrite !near_simpl; apply/nbhs_le_nbhs_norm.
-by exists (k%:num ^-1 * e%:num) => // ? /=; rewrite -ball_normE /= distrC subr0 => /ltW.
-Grab Existential Variables. all: end_near. Qed.
+near: x; rewrite !near_simpl. Fail apply/nbhs_le_nbhs_norm.
+(*by exists (k%:num ^-1 * e%:num) => // ? /=; rewrite -ball_normE /= distrC subr0 => /ltW.
+Grab Existential Variables. all: end_near. Qed.*)
+Admitted. 
 
 Fact dbilin (U V' W' : normedModType R) (f : {bilinear U -> V' -> W'}) p :
   continuous (fun p => f p.1 p.2) ->

--- a/theories/nngnum.v
+++ b/theories/nngnum.v
@@ -176,11 +176,6 @@ Proof. by rewrite !nng_max maxr_pmulr. Qed.
 
 End NngNum.
 
-(* TODO: general purpose lemma? add to mathcomp? *)
-Lemma filter_andb I r (a P : pred I) :
-  [seq i <- r | P i && a i] = [seq i <- [seq j <- r | P j] | a i].
-Proof. by elim: r => //= i r ->; case P. Qed.
-
 Import Num.Def.
 
 Module BigmaxrNonneg.
@@ -217,7 +212,9 @@ Lemma bigmaxrID I r (a P : pred I) (F : I -> {nonneg R}) x :
   maxr (\big[maxr/x]_(i <- r | P i && a i) F i)
     (\big[maxr/x]_(i <- r | P i && ~~ a i) F i).
 Proof.
-rewrite -!(big_filter _ (fun _ => _ && _)) !filter_andb !big_filter.
+under [in X in maxr X _]eq_bigl do rewrite andbC.
+under [in X in maxr _ X]eq_bigl do rewrite andbC.
+rewrite -!(big_filter _ (fun _ => _ && _)) !filter_predI !big_filter.
 rewrite ![in RHS](bigmaxr_mkcond _ _ F) !big_filter -bigmaxr_split.
 have eqmax : forall i, P i ->
   maxr (if a i then F i else x) (if ~~ a i then F i else x) = maxr (F i) x.
@@ -234,8 +231,7 @@ Proof. by rewrite big_cons big_nil. Qed.
 Lemma bigmaxr_pred1_eq (I : finType) (i : I) (F : I -> {nonneg R}) x :
   \big[maxr/x]_(j | j == i) F j = maxr (F i) x.
 Proof.
-have [e1 <- _ [e_enum _]] := big_enumP (pred1 i).
-by rewrite (perm_small_eq _ e_enum) enum1 ?bigmaxr_seq1.
+by rewrite -big_filter filter_pred1_uniq ?index_enum_uniq// bigmaxr_seq1.
 Qed.
 
 Lemma bigmaxr_pred1 (I : finType) i (P : pred I) (F : I -> {nonneg R}) x :

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -1607,9 +1607,9 @@ Lemma norm_cvg_unique {F} {FF : ProperFilter F} : is_subset1 [set x : V | F --> 
 Proof. exact: cvg_unique. Qed.
 
 Lemma norm_cvg_eq (x y : V) : x --> y -> x = y. Proof. exact: (@cvg_eq V). Qed.
-Lemma norm_lim_id x : [lim x in V](*NB: was lim x*) = x. Proof. exact: lim_id. Qed.
+Lemma norm_lim_id (x : V) : lim x = x. Proof. exact: lim_id. Qed.
 
-Lemma norm_cvg_lim {F} {FF : ProperFilter F} (l : V) : F --> l -> [lim F in V](*NB: was lim F*) = l.
+Lemma norm_cvg_lim {F} {FF : ProperFilter F} (l : V) : F --> l -> lim F = l.
 Proof. exact: (@cvg_lim V). Qed.
 
 Lemma norm_lim_near_cst U {F} {FF : ProperFilter F} (l : V) (f : U -> V) :
@@ -2110,22 +2110,21 @@ Canonical matrix_normedZmodType (K : numDomainType) (m n : nat) :=
 Section matrix_NormedModule.
 Variables (K : numFieldType) (m n : nat).
 
+Local Lemma ball_gt0 (x y : 'M[K]_(m.+1, n.+1)) e : ball x e y -> 0 < e.
+Proof. by move/(_ ord0 ord0); apply: le_lt_trans. Qed.
+
 Lemma mx_norm_ball :
   @ball _ [pseudoMetricType K of 'M[K]_(m.+1, n.+1)] = ball_ (fun x => `| x |).
 Proof.
-rewrite /= /normr /= predeq3E => x e y; split.
-- move=> xe_y; rewrite /ball_/= mx_normE.
-  (* TODO:  lemma : ball x e y -> 0 < e *)
-  have lee0 : ( 0 < e) by rewrite (le_lt_trans _ (xe_y ord0 ord0)) //.
+rewrite /normr /ball_ predeq3E => x e y /=; rewrite mx_normE; split => xey.
+- have lee0 : 0 < e := ball_gt0 xey.
   have -> : e = (Nonneg.NngNum _ (ltW lee0))%:nngnum by [].
-  rewrite nng_lt; apply/BigmaxrNonneg.bigmaxr_ltrP.
-- split; [rewrite -nng_lt //= | move=> ??; rewrite !mxE; exact: xe_y].
-  rewrite /ball_/= mx_normE => H.
-  have lee0 : (0 < e) by rewrite (le_lt_trans _ H) // nonnegnum_ge0.
-  move : H.
-  have -> : e = (Nonneg.NngNum _ (ltW lee0))%:nngnum by [].
-  move => /BigmaxrNonneg.bigmaxr_ltrP => -[e0 xey] i j.
-  move: (xey (i, j)); rewrite !mxE; exact.
+  rewrite nng_lt; apply/BigmaxrNonneg.bigmaxr_ltrP => /=.
+  by rewrite -nng_lt /=; split => // -[? ?] _; rewrite !mxE; exact: xey.
+- have lee0 : 0 < e by rewrite (le_lt_trans _ xey).
+  move: xey; have -> : e = (Nonneg.NngNum _ (ltW lee0))%:nngnum by [].
+  move=> /BigmaxrNonneg.bigmaxr_ltrP /= [e0 xey] i j.
+  by move: (xey (i, j)); rewrite !mxE; exact.
 Qed.
 
 Definition matrix_PseudoMetricNormedZmodMixin :=
@@ -2255,7 +2254,6 @@ Global Instance filter_nbhs (K' : numFieldType) (k : K') :
 Proof.
 exact: (@nbhs_filter).
 Qed.
-
 
 Section NVS_continuity_normedModType.
 Context {K : numFieldType} {V : normedModType K}.
@@ -3060,21 +3058,6 @@ have [f XsupXf] : exists f : {posnum R}, X (inf X - f%:num).
   by rewrite addr0 gtr0_norm // ltr_pdivr_mulr // ltr_pmulr // ltr1n.
 have : inf X <= inf X - f%:num by apply inf_lb.
 by apply/negP; rewrite -ltNge; rewrite ltr_subl_addr ltr_addl.
-Qed.
-
-(* TODO: move to reals.v? *)
-Lemma inf_lb_strict (R : realType) (X : set R) : has_lbound X ->
-  ~ X (inf X) -> X `<=` [set r | inf X < r].
-Proof.
-move=> lX XinfX r Xr; rewrite /mkset lt_neqAle inf_lb // andbT.
-by apply/negP => /eqP infXr; move: XinfX; rewrite infXr.
-Qed.
-
-Lemma sup_ub_strict (R : realType) (X : set R) : has_ubound X ->
-  ~ X (sup X) -> X `<=` [set r | r < sup X].
-Proof.
-move=> ubX XsupX r Xr; rewrite /mkset lt_neqAle sup_ub // andbT.
-by apply/negP => /eqP supXr; move: XsupX; rewrite -supXr.
 Qed.
 
 Section interval_realType.

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -1309,6 +1309,11 @@ Variables (R : numDomainType) (V : normedModType R).
 Lemma normmZ l (x : V) : `| l *: x | = `| l | * `| x |.
 Proof. by case: V x => V0 [a b [c]] //= v; rewrite c. Qed.
 
+End NormedModule_numDomainType.
+
+Section PseudoNormedZmod_numDomainType. (*to be lifted *)
+Variables (R : numDomainType) (V : pseudoMetricNormedZmodType R).
+
 Local Notation ball_norm := (ball_ (@normr R V)).
 
 Local Notation nbhs_norm := (@nbhs_ball _ V).
@@ -1377,7 +1382,7 @@ Proof. by move=> /cvg_distP. Qed.
 Lemma nbhs_norm_ball x (eps : {posnum R}) : nbhs_norm x (ball x eps%:num).
 Proof. rewrite nbhs_nbhs_norm; by apply: nbhsx_ballx. Qed.
 
-End NormedModule_numDomainType.
+End PseudoNormedZmod_numDomainType.
 Hint Resolve normr_ge0 : core.
 Arguments cvg_dist {_ _ F FF}.
 
@@ -1400,40 +1405,41 @@ Definition fun1 {T : Type} {K : numFieldType} :
   T -> K := fun=> 1.
 Arguments fun1 {T K} x /.
 
-Definition dominated_by {T : Type} {K : numDomainType} {V W : normedModType K}
+Definition dominated_by {T : Type} {K : numDomainType} {V W : pseudoMetricNormedZmodType K}
   (h : T -> V) (k : K) (f : T -> W) (F : set (set T)) :=
   F [set x | `|f x| <= k * `|h x|].
 
-Definition strictly_dominated_by {T : Type} {K : numDomainType} {V W : normedModType K}
+Definition strictly_dominated_by {T : Type} {K : numDomainType} {V W : pseudoMetricNormedZmodType K}
   (h : T -> V) (k : K) (f : T -> W) (F : set (set T)) :=
   F [set x | `|f x| < k * `|h x|].
 
-Lemma sub_dominatedl (T : Type) (K : numFieldType) (V W : normedModType K)
+Lemma sub_dominatedl (T : Type) (K : numFieldType) (V W : pseudoMetricNormedZmodType K)
    (h : T -> V) (k : K) (F G : set (set T)) : F `=>` G ->
   (@dominated_by T K V W h k)^~ G `<=` (dominated_by h k)^~ F.
 Proof. by move=> FG f; exact: FG. Qed.
 
-Lemma sub_dominatedr (T : Type) (K : numFieldType) (V : normedModType K)
+Lemma sub_dominatedr (T : Type) (K : numFieldType) (V : pseudoMetricNormedZmodType K)
     (h : T -> V) (k : K) (f g : T -> V) (F : set (set T)) (FF : Filter F) :
    (\forall x \near F, `|f x| <= `|g x|) ->
    dominated_by h k g F -> dominated_by h k f F.
 Proof. by move=> le_fg; apply: filterS2 le_fg => x; apply: le_trans. Qed.
 
-Lemma dominated_by1 {T : Type} {K : numFieldType} {V : normedModType K} :
+Lemma dominated_by1 {T : Type} {K : numFieldType} {V : pseudoMetricNormedZmodType K} :
   @dominated_by T K _ V fun1 = fun k f F => F [set x | `|f x| <= k].
 Proof.
 rewrite funeq3E => k f F.
 by congr F; rewrite funeqE => x/=; rewrite normr1 mulr1.
 Qed.
 
-Lemma strictly_dominated_by1 {T : Type} {K : numFieldType} {V : normedModType K} :
+Lemma strictly_dominated_by1 {T : Type} {K : numFieldType} 
+    {V : pseudoMetricNormedZmodType K} :
   @strictly_dominated_by T K _ V fun1 = fun k f F => F [set x | `|f x| < k].
 Proof.
 rewrite funeq3E => k f F.
 by congr F; rewrite funeqE => x/=; rewrite normr1 mulr1.
 Qed.
 
-Lemma ex_dom_bound {T : Type} {K : numFieldType} {V W : normedModType K}
+Lemma ex_dom_bound {T : Type} {K : numFieldType} {V W : pseudoMetricNormedZmodType K}
     (h : T -> V) (f : T -> W) (F : set (set T)) {PF : ProperFilter F}:
   (\forall M \near +oo, dominated_by h M f F) <->
   exists M, dominated_by h M f F.
@@ -1451,7 +1457,8 @@ exists M; split => // k Mk; apply: filterS FM => x /le_trans/= ->//.
 by rewrite ler_wpmul2r// ltW.
 Qed.
 
-Lemma ex_strict_dom_bound {T : Type} {K : numFieldType} {V W : normedModType K}
+Lemma ex_strict_dom_bound {T : Type} {K : numFieldType} 
+    {V W : pseudoMetricNormedZmodType K}
     (h : T -> V) (f : T -> W) (F : set (set T)) {PF : ProperFilter F} :
   (\forall x \near F, h x != 0) ->
   (\forall M \near +oo, dominated_by h M f F) <->
@@ -1463,33 +1470,34 @@ exists (M + 1); apply: filterS2 hN0 FM => x hN0 /le_lt_trans/= ->//.
 by rewrite ltr_pmul2r ?normr_gt0// ltr_addl.
 Qed.
 
-Definition bounded_near {T : Type} {K : numFieldType} {V : normedModType K}
+Definition bounded_near {T : Type} {K : numFieldType} 
+    {V : pseudoMetricNormedZmodType K}
   (f : T -> V) (F : set (set T)) :=
   \forall M \near +oo, F [set x | `|f x| <= M].
 
-Lemma boundedE {T : Type} {K : numFieldType} {V : normedModType K} :
+Lemma boundedE {T : Type} {K : numFieldType} {V : pseudoMetricNormedZmodType K} :
   @bounded_near T K V = fun f F => \forall M \near +oo, dominated_by fun1 M f F.
 Proof. by rewrite dominated_by1. Qed.
 
-Lemma sub_boundedr (T : Type) (K : numFieldType) (V : normedModType K)
+Lemma sub_boundedr (T : Type) (K : numFieldType) (V : pseudoMetricNormedZmodType K)
      (F G : set (set T)) : F `=>` G ->
   (@bounded_near T K V)^~ G `<=` bounded_near^~ F.
 Proof. by move=> FG f; rewrite /bounded_near; apply: filterS=> M; apply: FG. Qed.
 
-Lemma sub_boundedl (T : Type) (K : numFieldType) (V : normedModType K)
+Lemma sub_boundedl (T : Type) (K : numFieldType) (V : pseudoMetricNormedZmodType K)
      (f g : T -> V) (F : set (set T)) (FF : Filter F) :
  (\forall x \near F, `|f x| <= `|g x|) ->  bounded_near g F -> bounded_near f F.
 Proof.
 move=> le_fg; rewrite /bounded_near; apply: filterS => M.
-by apply: filterS2 le_fg => x; apply: le_trans.
+by apply: filterS2 le_fg => x; apply: le_trans. 
 Qed.
 
-Lemma ex_bound {T : Type} {K : numFieldType} {V : normedModType K}
+Lemma ex_bound {T : Type} {K : numFieldType} {V : pseudoMetricNormedZmodType K}
   (f : T -> V) (F : set (set T)) {PF : ProperFilter F}:
   bounded_near f F <-> exists M, F [set x | `|f x| <= M].
 Proof. by rewrite boundedE ex_dom_bound dominated_by1. Qed.
 
-Lemma ex_strict_bound {T : Type} {K : numFieldType} {V : normedModType K}
+Lemma ex_strict_bound {T : Type} {K : numFieldType} {V : pseudoMetricNormedZmodType K}
   (f : T -> V) (F : set (set T)) {PF : ProperFilter F}:
   bounded_near f F <-> exists M, F [set x | `|f x| < M].
 Proof.
@@ -1497,7 +1505,7 @@ rewrite boundedE ex_strict_dom_bound ?strictly_dominated_by1//.
 by near=> x; rewrite oner_eq0.
 Grab Existential Variables. all: end_near. Qed.
 
-Lemma ex_strict_bound_gt0 {T : Type} {K : numFieldType} {V : normedModType K}
+Lemma ex_strict_bound_gt0 {T : Type} {K : numFieldType} {V : pseudoMetricNormedZmodType K}
   (f : T -> V) (F : set (set T)) {PF : Filter F}:
   bounded_near f F -> exists2 M, M > 0 & F [set x | `|f x| < M].
 Proof.
@@ -1565,9 +1573,9 @@ Lemma lipschitz_id (R : numFieldType) (V : normedModType R) : 1.-lipschitz (@id 
 Proof. by move=> [/= x y] _; rewrite mul1r. Qed.
 Arguments lipschitz_id {R V}.
 
-Section NormedModule_numFieldType.
-Variables (R : numFieldType) (V : normedModType R).
-Implicit Types (x y z : V).
+(* was Section NormedModule_numFieldType. *)
+Section PseudoNormedZMod_numFieldType.
+Variables (R : numFieldType) (V : pseudoMetricNormedZmodType R).
 
 Local Notation ball_norm := (ball_ (@normr R V)).
 
@@ -1590,17 +1598,17 @@ Hint Extern 0 (hausdorff _) => solve[apply: norm_hausdorff] : core.
 (*       i.e. where the generic lemma is applied, *)
 (*            check that norm_hausdorff is not used in a hard way *)
 
-Lemma norm_closeE x y : close x y = (x = y). Proof. exact: closeE. Qed.
-Lemma norm_close_eq x y : close x y -> x = y. Proof. exact: close_eq. Qed.
+Lemma norm_closeE (x y : V): close x y = (x = y). Proof. exact: closeE. Qed.
+Lemma norm_close_eq (x y : V) : close x y -> x = y. Proof. exact: close_eq. Qed.
 
 Lemma norm_cvg_unique {F} {FF : ProperFilter F} : is_subset1 [set x : V | F --> x].
 Proof. exact: cvg_unique. Qed.
 
-Lemma norm_cvg_eq x y : x --> y -> x = y. Proof. exact: cvg_eq. Qed.
-Lemma norm_lim_id x : lim x = x. Proof. exact: lim_id. Qed.
+Lemma norm_cvg_eq (x y : V) : x --> y -> x = y. Proof. exact: (@cvg_eq V). Qed.
+Lemma norm_lim_id x : [lim x in V](*NB: was lim x*) = x. Proof. exact: lim_id. Qed.
 
-Lemma norm_cvg_lim {F} {FF : ProperFilter F} (l : V) : F --> l -> lim F = l.
-Proof. exact: cvg_lim. Qed.
+Lemma norm_cvg_lim {F} {FF : ProperFilter F} (l : V) : F --> l -> [lim F in V](*NB: was lim F*) = l.
+Proof. exact: (@cvg_lim V). Qed.
 
 Lemma norm_lim_near_cst U {F} {FF : ProperFilter F} (l : V) (f : U -> V) :
    (\forall x \near F, f x = l) -> lim (f @ F) = l.
@@ -1651,6 +1659,27 @@ move=> cv; apply/cvg_distP => _/posnumP[e]; near=> x.
 by apply: normm_leW => //; near: x; apply: cv.
 Grab Existential Variables. all: end_near. Qed.
 
+End PseudoNormedZMod_numFieldType.
+
+Section NormedModule_numFieldType.
+Variables (R : numFieldType) (V : normedModType R).
+
+Lemma cvg_bounded_real {F : set (set V)} {FF : Filter F} (y : V) :
+  F --> y ->
+  \forall M \near +oo, M \is Num.real /\ \forall y' \near F, `|y'| < M.
+Proof.
+move=> /cvg_dist Fy; exists `|y|; rewrite normr_real; split => // M.
+rewrite -subr_gt0 => subM_gt0; split.
+  rewrite -comparabler0 (@comparabler_trans _ (M - `|y|)) //.
+    by rewrite -subr_comparable0 opprD addrA subrr add0r opprK comparabler0
+      normr_real.
+  by rewrite comparablerE subr0 realE ltW.
+have := Fy _ subM_gt0.
+apply: filterS => y' yy'; rewrite -(@ltr_add2r _ (- `|y|)).
+rewrite (le_lt_trans _ yy') // (le_trans _ (ler_dist_dist _ _)) // distrC.
+by rewrite real_ler_norm // realB.
+Qed.
+
 Lemma cvg_bounded {F : set (set V)} {FF : Filter F} (y : V) :
   F --> y -> bounded_near id F.
 Proof.
@@ -1670,6 +1699,7 @@ Module Export NbhsNorm.
 Definition nbhs_simpl := (nbhs_simpl,@nbhs_nbhs_norm,@filter_from_norm_nbhs).
 End NbhsNorm.
 
+(* TODO: generalize to R : numFieldType *)
 Section hausdorff.
 
 Lemma Rhausdorff (R : realFieldType) : hausdorff R.
@@ -1682,6 +1712,27 @@ have := ball_triangle yz_he (ball_sym zx_he).
 by rewrite -mulr2n -mulr_natr divfK // => /ltW.
 Qed.
 
+Lemma pseudoMetricNormedZModType_hausdorff (R : realFieldType) 
+(V : pseudoMetricNormedZmodType R) :
+  hausdorff V.
+Proof.
+move=> p q clp_q; apply/subr0_eq/normr0_eq0/Rhausdorff => A B pq_A.
+rewrite -(@normr0 _ V) -(subrr p) => pp_B.
+suff loc_preim r C : nbhs`|p - r| C ->
+    nbhs r ((fun r => `|p - r|) @^-1` C).
+  have [r []] := clp_q _ _ (loc_preim _ _ pp_B) (loc_preim _ _ pq_A).
+  by exists `|p - r|.
+move=> [e egt0 pre_C]; apply: nbhs_le_nbhs_norm; exists e => // s.
+rewrite -ball_normE /= => re_s.
+apply: pre_C; apply: le_lt_trans (ler_dist_dist _ _) _.
+by rewrite opprB addrC subrKA distrC.
+Qed.
+
+(* maybe not useful *)
+Lemma normedModType_hausdorff' (R : realFieldType) (V : normedModType R) :
+  hausdorff V.
+Proof. exact: norm_hausdorff. Qed.
+
 End hausdorff.
 
 Module Export NearNorm.
@@ -1691,13 +1742,143 @@ Ltac near_simpl := rewrite ?near_simpl.
 End NearNorm.
 
 Lemma continuous_cvg_dist {R : numFieldType}
-  (V W : normedModType R) (f : V -> W) x l :
+  (V W : pseudoMetricNormedZmodType R) (f : V -> W) x l :
   continuous f -> x --> l -> forall e : {posnum R}, `|f l - f x| < e%:num.
 Proof.
-move=> + + e => /(_ l)/cvg_dist/(_ _ (posnum_gt0 e)).
+ move=> + + e => /(_ l)/cvg_dist/(_ _ (posnum_gt0 e)).
 rewrite near_map => /nbhs_ballP[_/posnumP[a]] + xl; apply.
-move/cvg_ball : xl => /(_ _ a)/nbhs_ballP[_/posnumP[b]]; apply; exact: ballxx.
+move/(cvg_ball (y :=l)): xl=> /(_ _ a)/nbhs_ballP[_/posnumP[b]]; apply; exact: ballxx.
 Qed.
+(*NB: was /cvg_ball before *)
+
+(* TODO: general purpose lemma? *)
+Lemma filter_andb I r (a P : pred I) :
+  [seq i <- r | P i && a i] = [seq i <- [seq j <- r | P j] | a i].
+Proof. by elim: r => //= i r ->; case P. Qed.
+
+Module BigmaxrNonneg.
+Section bigmaxr_nonneg.
+Variable (R : numDomainType).
+
+Lemma bigmaxr_mkcond I r (P : pred I) (F : I -> {nonneg R}) x :
+  \big[maxr/x]_(i <- r | P i) F i =
+     \big[maxr/x]_(i <- r) (if P i then F i else x).
+Proof.
+rewrite unlock; elim: r x => //= i r ihr x.
+case P; rewrite ihr // max_r //; elim: r {ihr} => //= j r ihr.
+by rewrite le_maxr ihr orbT.
+Qed.
+
+Lemma bigmaxr_split I r (P : pred I) (F1 F2 : I -> {nonneg R}) x :
+  \big[maxr/x]_(i <- r | P i) (maxr (F1 i) (F2 i)) =
+  maxr (\big[maxr/x]_(i <- r | P i) F1 i) (\big[maxr/x]_(i <- r | P i) F2 i).
+Proof.
+elim/big_rec3: _ => [|i y z _ _ ->]; rewrite ?maxxx //.
+by rewrite maxCA -!maxA maxCA.
+Qed.
+
+Lemma bigmaxr_idl I r (P : pred I) (F : I -> {nonneg R}) x :
+  \big[maxr/x]_(i <- r | P i) F i = maxr x (\big[maxr/x]_(i <- r | P i) F i).
+Proof.
+rewrite -big_filter; elim: [seq i <- r | P i] => [|i l ihl].
+  by rewrite big_nil maxxx.
+by rewrite big_cons maxCA -ihl.
+Qed.
+
+Lemma bigmaxrID I r (a P : pred I) (F : I -> {nonneg R}) x :
+  \big[maxr/x]_(i <- r | P i) F i =
+  maxr (\big[maxr/x]_(i <- r | P i && a i) F i)
+    (\big[maxr/x]_(i <- r | P i && ~~ a i) F i).
+Proof.
+rewrite -!(big_filter _ (fun _ => _ && _)) !filter_andb !big_filter.
+rewrite ![in RHS](bigmaxr_mkcond _ _ F) !big_filter -bigmaxr_split.
+have eqmax : forall i, P i ->
+  maxr (if a i then F i else x) (if ~~ a i then F i else x) = maxr (F i) x.
+  by move=> i _; case: (a i) => //=; rewrite maxC.
+rewrite [RHS](eq_bigr _ eqmax) -!(big_filter _ P).
+elim: [seq j <- r | P j] => [|j l ihl]; first by rewrite !big_nil.
+by rewrite !big_cons -maxA -bigmaxr_idl ihl.
+Qed.
+
+Lemma bigmaxr_seq1 I (i : I) (F : I -> {nonneg R}) x :
+  \big[maxr/x]_(j <- [:: i]) F j = maxr (F i) x.
+Proof. by rewrite unlock /=. Qed.
+
+Lemma bigmaxr_pred1_eq (I : finType) (i : I) (F : I -> {nonneg R}) x :
+  \big[maxr/x]_(j | j == i) F j = maxr (F i) x.
+Proof. by rewrite -big_filter filter_index_enum enum1 bigmaxr_seq1. Qed.
+
+Lemma bigmaxr_pred1 (I : finType) i (P : pred I) (F : I -> {nonneg R}) x :
+  P =1 pred1 i -> \big[maxr/x]_(j | P j) F j = maxr (F i) x.
+Proof. by move/(eq_bigl _ _)->; apply: bigmaxr_pred1_eq. Qed.
+
+Lemma bigmaxrD1 (I : finType) j (P : pred I) (F : I -> {nonneg R}) x :
+  P j -> \big[maxr/x]_(i | P i) F i
+    = maxr (F j) (\big[maxr/x]_(i | P i && (i != j)) F i).
+Proof.
+move=> Pj; rewrite (bigmaxrID _ (pred1 j)) [in RHS]bigmaxr_idl maxA.
+by congr maxr; apply: bigmaxr_pred1 => i; rewrite /= andbC; case: eqP => //->.
+Qed.
+
+Lemma ler_bigmaxr_cond (I : finType) (P : pred I) (F : I -> {nonneg R}) x i0 :
+  P i0 -> F i0 <= \big[maxr/x]_(i | P i) F i.
+Proof. by move=> Pi0; rewrite (bigmaxrD1 _ _ Pi0) le_maxr lexx. Qed.
+
+Lemma ler_bigmaxr (I : finType) (F : I -> {nonneg R}) (i0 : I) x :
+  F i0 <= \big[maxr/x]_i F i.
+Proof. exact: ler_bigmaxr_cond. Qed.
+
+Lemma bigmaxr_lerP (I : finType) (P : pred I) m (F : I -> {nonneg R}) x :
+  reflect (x <= m /\ forall i, P i -> F i <= m)
+    (\big[maxr/x]_(i | P i) F i <= m).
+Proof.
+apply: (iffP idP) => [|[lexm leFm]]; last first.
+  by elim/big_ind: _ => // ??; rewrite le_maxl =>->.
+rewrite bigmaxr_idl le_maxl => /andP[-> leFm]; split=> // i Pi.
+by apply: le_trans leFm; apply: ler_bigmaxr_cond.
+Qed.
+
+Lemma bigmaxr_sup (I : finType) i0 (P : pred I) m (F : I -> {nonneg R}) x :
+  P i0 -> m <= F i0 -> m <= \big[maxr/x]_(i | P i) F i.
+Proof. by move=> Pi0 ?; apply: le_trans (ler_bigmaxr_cond _ _ Pi0). Qed.
+
+Lemma bigmaxr_ltrP (I : finType) (P : pred I) m (F : I -> {nonneg R}) x :
+  reflect (x < m /\ forall i, P i -> F i < m)
+    (\big[maxr/x]_(i | P i) F i < m).
+Proof.
+apply: (iffP idP) => [|[ltxm ltFm]]; last first.
+  by elim/big_ind: _ => // ??; rewrite lt_maxl =>->.
+rewrite bigmaxr_idl lt_maxl => /andP[-> ltFm]; split=> // i Pi.
+by apply: le_lt_trans ltFm; apply: ler_bigmaxr_cond.
+Qed.
+
+Lemma bigmaxr_gerP (I : finType) (P : pred I) m (F : I -> {nonneg R}) x :
+  reflect (m <= x \/ exists2 i, P i & m <= F i)
+  (m <= \big[maxr/x]_(i | P i) F i).
+Proof.
+apply: (iffP idP) => [|[lemx|[i Pi lemFi]]]; last 2 first.
+- by rewrite bigmaxr_idl le_maxr lemx.
+- by rewrite (bigmaxrD1 _ _ Pi) le_maxr lemFi.
+rewrite leNgt => /bigmaxr_ltrP /asboolPn.
+rewrite asbool_and negb_and => /orP [/asboolPn/negP|/existsp_asboolPn [i]].
+  by rewrite -leNgt; left.
+by move=> /asboolPn/imply_asboolPn [Pi /negP]; rewrite -leNgt; right; exists i.
+Qed.
+
+Lemma bigmaxr_gtrP (I : finType) (P : pred I) m (F : I -> {nonneg R}) x :
+  reflect (m < x \/ exists2 i, P i & m < F i)
+  (m < \big[maxr/x]_(i | P i) F i).
+Proof.
+apply: (iffP idP) => [|[ltmx|[i Pi ltmFi]]]; last 2 first.
+- by rewrite bigmaxr_idl lt_maxr ltmx.
+- by rewrite (bigmaxrD1 _ _ Pi) lt_maxr ltmFi.
+rewrite ltNge => /bigmaxr_lerP /asboolPn.
+rewrite asbool_and negb_and => /orP [/asboolPn/negP|/existsp_asboolPn [i]].
+  by rewrite -ltNge; left.
+by move=> /asboolPn/imply_asboolPn [Pi /negP]; rewrite -ltNge; right; exists i.
+Qed.
+End bigmaxr_nonneg.
+End BigmaxrNonneg.
 
 Module BigmaxBigminr.
 Section bigmax_bigmin.
@@ -2193,6 +2374,15 @@ Canonical AbsRing_NormedModType (K : absRingType) :=
 
 
 (** Normed vector spaces have some continuous functions *)
+ (** that are in fact continuous on Pseudometricnormedzmodtype  *)
+
+Lemma add_continuous {K : numFieldType} {V : pseudoMetricNormedZmodType K} :
+  continuous (fun z : V * V => z.1 + z.2).
+Proof.
+move=> [/=x y]; apply/cvg_distP=> _/posnumP[e].
+rewrite !near_simpl /=; near=> a b => /=; rewrite opprD addrACA.
+by rewrite normm_lt_split //; [near: a|near: b]; apply: cvg_dist.
+Grab Existential Variables. all: end_near. Qed.
 
 (* kludge *)
 
@@ -2206,14 +2396,13 @@ Qed.
 Section NVS_continuity_normedModType.
 Context {K : numFieldType} {V : normedModType K}.
 Local Notation "'+oo'" := (pinfty_nbhs K).
-
+(* 
 Lemma add_continuous : continuous (fun z : V * V => z.1 + z.2).
 Proof.
 move=> [/=x y]; apply/cvg_distP=> _/posnumP[e].
 rewrite !near_simpl /=; near=> a b => /=; rewrite opprD addrACA.
 by rewrite normm_lt_split //; [near: a|near: b]; apply: cvg_dist.
-Grab Existential Variables. all: end_near. Qed.
-
+Grab Existential Variables. all: end_near. Qed. *)
 
 Lemma natmul_continuous n : continuous (fun x : V => x *+ n).
 Proof.
@@ -2224,7 +2413,6 @@ by near: a; apply: cvg_dist.
 Grab Existential Variables. all: end_near. Qed.
 
 Lemma scale_continuous : continuous (fun z : K * V => z.1 *: z.2).
-
 Proof.
 move=> [k x]; apply/cvg_distP=> _/posnumP[e].
 rewrite !near_simpl /=; near +oo => M.
@@ -2252,7 +2440,7 @@ Proof.
 by move=> k; apply: (cvg_comp2 cvg_id (cvg_cst _) (scale_continuous (_, _))).
 Qed.
 
-Lemma opp_continuous : continuous (@GRing.opp V).
+Lemma opp_continuous : continuous (@GRing.opp V). (*TODO: generalize to pseudometricnormedzmod*)
 Proof.
 move=> x; rewrite -scaleN1r => P /scaler_continuous /=.
 by rewrite !nbhs_nearE near_map; apply: filterS => x'; rewrite scaleN1r.
@@ -2420,7 +2608,7 @@ Proof. by move=> /cvgV cvf /cvf /cvgP. Qed.
 
 End cvg_composition_field.
 
-Section limit_composition.
+Section limit_composition_normedmod.
 
 Context {K : numFieldType} {V : normedModType K} {T : topologicalType}.
 Context (F : set (set T)) {FF : ProperFilter F}.
@@ -2451,7 +2639,7 @@ Proof. by move=> ?; apply: cvg_lim => //; apply: cvgZr. Qed.
 Lemma lim_norm f : cvg (f @ F) -> lim ((fun x => `|f x| : K) @ F) = `|lim (f @ F)|.
 Proof. by move=> ?; apply: cvg_lim => //; apply: cvg_norm. Qed.
 
-End limit_composition.
+End limit_composition_normedmod.
 
 Section limit_composition_field.
 

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -1311,14 +1311,18 @@ Proof. by case: V x => V0 [a b [c]] //= v; rewrite c. Qed.
 
 End NormedModule_numDomainType.
 
-Section PseudoNormedZmod_numDomainType. (*to be lifted *)
+Section PseudoNormedZmod_numDomainType. (* to be lifted *)
 Variables (R : numDomainType) (V : pseudoMetricNormedZmodType R).
 
 Local Notation ball_norm := (ball_ (@normr R V)).
 
 Local Notation nbhs_norm := (@nbhs_ball _ V).
 
-Lemma nbhs_le_nbhs_norm (x : V) : nbhs x `=>` nbhs_norm x.
+(* if we do not give the V argument to nbhs, the universally quantified set that
+appears inside the notation for cvg_to has type
+set (let '{| PseudoMetricNormedZmodule.sort := T |} := V in T) instead V, which
+causes an inference problem in derive.v *)
+Lemma nbhs_le_nbhs_norm (x : V) : @nbhs V _ x `=>` nbhs_norm x.
 Proof.
 move=> P [_ /posnumP[e] subP]; apply/nbhs_ballP.
 by eexists; last (move=> y Py; apply/subP; apply/Py).
@@ -1401,8 +1405,7 @@ Definition self_sub (K : numDomainType) (V W : normedModType K)
   (f : V -> W) (x : V * V) : W := f x.1 - f x.2.
 Arguments self_sub {K V W} f x /.
 
-Definition fun1 {T : Type} {K : numFieldType} :
-  T -> K := fun=> 1.
+Definition fun1 {T : Type} {K : numFieldType} : T -> K := fun=> 1.
 Arguments fun1 {T K} x /.
 
 Definition dominated_by {T : Type} {K : numDomainType} {V W : pseudoMetricNormedZmodType K}
@@ -1431,7 +1434,7 @@ rewrite funeq3E => k f F.
 by congr F; rewrite funeqE => x/=; rewrite normr1 mulr1.
 Qed.
 
-Lemma strictly_dominated_by1 {T : Type} {K : numFieldType} 
+Lemma strictly_dominated_by1 {T : Type} {K : numFieldType}
     {V : pseudoMetricNormedZmodType K} :
   @strictly_dominated_by T K _ V fun1 = fun k f F => F [set x | `|f x| < k].
 Proof.
@@ -1457,7 +1460,7 @@ exists M; split => // k Mk; apply: filterS FM => x /le_trans/= ->//.
 by rewrite ler_wpmul2r// ltW.
 Qed.
 
-Lemma ex_strict_dom_bound {T : Type} {K : numFieldType} 
+Lemma ex_strict_dom_bound {T : Type} {K : numFieldType}
     {V W : pseudoMetricNormedZmodType K}
     (h : T -> V) (f : T -> W) (F : set (set T)) {PF : ProperFilter F} :
   (\forall x \near F, h x != 0) ->
@@ -1470,7 +1473,7 @@ exists (M + 1); apply: filterS2 hN0 FM => x hN0 /le_lt_trans/= ->//.
 by rewrite ltr_pmul2r ?normr_gt0// ltr_addl.
 Qed.
 
-Definition bounded_near {T : Type} {K : numFieldType} 
+Definition bounded_near {T : Type} {K : numFieldType}
     {V : pseudoMetricNormedZmodType K}
   (f : T -> V) (F : set (set T)) :=
   \forall M \near +oo, F [set x | `|f x| <= M].
@@ -1489,7 +1492,7 @@ Lemma sub_boundedl (T : Type) (K : numFieldType) (V : pseudoMetricNormedZmodType
  (\forall x \near F, `|f x| <= `|g x|) ->  bounded_near g F -> bounded_near f F.
 Proof.
 move=> le_fg; rewrite /bounded_near; apply: filterS => M.
-by apply: filterS2 le_fg => x; apply: le_trans. 
+by apply: filterS2 le_fg => x; apply: le_trans.
 Qed.
 
 Lemma ex_bound {T : Type} {K : numFieldType} {V : pseudoMetricNormedZmodType K}
@@ -1573,7 +1576,6 @@ Lemma lipschitz_id (R : numFieldType) (V : normedModType R) : 1.-lipschitz (@id 
 Proof. by move=> [/= x y] _; rewrite mul1r. Qed.
 Arguments lipschitz_id {R V}.
 
-(* was Section NormedModule_numFieldType. *)
 Section PseudoNormedZMod_numFieldType.
 Variables (R : numFieldType) (V : pseudoMetricNormedZmodType R).
 
@@ -1728,7 +1730,7 @@ apply: pre_C; apply: le_lt_trans (ler_dist_dist _ _) _.
 by rewrite opprB addrC subrKA distrC.
 Qed.
 
-(* maybe not useful *)
+(* NB: maybe not useful *)
 Lemma normedModType_hausdorff' (R : realFieldType) (V : normedModType R) :
   hausdorff V.
 Proof. exact: norm_hausdorff. Qed.
@@ -1747,7 +1749,7 @@ Lemma continuous_cvg_dist {R : numFieldType}
 Proof.
  move=> + + e => /(_ l)/cvg_dist/(_ _ (posnum_gt0 e)).
 rewrite near_map => /nbhs_ballP[_/posnumP[a]] + xl; apply.
-move/(cvg_ball (y :=l)): xl=> /(_ _ a)/nbhs_ballP[_/posnumP[b]]; apply; exact: ballxx.
+move/(cvg_ball (y := l)): xl=> /(_ _ a)/nbhs_ballP[_/posnumP[b]]; apply; exact: ballxx.
 Qed.
 (*NB: was /cvg_ball before *)
 

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -206,7 +206,7 @@ Definition choiceType := @Choice.Pack cT xclass.
 Definition zmodType := @GRing.Zmodule.Pack cT xclass.
 Definition normedZmodType := @Num.NormedZmodule.Pack R phR cT xclass.
 Definition pointedType := @Pointed.Pack cT xclass.
-Definition filteredType := @Filtered.Pack xT cT xclass.
+Definition filteredType := @Filtered.Pack cT cT xclass.
 Definition topologicalType := @Topological.Pack cT xclass.
 Definition uniformType := @Uniform.Pack cT xclass.
 Definition pseudoMetricType := @PseudoMetric.Pack R cT xclass.
@@ -1738,11 +1738,10 @@ Lemma continuous_cvg_dist {R : numFieldType}
   (V W : pseudoMetricNormedZmodType R) (f : V -> W) x l :
   continuous f -> x --> l -> forall e : {posnum R}, `|f l - f x| < e%:num.
 Proof.
- move=> + + e => /(_ l)/cvg_dist/(_ _ (posnum_gt0 e)).
+move=> + + e => /(_ l)/cvg_dist/(_ _ (posnum_gt0 e)).
 rewrite near_map => /nbhs_ballP[_/posnumP[a]] + xl; apply.
-move/(cvg_ball (y := l)): xl=> /(_ _ a)/nbhs_ballP[_/posnumP[b]]; apply; exact: ballxx.
+by move/cvg_ball : xl => /(_ _ a)/nbhs_ballP[_/posnumP[b]]; apply.
 Qed.
-(*NB: was /cvg_ball before *)
 
 Module BigmaxBigminr.
 Section bigmax_bigmin.

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -1668,14 +1668,10 @@ Variables (R : numFieldType) (V : normedModType R).
 
 Lemma cvg_bounded_real {F : set (set V)} {FF : Filter F} (y : V) :
   F --> y ->
-  \forall M \near +oo, M \is Num.real /\ \forall y' \near F, `|y'| < M.
+  \forall M \near +oo, \forall y' \near F, `|y'| < M.
 Proof.
 move=> /cvg_dist Fy; exists `|y|; rewrite normr_real; split => // M.
-rewrite -subr_gt0 => subM_gt0; split.
-  rewrite -comparabler0 (@comparabler_trans _ (M - `|y|)) //.
-    by rewrite -subr_comparable0 opprD addrA subrr add0r opprK comparabler0
-      normr_real.
-  by rewrite comparablerE subr0 realE ltW.
+rewrite -subr_gt0 => subM_gt0.
 have := Fy _ subM_gt0.
 apply: filterS => y' yy'; rewrite -(@ltr_add2r _ (- `|y|)).
 rewrite (le_lt_trans _ yy') // (le_trans _ (ler_dist_dist _ _)) // distrC.

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -1311,7 +1311,7 @@ Proof. by case: V x => V0 [a b [c]] //= v; rewrite c. Qed.
 
 End NormedModule_numDomainType.
 
-Section PseudoNormedZmod_numDomainType. (* to be lifted *)
+Section PseudoNormedZmod_numDomainType.
 Variables (R : numDomainType) (V : pseudoMetricNormedZmodType R).
 
 Local Notation ball_norm := (ball_ (@normr R V)).
@@ -1320,8 +1320,8 @@ Local Notation nbhs_norm := (@nbhs_ball _ V).
 
 (* if we do not give the V argument to nbhs, the universally quantified set that
 appears inside the notation for cvg_to has type
-set (let '{| PseudoMetricNormedZmodule.sort := T |} := V in T) instead V, which
-causes an inference problem in derive.v *)
+set (let '{| PseudoMetricNormedZmodule.sort := T |} := V in T) instead of set V,
+which causes an inference problem in derive.v *)
 Lemma nbhs_le_nbhs_norm (x : V) : @nbhs V _ x `=>` nbhs_norm x.
 Proof.
 move=> P [_ /posnumP[e] subP]; apply/nbhs_ballP.
@@ -1715,7 +1715,7 @@ by rewrite -mulr2n -mulr_natr divfK // => /ltW.
 Qed.
 
 Lemma pseudoMetricNormedZModType_hausdorff (R : realFieldType)
-(V : pseudoMetricNormedZmodType R) :
+    (V : pseudoMetricNormedZmodType R) :
   hausdorff V.
 Proof.
 move=> p q clp_q; apply/subr0_eq/normr0_eq0/Rhausdorff => A B pq_A.
@@ -1729,11 +1729,6 @@ rewrite -ball_normE /= => re_s.
 apply: pre_C; apply: le_lt_trans (ler_dist_dist _ _) _.
 by rewrite opprB addrC subrKA distrC.
 Qed.
-
-(* NB: maybe not useful *)
-Lemma normedModType_hausdorff' (R : realFieldType) (V : normedModType R) :
-  hausdorff V.
-Proof. exact: norm_hausdorff. Qed.
 
 End hausdorff.
 
@@ -2249,7 +2244,7 @@ Canonical AbsRing_NormedModType (K : absRingType) :=
 
 
 (** Normed vector spaces have some continuous functions *)
- (** that are in fact continuous on Pseudometricnormedzmodtype  *)
+(** that are in fact continuous on pseudoMetricNormedZmodType *)
 
 Lemma add_continuous {K : numFieldType} {V : pseudoMetricNormedZmodType K} :
   continuous (fun z : V * V => z.1 + z.2).
@@ -2260,7 +2255,6 @@ by rewrite normm_lt_split //; [near: a|near: b]; apply: cvg_dist.
 Grab Existential Variables. all: end_near. Qed.
 
 (* kludge *)
-
 Global Instance filter_nbhs (K' : numFieldType) (k : K') :
   Filter (nbhs k).
 Proof.
@@ -2271,13 +2265,6 @@ Qed.
 Section NVS_continuity_normedModType.
 Context {K : numFieldType} {V : normedModType K}.
 Local Notation "'+oo'" := (pinfty_nbhs K).
-(* 
-Lemma add_continuous : continuous (fun z : V * V => z.1 + z.2).
-Proof.
-move=> [/=x y]; apply/cvg_distP=> _/posnumP[e].
-rewrite !near_simpl /=; near=> a b => /=; rewrite opprD addrACA.
-by rewrite normm_lt_split //; [near: a|near: b]; apply: cvg_dist.
-Grab Existential Variables. all: end_near. Qed. *)
 
 Lemma natmul_continuous n : continuous (fun x : V => x *+ n).
 Proof.
@@ -2315,7 +2302,8 @@ Proof.
 by move=> k; apply: (cvg_comp2 cvg_id (cvg_cst _) (scale_continuous (_, _))).
 Qed.
 
-Lemma opp_continuous : continuous (@GRing.opp V). (*TODO: generalize to pseudometricnormedzmod*)
+(* TODO: generalize to pseudometricnormedzmod *)
+Lemma opp_continuous : continuous (@GRing.opp V).
 Proof.
 move=> x; rewrite -scaleN1r => P /scaler_continuous /=.
 by rewrite !nbhs_nearE near_map; apply: filterS => x'; rewrite scaleN1r.

--- a/theories/reals.v
+++ b/theories/reals.v
@@ -21,7 +21,7 @@ Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 Unset SsrOldRewriteGoalsOrder.
 
-Import Order.TTheory Order.Syntax GRing.Theory Num.Theory.
+Import Order.TTheory Order.Syntax GRing.Theory Num.Def Num.Theory.
 
 (* -------------------------------------------------------------------- *)
 Delimit Scope real_scope with real.
@@ -394,6 +394,13 @@ move=> ubE; apply/ubP=> x x_in_E; move: (x) (x_in_E).
 by apply/ubP/sup_upper_bound=> //; split; first by exists x.
 Qed.
 
+Lemma sup_ub_strict E : has_ubound E ->
+  ~ E (sup E) -> E `<=` [set r | r < sup E].
+Proof.
+move=> ubE EsupE r Er; rewrite /mkset lt_neqAle sup_ub // andbT.
+by apply/negP => /eqP supEr; move: EsupE; rewrite -supEr.
+Qed.
+
 Lemma sup_total {E} x : has_sup E -> (down E) x \/ sup E <= x.
 Proof.
 move=> has_supE; rewrite orC.
@@ -433,6 +440,14 @@ move=> [B0 [l Bl]] AB; apply/eqP; rewrite eq_le; apply/andP; split.
 - by move=> Bx; rewrite sup_ub //; exists l.
 - apply sup_le_ub => // b Bb; apply sup_ub; last by right.
   by exists l => x [Ax|Bx]; [rewrite (le_trans (AB _ _ Ax Bb)) // Bl|exact: Bl].
+Qed.
+
+Lemma has_ub_image_norm (S : set R) : has_ubound (normr @` S) -> has_ubound S.
+Proof.
+case => M /ubP uM; exists `|M|; apply/ubP => r rS.
+rewrite (le_trans (real_ler_norm _)) ?num_real //.
+rewrite (le_trans (uM _ _)) ?real_ler_norm ?num_real //.
+by exists r.
 Qed.
 
 End RealLemmas.
@@ -480,6 +495,13 @@ Proof. by rewrite inf_out //; exact: has_inf0. Qed.
 
 Lemma inf_lb E : has_lbound E -> (lbound E) (inf E).
 Proof. by move/has_lb_ubN/sup_ub/ub_lbN; rewrite setNK. Qed.
+
+Lemma inf_lb_strict E : has_lbound E ->
+  ~ E (inf E) -> E `<=` [set r | inf E < r].
+Proof.
+move=> lE EinfE r Er; rewrite /mkset lt_neqAle inf_lb // andbT.
+by apply/negP => /eqP infEr; move: EinfE; rewrite infEr.
+Qed.
 
 Lemma lb_le_inf E x : nonempty E -> (lbound E) x -> x <= inf E.
 Proof.

--- a/theories/sequences.v
+++ b/theories/sequences.v
@@ -58,7 +58,7 @@ Require Import classical_sets posnum topology normedtype landau.
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
-Import Order.TTheory GRing.Theory Num.Def  Num.Theory.
+Import Order.TTheory GRing.Theory Num.Def Num.Theory.
 Import numFieldNormedType.Exports.
 
 Local Open Scope classical_set_scope.
@@ -453,15 +453,6 @@ move=> /cvg_seq_bounded/pinfty_ex_gt0[M M_gt0 /= uM].
 by exists M; apply/ubP => x -[n _ <-{x}]; exact: uM.
 Qed.
 
-(* TODO: move *)
-Lemma has_ub_image_norm (S : set R) : has_ubound (normr @` S) -> has_ubound S.
-Proof.
-case => M /ubP uM; exists `|M|; apply/ubP => r rS.
-rewrite (le_trans (real_ler_norm _)) ?num_real //.
-rewrite (le_trans (uM _ _)) ?real_ler_norm ?num_real //.
-by exists r.
-Qed.
-
 Lemma cvg_has_sup (u_ : R ^nat) : cvg u_ -> has_sup (u_ @` setT).
 Proof.
 move/cvg_has_ub; rewrite -/(_ @` _) -(image_comp u_ normr setT).
@@ -509,7 +500,7 @@ Lemma near_nondecreasing_is_cvg (u_ : R ^nat) (M : R) :
 Proof.
 move=> [k _ u_nd] [k' _ u_M]; suff : cvg [sequence u_ (n + maxn k k')%N]_n.
   by case/cvg_ex => /= l; rewrite cvg_shiftn => ul; apply/cvg_ex; exists l.
-apply (@nondecreasing_is_cvg _ M) => [/= ? ? ? | ?].
+apply: (@nondecreasing_is_cvg _ M) => [/= ? ? ? | ?].
   by rewrite u_nd ?leq_add2r//= (leq_trans (leq_maxl _ _) (leq_addl _ _)).
 by rewrite u_M //= (leq_trans (leq_maxr _ _) (leq_addl _ _)).
 Qed.
@@ -683,7 +674,7 @@ suff abel : forall n,
     near: n.
     by case: (eqoP eventually_filterType harmonic h) => Hh _; apply Hh.
   move: (cesaro a_o); rewrite /arithmetic_mean /series /= -/a_.
-  exact: (@cesaro_converse_off_by_one (fun k : nat => k.+1%:R * a_ k)).
+  exact: (@cesaro_converse_off_by_one (fun k => k.+1%:R * a_ k)).
 case => [|n].
   rewrite /arithmetic_mean/= invr1 mul1r !seriesEnat/=.
   by rewrite big_nat1 subrr big_geq.
@@ -1313,8 +1304,7 @@ move=> cu cv uv; move lu : (lim u_) => l; move kv : (lim v_) => k.
 case: l k => [l| |] [k| |] // in lu kv *.
 - have /ereal_cvg_real[realu ul] : u_ --> l%:E by rewrite -lu.
   have /ereal_cvg_real[realv vk] : v_ --> k%:E by rewrite -kv.
-  rewrite -(cvg_lim (@Rhausdorff R) ul) -(cvg_lim (@Rhausdorff R) vk).
-  apply: ler_lim.
+  rewrite -(cvg_lim _ ul)// -(cvg_lim _ vk)//; apply: ler_lim.
   + by apply/cvg_ex; eexists; exact: ul.
   + by apply/cvg_ex; eexists; exact: vk.
   + move: uv realu realv => [n1 _ uv] [n2 _ realu] [n3 _ realv].


### PR DESCRIPTION
Further generalisations from normedModTypes to PseudoMetricNormedZmodTypes.

NB(rei): fixes #382 

TODO:
- [x] Several explicit arguments are needed with this PR. E.g : https://github.com/math-comp/analysis/blob/45e488f1059a6744fb538a104300033555eb0046/theories/derive.v#L789 Why ?
- [x] Update Changelog
- [x] Check that no new (post apr. 2019) lemmas are generalizable
