### PR TITLE
rename/remove contra lemmas

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -22,8 +22,16 @@
   + `setUDl` -> `setUIl`
   + `setUDr` -> `setUIr`
   + `setIDr` -> `setIUl`
+- in `boolp.v`:
+  + `contrap` -> `contra_not`
+  + `contrapL` -> `contraPnot`
+  + `contrapR` -> `contra_notP`
+  + `contrapLR` -> `contraPP`
 
 ### Removed
+
+- in `boolp.v`:
+  + `contrapNN`, `contrapTN`, `contrapNT`, `contrapTT`
 
 ### Infrastructure
 

--- a/theories/altreals/discrete.v
+++ b/theories/altreals/discrete.v
@@ -38,7 +38,7 @@ Proof. by move/asboolPn/forallp_asboolPn. Qed.
 
 Lemma exists2NP : ~ (exists2 x, P x & Q x) -> forall x, ~ P x \/ ~ Q x.
 Proof.
-apply: contrapR; case/asboolPn/existsp_asboolPn=> [x].
+apply: contra_notP; case/asboolPn/existsp_asboolPn=> [x].
 by case/neg_or => /contrapT Px /contrapT Qx; exists x.
 Qed.
 
@@ -186,7 +186,7 @@ Lemma finiteNP (E : pred T): (forall s : seq T, ~ {subset E <= s}) ->
 Proof.
 move=> finN; elim=> [|n [s] [<- uq_s sE]]; first by exists [::].
 have [x sxN xE]: exists2 x, x \notin s & x \in E.
-  apply: contrapR (finN (filter (mem E) s)) => /exists2NP finE x Ex.
+  apply: contra_notP (finN (filter (mem E) s)) => /exists2NP finE x Ex.
   move/or_asboolP: (finE x).
   by rewrite !asbool_neg !asboolb negbK Ex mem_filter orbF [(mem E) x]Ex.
 exists (x :: s) => /=; rewrite sxN; split=> // y.

--- a/theories/altreals/realsum.v
+++ b/theories/altreals/realsum.v
@@ -457,7 +457,7 @@ Qed.
 
 Lemma ncvg_sum : ncvg (fun n => \sum_(i < n) S i) (psum S)%:E.
 Proof.
-set u := (fun n => _); apply: contrapLR smS => ncv _.
+set u := (fun n => _); apply: contraPP smS => ncv _.
 case: (ncvg_mono_bnd (u := u)) => //.
   by apply/ptsum_homo. by apply/psummable_ptbounded.
 move=> x cvux; suff xE: x = (psum S) by rewrite xE in cvux.

--- a/theories/boolp.v
+++ b/theories/boolp.v
@@ -269,37 +269,29 @@ by case=> x bPx; apply/asboolP; exists x; apply/asboolP.
 Qed.
 
 (* -------------------------------------------------------------------- *)
-Lemma contrap (Q P : Prop) : (Q -> P) -> ~ P -> ~ Q.
+Lemma contra_not (Q P : Prop) : (Q -> P) -> ~ P -> ~ Q.
 Proof.
 move=> cb /asboolPn nb; apply/asboolPn.
 by apply: contra nb => /asboolP /cb /asboolP.
 Qed.
 
-Definition contrapNN := contra.
-
-Lemma contrapL (Q P : Prop) : (Q -> ~ P) -> P -> ~ Q.
+Lemma contraPnot (Q P : Prop) : (Q -> ~ P) -> P -> ~ Q.
 Proof.
 move=> cb /asboolP hb; apply/asboolPn.
 by apply: contraL hb => /asboolP /cb /asboolPn.
 Qed.
 
-Definition contrapTN := contrapL.
-
-Lemma contrapR (Q P : Prop) : (~ Q -> P) -> ~ P -> Q.
+Lemma contra_notP (Q P : Prop) : (~ Q -> P) -> ~ P -> Q.
 Proof.
 move=> cb /asboolPn nb; apply/asboolP.
 by apply: contraR nb => /asboolP /cb /asboolP.
 Qed.
 
-Definition contrapNT := contrapR.
-
-Lemma contrapLR (Q P : Prop) : (~ Q -> ~ P) -> P -> Q.
+Lemma contraPP (Q P : Prop) : (~ Q -> ~ P) -> P -> Q.
 Proof.
 move=> cb /asboolP hb; apply/asboolP.
 by apply: contraLR hb => /asboolP /cb /asboolPn.
 Qed.
-
-Definition contrapTT := contrapLR.
 
 Lemma contrapT P : ~ ~ P -> P.
 Proof.
@@ -478,8 +470,8 @@ Hypothesis viewP : forall x, reflect (PP x) (P x).
 Lemma existsPP : reflect (exists x, PP x) `[exists x, P x].
 Proof.
 apply: (iffP idP).
-  move/asboolP; (* oops notation! *) apply: contrapR => nh x /=; apply: notTE.
-  by apply: contrap nh => /viewP Px; exists x.
+  move/asboolP; (* oops notation! *) apply: contra_notP => nh x /=; apply: notTE.
+  by apply: contra_not nh => /viewP Px; exists x.
 case=> x PPx; apply/asboolP=> /(_ x) /notT /=; rewrite -/(not (~ P x)) notK.
 exact/viewP.
 Qed.
@@ -561,7 +553,7 @@ Qed.
 
 Lemma not_andP (P Q : Prop) : ~ (P /\ Q) <-> ~ P \/ ~ Q.
 Proof.
-split => [/asboolPn|[|]]; try by apply: contrap => -[].
+split => [/asboolPn|[|]]; try by apply: contra_not => -[].
 by rewrite asbool_and negb_and => /orP[]/asboolPn; [left|right].
 Qed.
 

--- a/theories/classical_sets.v
+++ b/theories/classical_sets.v
@@ -418,7 +418,7 @@ Proof. by move=> AB /(subsetI_neq0 AB); rewrite -!set0P => /contra_eq. Qed.
 Lemma setD_eq0 A (X Y : set A) : (X `\` Y = set0) = (X `<=` Y).
 Proof.
 rewrite propeqE; split=> [XDY0 a|sXY].
-  by apply: contrapTT => nYa xA; rewrite -[False]/(set0 a) -XDY0.
+  by apply: contraPP => nYa xA; rewrite -[False]/(set0 a) -XDY0.
 by rewrite predeqE => ?; split=> // - [?]; apply; apply: sXY.
 Qed.
 
@@ -602,7 +602,7 @@ move: (erefl (xget x0 P)); set y := {2}(xget x0 P).
 rewrite /xget; case: pselect => /= [?|neqP _].
   by case: sigW => x /= /asboolP Px; rewrite [P x]propT //; constructor.
 suff NP x : ~ P x by rewrite [P x0]propF //; constructor.
-by apply: contrap neqP => Px; exists x; apply/asboolP.
+by apply: contra_not neqP => Px; exists x; apply/asboolP.
 Qed.
 
 Lemma xgetPex {T : choiceType} x0 (P : set T) : (exists x, P x) -> P (xget x0 P).

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -3446,7 +3446,7 @@ Variable R : realType.
 Lemma segment_connected (a b : R) : connected [set x : R^o | x \in `[a, b]].
 Proof.
 move=> A [y Ay] Aop Acl.
-move: Aop; apply: contrapTT; rewrite predeqE => /asboolPn /existsp_asboolPn [x].
+move: Aop; apply: contraPP; rewrite predeqE => /asboolPn /existsp_asboolPn [x].
 wlog ltyx : a b (* leab *) A y Ay Acl x / y < x.
   move=> scon; case: (ltrP y x); first exact: scon.
   rewrite le_eqVlt; case/orP=> [/eqP xey|ltxy].

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -708,7 +708,7 @@ Definition Build_ProperFilter {T : Type} (F : set (set T))
 Lemma filter_ex_subproof {T : Type} (F : set (set T)) :
      ~ F set0 -> (forall P, F P -> exists x, P x).
 Proof.
-move=> NFset0 P FP; apply: contrapNT NFset0 => nex; suff <- : P = set0 by [].
+move=> NFset0 P FP; apply: contra_notP NFset0 => nex; suff <- : P = set0 by [].
 by rewrite funeqE => x; rewrite propeqE; split=> // Px; apply: nex; exists x.
 Qed.
 
@@ -2125,7 +2125,8 @@ End Closed.
 Lemma closed_comp {T U : topologicalType} (f : T -> U) (D : set U) :
   {in ~` f @^-1` D, continuous f} -> closed D -> closed (f @^-1` D).
 Proof.
-rewrite !closedE=> f_continuous D_cl x /= xDf; apply: D_cl; apply: contrap xDf => fxD.
+rewrite !closedE=> f_continuous D_cl x /= xDf.
+apply: D_cl; apply: contra_not xDf => fxD.
 have NDfx : ~ D (f x).
   by move: fxD; rewrite -nbhs_nearE nbhsE => - [A [[??]]]; apply.
 by apply: f_continuous fxD; rewrite inE.
@@ -2505,7 +2506,7 @@ split=> [Aco I D f [g gop feAg] fcov|Aco I D f [g gcl feAg]].
   by exists p => i D'i; split=> // fip; apply: nUfp; exists i.
 case: (pselect (exists i, D i)) => [[j Dj] | /asboolP]; last first.
   by rewrite asbool_neg => /forallp_asboolPn D0 => _; exists point => ? /D0.
-apply: contrapTT => /asboolP; rewrite asbool_neg => /forallp_asboolPn If0.
+apply: contraPP => /asboolP; rewrite asbool_neg => /forallp_asboolPn If0.
 apply/asboolP; rewrite asbool_neg; apply/existsp_asboolPn.
 have Anfcov : A `<=` \bigcup_(i in D) (A `\` f i).
   move=> p Ap; have /asboolP := If0 p; rewrite asbool_neg => /existsp_asboolPn.
@@ -2588,7 +2589,7 @@ Lemma open_hausdorff : hausdorff T =
                 [/\ open AB.1, open AB.2 & AB.1 `&` AB.2 == set0]).
 Proof.
 rewrite propeqE; split => [T_filterT2|T_openT2] x y.
-  have := contrap (T_filterT2 x y); rewrite (rwP eqP) (rwP negP) => cl /cl.
+  have := contra_not (T_filterT2 x y); rewrite (rwP eqP) (rwP negP) => cl /cl.
   rewrite [cluster _ _](rwP forallp_asboolP) => /negP.
   rewrite forallbE => /existsp_asboolPn/=[A]/negP/existsp_asboolPn/=[B].
   rewrite [nbhs _ _ -> _](rwP imply_asboolP) => /negP.
@@ -2597,7 +2598,7 @@ rewrite propeqE; split => [T_filterT2|T_openT2] x y.
   move: xA yB; rewrite !nbhsE.
   move=> - [oA [[oA_open oAx] oAA]] [oB [[oB_open oBx] oBB]].
   by exists (oA, oB); rewrite ?inE; split => //; apply: subsetI_eq0 AIB_eq0.
-apply: contrapTT => /eqP /T_openT2[[/=A B]].
+apply: contraPP => /eqP /T_openT2[[/=A B]].
 rewrite !inE => - [xA yB] [Aopen Bopen /eqP AIB_eq0].
 move=> /(_ A B (open_nbhs_nbhs _) (open_nbhs_nbhs _)).
 by rewrite -set0P => /(_ _ _)/negP; apply.


### PR DESCRIPTION
Rename `contra` lemmas following the notation scheme adopted in MathComp and remove duplicate definitions of contra lemmas.

TODO when merging: add an issue to remove `contra_not` when it is available with a future release of MathComp