### PR TITLE
Big refactoring about naming conventions

### DIFF
--- a/theories/landau.v
+++ b/theories/landau.v
@@ -883,8 +883,8 @@ Proof.
 split=> fFl.
   apply/eqaddoP => _/posnumP[eps]; near=> x.
   rewrite /cst ltW //= distrC; near: x.
-  by apply: (cvg_norm _ fFl); rewrite mulr_gt0 // normr1.
-apply/cvg_normP=> _/posnumP[eps]; rewrite /= near_simpl.
+  by apply: (cvg_dist _ fFl); rewrite mulr_gt0 // normr1.
+apply/cvg_distP=> _/posnumP[eps]; rewrite /= near_simpl.
 have lt_eps x : x <= (eps%:num / 2%:R) * `|1 : K^o|%real -> x < eps%:num.
   rewrite normr1 mulr1 => /le_lt_trans; apply.
   by rewrite ltr_pdivr_mulr // ltr_pmulr // ltr1n.
@@ -1145,7 +1145,7 @@ Lemma linear_for_continuous (f : {linear U -> V | GRing.Scale.op s_law}) :
   (f : _ -> _) =O_ (0 : U) (cst (1 : R^o)) -> continuous f.
 Proof.
 move=> /eqO_exP [_/posnumP[k0] Of1] x.
-apply/cvg_normP => _/posnumP[e]; rewrite !near_simpl.
+apply/cvg_distP => _/posnumP[e]; rewrite !near_simpl.
 rewrite (near_shift 0) /= subr0; near=> y => /=.
 rewrite -linearB opprD addrC addrNK linearN normrN; near: y.
 suff flip : \forall k \near +oo, forall x, `|f x| <= k * `|x|.


### PR DESCRIPTION
- complete the theory of `cvg_`, `is_cvg_` and `lim_` in normedtype.v
  with consistent naming schemes
- fixed differential of `inv` which was defined on `1 / x` instead of `x^-1`
- two versions of lemmas on inverse exist
  + one in realType (`Rinv_` lemmas), for which we have differential
  + one in numClosedFieldType (no differential so far, just continuity)
- renamed `cvg_norm` to `cvg_dist` to reuse the name `cvg_norm` for convergence under the norm

fixes #155 
closes #198 by subsuming it