### PR TITLE
Move stdlib-related code to Rbar/Rstruct

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -57,6 +57,12 @@
   + `cauchy` is based on entourages and its former version is renamed
     `cauchy_ball`
   + `completeType` inherits from `uniformType` and not from `pseudoMetricType`
+- moved from `posnum.v` to `Rbar.v`: notation `posreal`
+- moved from `normedtype.v` to `Rstruct.v`:
+  + definitions `R_pointedType`, `R_filteredType`, `R_topologicalType`,
+    `R_uniformType`, `R_pseudoMetricType`
+  + lemmas `continuity_pt_nbhs`, `continuity_pt_cvg`, `continuity_ptE`,
+    `continuity_pt_cvg'`, `continuity_pt_nbhs'`, `nbhs_pt_comp`
 
 ### Renamed
 

--- a/theories/Rbar.v
+++ b/theories/Rbar.v
@@ -28,6 +28,7 @@ From mathcomp Require Import ssralg ssrnum.
 Require Import Rstruct posnum.
 Import Order.TTheory GRing.Theory Num.Theory.
 Local Open Scope ring_scope.
+Bind Scope ring_scope with R.
 
 (** This file contains the definition and properties of the set
  [R] # &#8746; {+ &infin;} &#8746; {- &infin;} # denoted by [Rbar]. We have defined:
@@ -159,6 +160,8 @@ Definition ex_Rbar_mult (x y : Rbar) : Prop :=
     | _, _ => true
   end.
 Arguments ex_Rbar_mult !x !y /.
+
+Notation posreal := {posnum R}.
 
 Definition Rbar_mult_pos (x : Rbar) (y : posreal) :=
   match x with

--- a/theories/Rstruct.v
+++ b/theories/Rstruct.v
@@ -665,3 +665,82 @@ Qed.
 End bigmaxr.
 
 End ssreal_struct_contd.
+
+Require Import posnum topology normedtype.
+
+Section analysis_struct.
+
+Canonical R_pointedType := [pointedType of R for pointed_of_zmodule R_ringType].
+Canonical R_filteredType :=
+  [filteredType R of R for filtered_of_normedZmod R_normedZmodType].
+Canonical R_topologicalType : topologicalType := TopologicalType R
+  (topologyOfEntourageMixin
+    (uniformityOfBallMixin
+      (@nbhs_ball_normE _ R_normedZmodType)
+      (pseudoMetric_of_normedDomain R_normedZmodType))).
+Canonical R_uniformType : uniformType :=
+  UniformType R
+  (uniformityOfBallMixin (@nbhs_ball_normE _ R_normedZmodType)
+    (pseudoMetric_of_normedDomain R_normedZmodType)).
+Canonical R_pseudoMetricType : pseudoMetricType R_numDomainType :=
+  PseudoMetricType R (pseudoMetric_of_normedDomain R_normedZmodType).
+
+(* TODO: express using ball?*)
+Lemma continuity_pt_nbhs (f : R -> R) x :
+  continuity_pt f x <->
+  forall eps : {posnum R}, nbhs x (fun u => `|f u - f x| < eps%:num).
+Proof.
+split=> [fcont e|fcont _/RltP/posnumP[e]]; last first.
+  have [_/posnumP[d] xd_fxe] := fcont e.
+  exists d%:num; split; first by apply/RltP; have := [gt0 of d%:num].
+  by move=> y [_ /RltP yxd]; apply/RltP/xd_fxe; rewrite /= distrC.
+have /RltP egt0 := [gt0 of e%:num].
+have [_ [/RltP/posnumP[d] dx_fxe]] := fcont e%:num egt0.
+exists d%:num => // y xyd; case: (eqVneq x y) => [->|xney].
+  by rewrite subrr normr0.
+apply/RltP/dx_fxe; split; first by split=> //; apply/eqP.
+by have /RltP := xyd; rewrite distrC.
+Qed.
+
+Lemma continuity_pt_cvg (f : R -> R) (x : R) :
+  continuity_pt f x <-> {for x, continuous f}.
+Proof.
+eapply iff_trans; first exact: continuity_pt_nbhs.
+apply iff_sym.
+have FF : Filter (f @ x).
+  by typeclasses eauto.
+  (*by apply fmap_filter; apply: @filter_filter' (locally_filter _).*)
+case: (@cvg_ballP _ _ (f @ x) FF (f x)) => {FF}H1 H2.
+(* TODO: in need for lemmas and/or refactoring of already existing lemmas (ball vs. Rabs) *)
+split => [{H2} - /H1 {H1} H1 eps|{H1} H].
+- have {H1} [//|_/posnumP[x0] Hx0] := H1 eps%:num.
+  exists x0%:num => // Hx0' /Hx0 /=.
+  by rewrite /= distrC; apply.
+- apply H2 => _ /posnumP[eps]; move: (H eps) => {H} [_ /posnumP[x0] Hx0].
+  exists x0%:num => // y /Hx0 /= {Hx0}Hx0.
+  by rewrite /ball /= distrC.
+Qed.
+
+Lemma continuity_ptE (f : R -> R) (x : R) :
+  continuity_pt f x <-> {for x, continuous f}.
+Proof. exact: continuity_pt_cvg. Qed.
+
+Local Open Scope classical_set_scope.
+
+Lemma continuity_pt_cvg' f x :
+  continuity_pt f x <-> f @ nbhs' x --> f x.
+Proof. by rewrite continuity_ptE continuous_withinNx. Qed.
+
+Lemma continuity_pt_nbhs' f x :
+  continuity_pt f x <->
+  forall eps, 0 < eps -> nbhs' x (fun u => `|f x - f u| < eps).
+Proof.
+rewrite continuity_pt_cvg' (@cvg_distP _ [normedModType _ of R^o]).
+exact.
+Qed.
+
+Lemma nbhs_pt_comp (P : R -> Prop) (f : R -> R) (x : R) :
+  nbhs (f x) P -> continuity_pt f x -> \near x, P (f x).
+Proof. by move=> Lf /continuity_pt_cvg; apply. Qed.
+
+End analysis_struct.

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -1,9 +1,8 @@
 (* mathcomp analysis (c) 2017 Inria and AIST. License: CeCILL-C.              *)
-Require Reals.
 From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype choice.
 From mathcomp Require Import seq fintype bigop order ssralg ssrint ssrnum finmap.
 From mathcomp Require Import matrix interval zmodp.
-Require Import boolp ereal reals Rstruct.
+Require Import boolp ereal reals.
 Require Import classical_sets posnum topology prodnormedzmodule.
 
 (******************************************************************************)
@@ -268,22 +267,6 @@ rewrite /nbhs_ entourage_E predeq2E => x A; split.
 by move=> [E [e egt0 sbeE] sEA]; exists e => // ??; apply/sEA/sbeE.
 Qed.
 End pseudoMetric_of_normedDomain.
-Canonical R_pointedType := [pointedType of
-  Rdefinitions.R for pointed_of_zmodule R_ringType].
-(* NB: similar definition in topology.v *)
-Canonical R_filteredType := [filteredType Rdefinitions.R of
-  Rdefinitions.R for filtered_of_normedZmod R_normedZmodType].
-Canonical R_topologicalType : topologicalType := TopologicalType Rdefinitions.R
-  (topologyOfEntourageMixin
-    (uniformityOfBallMixin
-      (@nbhs_ball_normE _ R_normedZmodType)
-      (pseudoMetric_of_normedDomain R_normedZmodType))).
-Canonical R_uniformType : uniformType :=
-  UniformType Rdefinitions.R
-  (uniformityOfBallMixin (@nbhs_ball_normE _ R_normedZmodType)
-    (pseudoMetric_of_normedDomain R_normedZmodType)).
-Canonical R_pseudoMetricType : pseudoMetricType R_numDomainType :=
-  PseudoMetricType Rdefinitions.R (pseudoMetric_of_normedDomain R_normedZmodType).
 
 Section numFieldType_canonical.
 Variable R : numFieldType.
@@ -4156,46 +4139,6 @@ apply: lt_le_trans (floorS_gtr _) _; rewrite floorE Nfloor ler_add //.
 by rewrite ler_nat.
 Qed.
 
-(* TODO: express using ball?*)
-Lemma continuity_pt_nbhs (f : Rdefinitions.R -> Rdefinitions.R) x :
-  Ranalysis1.continuity_pt f x <->
-  forall eps : {posnum Rdefinitions.R}, nbhs x (fun u => `|f u - f x| < eps%:num).
-Proof.
-split=> [fcont e|fcont _/RltP/posnumP[e]]; last first.
-  have [_/posnumP[d] xd_fxe] := fcont e.
-  exists d%:num; split; first by apply/RltP; have := [gt0 of d%:num].
-  by move=> y [_ /RltP yxd]; apply/RltP/xd_fxe; rewrite /= distrC.
-have /RltP egt0 := [gt0 of e%:num].
-have [_ [/RltP/posnumP[d] dx_fxe]] := fcont e%:num egt0.
-exists d%:num => // y xyd; case: (eqVneq x y) => [->|xney].
-  by rewrite subrr normr0.
-apply/RltP/dx_fxe; split; first by split=> //; apply/eqP.
-by have /RltP := xyd; rewrite distrC.
-Qed.
-
-Lemma continuity_pt_cvg (f : Rdefinitions.R -> Rdefinitions.R) (x : Rdefinitions.R) :
-  Ranalysis1.continuity_pt f x <-> {for x, continuous f}.
-Proof.
-eapply iff_trans; first exact: continuity_pt_nbhs.
-apply iff_sym.
-have FF : Filter (f @ x).
-  by typeclasses eauto.
-  (*by apply fmap_filter; apply: @filter_filter' (locally_filter _).*)
-case: (@cvg_ballP _ _ (f @ x) FF (f x)) => {FF}H1 H2.
-(* TODO: in need for lemmas and/or refactoring of already existing lemmas (ball vs. Rabs) *)
-split => [{H2} - /H1 {H1} H1 eps|{H1} H].
-- have {H1} [//|_/posnumP[x0] Hx0] := H1 eps%:num.
-  exists x0%:num => // Hx0' /Hx0 /=.
-  by rewrite /= distrC; apply.
-- apply H2 => _ /posnumP[eps]; move: (H eps) => {H} [_ /posnumP[x0] Hx0].
-  exists x0%:num => // y /Hx0 /= {Hx0}Hx0.
-  by rewrite /ball /= distrC.
-Qed.
-
-Lemma continuity_ptE (f : Rdefinitions.R -> Rdefinitions.R) (x : Rdefinitions.R) :
-  Ranalysis1.continuity_pt f x <-> {for x, continuous f}.
-Proof. exact: continuity_pt_cvg. Qed.
-
 Lemma continuous_withinNx (R : numFieldType) {U V : pseudoMetricType R}
   (f : U -> V) x :
   {for x, continuous f} <-> f @ nbhs' x --> f x.
@@ -4209,20 +4152,3 @@ rewrite !nbhs_nearE !near_map !near_nbhs in fxP *; have /= := cfx P fxP.
 rewrite !near_simpl near_withinE near_simpl => Pf; near=> y.
 by have [->|] := eqVneq y x; [by apply: nbhs_singleton|near: y].
 Grab Existential Variables. all: end_near. Qed.
-
-Lemma continuity_pt_cvg' f x :
-  Ranalysis1.continuity_pt f x <-> f @ nbhs' x --> f x.
-Proof. by rewrite continuity_ptE continuous_withinNx. Qed.
-
-Lemma continuity_pt_nbhs' f x :
-  Ranalysis1.continuity_pt f x <->
-  forall eps, 0 < eps -> nbhs' x (fun u => `|f x - f u| < eps).
-Proof.
-rewrite continuity_pt_cvg' (@cvg_distP _ [normedModType _ of Rdefinitions.R^o]).
-exact.
-Qed.
-
-Lemma nbhs_pt_comp (P : Rdefinitions.R -> Prop)
-  (f : Rdefinitions.R -> Rdefinitions.R) (x : Rdefinitions.R) :
-  nbhs (f x) P -> Ranalysis1.continuity_pt f x -> \near x, P (f x).
-Proof. by move=> Lf /continuity_pt_cvg; apply. Qed.

--- a/theories/posnum.v
+++ b/theories/posnum.v
@@ -1,8 +1,7 @@
 (* mathcomp analysis (c) 2017 Inria and AIST. License: CeCILL-C.              *)
-Require Import Reals.
 From Coq Require Import ssreflect ssrfun ssrbool.
 From mathcomp Require Import ssrnat eqtype choice order ssralg ssrnum.
-Require Import boolp reals.
+Require Import boolp.
 
 (******************************************************************************)
 (* This file develops tools to make the manipulation of positive numbers      *)
@@ -41,9 +40,7 @@ Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 Import Order.TTheory Order.Syntax GRing.Theory Num.Theory.
 
-Delimit Scope R_scope with coqR.
 Local Open Scope ring_scope.
-Bind Scope ring_scope with R.
 
 (* Enrico's trick for tc resolution in have *)
 Notation "!! x" := (ltac:(refine x)) (at level 100, only parsing).
@@ -71,7 +68,6 @@ Notation "x %:num" := (num_of_pos x) : ring_scope.
 Definition pos_of_num (R : numDomainType) (x : {posnum R})
    (phx : phantom R x%:num) := x.
 Notation "x %:pos" := (pos_of_num (Phantom _ x)) : ring_scope.
-Notation posreal := {posnum R}.
 Notation "2" := 2%:R : ring_scope.
 
 Section Order.

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -1,8 +1,7 @@
 (* mathcomp analysis (c) 2017 Inria and AIST. License: CeCILL-C.              *)
-Require Import Reals.
 From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype choice div.
 From mathcomp Require Import seq fintype bigop order ssralg ssrnum finmap matrix.
-Require Import boolp Rstruct classical_sets posnum.
+Require Import boolp classical_sets posnum.
 
 (******************************************************************************)
 (* This file develops tools for the manipulation of filters and basic         *)


### PR DESCRIPTION
This PR removes the dependency on stdlib's reals from the main parts of the library.