### PR TITLE
fixes #155

### DIFF
--- a/theories/derive.v
+++ b/theories/derive.v
@@ -307,7 +307,7 @@ rewrite (_ : g = g1 + g2) ?funeqE // -(addr0 (_ _ v)); apply: (@cvgD _ _ [topolo
   by exists e => //= x _ x0; apply eX; rewrite mulVr // ?unitfE // subrr normr0.
 rewrite /g2.
 have [/eqP ->|v0] := boolP (v == 0).
-  rewrite (_ : (fun _ => _) = cst 0); first exact: cst_continuous.
+  rewrite (_ : (fun _ => _) = cst 0); first exact: cvg_cst.
   by rewrite funeqE => ?; rewrite scaler0 /k littleo_lim0 // scaler0.
 apply/cvg_normP => e e0.
 rewrite nearE /=; apply/locallyP; rewrite locally_E.

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -1767,12 +1767,12 @@ Arguments scale_continuous _ _ : clear implicits.
 
 Lemma scaler_continuous k : continuous (fun x : V => k *: x).
 Proof.
-by move=> x; apply: (cvg_comp2 (cvg_const _) cvg_id (scale_continuous (_, _))).
+by move=> x; apply: (cvg_comp2 (cvg_cst _) cvg_id (scale_continuous (_, _))).
 Qed.
 
 Lemma scalel_continuous (x : V) : continuous (fun k : K^o => k *: x).
 Proof.
-by move=> k; apply: (cvg_comp2 cvg_id (cvg_const _) (scale_continuous (_, _))).
+by move=> k; apply: (cvg_comp2 cvg_id (cvg_cst _) (scale_continuous (_, _))).
 Qed.
 
 Lemma opp_continuous : continuous (@GRing.opp V).
@@ -1786,10 +1786,6 @@ End NVS_continuity1.
 Section limit_composition.
 
 Context {K : numFieldType} {V : normedModType K} {T : topologicalType}.
-
-Lemma cvg_cst (a : V) (F : set (set V)) {FF : Filter F} : (fun=> a) @ F --> a.
-Proof. exact: cst_continuous. Qed.
-Hint Resolve cvg_cst : core.
 
 Lemma cvgD (F : set (set T)) (FF : Filter F) (f g : T -> V) (a b : V) :
   f @ F --> a -> g @ F --> b -> (f \+ g) @ F --> a + b.
@@ -1807,13 +1803,11 @@ Proof. move=> ??; apply: cvg_continuous2 => //; exact: scale_continuous. Qed.
 
 Lemma cvgZl (F : set (set T)) (FF : Filter F) (f : T -> K) (a : V) (k : K^o) :
   f @ F --> k -> (fun x => (f x) *: a) @ F --> k *: a.
-Proof. by move=> ?; apply: cvgZ => //; exact: cst_continuous. Qed.
+Proof. by move=> ?; apply: cvgZ => //; exact: cvg_cst. Qed.
 
 Lemma cvgZr (F : set (set T)) (FF : Filter F) (f : T -> V) (k : K) (a : V) :
   f @ F --> a -> k \*: f  @ F --> k *: a.
-Proof.
-apply: cvgZ => //; exact: (@cst_continuous _ [topologicalType of K^o]).
-Qed.
+Proof. apply: cvgZ => //; exact: (@cvg_cst _ [topologicalType of K^o]). Qed.
 
 Lemma continuousZ (f : T -> V) k x :
   {for x, continuous f} -> {for x, continuous (k \*: f)}.

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -1493,15 +1493,6 @@ move=> h_continuous fa fb; apply: (cvg_trans _ h_continuous).
 exact: (@cvg_comp _ _ _ _ (fun x => h x.1 x.2) _ _ _ (cvg_pair fa fb)).
 Qed.
 
-Lemma cst_continuous {T : Type} {T' : topologicalType} (k : T')
-  (F : set (set T)) {FF : Filter F} :
-  (fun _ : T => k) @ F --> k.
-Proof.
-by move=> x; rewrite !near_simpl => /locally_singleton ?; apply: filterE.
-Qed.
-Arguments cst_continuous {T T'} k F {FF}.
-Hint Resolve cst_continuous : core.
-
 Lemma cvg_fconst (T : Type) (U : topologicalType)
   (f : T -> U) (F : set (set T)) (l : U) :
   Filter F ->
@@ -1511,11 +1502,13 @@ move=> FF fFl P /=; rewrite !near_simpl => Pl.
 by apply: filterS fFl => _ ->; apply: locally_singleton.
 Qed.
 
-Lemma cvg_const (T : Type) (U : topologicalType) (F : set (set T)) {FF : Filter F}
+Lemma cvg_cst (T : Type) (U : topologicalType) (F : set (set T)) {FF : Filter F}
   (x : U) : (fun _ : T => x) @ F --> x.
-Proof. by apply: cvg_fconst; near=> x0.
-Grab Existential Variables. all: end_near. Qed.
-Arguments cvg_const {T U F FF} x.
+Proof.
+by move=> S; rewrite !near_simpl => /locally_singleton ?; apply: filterE.
+Qed.
+Arguments cvg_cst {T U F FF} x.
+Hint Resolve cvg_cst : core.
 
 (** ** Topology defined by a filter *)
 


### PR DESCRIPTION
`cst_continuous` and `cvg_cst` are special cases of `cvg_const`, which can be used instead and renamed `cvg_cst`.

fixes #155 (in addition to the recent renaming)