### PR TITLE
Renaming flim to cvg

### DIFF
--- a/etc/pr193.sed
+++ b/etc/pr193.sed
@@ -1,0 +1,25 @@
+s/cvg_within/cvg_app_within/g;
+s/cvg/PREPROCESS/g;
+s/\([^n]\)lim_add/\1cvgD/g;
+s/\([^n]\)lim_opp/\1cvgN/g;
+s/\([^n]\)lim_mult/\1cvgM/g;
+s/\([^n]\)lim_mul/\1cvgM/g;
+s/\([^n]\)lim_scale/\1cvgZ/g;
+s/\([^n]\)lim_sub/\1cvgN/g;
+s/\([^n]\)lim_cst/\1cvg_cst/g;
+s/\([^n]\)lim_cont/\1cvg_cont/g;
+s/Definition flim/Definition cvg_to/g;
+s/(flim F G)/(cvg_to F G)/g;
+s/(flim \[/(cvg_to \[/g;
+s/flim/cvg/g;
+s/approaches/cvg/g;
+s/approach/cvg/g;
+s/\(is_\)\?filter_\?lim/cvg/g;
+s/filtermap/fmap/g;
+s/close_lim/close_cvg/g;
+s/Flim/Cvg/g;
+s/_cont\([^a-z]\)/_continuous\1/g
+s/fcvg/cvg/g;
+s/subset_fmap/cvg_fmap2/;
+s/\([ (]\)cvg *(\([^)]*\)) *(\([^)]*\))/\1\2 `=>` \3/g;
+s/PREPROCESS/cvg/g;

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -171,8 +171,8 @@ rewrite (littleo_bigO_eqo (cst (1 : R^o))); last first.
   apply/eqOP; near=> k; rewrite /cst [`|1 : R^o|]normr1 mulr1.
   near=> y; rewrite ltW //; near: y; apply/locally_normP.
   by exists k; [near: k; exists 0; rewrite real0|move=> ? /=; rewrite sub0r normrN].
-rewrite addfo; first by move=> /eqolim; rewrite flim_shift add0r.
-by apply/eqolim0P; apply: (flim_trans (dfc 0)); rewrite linear0.
+rewrite addfo; first by move=> /eqolim; rewrite cvg_shift add0r.
+by apply/eqolim0P; apply: (cvg_trans (dfc 0)); rewrite linear0.
 Grab Existential Variables. all: end_near. Qed.
 
 Section littleo_lemmas.
@@ -297,11 +297,11 @@ rewrite /derive => /diff_locally -> /=; set k := 'o _.
 evar (g : R -> W); rewrite [X in X @ _](_ : _ = g) /=; last first.
   rewrite funeqE=> h; rewrite !scalerDr scalerN /cst /=.
   by rewrite addrC !addrA addNr add0r linearZ /= scalerA /g.
-apply: flim_map_lim.
+apply: cvg_map_lim.
 pose g1 : R -> W := fun h => (h^-1 * h) *: 'd f a v.
 pose g2 : R -> W := fun h : R => h^-1 *: k (h *: v ).
-rewrite (_ : g = g1 + g2) ?funeqE // -(addr0 (_ _ v)); apply: (@lim_add _ _ [topologicalType of R^o]).
-  rewrite -(scale1r (_ _ v)); apply: lim_scalel => /= X [e e0].
+rewrite (_ : g = g1 + g2) ?funeqE // -(addr0 (_ _ v)); apply: (@cvgD _ _ [topologicalType of R^o]).
+  rewrite -(scale1r (_ _ v)); apply: cvgZl => /= X [e e0].
   rewrite /ball_ /= => eX.
   apply/locallyP; rewrite locally_E.
   by exists e => //= x _ x0; apply eX; rewrite mulVr // ?unitfE // subrr normr0.
@@ -309,7 +309,7 @@ rewrite /g2.
 have [/eqP ->|v0] := boolP (v == 0).
   rewrite (_ : (fun _ => _) = cst 0); first exact: cst_continuous.
   by rewrite funeqE => ?; rewrite scaler0 /k littleo_lim0 // scaler0.
-apply/flim_normP => e e0.
+apply/cvg_normP => e e0.
 rewrite nearE /=; apply/locallyP; rewrite locally_E.
 have /(littleoP [littleo of k]) /locallyP[i i0 Hi] : 0 < e / (2 * `|v|).
   by rewrite divr_gt0 // pmulr_rgt0 // normr_gt0.
@@ -838,8 +838,8 @@ Canonical Rmult_bilinear :=
 Global Instance is_diff_Rmult (p : [filteredType R^o * R^o of R^o * R^o]) :
   is_diff p (fun q => q.1 * q.2) (fun q => p.1 * q.2 + q.1 * p.2).
 Proof.
-apply: DiffDef; first by apply: differentiable_bilin =>?; apply: lim_mult.
-by rewrite diff_bilin // => ?; apply: lim_mult.
+apply: DiffDef; first by apply: differentiable_bilin =>?; apply: cvgM.
+by rewrite diff_bilin // => ?; apply: cvgM.
 Qed.
 
 Lemma eqo_pair (U V' W' : normedModType R) (F : filter_on U)
@@ -856,7 +856,7 @@ Fact dpair (U V' W' : normedModType R) (f : U -> V') (g : U -> W') x :
   (fun y => (f y, g y)) \o shift x = cst (f x, g x) +
   (fun y => ('d f x y, 'd g x y)) +o_ (0 : U) id.
 Proof.
-move=> df dg; split=> [?|]; first by apply: flim_pair; apply: diff_continuous.
+move=> df dg; split=> [?|]; first by apply: cvg_pair; apply: diff_continuous.
 apply/eqaddoE; rewrite funeqE => y /=.
 rewrite ![_ (_ + x)]diff_locallyx//.
 (* fixme *)
@@ -981,8 +981,8 @@ Lemma lim_inv (T : topologicalType) (F : set (set T)) (FF : Filter F)
   (f : T -> R^o) (a : R^o) :
   a != 0 -> f @ F --> a -> (fun y => 1 / f y) @ F --> 1 / a.
 Proof.
-move=> an0 fa; apply: (flim_trans _ (inv_continuous an0)).
-exact: (@flim_comp _ _ _ f (fun y => 1 / y) _ _ _ fa).
+move=> an0 fa; apply: (cvg_trans _ (inv_continuous an0)).
+exact: (@cvg_comp _ _ _ f (fun y => 1 / y) _ _ _ fa).
 Qed.
 
 Lemma diffV (f : V -> R^o) x : differentiable f x -> f x != 0 ->
@@ -1098,12 +1098,12 @@ move=> df dg.
 evar (fg : R -> W); rewrite [X in X @ _](_ : _ = fg) /=; last first.
   rewrite funeqE => h.
   by rewrite !scalerDr scalerN scalerDr opprD addrACA -!scalerBr /fg.
-exact: (@lim_add _ _ [topologicalType of R^o]).
+exact: (@cvgD _ _ [topologicalType of R^o]).
 Qed.
 
 Lemma deriveD (f g : V -> W) (x v : V) : derivable f x v -> derivable g x v ->
   'D_v (f + g) x = 'D_v f x + 'D_v g x.
-Proof. by move=> df dg; apply: flim_map_lim (der_add df dg). Qed.
+Proof. by move=> df dg; apply: cvg_map_lim (der_add df dg). Qed.
 
 Lemma derivableD (f g : V -> W) (x v : V) :
   derivable f x v -> derivable g x v -> derivable (f + g) x v.
@@ -1150,12 +1150,12 @@ Fact der_opp (f : V -> W) (x v : V) : derivable f x v ->
 Proof.
 move=> df; evar (g : R -> W); rewrite [X in X @ _](_ : _ = g) /=; last first.
   by rewrite funeqE => h; rewrite !scalerDr !scalerN -opprD -scalerBr /g.
-exact: (@lim_opp _ _ [topologicalType of R^o]).
+exact: (@cvgN _ _ [topologicalType of R^o]).
 Qed.
 
 Lemma deriveN (f : V -> W) (x v : V) : derivable f x v ->
   'D_v (- f) x = - 'D_v f x.
-Proof. by move=> df; apply: flim_map_lim (der_opp df). Qed.
+Proof. by move=> df; apply: cvg_map_lim (der_opp df). Qed.
 
 Lemma derivableN (f : V -> W) (x v : V) :
   derivable f x v -> derivable (- f) x v.
@@ -1191,12 +1191,12 @@ Proof.
 move=> df; evar (g : R -> W); rewrite [X in X @ _](_ : _ = g) /=; last first.
   rewrite funeqE => h.
   by rewrite scalerBr !scalerA mulrC -!scalerA -!scalerBr /g.
-exact: (@lim_scaler _ _ [topologicalType of R^o]).
+exact: (@cvgZr _ _ [topologicalType of R^o]).
 Qed.
 
 Lemma deriveZ (f : V -> W) (k : R) (x v : V) : derivable f x v ->
   'D_v (k \*: f) x = k *: 'D_v f x.
-Proof. by move=> df; apply: flim_map_lim (der_scal df). Qed.
+Proof. by move=> df; apply: cvg_map_lim (der_scal df). Qed.
 
 Lemma derivableZ (f : V -> W) (k : R) (x v : V) :
   derivable f x v -> derivable (k \*: f) x v.
@@ -1224,8 +1224,8 @@ evar (fg : R -> R); rewrite [X in X @ _](_ : _ = fg) /=; last first.
     by rewrite !scalerBr -addrA ![g x *: _]mulrC addKr.
   rewrite scalerDr scalerA mulrC -scalerA.
   by rewrite [_ *: (g x *: _)]scalerA mulrC -scalerA /fg.
-apply: (@lim_add _ _ [topologicalType of R^o]); last exact: lim_scaler df.
-apply: flim_comp2 (@lim_mult _ _ _) => /=; last exact: dg.
+apply: (@cvgD _ _ [topologicalType of R^o]); last exact: cvgZr df.
+apply: cvg_comp2 (@cvgM _ _ _) => /=; last exact: dg.
 suff : {for 0, continuous (fun h : [filteredType _ of R^o] => f(h *: v + x))}.
   by move=> /continuous_withinNx; rewrite scale0r add0r.
 exact/(@differentiable_continuous _ _ _ (0 : R^o))/derivable1_diffP/derivable1P.
@@ -1234,7 +1234,7 @@ Qed.
 Lemma deriveM (f g : V -> R^o) (x v : V) :
   derivable f x v -> derivable g x v ->
   'D_v (f * g) x = f x *: 'D_v g x + g x *: 'D_v f x.
-Proof. by move=> df dg; apply: flim_map_lim (der_mult df dg). Qed.
+Proof. by move=> df dg; apply: cvg_map_lim (der_mult df dg). Qed.
 
 Lemma derivableM (f g : V -> R^o) (x v : V) :
   derivable f x v -> derivable g x v -> derivable (f * g) x v.
@@ -1285,10 +1285,10 @@ have fn0 : locally' (0 : R^o) [set h | f (h *: v + x) != 0].
 have : (fun h => - ((1 / f x) * (1 / f (h *: v + x))) *:
   (h^-1 *: (f (h *: v + x) - f x))) @ locally' (0 : R^o) -->
   - (1 / f x) ^+2 *: 'D_v f x.
-  apply: flim_comp2 (@lim_mult _ _ _) => //=.
-  apply: (@lim_opp _ [normedModType R of R^o] [topologicalType of R^o]); rewrite expr2.
-  by apply: lim_scaler; apply: lim_inv.
-apply: flim_trans => A [_/posnumP[e] /= Ae].
+  apply: cvg_comp2 (@cvgM _ _ _) => //=.
+  apply: (@cvgN _ [normedModType R of R^o] [topologicalType of R^o]); rewrite expr2.
+  by apply: cvgZr; apply: lim_inv.
+apply: cvg_trans => A [_/posnumP[e] /= Ae].
 move: fn0; apply: filter_app; near=> h => /=.
 move=> fhvxn0; have he : ball 0 e%:num (h : R^o) by near: h; exists e%:num.
 have hn0 : h != 0 by near: h; exists e%:num.
@@ -1303,7 +1303,7 @@ Grab Existential Variables. all: end_near. Qed.
 
 Lemma deriveV (f : V -> R^o) x v : f x != 0 -> derivable f x v ->
   'D_v[fun y => 1 / f y] x = - (1 / f x) ^+2 *: 'D_v f x.
-Proof. by move=> fxn0 df; apply: flim_map_lim (der_inv fxn0 df). Qed.
+Proof. by move=> fxn0 df; apply: cvg_map_lim (der_inv fxn0 df). Qed.
 
 Lemma derivableV (f : V -> R^o) (x v : V) :
   f x != 0 -> derivable f x v -> derivable (fun y => 1 / f y) x v.
@@ -1337,14 +1337,14 @@ have {imf_ltsup} imf_ltsup : forall t, t \in `[a, b] -> f t < sup imf.
   rewrite falseE; apply: imf_ltsup; exists t => //.
   apply/eqP; rewrite eq_le supleft sup_upper_bound => //.
   by rewrite !inE; apply/asboolP/imageP.
-have invf_cont : {in `[a, b], continuous (fun t => 1 / (sup imf - f t) : R^o)}.
+have invf_continuous : {in `[a, b], continuous (fun t => 1 / (sup imf - f t) : R^o)}.
   move=> t tab; apply: (@lim_inv _ [topologicalType of R^o]).
     by rewrite neq_lt subr_gt0 orbC imf_ltsup.
-  by apply: lim_add; [apply: continuous_cst|apply: lim_opp; apply:fcont].
+  by apply: cvgD; [apply: continuous_cst|apply: cvgN; apply:fcont].
 have [M [Mreal imVfltM]] : bounded ((fun t => 1 / (sup imf - f t)) @`
   [set x | x \in `[a, b]] : set R^o).
   apply/compact_bounded/continuous_compact; last exact: segment_compact.
-  by move=> ?; rewrite inE => /asboolP /invf_cont.
+  by move=> ?; rewrite inE => /asboolP /invf_continuous.
 set k := Num.max (M + 1) 1; have kgt0 : 0 < k by rewrite ltxU ltr01 orbC.
 have : exists2 y, y \in imf & sup imf - k^-1 < y.
   by apply: sup_adherent => //; rewrite invr_gt0.
@@ -1376,7 +1376,7 @@ Proof.
 move=> cvfx; apply/Logic.eq_sym.
 (* should be inferred *)
 have atrF := at_right_proper_filter x.
-apply: (@flim_map_lim _ _ _ (at_right _)) => A /cvfx /locallyP [_ /posnumP[e] xe_A].
+apply: (@cvg_map_lim _ _ _ (at_right _)) => A /cvfx /locallyP [_ /posnumP[e] xe_A].
 by exists e%:num => // y xe_y; rewrite lt_def => /andP [xney _]; apply: xe_A.
 Qed.
 
@@ -1386,12 +1386,12 @@ Proof.
 move=> cvfx; apply/Logic.eq_sym.
 (* should be inferred *)
 have atrF := at_left_proper_filter x.
-apply: (@flim_map_lim _ _ _ (at_left _)) => A /cvfx /locallyP [_ /posnumP[e] xe_A].
+apply: (@cvg_map_lim _ _ _ (at_left _)) => A /cvfx /locallyP [_ /posnumP[e] xe_A].
 exists e%:num => // y xe_y; rewrite lt_def => /andP [xney _].
 by apply: xe_A => //; rewrite eq_sym.
 Qed.
 
-Lemma le0r_flim_map (R : realFieldType) (T : topologicalType) (F : set (set T))
+Lemma le0r_cvg_map (R : realFieldType) (T : topologicalType) (F : set (set T))
   (FF : ProperFilter F) (f : T -> R^o) :
   (\forall x \near F, 0 <= f x) -> cvg (f @ F) -> 0 <= lim (f @ F).
 Proof.
@@ -1405,27 +1405,27 @@ rewrite ltr_subl_addr => /lt_le_trans; apply.
 by rewrite ltr0_norm // addrC subrr.
 Grab Existential Variables. all: end_near. Qed.
 
-Lemma ler0_flim_map (R : realFieldType) (T : topologicalType) (F : set (set T))
+Lemma ler0_cvg_map (R : realFieldType) (T : topologicalType) (F : set (set T))
   (FF : ProperFilter F) (f : T -> R^o) :
   (\forall x \near F, f x <= 0) -> cvg (f @ F) -> lim (f @ F) <= 0.
 Proof.
 move=> fle0 fcv; rewrite -oppr_ge0.
 have limopp : - lim (f @ F) = lim (- f @ F).
-  by apply: Logic.eq_sym; apply: flim_map_lim; apply: lim_opp.
-rewrite limopp; apply: le0r_flim_map; last by rewrite -limopp; apply: lim_opp.
+  by apply: Logic.eq_sym; apply: cvg_map_lim; apply: cvgN.
+rewrite limopp; apply: le0r_cvg_map; last by rewrite -limopp; apply: cvgN.
 by move: fle0; apply: filterS => x; rewrite oppr_ge0.
 Qed.
 
-Lemma ler_flim_map (R : realFieldType) (T : topologicalType) (F : set (set T)) (FF : ProperFilter F)
+Lemma ler_cvg_map (R : realFieldType) (T : topologicalType) (F : set (set T)) (FF : ProperFilter F)
   (f g : T -> R^o) :
   (\forall x \near F, f x <= g x) -> cvg (f @ F) -> cvg (g @ F) ->
   lim (f @ F) <= lim (g @ F).
 Proof.
 move=> lefg fcv gcv; rewrite -subr_ge0.
 have eqlim : lim (g @ F) - lim (f @ F) = lim ((g - f) @ F).
-  by apply: Logic.eq_sym; apply: flim_map_lim; apply: lim_add => //; apply: lim_opp.
-rewrite eqlim; apply: le0r_flim_map; last first.
-  by rewrite /(cvg _) -eqlim /=; apply: lim_add => //; apply: lim_opp.
+  by apply: Logic.eq_sym; apply: cvg_map_lim; apply: cvgD => //; apply: cvgN.
+rewrite eqlim; apply: le0r_cvg_map; last first.
+  by rewrite /(cvg _) -eqlim /=; apply: cvgD => //; apply: cvgN.
 by move: lefg; apply: filterS => x; rewrite subr_ge0.
 Qed.
 
@@ -1436,10 +1436,10 @@ Proof.
 move=> leab fdrvbl cab cmax; apply: DeriveDef; first exact: fdrvbl.
 apply/eqP; rewrite eq_le; apply/andP; split.
   rewrite ['D_1 f c]cvg_at_rightE; last exact: fdrvbl.
-  apply: ler0_flim_map; last first.
+  apply: ler0_cvg_map; last first.
     have /fdrvbl dfc := cab.
     rewrite -(@cvg_at_rightE _ _ (fun h : R^o => h^-1 *: ((f \o shift c) _ - f c))) //.
-    apply: flim_trans dfc; apply: flim_app.
+    apply: cvg_trans dfc; apply: cvg_app.
     move=> A [e egt0 Ae]; exists e => // x xe xgt0; apply: Ae => //.
     exact/lt0r_neq0.
   near=> h; apply: mulr_ge0_le0.
@@ -1450,9 +1450,9 @@ apply/eqP; rewrite eq_le; apply/andP; split.
   move=> /(le_lt_trans (ler_norm _)); rewrite ltr_subr_addr inE/= => ->.
   by move=> /ltr_spsaddl -> //; rewrite (itvP cab).
 rewrite ['D_1 f c]cvg_at_leftE; last exact: fdrvbl.
-apply: le0r_flim_map; last first.
+apply: le0r_cvg_map; last first.
   have /fdrvbl dfc := cab; rewrite -(@cvg_at_leftE _ _ (fun h => h^-1 *: ((f \o shift c) _ - f c))) //.
-  apply: flim_trans dfc; apply: flim_app.
+  apply: cvg_trans dfc; apply: cvg_app.
   move=> A [e egt0 Ae]; exists e => // x xe xgt0; apply: Ae => //.
   exact/ltr0_neq0.
 near=> h; apply: mulr_le0.

--- a/theories/landau.v
+++ b/theories/landau.v
@@ -883,8 +883,8 @@ Proof.
 split=> fFl.
   apply/eqaddoP => _/posnumP[eps]; near=> x.
   rewrite /cst ltW //= distrC; near: x.
-  by apply: (flim_norm _ fFl); rewrite mulr_gt0 // normr1.
-apply/flim_normP=> _/posnumP[eps]; rewrite /= near_simpl.
+  by apply: (cvg_norm _ fFl); rewrite mulr_gt0 // normr1.
+apply/cvg_normP=> _/posnumP[eps]; rewrite /= near_simpl.
 have lt_eps x : x <= (eps%:num / 2%:R) * `|1 : K^o|%real -> x < eps%:num.
   rewrite normr1 mulr1 => /le_lt_trans; apply.
   by rewrite ltr_pdivr_mulr // ltr_pmulr // ltr1n.
@@ -1120,7 +1120,7 @@ have /= := ye (t - (x - y)); rewrite addrNK; apply.
 by rewrite opprB addrCA opprD addrA subrr add0r opprB.
 Qed.
 
-Lemma flim_shift {T : Type} {K : numDomainType} {R : normedModType K}
+Lemma cvg_shift {T : Type} {K : numDomainType} {R : normedModType K}
   (x y : R) (f : R -> T) :
   (f \o shift x) @ y = f @ (y + x).
 Proof.
@@ -1145,7 +1145,7 @@ Lemma linear_for_continuous (f : {linear U -> V | GRing.Scale.op s_law}) :
   (f : _ -> _) =O_ (0 : U) (cst (1 : R^o)) -> continuous f.
 Proof.
 move=> /eqO_exP [_/posnumP[k0] Of1] x.
-apply/flim_normP => _/posnumP[e]; rewrite !near_simpl.
+apply/cvg_normP => _/posnumP[e]; rewrite !near_simpl.
 rewrite (near_shift 0) /= subr0; near=> y => /=.
 rewrite -linearB opprD addrC addrNK linearN normrN; near: y.
 suff flip : \forall k \near +oo, forall x, `|f x| <= k * `|x|.

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -650,13 +650,13 @@ Local Notation ball_norm := (ball_ (@normr R V)).
 
 Local Notation locally_norm := (locally_ ball_norm).
 
-Lemma locally_le_locally_norm (x : V) : flim (locally x) (locally_norm x).
+Lemma locally_le_locally_norm (x : V) : locally x `=>` locally_norm x.
 Proof.
 move=> P [_ /posnumP[e] subP]; apply/locallyP.
 by eexists; last (move=> y Py; apply/subP; rewrite ball_normE; apply/Py).
 Qed.
 
-Lemma locally_norm_le_locally x : flim (locally_norm x) (locally x).
+Lemma locally_norm_le_locally x : locally_norm x `=>` locally x.
 Proof.
 move=> P /locallyP [_ /posnumP[e] Pxe].
 by exists e%:num => // y; rewrite ball_normE; apply/Pxe.
@@ -706,13 +706,13 @@ Proof. by move=> e1e2 y /lt_le_trans; apply. Qed.
 Let locally_simpl :=
   (locally_simpl,@locally_locally_norm,@filter_from_norm_locally).
 
-Lemma flim_normP {F : set (set V)} {FF : Filter F} (y : V) :
+Lemma cvg_normP {F : set (set V)} {FF : Filter F} (y : V) :
   F --> y <-> forall eps, 0 < eps -> \forall y' \near F, `|y - y'| < eps.
 Proof. by rewrite -filter_fromP /= !locally_simpl. Qed.
 
-Lemma flim_norm {F : set (set V)} {FF : Filter F} (y : V) :
+Lemma cvg_norm {F : set (set V)} {FF : Filter F} (y : V) :
   F --> y -> forall eps, eps > 0 -> \forall y' \near F, `|y - y'| < eps.
-Proof. by move=> /flim_normP. Qed.
+Proof. by move=> /cvg_normP. Qed.
 
 Lemma closeE (x y : V) : close x y = (x = y).
 Proof.
@@ -734,7 +734,7 @@ Proof. by rewrite propeqE ball_normE. Qed.
 
 End NormedModule_numDomainType.
 Hint Resolve normr_ge0 : core.
-Arguments flim_norm {_ _ F FF}.
+Arguments cvg_norm {_ _ F FF}.
 
 Section NormedModule_numFieldType.
 Variables (R : numFieldType) (V : normedModType R).
@@ -767,49 +767,49 @@ Proof.
 by move=> xlt ylt; rewrite -[y]opprK (@distm_lt_split 0) ?subr0 ?opprK ?add0r.
 Qed.
 
-Lemma flim_unique {F} {FF : ProperFilter F} :
+Lemma cvg_unique {F} {FF : ProperFilter F} :
   is_prop [set x : V | F --> x].
-Proof. by move=> Fx Fy; rewrite -closeE; apply: flim_close. Qed.
+Proof. by move=> Fx Fy; rewrite -closeE; apply: cvg_close. Qed.
 
-Lemma locally_flim_unique (x y : V) : x --> y -> x = y.
-Proof. by rewrite -closeE; apply: flim_close. Qed.
+Lemma locally_cvg_unique (x y : V) : x --> y -> x = y.
+Proof. by rewrite -closeE; apply: cvg_close. Qed.
 
 Lemma lim_id (x : V) : lim x = x.
-Proof. by symmetry; apply: locally_flim_unique; apply/cvg_ex; exists x. Qed.
+Proof. by symmetry; apply: locally_cvg_unique; apply/cvg_ex; exists x. Qed.
 
-Lemma flim_lim {F} {FF : ProperFilter F} (l : V) :
+Lemma cvg_lim {F} {FF : ProperFilter F} (l : V) :
   F --> l -> lim F = l.
-Proof. by move=> Fl; have Fcv := cvgP Fl; apply: (@flim_unique F). Qed.
+Proof. by move=> Fl; have Fcv := cvgP Fl; apply: (@cvg_unique F). Qed.
 
-Lemma flim_map_lim {T : Type} {F} {FF : ProperFilter F} (f : T -> V) (l : V) :
+Lemma cvg_map_lim {T : Type} {F} {FF : ProperFilter F} (f : T -> V) (l : V) :
   f @ F --> l -> lim (f @ F) = l.
-Proof. exact: flim_lim. Qed.
+Proof. exact: cvg_lim. Qed.
 
-Lemma flimi_unique {T : Type} {F} {FF : ProperFilter F} (f : T -> set V) :
+Lemma cvgi_unique {T : Type} {F} {FF : ProperFilter F} (f : T -> set V) :
   {near F, is_fun f} -> is_prop [set x : V | f `@ F --> x].
-Proof. by move=> ffun fx fy; rewrite -closeE; apply: flimi_close. Qed.
+Proof. by move=> ffun fx fy; rewrite -closeE; apply: cvgi_close. Qed.
 
-Lemma flim_normW {F : set (set V)} {FF : Filter F} (y : V) :
+Lemma cvg_normW {F : set (set V)} {FF : Filter F} (y : V) :
   (forall eps, 0 < eps -> \forall y' \near F, `|y - y'| <= eps) ->
   F --> y.
 Proof.
-move=> cv; apply/flim_normP => _/posnumP[e]; near=> x.
+move=> cv; apply/cvg_normP => _/posnumP[e]; near=> x.
 by apply: normm_leW => //; near: x; apply: cv.
 Grab Existential Variables. all: end_near. Qed.
 
-Lemma flimi_map_lim {T} {F} {FF : ProperFilter F} (f : T -> V -> Prop) (l : V) :
+Lemma cvgi_map_lim {T} {F} {FF : ProperFilter F} (f : T -> V -> Prop) (l : V) :
   F (fun x : T => is_prop (f x)) ->
   f `@ F --> l -> lim (f `@ F) = l.
 Proof.
 move=> f_prop f_l; apply: get_unique => // l' f_l'.
-exact: flimi_unique _ f_l' f_l.
+exact: cvgi_unique _ f_l' f_l.
 Qed.
 
-Lemma flim_bounded_real {F : set (set V)} {FF : Filter F} (y : V) :
+Lemma cvg_bounded_real {F : set (set V)} {FF : Filter F} (y : V) :
   F --> y ->
   \forall M \near +oo, M \is Num.real /\ \forall y' \near F, `|y'| < M.
 Proof.
-move=> /flim_norm Fy; exists `|y|; rewrite normr_real; split => // M.
+move=> /cvg_norm Fy; exists `|y|; rewrite normr_real; split => // M.
 rewrite -subr_gt0 => subM_gt0; split.
   rewrite -comparabler0 (@comparabler_trans _ (M - `|y|)) //.
     by rewrite -subr_comparable0 opprD addrA subrr add0r opprK comparabler0
@@ -821,12 +821,12 @@ rewrite (le_lt_trans _ yy') // (le_trans _ (ler_dist_dist _ _)) // distrC.
 by rewrite real_ler_norm // realB.
 Qed.
 
-Lemma flim_bounded {F : set (set V)} {FF : Filter F} (y : V) :
+Lemma cvg_bounded {F : set (set V)} {FF : Filter F} (y : V) :
   F --> y -> \forall M \near +oo, \forall y' \near F, `|y'| < M.
-Proof. move/flim_bounded_real; by apply: filterS => x []. Qed.
+Proof. move/cvg_bounded_real; by apply: filterS => x []. Qed.
 
 End NormedModule_numFieldType.
-Arguments flim_bounded {_ _ F FF}.
+Arguments cvg_bounded {_ _ F FF}.
 
 Module Export LocallyNorm.
 Definition locally_simpl :=
@@ -868,14 +868,14 @@ Definition near_simpl := (@near_simpl, @locally_normE,
 Ltac near_simpl := rewrite ?near_simpl.
 End NearNorm.
 
-Lemma continuous_flim_norm {R : numFieldType}
+Lemma continuous_cvg_norm {R : numFieldType}
   (V W : normedModType R) (f : V -> W) x l :
   continuous f -> x --> l -> forall e : {posnum R}, `|f l - f x| < e%:num.
 Proof.
 move=> cf xl e.
-move/flim_norm: (cf l) => /(_ _ (posnum_gt0 e)).
+move/cvg_norm: (cf l) => /(_ _ (posnum_gt0 e)).
 rewrite nearE /= => /locallyP; rewrite locally_E => -[i i0]; apply.
-have /@flim_norm : Filter [filter of x] by apply: filter_on_Filter.
+have /@cvg_norm : Filter [filter of x] by apply: filter_on_Filter.
 move/(_ _ xl _ i0).
 rewrite nearE /= => /locallyP; rewrite locally_E => -[j j0].
 by move/(_ _ (ballxx _ j0)); rewrite -ball_normE.
@@ -1441,33 +1441,33 @@ Section prod_NormedModule_lemmas.
 
 Context {T : Type} {K : numDomainType} {U V : normedModType K}.
 
-Lemma flim_norm2P {F : set (set U)} {G : set (set V)}
+Lemma cvg_norm2P {F : set (set U)} {G : set (set V)}
   {FF : Filter F} {FG : Filter G} (y : U) (z : V):
   (F, G) --> (y, z) <->
   forall eps, 0 < eps ->
    \forall y' \near F & z' \near G, `| (y, z) - (y', z') | < eps.
-Proof. exact: flim_normP. Qed.
+Proof. exact: cvg_normP. Qed.
 
-(* Lemma flim_norm_supP {F : set (set U)} {G : set (set V)} *)
+(* Lemma cvg_norm_supP {F : set (set U)} {G : set (set V)} *)
 (*   {FF : Filter F} {FG : Filter G} (y : U) (z : V): *)
 (*   (F, G) --> (y, z) <-> *)
 (*   forall eps : {posnum R}, {near F & G, forall y' z', *)
 (*           (`|[y - y']| < eps) /\ (`|[z - z']| < eps) }. *)
 (* Proof. *)
-(* rewrite flim_ballP; split => [] P eps. *)
+(* rewrite cvg_ballP; split => [] P eps. *)
 (* - have [[A B] /=[FA GB] ABP] := P eps; exists (A, B) => -//[a b] [/= Aa Bb]. *)
 (*   apply/andP; rewrite -ltr_maxl. *)
 (*   have /= := (@sub_ball_norm_rev _ _ (_, _)). *)
 
-Lemma flim_norm2 {F : set (set U)} {G : set (set V)}
+Lemma cvg_norm2 {F : set (set U)} {G : set (set V)}
   {FF : Filter F} {FG : Filter G} (y : U) (z : V):
   (F, G) --> (y, z) ->
   forall eps, 0 < eps ->
    \forall y' \near F & z' \near G, `|(y, z) - (y', z')| < eps.
-Proof. by rewrite flim_normP. Qed.
+Proof. by rewrite cvg_normP. Qed.
 
 End prod_NormedModule_lemmas.
-Arguments flim_norm2 {_ _ _ F G FF FG}.
+Arguments cvg_norm2 {_ _ _ F G FF FG}.
 
 (** Rings with absolute values are normed modules *)
 
@@ -1494,9 +1494,9 @@ Context {K : numFieldType} {V : normedModType K}.
 
 Lemma add_continuous : continuous (fun z : V * V => z.1 + z.2).
 Proof.
-move=> [/=x y]; apply/flim_normP=> _/posnumP[e].
+move=> [/=x y]; apply/cvg_normP=> _/posnumP[e].
 rewrite !near_simpl /=; near=> a b => /=; rewrite opprD addrACA.
-by rewrite normm_lt_split //; [near: a|near: b]; apply: flim_norm.
+by rewrite normm_lt_split //; [near: a|near: b]; apply: cvg_norm.
 Grab Existential Variables. all: end_near. Qed.
 
 End NVS_continuity.
@@ -1514,18 +1514,18 @@ Local Notation "'+oo'" := (@ERPInf K).
 
 Lemma scale_continuous : continuous (fun z : K^o * V => z.1 *: z.2).
 Proof.
-move=> [k x]; apply/flim_normP=> _/posnumP[e].
+move=> [k x]; apply/cvg_normP=> _/posnumP[e].
 rewrite !near_simpl /=; near +oo => M; near=> l z => /=.
 rewrite (@distm_lt_split _ _ (k *: z)) // -?(scalerBr, scalerBl) normmZ.
   rewrite (le_lt_trans (ler_pmul _ _ (_ : _ <= `|k| + 1) (lexx _))) //.
   by rewrite ler_addl.
   rewrite -ltr_pdivl_mull // ?(lt_le_trans ltr01) ?ler_addr //; near: z.
-  by apply: flim_norm; rewrite // mulr_gt0 // ?invr_gt0 ltr_paddl.
+  by apply: cvg_norm; rewrite // mulr_gt0 // ?invr_gt0 ltr_paddl.
 have zM : @normr _ V z < M.
-  by near: z; near: M; apply: flim_bounded; apply: flim_refl.
+  by near: z; near: M; apply: cvg_bounded; apply: cvg_refl.
 rewrite (le_lt_trans (ler_pmul _ _ (lexx _) (_ : _ <= M))) // ?ltW //.
 rewrite -ltr_pdivl_mulr ?(le_lt_trans _ zM) //.
-near: l; apply: (flim_norm (_ : K^o)) => //.
+near: l; apply: (cvg_norm (_ : K^o)) => //.
 by rewrite divr_gt0 //; near: M; exists 0; rewrite real0.
 (* NB: the last three lines used to be one *)
 Grab Existential Variables. all: end_near. Qed.
@@ -1534,12 +1534,12 @@ Arguments scale_continuous _ _ : clear implicits.
 
 Lemma scaler_continuous k : continuous (fun x : V => k *: x).
 Proof.
-by move=> x; apply: (flim_comp2 (flim_const _) flim_id (scale_continuous (_, _))).
+by move=> x; apply: (cvg_comp2 (cvg_const _) cvg_id (scale_continuous (_, _))).
 Qed.
 
 Lemma scalel_continuous (x : V) : continuous (fun k : K^o => k *: x).
 Proof.
-by move=> k; apply: (flim_comp2 flim_id (flim_const _) (scale_continuous (_, _))).
+by move=> k; apply: (cvg_comp2 cvg_id (cvg_const _) (scale_continuous (_, _))).
 Qed.
 
 Lemma opp_continuous : continuous (@GRing.opp V).
@@ -1554,57 +1554,57 @@ Section limit_composition.
 
 Context {K : numFieldType} {V : normedModType K} {T : topologicalType}.
 
-Lemma lim_cst (a : V) (F : set (set V)) {FF : Filter F} : (fun=> a) @ F --> a.
+Lemma cvg_cst (a : V) (F : set (set V)) {FF : Filter F} : (fun=> a) @ F --> a.
 Proof. exact: cst_continuous. Qed.
-Hint Resolve lim_cst : core.
+Hint Resolve cvg_cst : core.
 
-Lemma lim_add (F : set (set T)) (FF : Filter F) (f g : T -> V) (a b : V) :
+Lemma cvgD (F : set (set T)) (FF : Filter F) (f g : T -> V) (a b : V) :
   f @ F --> a -> g @ F --> b -> (f \+ g) @ F --> a + b.
-Proof. by move=> ??; apply: lim_cont2 => //; exact: add_continuous. Qed.
+Proof. by move=> ??; apply: cvg_continuous2 => //; exact: add_continuous. Qed.
 
 Lemma continuousD (f g : T -> V) x :
   {for x, continuous f} -> {for x, continuous g} ->
   {for x, continuous (fun x => f x + g x)}.
-Proof. by move=> ??; apply: lim_add. Qed.
+Proof. by move=> ??; apply: cvgD. Qed.
 
-Lemma lim_scale (F : set (set T)) (FF : Filter F) (f : T -> K) (g : T -> V)
+Lemma cvgZ (F : set (set T)) (FF : Filter F) (f : T -> K) (g : T -> V)
   (k : K^o) (a : V) :
   f @ F --> k -> g @ F --> a -> (fun x => (f x) *: (g x)) @ F --> k *: a.
-Proof. move=> ??; apply: lim_cont2 => //; exact: scale_continuous. Qed.
+Proof. move=> ??; apply: cvg_continuous2 => //; exact: scale_continuous. Qed.
 
-Lemma lim_scalel (F : set (set T)) (FF : Filter F) (f : T -> K) (a : V) (k : K^o) :
+Lemma cvgZl (F : set (set T)) (FF : Filter F) (f : T -> K) (a : V) (k : K^o) :
   f @ F --> k -> (fun x => (f x) *: a) @ F --> k *: a.
-Proof. by move=> ?; apply: lim_scale => //; exact: cst_continuous. Qed.
+Proof. by move=> ?; apply: cvgZ => //; exact: cst_continuous. Qed.
 
-Lemma lim_scaler (F : set (set T)) (FF : Filter F) (f : T -> V) (k : K) (a : V) :
+Lemma cvgZr (F : set (set T)) (FF : Filter F) (f : T -> V) (k : K) (a : V) :
   f @ F --> a -> k \*: f  @ F --> k *: a.
 Proof.
-apply: lim_scale => //; exact: (@cst_continuous _ [topologicalType of K^o]).
+apply: cvgZ => //; exact: (@cst_continuous _ [topologicalType of K^o]).
 Qed.
 
 Lemma continuousZ (f : T -> V) k x :
   {for x, continuous f} -> {for x, continuous (k \*: f)}.
-Proof. by move=> ?; apply: lim_scaler. Qed.
+Proof. by move=> ?; apply: cvgZr. Qed.
 
 Lemma continuousZl (k : T -> K^o) (f : V) x :
   {for x, continuous k} -> {for x, continuous (fun z => k z *: f)}.
-Proof. by move=> ?; apply: lim_scalel. Qed.
+Proof. by move=> ?; apply: cvgZl. Qed.
 
-Lemma lim_opp (F : set (set T)) (FF : Filter F) (f : T -> V) (a : V) :
+Lemma cvgN (F : set (set T)) (FF : Filter F) (f : T -> V) (a : V) :
   f @ F --> a -> (fun x => - f x) @ F --> - a.
-Proof. by move=> ?; apply: lim_cont => //; apply: opp_continuous. Qed.
+Proof. by move=> ?; apply: cvg_continuous => //; apply: opp_continuous. Qed.
 
 Lemma continuousN (f : T -> V) x :
   {for x, continuous f} -> {for x, continuous (fun x => - f x)}.
-Proof. by move=> ?; apply: lim_opp. Qed.
+Proof. by move=> ?; apply: cvgN. Qed.
 
-Lemma lim_mult (x y : K^o) : z.1 * z.2 @[z --> (x, y)] --> x * y.
+Lemma cvgM (x y : K^o) : z.1 * z.2 @[z --> (x, y)] --> x * y.
 Proof. exact: (@scale_continuous _ [normedModType K of K^o]). Qed.
 
 Lemma continuousM (f g : T -> K^o) x :
   {for x, continuous f} -> {for x, continuous g} ->
   {for x, continuous (fun x => f x * g x)}.
-Proof. by move=> fc gc; apply: flim_comp2 fc gc _; apply: lim_mult. Qed.
+Proof. by move=> fc gc; apply: cvg_comp2 fc gc _; apply: cvgM. Qed.
 
 End limit_composition.
 
@@ -1760,7 +1760,7 @@ Export CompleteNormedModule.Exports.
 (* Qed. *)
 (* Admitted. *)
 
-Arguments flim_normW {_ _ F FF}.
+Arguments cvg_normW {_ _ F FF}.
 
 Lemma R_complete (R : realType) (F : set (set R^o)) : ProperFilter F -> cauchy F -> cvg F.
 Proof.
@@ -1776,7 +1776,7 @@ have D_has_sup : has_sup (mem D); first split.
   rewrite -[ball _ _ _]/(_ (_ < _)) ltr_distl ltr_subl_addr => /andP[/ltW].
   by move=> /(le_trans _) yx01 _ /yx01.
 exists (sup (mem D)).
-apply: (flim_normW (_ : R^o)) => /= _ /posnumP[eps]; near=> x.
+apply: (cvg_normW (_ : R^o)) => /= _ /posnumP[eps]; near=> x.
 rewrite ler_distl sup_upper_bound //=.
   apply: sup_le_ub => //; first by case: D_has_sup.
   apply/forallbP => y; apply/implyP; rewrite in_setE.
@@ -1828,18 +1828,18 @@ Typeclasses Opaque at_left at_right.
 Lemma continuous_norm {K : numFieldType} {V : normedModType K} :
   continuous ((@normr _ V) : V -> K^o).
 Proof.
-move=> x; apply/(@flim_normP _ [normedModType K of K^o]) => _/posnumP[e] /=.
+move=> x; apply/(@cvg_normP _ [normedModType K of K^o]) => _/posnumP[e] /=.
 rewrite !near_simpl; apply/locally_normP; exists e%:num => // y Hy.
 exact/(le_lt_trans (ler_dist_dist _ _)).
 Qed.
 
 (* :TODO: yet, not used anywhere?! *)
-Lemma flim_norm0 {U} {K : numFieldType} {V : normedModType K}
+Lemma cvg_norm0 {U} {K : numFieldType} {V : normedModType K}
   {F : set (set U)} {FF : Filter F} (f : U -> V) :
   (fun x => `|f x|) @ F --> (0 : K^o)
   -> f @ F --> (0 : V).
 Proof.
-move=> /(flim_norm (_ : K^o)) fx0; apply/flim_normP => _/posnumP[e].
+move=> /(cvg_norm (_ : K^o)) fx0; apply/cvg_normP => _/posnumP[e].
 rewrite near_simpl; have := fx0 _ [gt0 of e%:num]; rewrite near_simpl.
 by apply: filterS => x; rewrite !sub0r !normrN [ `|_| ]ger0_norm.
 Qed.
@@ -1873,7 +1873,7 @@ Proof.
 move=> a_cvg; suff: exists M, M \is Num.real /\ forall n, `|a n| <= M.
   by move=> /(@getPex [pointedType of K^o]) [?]; set M := get _; exists M.
 near +oo => M.
-have [//|Mreal [N _ /(_ _ _) /ltW a_leM]] := !! near (flim_bounded_real a_cvg) M.
+have [//|Mreal [N _ /(_ _ _) /ltW a_leM]] := !! near (cvg_bounded_real a_cvg) M.
 exists (maxr `|M|%:nng (\big[maxr/0%:nng]_(n < N) `|a (val (rev_ord n))|%:nng))%:nngnum.
 split => [|/= n]; first by rewrite realE nng_lexU normr_ge0.
 rewrite nng_lexU; have [nN|nN] := leqP N n.
@@ -2500,7 +2500,7 @@ Definition ereal_loc_seq (R : numDomainType) (x : {ereal R}) (n : nat) :=
     | -oo => - n%:R
   end.
 
-Lemma flim_ereal_loc_seq (R : realType) (x : {ereal R}) :
+Lemma cvg_ereal_loc_seq (R : realType) (x : {ereal R}) :
   ereal_loc_seq x --> ereal_locally' x.
 Proof.
 move=> P; rewrite /ereal_loc_seq.
@@ -2547,15 +2547,15 @@ apply/RltP/dx_fxe; split; first by split=> //; apply/eqP.
 by have /RltP := xyd; rewrite distrC.
 Qed.
 
-Lemma continuity_pt_flim (f : Rdefinitions.R -> Rdefinitions.R) (x : Rdefinitions.R) :
+Lemma continuity_pt_cvg (f : Rdefinitions.R -> Rdefinitions.R) (x : Rdefinitions.R) :
   Ranalysis1.continuity_pt f x <-> {for x, continuous f}.
 Proof.
 eapply iff_trans; first exact: continuity_pt_locally.
 apply iff_sym.
 have FF : Filter (f @ x).
   by typeclasses eauto.
-  (*by apply filtermap_filter; apply: @filter_filter' (locally_filter _).*)
-case: (@flim_ballP _ _ (f @ x) FF (f x)) => {FF}H1 H2.
+  (*by apply fmap_filter; apply: @filter_filter' (locally_filter _).*)
+case: (@cvg_ballP _ _ (f @ x) FF (f x)) => {FF}H1 H2.
 (* TODO: in need for lemmas and/or refactoring of already existing lemmas (ball vs. Rabs) *)
 split => [{H2} - /H1 {H1} H1 eps|{H1} H].
 - have {H1} [//|_/posnumP[x0] Hx0] := H1 eps%:num.
@@ -2568,7 +2568,7 @@ Qed.
 
 Lemma continuity_ptE (f : Rdefinitions.R -> Rdefinitions.R) (x : Rdefinitions.R) :
   Ranalysis1.continuity_pt f x <-> {for x, continuous f}.
-Proof. exact: continuity_pt_flim. Qed.
+Proof. exact: continuity_pt_cvg. Qed.
 
 Lemma continuous_withinNx (R : numFieldType) {U V : pseudoMetricType R}
   (f : U -> V) x :
@@ -2576,7 +2576,7 @@ Lemma continuous_withinNx (R : numFieldType) {U V : pseudoMetricType R}
 Proof.
 split=> - cfx P /= fxP.
   rewrite /locally' !near_simpl near_withinE.
-  by rewrite /locally'; apply: flim_within; apply/cfx.
+  by rewrite /locally'; apply: cvg_within; apply/cfx.
  (* :BUG: ssr apply: does not work,
     because the type of the filter is not inferred *)
 rewrite !locally_nearE !near_map !near_locally in fxP *; have /= := cfx P fxP.
@@ -2584,7 +2584,7 @@ rewrite !near_simpl near_withinE near_simpl => Pf; near=> y.
 by have [->|] := eqVneq y x; [by apply: locally_singleton|near: y].
 Grab Existential Variables. all: end_near. Qed.
 
-Lemma continuity_pt_flim' f x :
+Lemma continuity_pt_cvg' f x :
   Ranalysis1.continuity_pt f x <-> f @ locally' x --> f x.
 Proof. by rewrite continuity_ptE continuous_withinNx. Qed.
 
@@ -2592,11 +2592,11 @@ Lemma continuity_pt_locally' f x :
   Ranalysis1.continuity_pt f x <->
   forall eps, 0 < eps -> locally' x (fun u => `|f x - f u| < eps).
 Proof.
-rewrite continuity_pt_flim' (@flim_normP _ [normedModType _ of Rdefinitions.R^o]).
+rewrite continuity_pt_cvg' (@cvg_normP _ [normedModType _ of Rdefinitions.R^o]).
 exact.
 Qed.
 
 Lemma locally_pt_comp (P : Rdefinitions.R -> Prop)
   (f : Rdefinitions.R -> Rdefinitions.R) (x : Rdefinitions.R) :
   locally (f x) P -> Ranalysis1.continuity_pt f x -> \near x, P (f x).
-Proof. by move=> Lf /continuity_pt_flim; apply. Qed.
+Proof. by move=> Lf /continuity_pt_cvg; apply. Qed.

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -71,14 +71,14 @@ Require Import boolp Rstruct classical_sets posnum.
 (*                 PFilterPack F FF == packs the set of sets F with the proof *)
 (*                                     FF of ProperFilter F to build a        *)
 (*                                     pfilter_on T structure.                *)
-(*                    filtermap f F == image of the filter F by the function  *)
+(*                    fmap f F == image of the filter F by the function  *)
 (*                                     f.                                     *)
 (*                     E @[x --> F] == image of the canonical filter          *)
 (*                                     associated to F by the function        *)
 (*                                     (fun x => E).                          *)
 (*                            f @ F == image of the canonical filter          *)
 (*                                     associated to F by the function f.     *)
-(*                   filtermapi f F == image of the filter F by the relation  *)
+(*                   fmapi f F == image of the filter F by the relation  *)
 (*                                     f.                                     *)
 (*                    E `@[x --> F] == image of the canonical filter          *)
 (*                                     associated to F by the relation        *)
@@ -219,7 +219,7 @@ Require Import boolp Rstruct classical_sets posnum.
 (*                                   "neighbourhood" of the diagonal set      *)
 (*                                   D = {(x, x) | x in T}.                   *)
 (*                   ball_set A e == set A extended with a band of width e    *)
-(*                   unif_cont f <-> f is uniformly continuous.               *)
+(*                   unif_continuous f <-> f is uniformly continuous.               *)
 (*                                                                            *)
 (* * Complete spaces :                                                        *)
 (*                   cauchy_ex F <-> the set of sets F is a cauchy filter     *)
@@ -473,16 +473,16 @@ Module Export LocallyFilter.
 Definition locally_simpl := (@filter_of_filterE, @locally_filterE).
 End LocallyFilter.
 
-Definition flim {T : Type} (F G : set (set T)) := G `<=` F.
-Notation "F `=>` G" := (flim F G) : classical_set_scope.
-Lemma flim_refl T (F : set (set T)) : F `=>` F.
+Definition cvg_to {T : Type} (F G : set (set T)) := G `<=` F.
+Notation "F `=>` G" := (cvg_to F G) : classical_set_scope.
+Lemma cvg_refl T (F : set (set T)) : F `=>` F.
 Proof. exact. Qed.
 
-Lemma flim_trans T (G F H : set (set T)) :
+Lemma cvg_trans T (G F H : set (set T)) :
   (F `=>` G) -> (G `=>` H) -> (F `=>` H).
 Proof. by move=> FG GH P /GH /FG. Qed.
 
-Notation "F --> G" := (flim [filter of F] [filter of G]) : classical_set_scope.
+Notation "F --> G" := (cvg_to [filter of F] [filter of G]) : classical_set_scope.
 Definition type_of_filter {T} (F : set (set T)) := T.
 
 Definition lim_in {U : Type} (T : filteredType U) :=
@@ -499,7 +499,7 @@ Canonical filtered_prod X1 X2 (Z1 : filteredType X1)
   FilteredType (X1 * X2) (Z1 * Z2)
     (fun x => filter_prod (locally x.1) (locally x.2)).
 
-Lemma flim_prod T {U U' V V' : filteredType T} (x : U) (l : U') (y : V) (k : V') :
+Lemma cvg_prod T {U U' V V' : filteredType T} (x : U) (l : U') (y : V) (k : V') :
   x --> l -> y --> k -> (x, y) --> (l, k).
 Proof.
 move=> xl yk X [[X1 X2] /= [HX1 HX2] H]; exists (X1, X2) => //=.
@@ -907,51 +907,51 @@ Qed.
 
 (** ** Limits expressed with filters *)
 
-Definition filtermap {T U : Type} (f : T -> U) (F : set (set T)) :=
+Definition fmap {T U : Type} (f : T -> U) (F : set (set T)) :=
   [set P | F (f @^-1` P)].
-Arguments filtermap _ _ _ _ _ /.
+Arguments fmap _ _ _ _ _ /.
 
-Lemma filtermapE {U V : Type} (f : U -> V)
-  (F : set (set U)) (P : set V) : filtermap f F P = F (f @^-1` P).
+Lemma fmapE {U V : Type} (f : U -> V)
+  (F : set (set U)) (P : set V) : fmap f F P = F (f @^-1` P).
 Proof. by []. Qed.
 
 Notation "E @[ x --> F ]" :=
-  (filtermap (fun x => E) [filter of F]) : classical_set_scope.
-Notation "f @ F" := (filtermap f [filter of F]) : classical_set_scope.
-Global Instance filtermap_filter T U (f : T -> U) (F : set (set T)) :
+  (fmap (fun x => E) [filter of F]) : classical_set_scope.
+Notation "f @ F" := (fmap f [filter of F]) : classical_set_scope.
+Global Instance fmap_filter T U (f : T -> U) (F : set (set T)) :
   Filter F -> Filter (f @ F).
 Proof.
-move=> FF; constructor => [|P Q|P Q PQ]; rewrite ?filtermapE ?filter_ofE //=.
+move=> FF; constructor => [|P Q|P Q PQ]; rewrite ?fmapE ?filter_ofE //=.
 - exact: filterT.
 - exact: filterI.
 - by apply: filterS=> ?/PQ.
 Qed.
-Typeclasses Opaque filtermap.
+Typeclasses Opaque fmap.
 
-Global Instance filtermap_proper_filter T U (f : T -> U) (F : set (set T)) :
+Global Instance fmap_proper_filter T U (f : T -> U) (F : set (set T)) :
   ProperFilter F -> ProperFilter (f @ F).
 Proof.
 move=> FF; apply: Build_ProperFilter';
-by rewrite filtermapE; apply: filter_not_empty.
+by rewrite fmapE; apply: filter_not_empty.
 Qed.
-Definition filtermap_proper_filter' := filtermap_proper_filter.
+Definition fmap_proper_filter' := fmap_proper_filter.
 
-Definition filtermapi {T U : Type} (f : T -> set U) (F : set (set T)) :=
+Definition fmapi {T U : Type} (f : T -> set U) (F : set (set T)) :=
   [set P | \forall x \near F, exists y, f x y /\ P y].
 
 Notation "E `@[ x --> F ]" :=
-  (filtermapi (fun x => E) [filter of F]) : classical_set_scope.
-Notation "f `@ F" := (filtermapi f [filter of F]) : classical_set_scope.
+  (fmapi (fun x => E) [filter of F]) : classical_set_scope.
+Notation "f `@ F" := (fmapi f [filter of F]) : classical_set_scope.
 
-Lemma filtermapiE {U V : Type} (f : U -> set V)
+Lemma fmapiE {U V : Type} (f : U -> set V)
   (F : set (set U)) (P : set V) :
-  filtermapi f F P = \forall x \near F, exists y, f x y /\ P y.
+  fmapi f F P = \forall x \near F, exists y, f x y /\ P y.
 Proof. by []. Qed.
 
-Global Instance filtermapi_filter T U (f : T -> set U) (F : set (set T)) :
+Global Instance fmapi_filter T U (f : T -> set U) (F : set (set T)) :
   infer {near F, is_totalfun f} -> Filter F -> Filter (f `@ F).
 Proof.
-move=> f_totalfun FF; rewrite /filtermapi; apply: Build_Filter. (* bug *)
+move=> f_totalfun FF; rewrite /fmapi; apply: Build_Filter. (* bug *)
 - by apply: filterS f_totalfun => x [[y Hy] H]; exists y.
 - move=> P Q FP FQ; near=> x.
     have [//|y [fxy Py]] := near FP x.
@@ -962,49 +962,49 @@ move=> f_totalfun FF; rewrite /filtermapi; apply: Build_Filter. (* bug *)
   by have [//|y [fxy /subPQ Qy]] := near FP x; exists y.
 Grab Existential Variables. all: end_near. Qed.
 
-Typeclasses Opaque filtermapi.
+Typeclasses Opaque fmapi.
 
-Global Instance filtermapi_proper_filter
+Global Instance fmapi_proper_filter
   T U (f : T -> U -> Prop) (F : set (set T)) :
   infer {near F, is_totalfun f} ->
   ProperFilter F -> ProperFilter (f `@ F).
 Proof.
 move=> f_totalfun FF; apply: Build_ProperFilter.
-by move=> P; rewrite /filtermapi => /filter_ex [x [y [??]]]; exists y.
+by move=> P; rewrite /fmapi => /filter_ex [x [y [??]]]; exists y.
 Qed.
-Definition filter_map_proper_filter' := filtermapi_proper_filter.
+Definition filter_map_proper_filter' := fmapi_proper_filter.
 
-Lemma flim_id T (F : set (set T)) : x @[x --> F] --> F.
+Lemma cvg_id T (F : set (set T)) : x @[x --> F] --> F.
 Proof. exact. Qed.
-Arguments flim_id {T F}.
+Arguments cvg_id {T F}.
 
 Lemma appfilter U V (f : U -> V) (F : set (set U)) :
   f @ F = [set P : set _ | \forall x \near F, P (f x)].
 Proof. by []. Qed.
 
-Lemma flim_app U V (F G : set (set U)) (f : U -> V) :
+Lemma cvg_app U V (F G : set (set U)) (f : U -> V) :
   F --> G -> f @ F --> f @ G.
 Proof. by move=> FG P /=; exact: FG. Qed.
 
-Lemma flimi_app U V (F G : set (set U)) (f : U -> set V) :
+Lemma cvgi_app U V (F G : set (set U)) (f : U -> set V) :
   F --> G -> f `@ F --> f `@ G.
 Proof. by move=> FG P /=; exact: FG. Qed.
 
-Lemma flim_comp T U V (f : T -> U) (g : U -> V)
+Lemma cvg_comp T U V (f : T -> U) (g : U -> V)
   (F : set (set T)) (G : set (set U)) (H : set (set V)) :
   f @ F `=>` G -> g @ G `=>` H -> g \o f @ F `=>` H.
-Proof. by move=> fFG gGH; apply: flim_trans gGH => P /fFG. Qed.
+Proof. by move=> fFG gGH; apply: cvg_trans gGH => P /fFG. Qed.
 
-Lemma flimi_comp T U V (f : T -> U) (g : U -> set V)
+Lemma cvgi_comp T U V (f : T -> U) (g : U -> set V)
   (F : set (set T)) (G : set (set U)) (H : set (set V)) :
   f @ F `=>` G -> g `@ G `=>` H -> g \o f `@ F `=>` H.
-Proof. by move=> fFG gGH; apply: flim_trans gGH => P /fFG. Qed.
+Proof. by move=> fFG gGH; apply: cvg_trans gGH => P /fFG. Qed.
 
-Lemma flim_eq_loc {T U} {F : set (set T)} {FF : Filter F} (f g : T -> U) :
+Lemma cvg_eq_loc {T U} {F : set (set T)} {FF : Filter F} (f g : T -> U) :
   {near F, f =1 g} -> g @ F `=>` f @ F.
 Proof. by move=> eq_fg P /=; apply: filterS2 eq_fg => x <-. Qed.
 
-Lemma flimi_eq_loc {T U} {F : set (set T)} {FF : Filter F} (f g : T -> set U) :
+Lemma cvgi_eq_loc {T U} {F : set (set T)} {FF : Filter F} (f g : T -> set U) :
   {near F, f =2 g} -> g `@ F `=>` f `@ F.
 Proof.
 move=> eq_fg P /=; apply: filterS2 eq_fg => x eq_fg [y [fxy Py]].
@@ -1078,11 +1078,11 @@ Lemma near_pair {T U} {F : set (set T)} {G : set (set U)}
        prop_of P x.1 -> prop_of Q x.2 -> prop_of (in_filter_prod P Q) x.
 Proof. by case: x=> x y; do ?rewrite prop_ofE /=; split. Qed.
 
-Lemma flim_fst {T U F G} {FG : Filter G} :
+Lemma cvg_fst {T U F G} {FG : Filter G} :
   (@fst T U) @ filter_prod F G --> F.
 Proof. by move=> P; apply: filter_prod1. Qed.
 
-Lemma flim_snd {T U F G} {FF : Filter F} :
+Lemma cvg_snd {T U F G} {FF : Filter F} :
   (@snd T U) @ filter_prod F G --> G.
 Proof. by move=> P; apply: filter_prod2. Qed.
 
@@ -1101,7 +1101,7 @@ move=> FF FG; rewrite propeqE; split=> -[[A B] /= [fFA fGB] ABP].
   by apply: (ABP (_, _)); apply: xyAB.
 exists (f @` A, g @` B) => //=; last first.
   by move=> -_ [/= [x Ax <-] [x' Bx' <-]]; apply: (ABP (_, _)).
-rewrite !locally_simpl /filtermap /=; split.
+rewrite !locally_simpl /fmap /=; split.
   by apply: filterS fFA=> x Ax; exists x.
 by apply: filterS fGB => x Bx; exists x.
 Qed.
@@ -1118,7 +1118,7 @@ Proof. by []. Qed.
 (* Proof. *)
 (* move=> FF FF' P P' Q PQ [FP FP']; near=> x. *)
 (* have := PQ x.1 x.2; rewrite -surjective_pairing; apply; near: x; *)
-(* by [apply: flim_fst|apply: flim_snd]. *)
+(* by [apply: cvg_fst|apply: cvg_snd]. *)
 (* Grab Existential Variables. all: end_near. Qed. *)
 
 Lemma filter_pair_near_of (T T' : Type) (F : set (set T)) (F' : set (set T')) :
@@ -1129,7 +1129,7 @@ Lemma filter_pair_near_of (T T' : Type) (F : set (set T)) (F' : set (set T')) :
 Proof.
 move=> FF FF' [P FP] [P' FP'] Q PQ; rewrite prop_ofE in FP FP' PQ.
 near=> x; have := PQ x.1 x.2; rewrite -surjective_pairing; apply; near: x;
-by [apply: flim_fst|apply: flim_snd].
+by [apply: cvg_fst|apply: cvg_snd].
 Grab Existential Variables. all: end_near. Qed.
 
 Tactic Notation "near=>" ident(x) ident(y) :=
@@ -1142,7 +1142,7 @@ Definition near_simpl := (@near_simpl, @near_map, @near_mapi, @near_map2).
 Ltac near_simpl := rewrite ?near_simpl.
 End NearMap.
 
-Lemma flim_pair {T U V F} {G : set (set U)} {H : set (set V)}
+Lemma cvg_pair {T U V F} {G : set (set U)} {H : set (set V)}
   {FF : Filter F} {FG : Filter G} {FH : Filter H} (f : T -> U) (g : T -> V) :
   f @ F --> G -> g @ F --> H ->
   (f x, g x) @[x --> F] --> (G, H).
@@ -1151,18 +1151,18 @@ move=> fFG gFH P; rewrite !near_simpl => -[[A B] /=[GA HB] ABP]; near=> x.
 by apply: (ABP (_, _)); split=> //=; near: x; [apply: fFG|apply: gFH].
 Grab Existential Variables. all: end_near. Qed.
 
-Lemma flim_comp2 {T U V W}
+Lemma cvg_comp2 {T U V W}
   {F : set (set T)} {G : set (set U)} {H : set (set V)} {I : set (set W)}
   {FF : Filter F} {FG : Filter G} {FH : Filter H}
   (f : T -> U) (g : T -> V) (h : U -> V -> W) :
   f @ F --> G -> g @ F --> H ->
   h (fst x) (snd x) @[x --> (G, H)] --> I ->
   h (f x) (g x) @[x --> F] --> I.
-Proof. by move=> fFG gFH hGHI P /= IP; apply: flim_pair (hGHI _ IP). Qed.
-Arguments flim_comp2 {T U V W F G H I FF FG FH f g h} _ _ _.
-Definition flim_comp_2 := @flim_comp2.
+Proof. by move=> fFG gFH hGHI P /= IP; apply: cvg_pair (hGHI _ IP). Qed.
+Arguments cvg_comp2 {T U V W F G H I FF FG FH f g h} _ _ _.
+Definition cvg_to_comp_2 := @cvg_comp2.
 
-(* Lemma flimi_comp_2 {T U V W} *)
+(* Lemma cvgi_comp_2 {T U V W} *)
 (*   {F : set (set T)} {G : set (set U)} {H : set (set V)} {I : set (set W)} *)
 (*   {FF : Filter F} *)
 (*   (f : T -> U) (g : T -> V) (h : U -> V -> set W) : *)
@@ -1172,8 +1172,8 @@ Definition flim_comp_2 := @flim_comp2.
 (* Proof. *)
 (* intros Cf Cg Ch. *)
 (* change (fun x => h (f x) (g x)) with (fun x => h (fst (f x, g x)) (snd (f x, g x))). *)
-(* apply: flimi_comp Ch. *)
-(* now apply flim_pair. *)
+(* apply: cvgi_comp Ch. *)
+(* now apply cvg_pair. *)
 (* Qed. *)
 
 (** Restriction of a filter to a domain *)
@@ -1205,7 +1205,7 @@ Typeclasses Opaque within.
 Canonical within_filter_on T D (F : filter_on T) :=
   FilterType (within D F) (within_filter _ _).
 
-Lemma flim_within {T} {F : set (set T)} {FF : Filter F} D :
+Lemma cvg_within {T} {F : set (set T)} {FF : Filter F} D :
   within D F --> F.
 Proof. by move=> P; apply: filterS. Qed.
 
@@ -1430,7 +1430,7 @@ Qed.
 Lemma continuous_comp (R S T : topologicalType) (f : R -> S) (g : S -> T) x :
   {for x, continuous f} -> {for (f x), continuous g} ->
   {for x, continuous (g \o f)}.
-Proof. exact: flim_comp. Qed.
+Proof. exact: cvg_comp. Qed.
 
 Lemma open_comp  {T U : topologicalType} (f : T -> U) (D : set U) :
   {in f @^-1` D, continuous f} -> open D -> open (f @^-1` D).
@@ -1439,7 +1439,7 @@ rewrite !openE => fcont Dop x /= Dfx.
 by apply: fcont; [rewrite in_setE|apply: Dop].
 Qed.
 
-Lemma is_filter_lim_filtermap {T: topologicalType} {U : topologicalType}
+Lemma cvg_fmap {T: topologicalType} {U : topologicalType}
   (F : set (set T)) x (f : T -> U) :
    {for x, continuous f} -> F --> x -> f @ F --> f x.
 Proof. by move=> cf fx P /cf /fx. Qed.
@@ -1457,24 +1457,24 @@ Grab Existential Variables. all: end_near. Qed.
 
 (* limit composition *)
 
-Lemma lim_cont {T : Type} {V U : topologicalType}
+Lemma cvg_continuous {T : Type} {V U : topologicalType}
   (F : set (set T)) (FF : Filter F)
   (f : T -> V) (h : V -> U) (a : V) :
   {for a, continuous h} ->
   f @ F --> a -> (h \o f) @ F --> h a.
 Proof.
-move=> h_cont fa fb; apply: (flim_trans _ h_cont).
-exact: (@flim_comp _ _ _ _ h _ _ _ fa).
+move=> h_continuous fa fb; apply: (cvg_trans _ h_continuous).
+exact: (@cvg_comp _ _ _ _ h _ _ _ fa).
 Qed.
 
-Lemma lim_cont2 {T : Type} {V W U : topologicalType}
+Lemma cvg_continuous2 {T : Type} {V W U : topologicalType}
   (F : set (set T)) (FF : Filter F)
   (f : T -> V) (g : T -> W) (h : V -> W -> U) (a : V) (b : W) :
   h z.1 z.2 @[z --> (a, b)] --> h a b ->
   f @ F --> a -> g @ F --> b -> (fun x => h (f x) (g x)) @ F --> h a b.
 Proof.
-move=> h_cont fa fb; apply: (flim_trans _ h_cont).
-exact: (@flim_comp _ _ _ _ (fun x => h x.1 x.2) _ _ _ (flim_pair fa fb)).
+move=> h_continuous fa fb; apply: (cvg_trans _ h_continuous).
+exact: (@cvg_comp _ _ _ _ (fun x => h x.1 x.2) _ _ _ (cvg_pair fa fb)).
 Qed.
 
 Lemma cst_continuous {T : Type} {T' : topologicalType} (k : T')
@@ -1746,7 +1746,7 @@ Definition weak_topologicalType :=
 Lemma weak_continuous : continuous (f : weak_topologicalType -> T).
 Proof. by apply/continuousP => A ?; exists A. Qed.
 
-Lemma flim_image (F : set (set S)) (s : S) :
+Lemma cvg_image (F : set (set S)) (s : S) :
   Filter F -> f @` setT = setT ->
   F --> (s : weak_topologicalType) <-> [set f @` A | A in F] --> (f s).
 Proof.
@@ -1779,7 +1779,7 @@ Definition sup_topologicalType :=
   Topological.Pack (@Topological.Class _ (Filtered.Class (Pointed.class T) _)
   sup_topologicalTypeMixin).
 
-Lemma flim_sup (F : set (set T)) (t : T) :
+Lemma cvg_sup (F : set (set T)) (t : T) :
   Filter F -> F --> (t : sup_topologicalType) <-> forall i, F --> (t : TS i).
 Proof.
 move=> Ffilt; split=> cvFt.
@@ -1860,20 +1860,20 @@ Typeclasses Opaque locally'.
 Canonical locally'_filter_on (T : topologicalType)  (x : T) :=
   FilterType (locally' x) (locally'_filter _).
 
-Lemma subset_filtermap (T U : Type) (f : T -> U):
+Lemma cvg_fmap2 (T U : Type) (f : T -> U):
   forall (F G : set (set T)), G `=>` F -> f @ G `=>` f @ F.
 Proof. by move=> F G H A fFA ; exact: H (preimage f A) fFA. Qed.
 
-Lemma flim_within_filter {T U} {f : T -> U} (F : set (set T)) {FF : (Filter F) }
+Lemma cvg_within_filter {T U} {f : T -> U} (F : set (set T)) {FF : (Filter F) }
   (G : set (set U)) : forall (D : set T), (f @ F) --> G -> (f @ within D F) --> G.
-Proof. move=> ?;  exact: flim_trans (subset_filtermap (flim_within _)). Qed. 
+Proof. move=> ?;  exact: cvg_trans (cvg_fmap2 (cvg_within _)). Qed. 
 
-Lemma cvg_within {T} {U : topologicalType} (f : T -> U) (F : set (set T))
+Lemma cvg_app_within {T} {U : topologicalType} (f : T -> U) (F : set (set T))
   (D : set T): Filter F -> cvg (f @ F) -> cvg (f @ within D F).
-Proof. by move => FF /cvg_ex [l H]; apply/cvg_ex; exists l; exact: flim_within_filter. Qed.
+Proof. by move => FF /cvg_ex [l H]; apply/cvg_ex; exists l; exact: cvg_within_filter. Qed.
 
 Lemma locally_locally' {T : topologicalType} (x : T) : locally' x `=>` locally x.
-Proof. exact: flim_within. Qed.
+Proof. exact: cvg_within. Qed.
 
 (** ** Closed sets in topological spaces *)
 
@@ -1940,13 +1940,13 @@ End Closed.
 Lemma closed_comp {T U : topologicalType} (f : T -> U) (D : set U) :
   {in ~` f @^-1` D, continuous f} -> closed D -> closed (f @^-1` D).
 Proof.
-rewrite !closedE=> f_cont D_cl x /= xDf; apply: D_cl; apply: contrap xDf => fxD.
+rewrite !closedE=> f_continuous D_cl x /= xDf; apply: D_cl; apply: contrap xDf => fxD.
 have NDfx : ~ D (f x).
   by move: fxD; rewrite -locally_nearE locallyE => - [A [[??]]]; apply.
-by apply: f_cont fxD; rewrite in_setE.
+by apply: f_continuous fxD; rewrite in_setE.
 Qed.
 
-Lemma closed_flim_loc {T} {U : topologicalType} {F} {FF : ProperFilter F}
+Lemma closed_cvg_loc {T} {U : topologicalType} {F} {FF : ProperFilter F}
   (f : T -> U) (D : U -> Prop) :
   forall y, f @ F --> y -> F (f @^-1` D) -> closed D -> D y.
 Proof.
@@ -1954,11 +1954,11 @@ move=> y Ffy Df; apply => A /Ffy /=; rewrite locally_filterE.
 by move=> /(filterI Df); apply: filter_ex.
 Qed.
 
-Lemma closed_flim {T} {U : topologicalType} {F} {FF : ProperFilter F}
+Lemma closed_cvg {T} {U : topologicalType} {F} {FF : ProperFilter F}
   (f : T -> U) (D : U -> Prop) :
   forall y, f @ F --> y -> (forall x, D (f x)) -> closed D -> D y.
 Proof.
-by move=> y fy FDf; apply: (closed_flim_loc fy); apply: filterE.
+by move=> y fy FDf; apply: (closed_cvg_loc fy); apply: filterE.
 Qed.
 
 (** ** Compact sets *)
@@ -1973,10 +1973,10 @@ Definition cluster (F : set (set T)) (p : T) :=
 Lemma clusterE F : cluster F = \bigcap_(A in F) (closure A).
 Proof. by rewrite predeqE => p; split=> cF ????; apply: cF. Qed.
 
-Lemma flim_cluster F G : F --> G -> cluster F `<=` cluster G.
+Lemma cvg_cluster F G : F --> G -> cluster F `<=` cluster G.
 Proof. by move=> sGF p Fp P Q GP Qp; apply: Fp Qp; apply: sGF. Qed.
 
-Lemma cluster_flimE F :
+Lemma cluster_cvgE F :
   ProperFilter F ->
   cluster F = [set p | exists2 G, ProperFilter G & G --> p /\ F `<=` G].
 Proof.
@@ -2028,7 +2028,7 @@ Lemma compact_closed (A : set T) : hausdorff -> compact A -> closed A.
 Proof.
 move=> hT Aco p clAp; have pA := !! @withinT _ (locally p) A _.
 have [q [Aq clsAp_q]] := !! Aco _ _ pA; rewrite (hT p q) //.
-by apply: flim_cluster clsAp_q; apply: flim_within.
+by apply: cvg_cluster clsAp_q; apply: cvg_within.
 Qed.
 
 End Compact.
@@ -2057,12 +2057,12 @@ Class UltraFilter T (F : set (set T)) := {
   max_filter : forall G : set (set T), ProperFilter G -> F `<=` G -> G = F
 }.
 
-Lemma ultra_flim_clusterE (T : topologicalType) (F : set (set T)) :
+Lemma ultra_cvg_clusterE (T : topologicalType) (F : set (set T)) :
   UltraFilter F -> cluster F = [set p | F --> p].
 Proof.
 move=> FU; rewrite predeqE => p; split.
-  by rewrite cluster_flimE => - [G GF [cvGp /max_filter <-]].
-by move=> cvFp; rewrite cluster_flimE; exists F; [apply: ultra_proper|split].
+  by rewrite cluster_cvgE => - [G GF [cvGp /max_filter <-]].
+by move=> cvFp; rewrite cluster_cvgE; exists F; [apply: ultra_proper|split].
 Qed.
 
 Lemma ultraFilterLemma T (F : set (set T)) :
@@ -2105,11 +2105,11 @@ Lemma compact_ultra (T : topologicalType) :
   UltraFilter F -> F A -> A `&` [set p | F --> p] !=set0].
 Proof.
 rewrite predeqE => A; split=> Aco F FF FA.
-  by have /Aco [p [?]] := FA; rewrite ultra_flim_clusterE; exists p.
+  by have /Aco [p [?]] := FA; rewrite ultra_cvg_clusterE; exists p.
 have [G [GU sFG]] := ultraFilterLemma FF.
 have /Aco [p [Ap]] : G A by apply: sFG.
-rewrite -[_ --> p]/([set _ | _] p) -ultra_flim_clusterE.
-by move=> /(flim_cluster sFG); exists p.
+rewrite -[_ --> p]/([set _ | _] p) -ultra_cvg_clusterE.
+by move=> /(cvg_cluster sFG); exists p.
 Qed.
 
 Lemma filter_image (T U : Type) (f : T -> U) (F : set (set T)) :
@@ -2200,10 +2200,10 @@ have pFA : forall i, pF i (A i).
   move=> j; case: (eqVneq i j); first by case: _ /; rewrite subst_coordT.
   by move=> /subst_coordN ->; apply: Af.
 have cvpFA i : A i `&` [set p | pF i --> p] !=set0.
-  by rewrite -ultra_flim_clusterE; apply: Aco.
+  by rewrite -ultra_cvg_clusterE; apply: Aco.
 exists (fun i => get (A i `&` [set p | pF i --> p])).
 split=> [i|]; first by have /getPex [] := cvpFA i.
-by apply/flim_sup => i; apply/flim_image=> //; have /getPex [] := cvpFA i.
+by apply/cvg_sup => i; apply/cvg_image=> //; have /getPex [] := cvpFA i.
 Qed.
 
 End Tychonoff.
@@ -2539,27 +2539,27 @@ Lemma near_ball (y : M) (eps : {posnum R}) :
    \forall y' \near y, ball y eps%:num y'.
 Proof. exact: locally_ball. Qed.
 
-Lemma flim_ballP {F} {FF : Filter F} (y : M) :
+Lemma cvg_ballP {F} {FF : Filter F} (y : M) :
   F --> y <-> forall eps : R, 0 < eps -> \forall y' \near F, ball y eps y'.
 Proof. by rewrite -filter_fromP !locally_simpl /=. Qed.
 
-Definition flim_locally := @flim_ballP.
+Definition cvg_to_locally := @cvg_ballP.
 
-Lemma flim_ballPpos {F} {FF : Filter F} (y : M) :
+Lemma cvg_ballPpos {F} {FF : Filter F} (y : M) :
   F --> y <-> forall eps : {posnum R}, \forall y' \near F, ball y eps%:num y'.
 Proof.
-by split => [/flim_ballP|] pos; [case|apply/flim_ballP=> _/posnumP[eps] //].
+by split => [/cvg_ballP|] pos; [case|apply/cvg_ballP=> _/posnumP[eps] //].
 Qed.
 
-Lemma flim_ball {F} {FF : Filter F} (y : M) :
+Lemma cvg_ball {F} {FF : Filter F} (y : M) :
   F --> y -> forall eps : R, 0 < eps -> \forall y' \near F, ball y eps y'.
-Proof. by move/flim_ballP. Qed.
+Proof. by move/cvg_ballP. Qed.
 
-Lemma app_flim_locally T {F} {FF : Filter F} (f : T -> M) y :
+Lemma app_cvg_locally T {F} {FF : Filter F} (f : T -> M) y :
   f @ F --> y <-> forall eps : R, 0 < eps -> \forall x \near F, ball y eps (f x).
-Proof. exact: flim_ballP. Qed.
+Proof. exact: cvg_ballP. Qed.
 
-Lemma flimi_ballP T {F} {FF : Filter F} (f : T -> M -> Prop) y :
+Lemma cvgi_ballP T {F} {FF : Filter F} (f : T -> M -> Prop) y :
   f `@ F --> y <->
   forall eps : R, 0 < eps -> \forall x \near F, exists z, f x z /\ ball y eps z.
 Proof.
@@ -2569,14 +2569,14 @@ rewrite near_simpl near_mapi; near=> x.
 have [//|z [fxz yz]] := near (Fy _ (posnum_gt0 eps)) x.
 by exists z => //; split => //; apply: subP.
 Unshelve. all: end_near. Qed.
-Definition flimi_locally := @flimi_ballP.
+Definition cvg_toi_locally := @cvgi_ballP.
 
-Lemma flimi_ball T {F} {FF : Filter F} (f : T -> M -> Prop) y :
+Lemma cvgi_ball T {F} {FF : Filter F} (f : T -> M -> Prop) y :
   f `@ F --> y ->
   forall eps : R, 0 < eps -> F [set x | exists z, f x z /\ ball y eps z].
-Proof. by move/flimi_ballP. Qed.
+Proof. by move/cvgi_ballP. Qed.
 
-Lemma flim_const {T} {F : set (set T)}
+Lemma cvg_const {T} {F : set (set T)}
    {FF : Filter F} (a : M) : a @[_ --> F] --> a.
 Proof.
 move=> P /locallyP[_ /posnumP[eps] subP]; rewrite !near_simpl /=.
@@ -2590,7 +2590,7 @@ Canonical set_filter_source :=
 End pseudoMetricType_numDomainType.
 Hint Resolve locally_ball : core.
 Hint Resolve close_refl : core.
-Arguments flim_const {R M T F FF} a.
+Arguments cvg_const {R M T F FF} a.
 
 Section pseudoMetricType_numFieldType.
 Context {R : numFieldType} {M : pseudoMetricType R}.
@@ -2607,7 +2607,7 @@ Lemma ball_splitl (z x y : M) (e : R) :
   ball x (e / 2) z -> ball y (e / 2) z -> ball x e y.
 Proof. by move=> bxz /ball_sym /(ball_split bxz). Qed.
 
-Lemma flim_close {F} {FF : ProperFilter F} (x y : M) :
+Lemma cvg_close {F} {FF : ProperFilter F} (x y : M) :
   F --> x -> F --> y -> close x y.
 Proof.
 move=> Fx Fy e; near F => z; apply: (@ball_splitl z); near: z;
@@ -2617,52 +2617,52 @@ Grab Existential Variables. all: end_near. Qed.
 Lemma close_trans (x y z : M) : close x y -> close y z -> close x z.
 Proof. by move=> cxy cyz eps; apply: ball_split (cxy _) (cyz _). Qed.
 
-Lemma close_limxx (x y : M) : close x y -> x --> y.
+Lemma close_cvgxx (x y : M) : close x y -> x --> y.
 Proof.
 move=> cxy P /= /locallyP /= [_/posnumP [eps] epsP].
 apply/locallyP; exists (eps%:num / 2) => // z bxz.
 by apply: epsP; apply: ball_splitr (cxy _) bxz.
 Qed.
 
-Lemma flimx_close (x y : M) : x --> y -> close x y.
-Proof. exact: flim_close. Qed.
+Lemma cvgx_close (x y : M) : x --> y -> close x y.
+Proof. exact: cvg_close. Qed.
 
-Lemma flimi_close T {F} {FF: ProperFilter F} (f : T -> set M) (l l' : M) :
+Lemma cvgi_close T {F} {FF: ProperFilter F} (f : T -> set M) (l l' : M) :
   {near F, is_fun f} -> f `@ F --> l -> f `@ F --> l' -> close l l'.
 Proof.
 move=> f_prop fFl fFl'.
-suff f_totalfun: infer {near F, is_totalfun f} by exact: flim_close fFl fFl'.
+suff f_totalfun: infer {near F, is_totalfun f} by exact: cvg_close fFl fFl'.
 apply: filter_app f_prop; near=> x; split=> //=.
-by have [//|y [fxy _]] := near (flimi_ball fFl [gt0 of 1]) x; exists y.
+by have [//|y [fxy _]] := near (cvgi_ball fFl [gt0 of 1]) x; exists y.
 Grab Existential Variables. all: end_near. Qed.
-Definition flimi_locally_close := @flimi_close.
+Definition cvg_toi_locally_close := @cvgi_close.
 
-Lemma close_lim (F1 F2 : set (set M)) {FF2 : ProperFilter F2} :
+Lemma close_cvg (F1 F2 : set (set M)) {FF2 : ProperFilter F2} :
   F1 --> F2 -> F2 --> F1 -> close (lim F1) (lim F2).
 Proof.
-move=> F12 F21; have [/(flim_trans F21) F2l|dvgF1] := pselect (cvg F1).
-  by apply: (@flim_close F2) => //; apply: cvgP F2l.
-have [/(flim_trans F12)/cvgP//|dvgF2] := pselect (cvg F2).
+move=> F12 F21; have [/(cvg_trans F21) F2l|dvgF1] := pselect (cvg F1).
+  by apply: (@cvg_close F2) => //; apply: cvgP F2l.
+have [/(cvg_trans F12)/cvgP//|dvgF2] := pselect (cvg F2).
 rewrite dvgP // dvgP //; exact/close_refl.
 Qed.
 
-Lemma flim_closeP (F : set (set M)) (l : M) : ProperFilter F ->
+Lemma cvg_closeP (F : set (set M)) (l : M) : ProperFilter F ->
   F --> l <-> ([cvg F in M] /\ close (lim F) l).
 Proof.
 move=> FF; split=> [Fl|[cvF]Cl].
-  by have /cvgP := Fl; split=> //; apply: (@flim_close F).
-by apply: flim_trans (close_limxx Cl).
+  by have /cvgP := Fl; split=> //; apply: (@cvg_close F).
+by apply: cvg_trans (close_cvgxx Cl).
 Qed.
 
 End pseudoMetricType_numFieldType.
-Arguments close_lim {R M} F1 F2 {FF2} _.
+Arguments close_cvg {R M} F1 F2 {FF2} _.
 
 Section entourages.
 Variable R : numDomainType.
-Definition unif_cont (U V : pseudoMetricType R) (f : U -> V) :=
+Definition unif_continuous (U V : pseudoMetricType R) (f : U -> V) :=
   (fun xy => (f xy.1, f xy.2)) @ entourages --> entourages.
-Lemma unif_contP (U V : pseudoMetricType R) (f : U -> V) :
-  unif_cont f <->
+Lemma unif_continuousP (U V : pseudoMetricType R) (f : U -> V) :
+  unif_continuous f <->
   forall e, e > 0 -> exists2 d, d > 0 &
     forall x, ball x.1 d x.2 -> ball (f x.1) e (f x.2).
 Proof. exact: filter_fromP. Qed.
@@ -2755,12 +2755,12 @@ Canonical prod_pseudoMetricType (R : numDomainType) (U V : pseudoMetricType R) :
 
 Section Locally_fct2.
 Context {T : Type} {R : numDomainType} {U V : pseudoMetricType R}.
-Lemma flim_ball2P {F : set (set U)} {G : set (set V)}
+Lemma cvg_ball2P {F : set (set U)} {G : set (set V)}
   {FF : Filter F} {FG : Filter G} (y : U) (z : V):
   (F, G) --> (y, z) <->
   forall eps : R, eps > 0 -> \forall y' \near F & z' \near G,
                 ball y eps y' /\ ball z eps z'.
-Proof. exact: flim_ballP. Qed.
+Proof. exact: cvg_ballP. Qed.
 End Locally_fct2.
 
 (** Functional metric spaces *)
@@ -2894,7 +2894,7 @@ have /(_ _ _) /complete_cauchy cvF :
   by move=> ?? _ /posnumP[e]; rewrite near_simpl; apply: filterS (Fc _ _).
 apply/cvg_ex.
 exists (\matrix_(i, j) (lim ((fun M : 'M[T]_(m, n) => M i j) @ F) : T)).
-apply/flim_ballP => _ /posnumP[e]; near=> M => i j.
+apply/cvg_ballP => _ /posnumP[e]; near=> M => i j.
 rewrite mxE; near F => M' => /=; apply: (@ball_splitl _ _ (M' i j)).
   by near: M'; apply/cvF/locally_ball.
 by move: (i) (j); near: M'; near: M; apply: nearP_dep; apply: filterS (Fc _ _).
@@ -2910,7 +2910,7 @@ Proof.
 move=> Fc; have /(_ _) /complete_cauchy Ft_cvg : cauchy (@^~_ @ F).
   by move=> t e ?; rewrite near_simpl; apply: filterS (Fc _ _).
 apply/cvg_ex; exists (fun t => lim (@^~t @ F)).
-apply/flim_ballPpos => e; near=> f => t; near F => g => /=.
+apply/cvg_ballPpos => e; near=> f => t; near F => g => /=.
 apply: (@ball_splitl _ _ (g t)); first by near: g; exact/Ft_cvg/locally_ball.
 by move: (t); near: g; near: f; apply: nearP_dep; apply: filterS (Fc _ _).
 Grab Existential Variables. all: end_near. Qed.
@@ -2918,21 +2918,21 @@ Canonical fun_completeType := CompleteType (T -> U) fun_complete.
 End fun_Complete.
 
 (** ** Limit switching *)
-Section Flim_switch.
+Section Cvg_switch.
 Context {T1 T2 : choiceType}.
-Lemma flim_switch_1 {R : numFieldType} {U : pseudoMetricType R}
+Lemma cvg_switch_1 {R : numFieldType} {U : pseudoMetricType R}
   F1 {FF1 : ProperFilter F1} F2 {FF2 : Filter F2}
   (f : T1 -> T2 -> U) (g : T2 -> U) (h : T1 -> U) (l : U) :
   f @ F1 --> g -> (forall x1, f x1 @ F2 --> h x1) -> h @ F1 --> l ->
   g @ F2 --> l.
 Proof.
-move=> fg fh hl; apply/flim_ballPpos => e.
+move=> fg fh hl; apply/cvg_ballPpos => e.
 rewrite near_simpl; near F1 => x1; near=> x2.
 apply: (@ball_split _ _ (h x1)); first by near: x1; apply/hl/locally_ball.
 apply: (@ball_splitl _ _ (f x1 x2)); first by near: x2; apply/fh/locally_ball.
-by move: (x2); near: x1; apply/(flim_ball fg).
+by move: (x2); near: x1; apply/(cvg_ball fg).
 Grab Existential Variables. all: end_near. Qed.
-Lemma flim_switch_2 {R : numFieldType} {U : completeType R}
+Lemma cvg_switch_2 {R : numFieldType} {U : completeType R}
   F1 {FF1 : ProperFilter F1} F2 {FF2 : ProperFilter F2}
   (f : T1 -> T2 -> U) (g : T2 -> U) (h : T1 -> U) :
   f @ F1 --> g -> (forall x, f x @ F2 --> h x) ->
@@ -2943,23 +2943,23 @@ rewrite !near_simpl; near=> x1 y1=> /=; near F2 => x2.
 apply: (@ball_splitl _ _ (f x1 x2)); first by near: x2; apply/fh/locally_ball.
 apply: (@ball_split _ _ (f y1 x2)); first by near: x2; apply/fh/locally_ball.
 apply: (@ball_splitr _ _ (g x2)); move: (x2); [near: y1|near: x1];
-by apply/(flim_ball fg).
+by apply/(cvg_ball fg).
 Grab Existential Variables. all: end_near. Qed.
 
 (* Alternative version *)
-(* Lemma flim_switch {U : completeType} *)
+(* Lemma cvg_switch {U : completeType} *)
 (*   F1 (FF1 : ProperFilter F1) F2 (FF2 : ProperFilter F2) (f : T1 -> T2 -> U) (g : T2 -> U) (h : T1 -> U) : *)
 (*   [cvg f @ F1 in T2 -> U] -> (forall x, [cvg f x @ F2 in U]) -> *)
 (*   [/\ [cvg [lim f @ F1] @ F2 in U], [cvg (fun x => [lim f x @ F2]) @ F1 in U] *)
 (*   & [lim [lim f @ F1] @ F2] = [lim (fun x => [lim f x @ F2]) @ F1]]. *)
-Lemma flim_switch {R : numFieldType} {U : completeType R}
+Lemma cvg_switch {R : numFieldType} {U : completeType R}
   F1 (FF1 : ProperFilter F1) F2 (FF2 : ProperFilter F2)
   (f : T1 -> T2 -> U) (g : T2 -> U) (h : T1 -> U) :
   f @ F1 --> g -> (forall x1, f x1 @ F2 --> h x1) ->
   exists l : U, h @ F1 --> l /\ g @ F2 --> l.
 Proof.
-move=> Hfg Hfh; have hcv := !! flim_switch_2 Hfg Hfh.
-by exists [lim h @ F1 in U]; split=> //; apply: flim_switch_1 Hfg Hfh hcv.
+move=> Hfg Hfh; have hcv := !! cvg_switch_2 Hfg Hfh.
+by exists [lim h @ F1 in U]; split=> //; apply: cvg_switch_1 Hfg Hfh hcv.
 Qed.
 
-End Flim_switch.
+End Cvg_switch.


### PR DESCRIPTION
Fixes #29

- `cvg` corresponds to `_ --> _`
- `lim` corresponds to `lim _`
- `continuous`  corresponds to continuity
- some suffixes _opp, _add ... renamed to N, D, ...

Apply this substitution **before** rebasing on top of this commit:
```bash
sed -i -f etc/pr193.sed **/*.v
```

@math-comp/analysis what do you think about this conventions?