### PR TITLE
rename the short `ub` and `lb` to `ubound` and `lbound`

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -8,6 +8,8 @@
 
 ### Renamed
 
+- in `classical_sets.v`, `ub` and `lb` are renamed to `ubound` and `lbound`
+
 ### Removed
 
 ### Infrastructure

--- a/theories/Rstruct.v
+++ b/theories/Rstruct.v
@@ -378,13 +378,13 @@ Require Import reals boolp classical_sets.
 
 Section ssreal_struct_contd.
 
-Lemma is_upper_boundE (E : set R) x : is_upper_bound E x = ((ub E) x).
+Lemma is_upper_boundE (E : set R) x : is_upper_bound E x = ((ubound E) x).
 Proof.
 rewrite propeqE; split; [move=> h|move=> /ubP h y Ey; exact/RleP/h].
 by apply/ubP => y Ey; apply/RleP/h.
 Qed.
 
-Lemma boundE (E : set R) : bound E = has_ub E.
+Lemma boundE (E : set R) : bound E = has_ubound E.
 Proof. by apply/eq_exists=> x; rewrite is_upper_boundE. Qed.
 
 Lemma completeness' (E : set R) : has_sup E -> {m : R | is_lub E m}.
@@ -398,7 +398,7 @@ Proof.
 by move=> hsE; rewrite /real_sup; case: pselect=> // ?; case: completeness'.
 Qed.
 
-Lemma real_sup_ub (E : set R) : has_sup E -> (ub E) (real_sup E).
+Lemma real_sup_ub (E : set R) : has_sup E -> (ubound E) (real_sup E).
 Proof. by move=> /real_sup_is_lub []; rewrite is_upper_boundE. Qed.
 
 Lemma real_sup_out (E : set R) : ~ has_sup E -> real_sup E = 0.
@@ -410,7 +410,7 @@ Lemma real_sup_adherent (E : set R) (eps : R) :
   has_sup E -> 0 < eps -> exists2 e : R, E e & (real_sup E - eps) < e.
 Proof.
 move=> supE eps_gt0; set m := _ - eps; apply: contrapT=> mNsmall.
-have: (ub E) m.
+have: (ubound E) m.
   apply/ubP => y Ey.
   have /negP := mNsmall (ex_intro2 _ _ y Ey _).
   by rewrite -leNgt.

--- a/theories/altreals/realsum.v
+++ b/theories/altreals/realsum.v
@@ -349,7 +349,7 @@ End SumTh.
 
 (* -------------------------------------------------------------------- *)
 Lemma max_sup {R : realType} x (E : set R) :
-  (E `&` ub E)%classic x -> sup E = x.
+  (E `&` ubound E)%classic x -> sup E = x.
 Proof.
 case=> /= xE xubE; have nzE: nonempty E by exists x.
 apply/eqP; rewrite eq_le sup_le_ub //=.

--- a/theories/classical_sets.v
+++ b/theories/classical_sets.v
@@ -87,7 +87,7 @@ Require Import boolp.
 (*     premaximal if whenever t < s we also have s < t.                       *)
 (*                                                                            *)
 (* * Upper and lower bounds:                                                  *)
-(*                      ul, lb == upper bound and lower bound sets            *)
+(*              ubound, lbound == upper bound and lower bound sets            *)
 (*               supremum x0 E == supremum of E or x0 if E is empty           *)
 (*                                                                            *)
 (******************************************************************************)
@@ -831,27 +831,27 @@ Import Order.TTheory.
 Variables (d : unit) (T : porderType d).
 Implicit Types E : set T.
 
-Definition ub E : set T := [set z | forall y, E y -> (y <= z)%O].
-Definition lb E : set T := [set z | forall y, E y -> (z <= y)%O].
+Definition ubound E : set T := [set z | forall y, E y -> (y <= z)%O].
+Definition lbound E : set T := [set z | forall y, E y -> (z <= y)%O].
 
-Lemma ubP E x : (forall y, E y -> (y <= x)%O) <-> ub E x.
+Lemma ubP E x : (forall y, E y -> (y <= x)%O) <-> ubound E x.
 Proof. by []. Qed.
 
-Lemma lbP E x : (forall y, E y -> (x <= y)%O) <-> lb E x.
+Lemma lbP E x : (forall y, E y -> (x <= y)%O) <-> lbound E x.
 Proof. by []. Qed.
 
-Lemma ub_set1 x y : ub [set x] y = (x <= y)%O.
+Lemma ub_set1 x y : ubound [set x] y = (x <= y)%O.
 Proof.
 by rewrite propeqE; split => [/ubP/(_ x erefl)//|xy]; apply/ubP => z ->.
 Qed.
 
-Lemma lb_ub_set1 x y : lb (ub [set x]) y -> (y <= x)%O.
+Lemma lb_ub_set1 x y : lbound (ubound [set x]) y -> (y <= x)%O.
 Proof. by move/lbP => /(_ x); apply; rewrite ub_set1. Qed.
 
-Lemma lb_ub_refl x : lb (ub [set x]) x.
+Lemma lb_ub_refl x : lbound (ubound [set x]) x.
 Proof. by apply/lbP => y /ubP; apply. Qed.
 
-Lemma ub_lb_ub E x y : ub E y -> lb (ub E) x -> (x <= y)%O.
+Lemma ub_lb_ub E x y : ubound E y -> lbound (ubound E) x -> (x <= y)%O.
 Proof. by move=> Ey /lbP; apply. Qed.
 
 (* down set (i.e., generated order ideal) *)
@@ -859,29 +859,33 @@ Proof. by move=> Ey /lbP; apply. Qed.
 Definition down E : set T := [set x | exists y, E y /\ (x <= y)%O].
 
 (* Real set supremum and infimum existence condition. *)
-Definition has_ub  E := ub E !=set0.
-Definition has_sup E := E !=set0 /\ has_ub E.
-Definition has_lb  E := lb E !=set0.
-Definition has_inf E := E !=set0 /\ has_lb E.
+Definition has_ubound E := ubound E !=set0.
+Definition has_sup E := E !=set0 /\ has_ubound E.
+Definition has_lbound  E := lbound E !=set0.
+Definition has_inf E := E !=set0 /\ has_lbound E.
 
-Lemma has_ub_set1 x : has_ub [set x]. Proof. by exists x; rewrite ub_set1. Qed.
+Lemma has_ub_set1 x : has_ubound [set x].
+Proof. by exists x; rewrite ub_set1. Qed.
 
 Lemma downP E x : (exists2 y, E y & (x <= y)%O) <-> down E x.
 Proof. by split => [[y Ey xy]|[y [Ey xy]]]; [exists y| exists y]. Qed.
 
-Definition supremums E := ub E `&` lb (ub E).
+Definition supremums E := ubound E `&` lbound (ubound E).
 
 Lemma supremums_set1 x : supremums [set x] = [set x].
 Proof.
 rewrite /supremums predeqE => y; split => [[]|].
   rewrite ub_set1 => xy /lb_ub_set1 => yx.
   by apply/eqP; rewrite eq_le xy andbT yx // => z ->.
-by move=> xy; split; [rewrite -xy ub_set1 | rewrite -xy; apply: lb_ub_refl].
+by move=> xy; split; [rewrite -xy ub_set1 |
+  rewrite -xy; apply: lb_ub_refl].
 Qed.
 
 Lemma is_subset1_supremums E : is_subset1 (supremums E).
 Proof.
-move=> x y [Ex xE] [Ey yE]; have yx := ub_lb_ub Ex yE. have xy := ub_lb_ub Ey xE.
+move=> x y [Ex xE] [Ey yE].
+have yx := ub_lb_ub Ex yE.
+have xy := ub_lb_ub Ey xE.
 by apply/eqP; rewrite eq_le xy.
 Qed.
 

--- a/theories/ereal.v
+++ b/theories/ereal.v
@@ -402,10 +402,10 @@ Local Open Scope classical_set_scope.
 Implicit Types S : set {ereal R}.
 Implicit Types x : {ereal R}.
 
-Lemma ereal_ub_pinfty S : ub S +oo.
+Lemma ereal_ub_pinfty S : ubound S +oo.
 Proof. by apply/ubP=> x _; rewrite lee_pinfty. Qed.
 
-Lemma ereal_ub_ninfty S : ub S -oo -> S = set0 \/ S = [set -oo].
+Lemma ereal_ub_ninfty S : ubound S -oo -> S = set0 \/ S = [set -oo].
 Proof.
 have [[x Sx] /ubP Snoo|/set0P/negP] := pselect (S !=set0).
   right; rewrite predeqE => y; split => [/Snoo|->{y}].
@@ -423,7 +423,7 @@ move=> Spoo; rewrite /supremum.
 case: pselect => [a /= {a}|]; last by move=> S0; exfalso; apply S0; exists +oo%E.
 have sSoo : supremums S +oo%E.
   split; first exact: ereal_ub_pinfty.
-  move=> /= y; rewrite /ub => /(_ _ Spoo).
+  move=> /= y; rewrite /ubound => /(_ _ Spoo).
   by rewrite lee_pinfty_eq => /eqP ->.
 case: xgetP.
 by move=> y ->{y} sSxget; move: (is_subset1_supremums sSoo sSxget).
@@ -446,10 +446,10 @@ have [r Sr] : exists r, S r%:E.
   apply/existsPN => nS; move: Snoo1; apply; apply/eqP; rewrite predeqE.
   by case=> // r; split => // /nS.
 set U := [set x | (real_of_er_def r @` S) x ].
-have [ubU|/set0P/negP] := pselect (ub U !=set0); last first.
+have [ubU|/set0P/negP] := pselect (ubound U !=set0); last first.
   rewrite negbK => /eqP; rewrite -subset0 => U0; exists +oo.
   split; [exact/ereal_ub_pinfty | apply/lbP => /= -[r0 /ubP Sr0|//|]].
-  - suff : ub U r0 by move/U0.
+  - suff : ubound U r0 by move/U0.
     by apply/ubP=> y -[] [r1 Sr1 <-| // | /= _ <-{y}]; rewrite -lee_fin; apply Sr0.
   - by move/ereal_ub_ninfty => [|] /eqP //; move/set0P : S0 => /negbTE => ->.
 set u : R := sup U.
@@ -487,7 +487,7 @@ Qed.
 Lemma ereal_inf_set0 : ereal_inf set0 = +oo.
 Proof. by rewrite /ereal_inf image_set0 ereal_sup_set0. Qed.
 
-Lemma ereal_sup_ub S : ub S (ereal_sup S).
+Lemma ereal_sup_ub S : ubound S (ereal_sup S).
 Proof.
 move=> y Sy; rewrite /ereal_sup /supremum.
 case: pselect => /= [S0|/(_ (ex_intro S y Sy)) //].
@@ -499,7 +499,7 @@ Qed.
 Lemma ereal_sup_ninfty S : ereal_sup S = -oo%E -> S `<=` [set -oo%E].
 Proof. by move=> supS [r /ereal_sup_ub | /ereal_sup_ub |//]; rewrite supS. Qed.
 
-Lemma ub_ereal_sup S M : ub S M -> (ereal_sup S <= M)%E.
+Lemma ub_ereal_sup S M : ubound S M -> (ereal_sup S <= M)%E.
 Proof.
 rewrite /ereal_sup /supremum; case: pselect => /= [|_ _].
 - move=> S0 SM; case: xgetP => [x ->{x} [_]| _] /=; first exact.
@@ -511,7 +511,7 @@ Lemma ub_ereal_sup_adherent S (e : {posnum R}) (r : R) :
   ereal_sup S = r%:E -> exists x, S x /\ (ereal_sup S - e%:num%:E < x)%E.
 Proof.
 move=> Sr.
-have : ~ ub S (ereal_sup S - e%:num%:E)%E.
+have : ~ ubound S (ereal_sup S - e%:num%:E)%E.
   move/ub_ereal_sup; apply/negP.
   by rewrite -ltNge Sr lte_subl_addr lte_fin ltr_addl.
 move/asboolP; rewrite asbool_neg; case/existsp_asboolPn => /= x.

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -1163,10 +1163,11 @@ move=> S0; apply/eqP; rewrite eq_le; apply/andP; split; last first.
   move=> x [y Sy] <-{x}; rewrite le_contract; exact/ereal_sup_ub.
 rewrite leNgt; apply/negP.
 set supc := sup _; set csup := contract _; move=> ltsup.
-suff [y [ysupS ?]] : exists y, (y < ereal_sup S)%E /\ ub S y.
+suff [y [ysupS ?]] : exists y, (y < ereal_sup S)%E /\ ubound S y.
   have : (ereal_sup S <= y)%E by apply ub_ereal_sup.
   by move/(lt_le_trans ysupS); rewrite ltxx.
-suff [x [? [ubSx x1]]] : exists x, x < csup /\ ub (contract @` S) x /\ `|x| <= 1.
+suff [x [? [ubSx x1]]] : exists x, x < csup /\ ubound (contract @` S) x /\
+    `|x| <= 1.
   exists (expand x); split => [|y Sy].
     by rewrite -(contractK (ereal_sup S)) lt_expand // inE // contract_le1.
   by rewrite -(contractK y) le_expand //; apply ubSx; exists y.
@@ -3393,7 +3394,7 @@ move=> /asboolPn; rewrite asbool_and => /nandP [/asboolPn /(_ (sAab _))|] //.
 move=> /imply_asboolPn [abx nAx] [C Cop AeabC].
 set Altx := fun y => y \in A `&` [set y | y < x].
 have Altxn0 : Altx !=set0 by exists y; rewrite inE.
-have xub_Altx : (ub Altx) x by apply/ubP => ?; rewrite inE => - [_ /ltW].
+have xub_Altx : (ubound Altx) x by apply/ubP => ?; rewrite inE => - [_ /ltW].
 have Altxsup : has_sup Altx by split=> //; exists x.
 set z := sup Altx.
 have yxz : z \in `[y, x].

--- a/theories/reals.v
+++ b/theories/reals.v
@@ -37,7 +37,7 @@ Record mixin_of : Type := Mixin {
   sup : set R -> R;
    _  :
     forall E : set (Num.ArchimedeanField.sort R),
-      has_sup E -> ub E (sup E);
+      has_sup E -> ubound E (sup E);
    _  :
     forall (E : set (Num.ArchimedeanField.sort R)) (eps : R),
       has_sup E -> 0 < eps -> exists2 e : R, E e & (sup E - eps) < e;
@@ -179,7 +179,7 @@ Definition inf {R : realType} (E : set R) := - sup (-%R @` E).
 (* -------------------------------------------------------------------- *)
 
 Lemma sup_upper_bound {R : realType} (E : set R):
-  has_sup E -> ub E (sup E).
+  has_sup E -> ubound E (sup E).
 Proof. by move=> supE; case: R E supE=> ? [? ? []]. Qed.
 
 Lemma sup_adherent {R : realType} (E : set R) (eps : R) :
@@ -292,7 +292,7 @@ Variables (R : realType).
 Implicit Types E : set R.
 Implicit Types x : R.
 
-Lemma sup_ub {E} : has_ub E -> (ub E) (sup E).
+Lemma sup_ub {E} : has_ubound E -> (ubound E) (sup E).
 Proof.
 move=> ubE; apply/ubP=> x x_in_E; move: (x) (x_in_E).
 by apply/ubP/sup_upper_bound=> //; split; first by exists x.
@@ -307,7 +307,7 @@ case=> e Ee hlte; apply/downP; exists e => //; move: hlte.
 by rewrite opprB addrCA subrr addr0 => /ltW.
 Qed.
 
-Lemma sup_le_ub {E} x : E !=set0 -> (ub E) x -> sup E <= x.
+Lemma sup_le_ub {E} x : E !=set0 -> (ubound E) x -> sup E <= x.
 Proof.
 move=> hasE leEx; set y := sup E; pose z := (x + y) / 2%:R.
 have Dz: 2%:R * z = x + y.
@@ -321,7 +321,7 @@ rewrite -(ler_add2r y) -Dz -mulr2n -[X in X<=_]mulr_natl.
 by rewrite ler_pmul2l ?ltr0Sn.
 Qed.
 
-Lemma has_ubPn {E} : ~ has_ub E <-> (forall x, exists2 y, E y & x < y).
+Lemma has_ubPn {E} : ~ has_ubound E <-> (forall x, exists2 y, E y & x < y).
 Proof.
 split; last first.
   move=> h [x] /ubP hle; case/(_ x): h => y /hle.
@@ -361,14 +361,14 @@ rewrite propeqE; split => [Ex|[y Ey]]; [by exists x|].
 by move/eqP; rewrite eqr_opp => /eqP <-.
 Qed.
 
-Lemma lb_ubN E x : lb E x <-> ub (-%R @` E) (- x).
+Lemma lb_ubN E x : lbound E x <-> ubound (-%R @` E) (- x).
 Proof.
 split=> [/lbP xlbE|/ubP xlbE].
 by apply/ubP=> y [z Ez <-{y}]; rewrite ler_oppr opprK; apply xlbE.
 by apply/lbP => y Ey; rewrite -(opprK x) ler_oppl; apply xlbE; exists y.
 Qed.
 
-Lemma ub_lbN E x : ub E x <-> lb (-%R @` E) (- x).
+Lemma ub_lbN E x : ubound E x <-> lbound (-%R @` E) (- x).
 Proof.
 split=> [? | /lb_ubN].
 by apply/lb_ubN; rewrite opprK setNK.
@@ -388,7 +388,7 @@ by split; [apply/nonemptyN|exists (- x)].
 by split; [apply/nonemptyN|rewrite -[E]setNK; exists (- x)].
 Qed.
 
-Lemma inf_lower_bound E : has_inf E -> lb E (inf E).
+Lemma inf_lower_bound E : has_inf E -> lbound E (inf E).
 Proof.
 move=> /has_inf_supN /sup_upper_bound /ubP inflb; apply/lbP => x.
 by rewrite memNE => /inflb; rewrite ler_oppl.
@@ -408,20 +408,20 @@ move=> ninfE; rewrite -oppr0 -(@sup_out _ (-%R @` E)) => // supNE; apply: ninfE.
 exact/has_inf_supN.
 Qed.
 
-Lemma has_lb_ubN E : has_lb E <-> has_ub (-%R @` E).
+Lemma has_lb_ubN E : has_lbound E <-> has_ubound (-%R @` E).
 Proof.
 by split=> [[x /lb_ubN] | [x /ub_lbN]]; [|rewrite setNK]; exists (- x).
 Qed.
 
-Lemma inf_lb E : has_lb E -> (lb E) (inf E).
+Lemma inf_lb E : has_lbound E -> (lbound E) (inf E).
 Proof. by move/has_lb_ubN/sup_ub/ub_lbN; rewrite setNK. Qed.
 
-Lemma lb_le_inf E x : nonempty E -> (lb E) x -> x <= inf E.
+Lemma lb_le_inf E x : nonempty E -> (lbound E) x -> x <= inf E.
 Proof.
 by move=> /(nonemptyN E) En0 /lb_ubN /(sup_le_ub En0); rewrite ler_oppr.
 Qed.
 
-Lemma has_lbPn E : ~ has_lb E <-> (forall x, exists2 y, E y & y < x).
+Lemma has_lbPn E : ~ has_lbound E <-> (forall x, exists2 y, E y & y < x).
 Proof.
 split=> [/has_lb_ubN /has_ubPn NEnub x|Enlb /has_lb_ubN].
   have [y ENy ltxy] := NEnub (- x); exists (- y); rewrite 1?ltr_oppl //.

--- a/theories/sequences.v
+++ b/theories/sequences.v
@@ -347,14 +347,14 @@ Section sequences_R_lemmas.
 Variable R : realType.
 
 Lemma cvg_has_ub (u_ : R^o ^nat) :
-  cvg u_ -> has_ub [set `|u_ n| | n in setT].
+  cvg u_ -> has_ubound [set `|u_ n| | n in setT].
 Proof.
 move=> /cvg_seq_bounded/pinfty_ex_gt0[M M_gt0 /= uM].
 by exists M; apply/ubP => x -[n _ <-{x}]; exact: uM.
 Qed.
 
 (* TODO: move *)
-Lemma has_ub_image_norm (S : set R) : has_ub (normr @` S) -> has_ub S.
+Lemma has_ub_image_norm (S : set R) : has_ubound (normr @` S) -> has_ubound S.
 Proof.
 case => M /ubP uM; exists `|M|; apply/ubP => r rS.
 rewrite (le_trans (real_ler_norm _)) ?num_real //.


### PR DESCRIPTION
I have understood that it can be argued that `ub` and `lb` are too short identifiers. What about this renaming? @CohenCyril 