### PR TITLE
Add a distrLattice canonical structure to set T.

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -11,6 +11,8 @@
     `setDUr`, `setDUl`, `setIDA`, `setDD`
   + definition `dep_arrow_choiceType`
   + lemma `bigcup_set0`
+  + lemmas `setUK`, `setKU`, `setIK`, `setKI`, `subsetEset`, `subEset`, `complEset`, `botEset`, `topEset`, `meetEset`, `joinEset`
+  + Canonical `porderType`, `latticeType`, `distrLatticeType`, `blatticeType`, `tblatticeType`, `bDistrLatticeType`, `tbDistrLatticeType`, `cbDistrLatticeType`, `ctbDistrLatticeType`
 - in `normedtype.v`:
   + lemma `closed_ereal_le_ereal`
   + lemma `closed_ereal_ge_ereal`
@@ -47,6 +49,9 @@
   + lemma `oppe_continuous`
   + lemmas `setUCl`, `setDv`
   + lemmas `image_preimage_subset`, `image_subset`, `preimage_subset`
+  + lemmas `setUK`, `setKU`, `setIK`, `setKI`
+  + lemmas `setUK`, `setKU`, `setIK`, `setKI`, `subsetEset`, `subEset`, `complEset`, `botEset`, `topEset`, `meetEset`, `joinEset`, `setDset0`, `subsetNeqSetDnonempty`, `proper_neqAsubset`
+  + Canonical `porderType`, `latticeType`, `distrLatticeType`, `blatticeType`, `tblatticeType`, `bDistrLatticeType`, `tbDistrLatticeType`, `cbDistrLatticeType`, `ctbDistrLatticeType`.
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -13,6 +13,8 @@
   + lemma `bigcup_set0`
   + lemmas `setUK`, `setKU`, `setIK`, `setKI`, `subsetEset`, `subEset`, `complEset`, `botEset`, `topEset`, `meetEset`, `joinEset`
   + Canonical `porderType`, `latticeType`, `distrLatticeType`, `blatticeType`, `tblatticeType`, `bDistrLatticeType`, `tbDistrLatticeType`, `cbDistrLatticeType`, `ctbDistrLatticeType`
+  + lemma `not_exists2P`
+
 - in `normedtype.v`:
   + lemma `closed_ereal_le_ereal`
   + lemma `closed_ereal_ge_ereal`
@@ -49,9 +51,10 @@
   + lemma `oppe_continuous`
   + lemmas `setUCl`, `setDv`
   + lemmas `image_preimage_subset`, `image_subset`, `preimage_subset`
+  + definition `proper` and its notation `<`
   + lemmas `setUK`, `setKU`, `setIK`, `setKI`
-  + lemmas `setUK`, `setKU`, `setIK`, `setKI`, `subsetEset`, `subEset`, `complEset`, `botEset`, `topEset`, `meetEset`, `joinEset`, `setDset0`, `subsetNeqSetDnonempty`, `proper_neqAsubset`
-  + Canonical `porderType`, `latticeType`, `distrLatticeType`, `blatticeType`, `tblatticeType`, `bDistrLatticeType`, `tbDistrLatticeType`, `cbDistrLatticeType`, `ctbDistrLatticeType`.
+  + lemmas `setUK`, `setKU`, `setIK`, `setKI`, `subsetEset`, `subEset`, `complEset`, `botEset`, `topEset`, `meetEset`, `joinEset`, `properEneq`
+  + Canonical `porderType`, `latticeType`, `distrLatticeType`, `blatticeType`, `tblatticeType`, `bDistrLatticeType`, `tbDistrLatticeType`, `cbDistrLatticeType`, `ctbDistrLatticeType` on classical `set`.
 
 ### Changed
 
@@ -59,6 +62,7 @@
   + the index in `bigcup_set1` generalized from `nat` to some `Type`
   + lemma `bigcapCU` generalized
   + lemmas `preimage_setU` and `preimage_setI` are about the `setU` and `setI` (instead of `bigcup` and `bigcap`)
+  + `eqEsubset` changed from an implication to an equality
 - lemma `asboolb` moved from `discrete.v` to `boolp.v`
 - lemma `exists2NP` moved from `discrete.v` to `boolp.v`
 - lemma `neg_or` moved from `discrete.v` to `boolp.v` and renamed to `not_orP`
@@ -72,6 +76,8 @@
   + the first argument of `real_of_er` is now maximal implicit
   + the first argument of `is_real` is now maximal implicit
   + generalization of `lee_sum`
+- in `boolp.v`:
+  + rename `exists2NP` to `forall2NP` and make it bidirectionnal
 
 ### Renamed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -11,7 +11,7 @@
     `setDUr`, `setDUl`, `setIDA`, `setDD`
   + definition `dep_arrow_choiceType`
   + lemma `bigcup_set0`
-  + lemmas `setUK`, `setKU`, `setIK`, `setKI`, `subsetEset`, `subEset`, `complEset`, `botEset`, `topEset`, `meetEset`, `joinEset`
+  + lemmas `setUK`, `setKU`, `setIK`, `setKI`, `subsetEset`, `subEset`, `complEset`, `botEset`, `topEset`, `meetEset`, `joinEset`, `subsetPset`, `properPset`
   + Canonical `porderType`, `latticeType`, `distrLatticeType`, `blatticeType`, `tblatticeType`, `bDistrLatticeType`, `tbDistrLatticeType`, `cbDistrLatticeType`, `ctbDistrLatticeType`
   + lemma `not_exists2P`
 

--- a/theories/altreals/discrete.v
+++ b/theories/altreals/discrete.v
@@ -151,7 +151,7 @@ Lemma finiteNP (E : pred T): (forall s : seq T, ~ {subset E <= s}) ->
 Proof.
 move=> finN; elim=> [|n [s] [<- uq_s sE]]; first by exists [::].
 have [x sxN xE]: exists2 x, x \notin s & x \in E.
-  apply: contra_notP (finN (filter (mem E) s)) => /exists2NP finE x Ex.
+  apply: contra_notP (finN (filter (mem E) s)) => /forall2NP finE x Ex.
   move/or_asboolP: (finE x).
   by rewrite !asbool_neg !asboolb negbK Ex mem_filter orbF [(mem E) x]Ex.
 exists (x :: s) => /=; rewrite sxN; split=> // y.

--- a/theories/boolp.v
+++ b/theories/boolp.v
@@ -278,6 +278,18 @@ move=> cb /asboolPn nb; apply/asboolPn.
 by apply: contra nb => /asboolP /cb /asboolP.
 Qed.
 
+(** subsumed by mathcomp 1.2, to be removed *)
+Lemma contra_notT (P: Prop) (b:bool) : (~~ b -> P) -> ~ P -> b.
+Proof. by case: b => //= /(_ isT) HP /(_ HP). Qed.
+
+(** subsumed by mathcomp 1.2, to be removed *)
+Lemma contra_notN (P: Prop) (b:bool) : (b -> P) -> ~ P -> ~~ b.
+Proof. rewrite -{1}[b]negbK; exact: contra_notT. Qed.
+
+(** subsumed by mathcomp 1.2, to be removed *)
+Lemma contra_not_neq (T: eqType)  (P: Prop) (x y:T) : (x = y -> P) -> ~ P -> x != y.
+Proof. by move=> imp; apply: contra_notN => /eqP. Qed.
+
 Lemma contraPnot (Q P : Prop) : (Q -> ~ P) -> P -> ~ Q.
 Proof.
 move=> cb /asboolP hb; apply/asboolPn.

--- a/theories/boolp.v
+++ b/theories/boolp.v
@@ -278,15 +278,15 @@ move=> cb /asboolPn nb; apply/asboolPn.
 by apply: contra nb => /asboolP /cb /asboolP.
 Qed.
 
-(** subsumed by mathcomp 1.2, to be removed *)
+(** subsumed by mathcomp 1.12, to be removed *)
 Lemma contra_notT (P: Prop) (b:bool) : (~~ b -> P) -> ~ P -> b.
 Proof. by case: b => //= /(_ isT) HP /(_ HP). Qed.
 
-(** subsumed by mathcomp 1.2, to be removed *)
+(** subsumed by mathcomp 1.12, to be removed *)
 Lemma contra_notN (P: Prop) (b:bool) : (b -> P) -> ~ P -> ~~ b.
 Proof. rewrite -{1}[b]negbK; exact: contra_notT. Qed.
 
-(** subsumed by mathcomp 1.2, to be removed *)
+(** subsumed by mathcomp 1.12, to be removed *)
 Lemma contra_not_neq (T: eqType)  (P: Prop) (x y:T) : (x = y -> P) -> ~ P -> x != y.
 Proof. by move=> imp; apply: contra_notN => /eqP. Qed.
 
@@ -610,11 +610,18 @@ Proof. by rewrite forallNE. Qed.
 Lemma not_forallP T (P : T -> Prop) : (forall x, P x) <-> ~ exists x, ~ P x.
 Proof. by rewrite existsNE notK. Qed.
 
-Lemma exists2NP T (P Q : T -> Prop) :
-  ~ (exists2 x, P x & Q x) -> forall x, ~ P x \/ ~ Q x.
+Lemma not_exists2P T (P Q : T -> Prop) :
+  (exists2 x, P x & Q x) <-> ~ forall x, ~ P x \/ ~ Q x.
 Proof.
-apply: contra_notP; case/asboolPn/existsp_asboolPn=> [x].
-by case/not_orP => /contrapT Px /contrapT Qx; exists x.
+split=> [[x Px Qx] /(_ x) [|]//|]; apply: contra_notP => PQ t.
+by rewrite -not_andP; apply: contra_not PQ => -[Pt Qt]; exists t.
+Qed.
+
+Lemma forall2NP T (P Q : T -> Prop) :
+  (forall x, ~ P x \/ ~ Q x) <-> ~ (exists2 x, P x & Q x).
+Proof.
+split=> [PQ [t Pt Qt]|PQ t]; first by have [] := PQ t.
+by rewrite -not_andP => -[Pt Qt]; apply PQ; exists t.
 Qed.
 
 (* -------------------------------------------------------------------- *)

--- a/theories/classical_sets.v
+++ b/theories/classical_sets.v
@@ -481,7 +481,7 @@ by split => //; apply/negP; apply: contra_not YX => /eqP ->.
 by rewrite eqEsubset => XY YX; split => //; exact: contra_not XY.
 Qed.
 
-Lemma nonsubset {A} (X Y:set A): ~ (X `<=` Y) -> X `&` ~` Y !=set0.
+Lemma nonsubset {A} (X Y : set A) : ~ (X `<=` Y) -> X `&` ~` Y !=set0.
 Proof. by rewrite -setD_eq0 setDE -set0P => /eqP. Qed.
 
 Lemma setIC {A} (X Y : set A) : X `&` Y = Y `&` X.
@@ -1174,11 +1174,17 @@ Module SetOrder.
 Module Internal.
 Section SetOrder.
 
-Context {T: Type}.
-Implicit Types (X Y : set T).
+Context {T : Type}.
+Implicit Types X Y : set T.
 
-Lemma setI_meet X Y : `[< X `<=` Y >] = (X `&` Y == X).
+Lemma le_def X Y : `[< X `<=` Y >] = (X `&` Y == X).
 Proof. by apply/asboolP/eqP; rewrite setIidPl. Qed.
+
+Lemma lt_def X Y : `[< X `<` Y >] = (Y != X) && `[< X `<=` Y >].
+Proof.
+apply/idP/idP => [/asboolP|/andP[YX /asboolP XY]]; rewrite properEneq eq_sym;
+  by [move=> [] -> /asboolP|apply/asboolP].
+Qed.
 
 Fact SetOrder_joinKI (Y X : set T) : X `&` (X `|` Y) = X.
 Proof. by rewrite setUC setKU. Qed.
@@ -1186,33 +1192,32 @@ Proof. by rewrite setUC setKU. Qed.
 Fact SetOrder_meetKU (Y X : set T) : X `|` (X `&` Y) = X.
 Proof. by rewrite setIC setKI. Qed.
 
-Definition orderMixin := @MeetJoinMixin _ _ _ setI setU setI_meet
-  (fun _ _ => erefl) (@setIC _) (@setUC _) (@setIA _) (@setUA _)
-  SetOrder_joinKI SetOrder_meetKU (@setIUl _) setIid.
+Definition orderMixin := @MeetJoinMixin _ _ (fun X Y => `[<proper X Y>]) setI
+  setU le_def lt_def (@setIC _) (@setUC _) (@setIA _) (@setUA _) SetOrder_joinKI
+  SetOrder_meetKU (@setIUl _) setIid.
 
 Local Canonical porderType := POrderType set_display (set T) orderMixin.
 Local Canonical latticeType := LatticeType (set T) orderMixin.
 Local Canonical distrLatticeType := DistrLatticeType (set T) orderMixin.
 
-Fact SetOrder_sub0set (x: set T): (set0 <= x)%O.
-Proof. apply/asboolP; apply: sub0set. Qed.
+Fact SetOrder_sub0set (x : set T) : (set0 <= x)%O.
+Proof. by apply/asboolP; apply: sub0set. Qed.
 
-Fact SetOrder_setTsub (x:set T): (x <= setT)%O.
-Proof. apply/asboolP; by []. Qed.
+Fact SetOrder_setTsub (x : set T) : (x <= setT)%O.
+Proof. exact/asboolP. Qed.
 
-Local Canonical blatticeType :=
+Local Canonical bLatticeType :=
   BLatticeType (set T) (Order.BLattice.Mixin  SetOrder_sub0set).
-Local Canonical tblatticeType :=
+Local Canonical tbLatticeType :=
   TBLatticeType (set T) (Order.TBLattice.Mixin SetOrder_setTsub).
-Local Canonical bDistrLatticeType := [bDistrLatticeType of (set T)].
-Local Canonical tbDistrLatticeType := [tbDistrLatticeType of (set T)].
+Local Canonical bDistrLatticeType := [bDistrLatticeType of set T].
+Local Canonical tbDistrLatticeType := [tbDistrLatticeType of set T].
 
-Lemma subKI X Y : Y `&` (X `\` Y) = set0. Proof.
-  by rewrite setDE setICA setICr setI0.
-Qed.
-Lemma joinIB X Y : (X `&` Y) `|` X `\` Y = X. Proof.
-  by rewrite setDE -setIUr setUCr setIT.
-Qed.
+Lemma subKI X Y : Y `&` (X `\` Y) = set0.
+Proof. by rewrite setDE setICA setICr setI0. Qed.
+
+Lemma joinIB X Y : (X `&` Y) `|` X `\` Y = X.
+Proof. by rewrite setDE -setIUr setUCr setIT. Qed.
 
 Local Canonical cbDistrLatticeType := CBDistrLatticeType (set T)
   (@CBDistrLatticeMixin _ _ (fun X Y => X `\` Y) subKI joinIB).
@@ -1228,8 +1233,8 @@ Module Exports.
 Canonical Internal.porderType.
 Canonical Internal.latticeType.
 Canonical Internal.distrLatticeType.
-Canonical Internal.blatticeType.
-Canonical Internal.tblatticeType.
+Canonical Internal.bLatticeType.
+Canonical Internal.tbLatticeType.
 Canonical Internal.bDistrLatticeType.
 Canonical Internal.tbDistrLatticeType.
 Canonical Internal.cbDistrLatticeType.
@@ -1239,10 +1244,7 @@ Lemma subsetEset {T} (X Y : set T) : (X <= Y)%O = (X `<=` Y) :> Prop.
 Proof. by rewrite asboolE. Qed.
 
 Lemma properEset  {T} (X Y : set T) : (X < Y)%O = (X `<` Y) :> Prop.
-Proof.
-rewrite /Order.lt properEneq //=.
-by rewrite -[Y != X]asboolb -asbool_and asboolE eq_sym.
-Qed.
+Proof. by rewrite asboolE. Qed.
 
 Lemma subEset {T} (X Y : set T) : (X `\` Y)%O = (X `\` Y). Proof. by []. Qed.
 Lemma complEset {T} (X Y : set T) : (~` X)%O = ~` X. Proof. by []. Qed.

--- a/theories/classical_sets.v
+++ b/theories/classical_sets.v
@@ -1247,12 +1247,23 @@ Lemma properEset  {T} (X Y : set T) : (X < Y)%O = (X `<` Y) :> Prop.
 Proof. by rewrite asboolE. Qed.
 
 Lemma subEset {T} (X Y : set T) : (X `\` Y)%O = (X `\` Y). Proof. by []. Qed.
+
 Lemma complEset {T} (X Y : set T) : (~` X)%O = ~` X. Proof. by []. Qed.
+
 Lemma botEset {T} (X Y : set T) : 0%O = @set0 T. Proof. by []. Qed.
+
 Lemma topEset {T} (X Y : set T) : 1%O = @setT T. Proof. by []. Qed.
 
 Lemma meetEset {T} (X Y : set T) : (X `&` Y)%O = (X `&` Y). Proof. by []. Qed.
+
 Lemma joinEset {T} (X Y : set T) : (X `|` Y)%O = (X `|` Y). Proof. by []. Qed.
+
+Lemma subsetPset {T} (X Y : set T) : reflect (X `<=` Y) (X <= Y)%O.
+Proof. by apply: (iffP idP); rewrite subsetEset. Qed.
+
+Lemma properPset {T} (X Y : set T) : reflect (X `<` Y) (X < Y)%O.
+Proof. by apply: (iffP idP); rewrite properEset. Qed.
 
 End Exports.
 End SetOrder.
+Export SetOrder.Exports.

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -806,7 +806,7 @@ Definition near_simpl := (@near_simpl, @near_filter_onE).
 Program Definition trivial_filter_on T := FilterType [set setT : set T] _.
 Next Obligation.
 split=> // [_ _ -> ->|Q R sQR QT]; first by rewrite setIT.
-by apply: eqEsubset => // ? _; apply/sQR; rewrite QT.
+by move; rewrite eqEsubset; split => // ? _; apply/sQR; rewrite QT.
 Qed.
 Canonical trivial_filter_on.
 


### PR DESCRIPTION
Hi,

This add a canonical distrLattice structure to setT and subset relation.
I have far less experience in adding a canonical structure than I have writing lemma so the PR is likely a bit rough, any guidance is appreciated.

Some comments:
- For some reasons coq fails to unify the type of the lemma setU setI ... when passed as argument to MeetJoinMixin. I added "wrapper lemma" SetOrder_setCI SetOrder_setCU ... to force the type. I'm not sure this is the right thing to do (I could also use @setU (set T) directly in the argument but it would be quite hard to read) and the naming is maybe wrong.
- subset is a Prop while distrLattice expects a rel (ie result type is bool). I wrapped the subset relation in asboolsubset. This means that to use lemma in order (like in my case ltux) one need to map subset and asboolsubset forth and back so I provided subsetE. I don't know if it's the usual idiom.