### PR TITLE
addition of technical lemmas

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -4,12 +4,24 @@
 
 ### Added
 
+- in `boolp.v`:
+  + lemma `not_andP`
+- in `classical_sets.v`:
+  + lemmas `setIIl`, `setIIr`, `setCS`, `setSD`, `setDS`, `setDSS`, `setCI`,
+    `setDUr`, `setDUl`, `setIDA`, `setDD`
+
 ### Changed
 
 - in `classical_sets.v`:
   + the index in `bigcup_set1` generalized from `nat` to some `Type`
 
 ### Renamed
+
+- in `classical_sets.v`:
+  + `setIDl` -> `setIUl`
+  + `setUDl` -> `setUIl`
+  + `setUDr` -> `setUIr`
+  + `setIDr` -> `setIUl`
 
 ### Removed
 

--- a/theories/boolp.v
+++ b/theories/boolp.v
@@ -559,6 +559,12 @@ split=> [/asboolP|[p nq pq]]; [|exact/nq/pq].
 by rewrite asbool_neg => /imply_asboolPn.
 Qed.
 
+Lemma not_andP (P Q : Prop) : ~ (P /\ Q) <-> ~ P \/ ~ Q.
+Proof.
+split => [/asboolPn|[|]]; try by apply: contrap => -[].
+by rewrite asbool_and negb_and => /orP[]/asboolPn; [left|right].
+Qed.
+
 Lemma not_implyE (P Q : Prop) : (~ (P -> Q)) = (P /\ ~ Q).
 Proof. by rewrite propeqE not_implyP. Qed.
 


### PR DESCRIPTION
Mostly `classical_sets` lemmas. Naming follows `finset.v`. I have renamed `setIDl`, `setUDr`, `setUDl`, `setIDr` with a `U` instead of a `D` like it is in `finset.v`. I guess this is because `D` is put at better use for lemmas with the `\` operator.
