### PR TITLE
Making sure `[set x | P]` notations are not expanded eagerly

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -46,6 +46,13 @@
 - in `ereal.v`:
   + notation `x >= y` defined as `y <= x` (only parsing) instead of `gee`
   + notation `x > y` defined as `y < x` (only parsing) instead of `gte`
+  + definition `mkset`
+  + lemma `eq_set`
+
+### Changed
+
+- in `classical_sets.v`:
+  + notation `[set x : T | P]` now use definition `mkset`
 
 ### Renamed
 
@@ -53,6 +60,8 @@
   + `subset_empty` -> `subset_nonempty`
 - in `measure.v`:
   + `sigma_additive_implies_additive` -> `sigma_additive_is_additive`
+- in `topology.v`:
+  + `nbhs_of` -> `locally_of`
 
 ### Removed
 

--- a/theories/classical_sets.v
+++ b/theories/classical_sets.v
@@ -188,7 +188,10 @@ Bind Scope classical_set_scope with set.
 Local Open Scope classical_set_scope.
 Delimit Scope classical_set_scope with classic.
 
-Notation "[ 'set' x : T | P ]" := ((fun x => P) : set T) : classical_set_scope.
+Definition mkset {T} (P : T -> Prop) : set T := P.
+Arguments mkset _ _ _ /.
+
+Notation "[ 'set' x : T | P ]" := (mkset (fun x : T => P)) : classical_set_scope.
 Notation "[ 'set' x | P ]" := [set x : _ | P] : classical_set_scope.
 Notation "[ 'set' E | x 'in' A ]" :=
   [set y | exists2 x, A x & E = y] : classical_set_scope.
@@ -261,6 +264,10 @@ Proof.
 rewrite propeqE; split => [->|[FG GF]]; [by split|].
 by rewrite predeqE => t; split=> [/FG|/GF].
 Qed.
+
+Lemma eq_set T (P Q : T -> Prop): (forall x : T, P x = Q x) ->
+  [set x | P x] = [set x | Q x].
+Proof. by move=> /funext->. Qed.
 
 Lemma sub0set T (X : set T) : set0 `<=` X.
 Proof. by []. Qed.
@@ -385,7 +392,8 @@ Lemma image_preimage A B (f : A -> B) (X : set B) :
 Proof.
 move=> fsurj; rewrite predeqE => x; split; first by move=> [?? <-].
 move=> Xx; have : setT x by [].
-by rewrite -fsurj => - [y _ fy_eqx]; exists y => //; rewrite /preimage fy_eqx.
+rewrite -fsurj => - [y _ fy_eqx]; exists y => //.
+by rewrite /preimage/= fy_eqx.
 Qed.
 
 Lemma preimage_setU {A B} (f : A -> B) (X Y : set B) :
@@ -542,13 +550,13 @@ Lemma setIIr T (A B C : set T) : A `&` (B `&` C) = (A `&` B) `&` (A `&` C).
 Proof. by rewrite !(setIC A) setIIl. Qed.
 
 Lemma setUA A : associative (@setU A).
-Proof. move=> p q r; rewrite /setU predeqE => a; tauto. Qed.
+Proof. move=> p q r; rewrite /setU/mkset predeqE => a; tauto. Qed.
 
 Lemma setUid A : idempotent (@setU A).
-Proof. move=> p; rewrite /setU predeqE => a; tauto. Qed.
+Proof. move=> p; rewrite /setU/mkset predeqE => a; tauto. Qed.
 
 Lemma setUC A : commutative (@setU A).
-Proof. move=> p q; rewrite /setU predeqE => a; tauto. Qed.
+Proof. move=> p q; rewrite /setU/mkset predeqE => a; tauto. Qed.
 
 Lemma set0U T (X : set T) : set0 `|` X = X.
 Proof. by rewrite predeqE => t; split; [case|right]. Qed.
@@ -774,7 +782,8 @@ Qed.
 Lemma subset_bigsetU T m n (U : nat -> set T) : (m <= n)%N ->
   \big[setU/set0]_(i < m) U i `<=` \big[setU/set0]_(i < n) U i.
 Proof.
-by rewrite !bigcup_ord => mn x [i im ?]; exists i => //; rewrite (leq_trans im).
+rewrite !bigcup_ord => mn x [i im ?]; exists i => //.
+by rewrite /mkset (leq_trans im).
 Qed.
 
 Lemma bigcap_ord T n (A : nat -> set T) :

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -307,7 +307,7 @@ rewrite (_ : g = g1 + g2) ?funeqE // -(addr0 (_ _ v)); apply: (@cvgD _ _ [topolo
   rewrite -(scale1r (_ _ v)); apply: cvgZl => /= X [e e0].
   rewrite /ball_ /= => eX.
   apply/nbhs_ballP.
-  by exists e => //= x _ x0; apply eX; rewrite mulVr // ?unitfE // subrr normr0.
+  by exists e => //= x _ x0; apply eX; rewrite mulVr // ?unitfE //= subrr normr0.
 rewrite /g2.
 have [/eqP ->|v0] := boolP (v == 0).
   rewrite (_ : (fun _ => _) = cst 0); first exact: cvg_cst.
@@ -316,12 +316,12 @@ apply/cvg_distP => e e0.
 rewrite nearE /=; apply/nbhs_ballP.
 have /(littleoP [littleo of k]) /nbhs_ballP[i i0 Hi] : 0 < e / (2 * `|v|).
   by rewrite divr_gt0 // pmulr_rgt0 // normr_gt0.
-exists (i / `|v|); first by rewrite divr_gt0 // normr_gt0.
+exists (i / `|v|); first by rewrite /= divr_gt0 // normr_gt0.
 move=> /= j; rewrite /ball /= /ball_ add0r normrN.
 rewrite ltr_pdivl_mulr ?normr_gt0 // => jvi j0.
 rewrite add0r normrN normmZ -ltr_pdivl_mull ?normr_gt0 ?invr_neq0 //.
 have /Hi/le_lt_trans -> // : ball 0 i (j *: v).
-  by rewrite -ball_normE /ball_ add0r normrN (le_lt_trans _ jvi) // normmZ.
+  by rewrite -ball_normE /ball_/= add0r normrN (le_lt_trans _ jvi) // normmZ.
 rewrite -(mulrC e) -mulrA -ltr_pdivl_mull // mulrA mulVr ?unitfE ?gt_eqF //.
 rewrite normrV ?unitfE // div1r invrK ltr_pdivr_mull; last first.
   by rewrite pmulr_rgt0 // normr_gt0.
@@ -503,7 +503,7 @@ rewrite -ler_pdivl_mull; last by rewrite gtr0_norm.
 rewrite mulrCA (@le_trans _ _ (e%:num * `|k^-1 *: x|)) //; last first.
   by rewrite ler_pmul // normmZ normfV.
 apply dfe.
-rewrite -ball_normE /ball_ sub0r normrN normmZ.
+rewrite -ball_normE /ball_/= sub0r normrN normmZ.
 rewrite invrK -ltr_pdivl_mulr // ger0_norm // ltr_pdivr_mulr //.
 by rewrite -mulrA mulVf ?lt0r_neq0 // mulr1 [X in _ < X]splitr ltr_addl.
 Qed.
@@ -935,7 +935,7 @@ rewrite -[X in X + _]mulr1 -[X in 1 / _ * X](@mulfVK _ (x ^+ 2)); last first.
 rewrite mulrA mulf_div mulr1.
 have hDx_neq0 : h + x != 0.
   near: h; rewrite !nbhs_simpl; apply/nbhs_normP.
-  exists `|x|; first by rewrite normr_gt0.
+  exists `|x|; first by rewrite /= normr_gt0.
   move=> h /=; rewrite -ball_normE /= distrC subr0 -subr_gt0 => lthx.
   rewrite -(normr_gt0 (h + x : R^o)) addrC -[h]opprK.
   apply: lt_le_trans (ler_dist_dist _ _).
@@ -950,10 +950,10 @@ rewrite mulrA mulrAC ler_pdivr_mulr ?normr_gt0 ?mulf_neq0 //.
 rewrite mulrAC ler_pdivr_mulr ?normr_gt0 //.
 have : `|h * h| <= `|x / 2| * (e%:num * `|x * x| * `|h : R^o|).
   rewrite !mulrA; near: h; exists (`|x / 2| * e%:num * `|x * x|).
-    by rewrite !pmulr_rgt0 // normr_gt0 mulf_neq0.
+    by rewrite /= !pmulr_rgt0 // normr_gt0 mulf_neq0.
   by move=> h /ltW; rewrite distrC subr0 [`|h * _|]normrM => /ler_pmul; apply.
 move=> /le_trans-> //; rewrite [X in X <= _]mulrC ler_pmul ?mulr_ge0 //.
-near: h; exists (`|x| / 2); first by rewrite divr_gt0 ?normr_gt0.
+near: h; exists (`|x| / 2); first by rewrite /= divr_gt0 ?normr_gt0.
 move=> h; rewrite /= distrC subr0 => lthhx; rewrite addrC -[h]opprK.
 apply: le_trans (@ler_dist_dist _ [normedModType R of R^o] _ _).
 rewrite normrN [X in _ <= X]ger0_norm; last first.
@@ -1271,7 +1271,7 @@ move=> fxn0 df.
 have /derivable1P/derivable1_diffP/differentiable_continuous := df.
 move=> /continuous_withinNx; rewrite scale0r add0r => fc.
 have fn0 : nbhs' (0 : R^o) [set h | f (h *: v + x) != 0].
-  apply: (fc [set x | x != 0]); exists `|f x|; first by rewrite normr_gt0.
+  apply: (fc [set x | x != 0]); exists `|f x|; first by rewrite /= normr_gt0.
   move=> y; rewrite /= => yltfx.
   by apply/eqP => y0; move: yltfx; rewrite y0 subr0 ltxx.
 have : (fun h => - ((f x)^-1 * (f (h *: v + x))^-1) *:
@@ -1312,7 +1312,7 @@ Proof.
 move=> leab fcont; set imf := [set t | (f @` [set x | x \in `[a, b]]) t].
 have imf_sup : has_sup imf.
   split.
-    by exists (f a) => //; rewrite /imf; apply/imageP; rewrite inE /= lexx.
+    by exists (f a) => //; rewrite /imf; apply/imageP; rewrite /= inE /= lexx.
   have [M [Mreal imfltM]] : bounded_set (f @` [set x | x \in `[a, b]] : set R^o).
     apply/compact_bounded/continuous_compact; last exact: segment_compact.
     by move=> ?; rewrite inE => /fcont.
@@ -1429,7 +1429,7 @@ apply/eqP; rewrite eq_le; apply/andP; split.
   near=> h; apply: mulr_ge0_le0.
     by rewrite invr_ge0; apply: ltW; near: h; exists 1.
   rewrite subr_le0 [_%:A]mulr1; apply: cmax; near: h.
-  exists (b - c); first by rewrite subr_gt0 (itvP cab).
+  exists (b - c); first by rewrite /= subr_gt0 (itvP cab).
   move=> h; rewrite /= distrC subr0.
   move=> /(le_lt_trans (ler_norm _)); rewrite ltr_subr_addr inE/= => ->.
   by move=> /ltr_spsaddl -> //; rewrite (itvP cab).
@@ -1442,7 +1442,7 @@ apply: le0r_cvg_map; last first.
 near=> h; apply: mulr_le0.
   by rewrite invr_le0; apply: ltW; near: h; exists 1.
 rewrite subr_le0 [_%:A]mulr1; apply: cmax; near: h.
-exists (c - a); first by rewrite subr_gt0 (itvP cab).
+exists (c - a); first by rewrite /= subr_gt0 (itvP cab).
 move=> h; rewrite /= distrC subr0.
 move=> /ltr_normlP []; rewrite ltr_subr_addl ltr_subl_addl inE/= => -> _.
 by move=> /ltr_snsaddl -> //; rewrite (itvP cab).

--- a/theories/ereal.v
+++ b/theories/ereal.v
@@ -1581,10 +1581,10 @@ rewrite predeq2E => x A; split.
                         (contract (r%:E + e%:num%:E) - contract r%:E)%R.
     exists (diag e'); rewrite /diag.
       exists e' => //.
-      rewrite /e' lt_minr; apply/andP; split.
+      rewrite /= /e' lt_minr; apply/andP; split.
         by rewrite subr_gt0 lt_contract lte_fin ltr_subl_addr ltr_addl.
       by rewrite subr_gt0 lt_contract lte_fin ltr_addl.
-    case=> [r' re'r'| |].
+    case=> [r' /= re'r'| |]/=.
     * rewrite /ereal_ball in re'r'.
       have [r'r|rr'] := lerP (contract r'%:E) (contract r%:E).
         apply reA.
@@ -1638,9 +1638,9 @@ rewrite predeq2E => x A; split.
       move: h; apply/negP; rewrite -leNgt -ler_oppl.
       by move: (contract_le1 (r%:E - e%:num%:E)); rewrite ler_norml => /andP[].
   + exists (diag (1 - contract M%:E))%R; rewrite /diag.
-      exists (1 - contract M%:E)%R => //.
+      exists (1 - contract M%:E)%R => //=.
       by rewrite subr_gt0 (le_lt_trans _ (contract_lt1 M)) // ler_norm.
-    case=> [r| |].
+    case=> [r| |]/=.
     * rewrite /ereal_ball [_ +oo%E]/= => rM1.
       apply MA.
       rewrite lte_fin.
@@ -1657,11 +1657,11 @@ rewrite predeq2E => x A; split.
       rewrite -/(contract M%:E) addrC -ler_subl_addr opprD addrA subrr sub0r.
       by move: (contract_le1 M%:E); rewrite ler_norml => /andP[].
   + exists (diag (1 + contract M%:E)%R); rewrite /diag.
-      exists (1 + contract M%:E)%R => //.
+      exists (1 + contract M%:E)%R => //=.
       rewrite -ltr_subl_addl sub0r.
       by move: (contract_lt1 M); rewrite ltr_norml => /andP[].
     case=> [r| |].
-    * rewrite /ereal_ball [_ -oo%E]/= => rM1.
+    * rewrite /ereal_ball => /= rM1.
       apply MA.
       rewrite lte_fin.
       rewrite ler0_norm in rM1; last first.

--- a/theories/landau.v
+++ b/theories/landau.v
@@ -1158,7 +1158,7 @@ suff flip : \forall k \near +oo, forall x, `|f x| <= k * `|x|.
   rewrite (le_lt_trans (near flip k _ _)) // -ltr_pdivl_mull; last by near: k; exists 0; rewrite real0.
   near: y; apply/nbhs_normP.
   eexists; last by move=> ?; rewrite -ball_normE /= sub0r normrN; apply.
-  by rewrite mulr_gt0 // invr_gt0; near: k; exists 0; rewrite real0.
+  by rewrite /= mulr_gt0 // invr_gt0; near: k; exists 0; rewrite real0.
 have /nbhs_normP [_/posnumP[d]] := Of1.
 rewrite /cst [X in _ * X]normr1 mulr1 => fk; near=> k => y.
 case: (ler0P `|y|) => [|y0].

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -560,8 +560,8 @@ Proof.
 move=> ndA; rewrite funeqE => x; rewrite propeqE; split.
   move=> -[n _]; rewrite (eq_bigsetUB_of _ ndA) bigcup_ord => -[m mn ?].
   by exists m.
-move=> -[m _] myBAmx; exists m => //; rewrite (eq_bigsetUB_of _ ndA) bigcup_ord.
-by exists m.
+move=> -[m _] myBAmx; exists m => //=.
+by rewrite (eq_bigsetUB_of _ ndA) bigcup_ord; exists m => /=.
 Qed.
 
 End trivIfy.
@@ -650,7 +650,7 @@ move/(@cvg_mu_inc _ _ mu _ mB _) : ndB => /(_ _)/cvg_lim <- //; last first.
   by rewrite -AB.
 have -> : lim (mu \o B) = ereal_sup ((mu \o B) @` setT).
   suff : nondecreasing_seq (mu \o B).
-    by move/nondecreasing_seq_ereal_cvg; apply/cvg_lim.
+    by move/nondecreasing_seq_ereal_cvg; apply/(@cvg_lim _ _ (mu \o B @ \oo)). (* bug *)
   move=> n m nm; apply: le_measure => //; try by rewrite inE; apply mB.
   exact: subset_bigsetU.
 have BA : forall m, (mu (B m) <= lim (fun n : nat => \sum_(i < n) mu (A i)))%E.

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -716,7 +716,7 @@ Lemma ball_norm_dec x y (e : R) : {ball_norm x e y} + {~ ball_norm x e y}.
 Proof. exact: pselect. Qed.
 
 Lemma ball_norm_sym x y (e : R) : ball_norm x e y -> ball_norm y e x.
-Proof. by rewrite /ball_norm -opprB normrN. Qed.
+Proof. by rewrite /ball_norm/= -opprB normrN. Qed.
 
 Lemma ball_norm_le x (e1 e2 : R) :
   e1 <= e2 -> ball_norm x e1 `<=` ball_norm x e2.
@@ -781,14 +781,14 @@ Lemma dominated_by1 {T : Type} {K : numFieldType} {V : normedModType K} :
   @dominated_by T K _ V fun1 = fun k f F => F [set x | `|f x| <= k].
 Proof.
 rewrite funeq3E => k f F.
-by congr F; rewrite funeqE => x; rewrite normr1 mulr1.
+by congr F; rewrite funeqE => x/=; rewrite normr1 mulr1.
 Qed.
 
 Lemma strictly_dominated_by1 {T : Type} {K : numFieldType} {V : normedModType K} :
   @strictly_dominated_by T K _ V fun1 = fun k f F => F [set x | `|f x| < k].
 Proof.
 rewrite funeq3E => k f F.
-by congr F; rewrite funeqE => x; rewrite normr1 mulr1.
+by congr F; rewrite funeqE => x/=; rewrite normr1 mulr1.
 Qed.
 
 Lemma ex_dom_bound {T : Type} {K : numFieldType} {V W : normedModType K}
@@ -800,12 +800,12 @@ rewrite /dominated_by; split => [/pinfty_ex_gt0[M M_gt0]|[M]] FM.
   by exists M.
 have [] := pselect (exists x, (h x != 0) && (`|f x| <= M * `|h x|)); last first.
   rewrite -forallNE; move=> Nex; exists 0; rewrite real0; split => //.
-  move=> k k_gt0; apply: filterS FM => x f_le_Mh.
+  move=> k k_gt0; apply: filterS FM => x /= f_le_Mh.
   have /negP := Nex x; rewrite negb_and negbK f_le_Mh orbF => /eqP h_eq0.
   by rewrite h_eq0 normr0 !mulr0 in f_le_Mh *.
 case => x0 /andP[hx0_neq0] /(le_trans (normr_ge0 _)) /ger0_real.
 rewrite realrM // ?normr_eq0// => M_real.
-exists M; split => // k Mk; apply: filterS FM => x /le_trans->//.
+exists M; split => // k Mk; apply: filterS FM => x /le_trans/= ->//.
 by rewrite ler_wpmul2r// ltW.
 Qed.
 
@@ -817,7 +817,7 @@ Lemma ex_strict_dom_bound {T : Type} {K : numFieldType} {V W : normedModType K}
 Proof.
 move=> hN0; rewrite ex_dom_bound /dominated_by /strictly_dominated_by.
 split => -[] M FM; last by exists M; apply: filterS FM => x /ltW.
-exists (M + 1); apply: filterS2 hN0 FM => x hN0 /le_lt_trans->//.
+exists (M + 1); apply: filterS2 hN0 FM => x hN0 /le_lt_trans/= ->//.
 by rewrite ltr_pmul2r ?normr_gt0// ltr_addl.
 Qed.
 
@@ -860,7 +860,7 @@ Lemma ex_strict_bound_gt0 {T : Type} {K : numFieldType} {V : normedModType K}
   bounded_on f F -> exists2 M, M > 0 & F [set x | `|f x| < M].
 Proof.
 move=> /pinfty_ex_gt0[M M_gt0 FM]; exists (M + 1); rewrite ?addr_gt0//.
-by apply: filterS FM => x /le_lt_trans->//; rewrite ltr_addl.
+by apply: filterS FM => x /le_lt_trans/= ->//; rewrite ltr_addl.
 Qed.
 
 Notation "[ 'bounded' E | x 'in' A ]" := (bounded_on (fun x => E) (globally A))
@@ -1428,13 +1428,13 @@ Lemma mx_norm_ball :
   @ball _ [pseudoMetricType K of 'M[K^o]_(m.+1, n.+1)] = ball_ (fun x => `| x |).
 Proof.
 rewrite /= /normr /= predeq3E => x e y; split.
-- move=> xe_y; rewrite /ball_ mx_normE.
+- move=> xe_y; rewrite /ball_/= mx_normE.
   (* TODO:  lemma : ball x e y -> 0 < e *)
   have lee0 : ( 0 < e) by rewrite (le_lt_trans _ (xe_y ord0 ord0)) //.
   have -> : e = (Nonneg.NngNum _ (ltW lee0))%:nngnum by [].
   rewrite nng_lt; apply/BigmaxrNonneg.bigmaxr_ltrP.
 - split; [rewrite -nng_lt //= | move=> ??; rewrite !mxE; exact: xe_y].
-  rewrite /ball_; rewrite mx_normE => H.
+  rewrite /ball_/= mx_normE => H.
   have lee0 : (0 < e) by rewrite (le_lt_trans _ H) // nonnegnum_ge0.
   move : H.
   have -> : e = (Nonneg.NngNum _ (ltW lee0))%:nngnum by [].
@@ -1647,7 +1647,7 @@ have y_gt : `|y| > `|x| / 2.
   by rewrite ltr_subl_addr -ltr_subl_addl {1}[ `|x| ]splitr addrK.
 have y_neq0 : y != 0.
   by rewrite -normr_eq0 gt_eqF// (le_lt_trans _ y_gt) ?divr_ge0.
-rewrite -div1r -[y^-1]div1r -mulNr addf_div// mul1r mulN1r normrM normfV.
+rewrite /= -div1r -[y^-1]div1r -mulNr addf_div// mul1r mulN1r normrM normfV.
 rewrite ltr_pdivr_mulr ?normr_gt0 ?mulf_neq0//.
 apply: (@lt_le_trans _ _ (e%:num * (`|x| * (`|x| / 2)))).
   by rewrite distrC; near: y; apply: cvg_dist; rewrite ?mulr_gt0// ?normr_gt0.
@@ -2076,7 +2076,7 @@ rewrite ler_distl; move/ubP: (sup_upper_bound D_has_sup) => -> //=.
   have Fxeps : F (ball_ [eta normr] x (eps)%:num).
     by near: x; apply: nearP_dep; apply: F_cauchy.
   apply/ubP => y /(_ _ Fxeps) /downP[z].
-  rewrite /ball_ ltr_distl ltr_subl_addr.
+  rewrite /ball_/= ltr_distl ltr_subl_addr.
   by move=> /andP [/ltW /(le_trans _) le_xeps _ /le_xeps].
 rewrite /D /= => A FA; near F => y.
 apply/downP; exists y.
@@ -2143,9 +2143,10 @@ Local Notation "'+oo'" := (@pinfty_nbhs K).
 Lemma cvg_seq_bounded {V : normedModType K} (a : nat -> V) :
   cvg a -> bounded_fun a.
 Proof.
-move=> /cvg_bounded/ex_bound => -[/= Moo]; rewrite !near_simpl.
+move=> /cvg_bounded/ex_bound => -[/= Moo]; rewrite !near_simpl/=.
 rewrite [(\near a, _ <= _)](near_map _ \oo) => -[N _ /(_ _) a_leM].
-have Moo_real : Moo \is Num.real by rewrite ger0_real ?(le_trans _ (a_leM N _)).
+have Moo_real : Moo \is Num.real
+  by rewrite ger0_real ?(le_trans _ (a_leM N _))/=.
 rewrite /bounded_on /=; near=> M => n _.
 have [nN|nN]/= := leqP N n.
   by apply: (le_trans (a_leM _ _)) => //; near: M; apply: nbhs_pinfty_ge_real.
@@ -2231,9 +2232,9 @@ wlog ltyx : a b (* leab *) A y Ay Acl x / y < x.
   have setIN B : A = [set x | x \in `[a, b]] `&` B ->
     [set - x | x in A] = [set x | x \in `[(- b), (- a)]] `&` [set - x | x in B].
     move=> AeabB; rewrite predeqE => z; split.
-      move=> [t At]; have := At; rewrite AeabB => - [abt Bt] <-.
-      by split; [rewrite oppr_itvcc !opprK|exists t].
-    move=> [abz [t Bt tez]]; exists t => //; rewrite AeabB; split=> //.
+      move=> [t At]; have := At; rewrite AeabB => - [/= abt Bt] <-.
+      by split; [rewrite /= oppr_itvcc !opprK|exists t].
+    move=> [/= abz [t Bt tez]]; exists t => //; rewrite AeabB; split=> //=.
     by rewrite -[t]opprK tez oppr_itvcc.
   apply: (scon (- b) (- a) (* _ *) [set - x | x in A] (- y)) (- x) _ _ _.
   - by exists y.
@@ -2280,14 +2281,14 @@ suff [t Altxt] : exists2 t, Altx t & z < t.
 exists (z + (minr (e%:num / 2) ((PosNum ltzx)%:num / 2))); last first.
   by rewrite ltr_addl.
 rewrite inE; split; last first.
-  rewrite -[_ < _]ltr_subr_addl lt_minl; apply/orP; right.
+  rewrite /= -[_ < _]ltr_subr_addl lt_minl; apply/orP; right.
   by rewrite ltr_pdivr_mulr // mulrDr mulr1 ltr_addl.
 rewrite AeabC; split; last first.
-  apply: ze_C; rewrite /ball_ ltr_distl.
+  apply: ze_C; rewrite /ball_/mkset ltr_distl.
   apply/andP; split; last by rewrite -addrA ltr_addl.
   rewrite -addrA gtr_addl subr_lt0 lt_minl; apply/orP; left.
   by rewrite [X in _ < X]splitr ltr_addl.
-rewrite inE; apply/andP; split.
+rewrite /mkset inE; apply/andP; split.
   by apply: ler_paddr => //; have := Az; rewrite AeabB => - [/itvP->].
 have : x <= b by rewrite (itvP abx).
 apply: le_trans; rewrite -ler_subr_addl le_minl; apply/orP; right.
@@ -2297,7 +2298,7 @@ Qed.
 Lemma segment_closed (a b : R) : closed [set x : R^o | x \in `[a, b]].
 Proof.
 have -> : [set x | x \in `[a, b]] = [set x | x >= a] `&` [set x | x <= b].
-  by rewrite predeqE => ?; rewrite inE; split=> [/andP [] | /= [->]].
+  by rewrite predeqE => ?; rewrite /= inE; split=> [/andP [] | /= [->]].
 by apply closedI; [apply closed_ge | apply closed_le].
 Qed.
 
@@ -2312,21 +2313,21 @@ set B := [set x | exists2 D' : {fset I}, {subset D' <= D} &
 set A := [set x | x \in `[a, b]] `&` B.
 suff Aeab : A = [set x | x \in `[a, b]].
   suff [_ [D' ? []]] : A b by exists D'.
-  by rewrite Aeab inE/=; apply/andP.
+  by rewrite Aeab/= inE/=; apply/andP.
 apply: segment_connected.
 - have aba : a \in `[a, b] by rewrite inE/=; apply/andP.
-  exists a; split=> //; have /sabUf [i Di fia] := aba.
+  exists a; split=> //; have /sabUf [i /= Di fia] := aba.
   exists [fset i]%fset; first by move=> ?; rewrite inE inE => /eqP->.
-  split; last by exists i => //; rewrite inE.
-  move=> x aex; exists i; [by rewrite inE|suff /eqP-> : x == a by []].
+  split; last by exists i => //=; rewrite inE.
+  move=> x /= aex; exists i; [by rewrite /= inE|suff /eqP-> : x == a by []].
   by rewrite eq_le !(itvP aex).
 - exists B => //; rewrite openE => x [D' sD [saxUf [i Di fx]]].
   have : open (f i) by have /sD := Di; rewrite inE => /fop.
   rewrite openE => /(_ _ fx) [e egt0 xe_fi]; exists e => // y xe_y.
   exists D' => //; split; last by exists i => //; apply/xe_fi.
-  move=> z ayz; case: (lerP z x) => [lezx|ltxz].
-    by apply/saxUf; rewrite inE/= (itvP ayz) lezx.
-  exists i=> //; apply/xe_fi; rewrite /ball_ distrC ger0_norm.
+  move=> z /= ayz; case: (lerP z x) => [lezx|ltxz].
+    by apply/saxUf; rewrite /= inE/= (itvP ayz) lezx.
+  exists i => //; apply/xe_fi; rewrite /ball_/= distrC ger0_norm.
     have lezy : z <= y by rewrite (itvP ayz).
     rewrite ltr_subl_addl; apply: le_lt_trans lezy _; rewrite -ltr_subl_addr.
     by have := xe_y; rewrite /ball_ => /ltr_distW.
@@ -2339,13 +2340,13 @@ have /fop := Di; rewrite openE => /(_ _ fx) [_ /posnumP[e] xe_fi].
 have /clAx [y [[aby [D' sD [sayUf _]]] xe_y]] := nbhsx_ballx x e.
 exists (i |` D')%fset; first by move=> j /fset1UP[->|/sD] //; rewrite inE.
 split=> [z axz|]; last first.
-  exists i; first by rewrite !inE eq_refl.
-  by apply/xe_fi; rewrite /ball_ subrr normr0.
+  exists i; first by rewrite /= !inE eq_refl.
+  by apply/xe_fi; rewrite /ball_/= subrr normr0.
 case: (lerP z y) => [lezy|ltyz].
   have /sayUf [j Dj fjz] : z \in `[a, y] by rewrite inE/= (itvP axz) lezy.
-  by exists j => //; rewrite inE orbC Dj.
-exists i; first by rewrite !inE eq_refl.
-apply/xe_fi; rewrite /ball_ ger0_norm; last first.
+  by exists j => //=; rewrite inE orbC Dj.
+exists i; first by rewrite /= !inE eq_refl.
+apply/xe_fi; rewrite /ball_/= ger0_norm; last first.
   by rewrite subr_ge0 (itvP axz).
 rewrite ltr_subl_addl -ltr_subl_addr; apply: lt_trans ltyz.
 by apply: ltr_distW; rewrite distrC.
@@ -2385,7 +2386,7 @@ have supA : has_sup A by split=> //; exists b; apply/ubP => ? /andP [].
 have supAab : sup A \in `[a, b].
   rewrite inE; apply/andP; split; last first.
     by apply: sup_le_ub => //; apply/ubP => ? /andP [].
-  by move/ubP : (sup_upper_bound supA); apply; rewrite /A leab andTb ltW.
+  by move/ubP : (sup_upper_bound supA); apply; rewrite /A/= leab andTb ltW.
 exists (sup A) => //; have lefsupv : f (sup A) <= v.
   rewrite leNgt; apply/negP => ltvfsup.
   have vltfsup : 0 < f (sup A) - v by rewrite subr_gt0.
@@ -2408,14 +2409,14 @@ have /supdfe /= : @ball _ [normedModType R of R^o] (sup A) d%:num x.
 rewrite /= => /ltr_distW; apply: le_lt_trans.
 rewrite ler_add2r ltW //; suff : forall t, t \in `](sup A), b] -> v < f t.
   apply; rewrite inE; apply/andP; split; first by near: x; exists 1.
-  near: x; exists (b - sup A).
+  near: x; exists (b - sup A) => /=.
     rewrite subr_gt0 lt_def (itvP supAab) andbT; apply/negP => /eqP besup.
     by move: lefsupv; rewrite leNgt -besup ltvfb.
   move=> t lttb ltsupt; move: lttb; rewrite /= distrC.
   by rewrite gtr0_norm ?subr_gt0 // ltr_add2r; apply: ltW.
 move=> t /andP [ltsupt /= letb]; rewrite ltNge; apply/negP => leftv.
 move: ltsupt => /=; rewrite ltNge => /negP; apply.
-by move/ubP : (sup_upper_bound supA); apply; rewrite /A leftv letb.
+by move/ubP : (sup_upper_bound supA); apply; rewrite /A/= leftv letb.
 Grab Existential Variables. all: end_near. Qed.
 
 (** Local properties in [R] *)
@@ -2576,7 +2577,7 @@ have covA : A `<=` \bigcup_(n : int) [set p | `|p| < n%:~R].
   move=> p Ap; exists (ifloor `|p| + 1) => //.
   by rewrite rmorphD /= -floorE floorS_gtr.
 have /Aco [] := covA.
-  move=> n _; rewrite openE => p; rewrite -subr_gt0 => ltpn.
+  move=> n _; rewrite openE => p; rewrite /= -subr_gt0 => ltpn.
   apply/nbhs_ballP; exists (n%:~R - `|p|) => // q.
   rewrite -ball_normE /= ltr_subr_addr distrC; apply: le_lt_trans.
   by rewrite -{1}(subrK p q) ler_norm_add.
@@ -2609,13 +2610,13 @@ have [f [Af clGf]] : [set f | forall i, A i (f i)] `&`
     by rewrite predeqE => f; split => Af i; [have := Af i|]; rewrite row_simpl'.
   apply Build_ProperFilter.
     move=> _ [C FC <-]; have /filter_ex [v Cv] := FC.
-    by exists (v ord0); rewrite row_simpl.
+    by exists (v ord0); rewrite /= row_simpl.
   split.
   - by exists setT => //; apply: filterT.
   - by move=> _ _ [C FC <-] [D FD <-]; exists (C `&` D) => //; apply: filterI.
   move=> C D sCD [E FE EeqC]; exists [set v : 'rV[T]_n.+1 | D (v ord0)].
-    by apply: filterS FE => v Ev; apply/sCD; rewrite -EeqC row_simpl.
-  by rewrite predeqE => ?; rewrite row_simpl'.
+    by apply: filterS FE => v Ev; apply/sCD; rewrite -EeqC/= row_simpl.
+  by rewrite predeqE => ? /=; rewrite row_simpl'.
 exists (\row_j f j); split; first by move=> i; rewrite mxE; apply: Af.
 move=> C D FC f_D; have {}f_D :
   nbhs (f : product_topologicalType _) [set g | D (\row_j g j)].
@@ -2640,8 +2641,8 @@ move=> C D FC f_D; have {}f_D :
     by have /getPex [[]] := exPj j.
   rewrite predeqE => g; split=> [Ig j|Ig B'].
     apply: (Ig ((@^~ j) @^-1` (get (Pj j)))).
-    by rewrite in_fset; apply/mapP; exists j => //; rewrite mem_enum.
-  by rewrite in_fset => /mapP [j _ ->]; apply: Ig.
+    by rewrite /= in_fset; apply/mapP; exists j => //; rewrite mem_enum.
+  by rewrite /= in_fset => /mapP [j _ ->]; apply: Ig.
 have GC : G [set g | C (\row_j g j)] by exists C.
 by have [g []] := clGf _ _ GC f_D; exists (\row_j (g j : T)).
 Qed.
@@ -2672,18 +2673,18 @@ Lemma open_ereal_lt y : open [set r : R^o | r%:E < y]%E.
 Proof.
 case: y => [y||] /=; first exact: open_lt.
 rewrite [X in open X](_ : _ = setT); first exact: openT.
-by rewrite funeqE => ?; rewrite lte_pinfty trueE.
+by rewrite funeqE => ? /=; rewrite lte_pinfty trueE.
 rewrite [X in open X](_ : _ = set0); first exact: open0.
-by rewrite funeqE => ?; rewrite falseE.
+by rewrite funeqE => ? /=; rewrite falseE.
 Qed.
 
 Lemma open_ereal_gt y : open [set r : R^o | y < r%:E]%E.
 Proof.
 case: y => [y||] /=; first exact: open_gt.
 rewrite [X in open X](_ : _ = set0); first exact: open0.
-by rewrite funeqE => ?; rewrite falseE.
+by rewrite funeqE => ? /=; rewrite falseE.
 rewrite [X in open X](_ : _ = setT); first exact: openT.
-by rewrite funeqE => ?; rewrite lte_ninfty trueE.
+by rewrite funeqE => ? /=; rewrite lte_ninfty trueE.
 Qed.
 
 Lemma open_ereal_lt' x y : (x < y)%E -> ereal_nbhs x (fun u => u < y)%E.
@@ -2710,7 +2711,7 @@ Qed.
 Let open_ereal_lt_real r : open (fun x => x < r%:E)%E.
 Proof.
 case => [? | // | ?]; [rewrite lte_fin => xy | by exists r].
-by move: (@open_ereal_lt r%:E); rewrite openE; apply; rewrite lte_fin.
+by move: (@open_ereal_lt r%:E); rewrite openE; apply; rewrite /= lte_fin.
 Qed.
 
 Lemma open_ereal_lt_ereal x : open [set y | y < x]%E.
@@ -2718,17 +2719,17 @@ Proof.
 case: x => [x | | [] // ] /=; first exact: open_ereal_lt_real.
 suff -> : ([set y | y < +oo] = \bigcup_r [set y : {ereal R} | y < r%:E])%E.
   by apply open_bigU => x _; exact: open_ereal_lt_real.
-rewrite predeqE => -[r | | ].
+rewrite predeqE => -[r | | ]/=.
 - rewrite lte_pinfty; split => // _.
-  by exists (r + 1) => //; rewrite lte_fin ltr_addl.
-- by rewrite ltxx; split => // -[] x; rewrite ltNge lee_pinfty.
-- by split => // _; exists 0 => //; rewrite lte_ninfty.
+  by exists (r + 1) => //=; rewrite lte_fin ltr_addl.
+- by rewrite ltxx; split => // -[] x /=; rewrite ltNge lee_pinfty.
+- by split => // _; exists 0 => //=; rewrite lte_ninfty.
 Qed.
 
 Let open_ereal_gt_real r : open (fun x => r%:E < x)%E.
 Proof.
 case => [? | ? | //]; [rewrite lte_fin => xy | by exists r].
-by move: (@open_ereal_gt r%:E); rewrite openE; apply; rewrite lte_fin.
+by move: (@open_ereal_gt r%:E); rewrite openE; apply; rewrite /= lte_fin.
 Qed.
 
 Lemma open_ereal_gt_ereal x : open [set y | x < y]%E.
@@ -2736,11 +2737,11 @@ Proof.
 case: x => [x | [] // | ] /=; first exact: open_ereal_gt_real.
 suff -> : ([set y | -oo < y] = \bigcup_r [set y : {ereal R} | r%:E < y])%E.
   by apply open_bigU => x _; exact: open_ereal_gt_real.
-rewrite predeqE => -[r | | ].
+rewrite predeqE => -[r | | ]/=.
 - rewrite lte_ninfty; split => // _.
-  by exists (r - 1) => //; rewrite lte_fin ltr_subl_addr ltr_addl.
-- by split => // _; exists 0 => //; rewrite lte_pinfty.
-- by rewrite ltxx; split => // -[] x _; rewrite ltNge lee_ninfty.
+  by exists (r - 1) => //=; rewrite lte_fin ltr_subl_addr ltr_addl.
+- by split => // _; exists 0 => //=; rewrite lte_pinfty.
+- by rewrite ltxx; split => // -[] x _ /=; rewrite ltNge lee_ninfty.
 Qed.
 
 Lemma closed_ereal_le_ereal y : closed [set x | (y <= x)%E].
@@ -2774,26 +2775,26 @@ Lemma nbhs_open_ereal_lt r (f : R -> R) : r < f r ->
   nbhs r%:E [set y | y < (f r)%:E]%E.
 Proof.
 move=> xfx; rewrite nbhsE /=; eexists; split; last by move=> y; exact.
-by split; [apply open_ereal_lt_ereal | rewrite lte_fin].
+by split; [apply open_ereal_lt_ereal | rewrite /= lte_fin].
 Qed.
 
 Lemma nbhs_open_ereal_gt r (f : R -> R) : f r < r ->
   nbhs r%:E [set y | (f r)%:E < y]%E.
 Proof.
 move=> xfx; rewrite nbhsE /=; eexists; split; last by move=> y; exact.
-by split; [apply open_ereal_gt_ereal | rewrite lte_fin].
+by split; [apply open_ereal_gt_ereal | rewrite /= lte_fin].
 Qed.
 
 Lemma nbhs_open_ereal_pinfty r : nbhs +oo%E [set y | r%:E < y]%E.
 Proof.
 rewrite nbhsE /=; eexists; split; last by move=> y; exact.
-by split; [apply open_ereal_gt_ereal | rewrite lte_pinfty].
+by split; [apply open_ereal_gt_ereal | rewrite /= lte_pinfty].
 Qed.
 
 Lemma nbhs_open_ereal_ninfty r : nbhs -oo%E [set y | y < r%:E]%E.
 Proof.
 rewrite nbhsE /=; eexists; split; last by move=> y; exact.
-by split; [apply open_ereal_lt_ereal | rewrite lte_ninfty].
+by split; [apply open_ereal_lt_ereal | rewrite /= lte_ninfty].
 Qed.
 
 Lemma ereal_hausdorff : hausdorff (ereal_topologicalType R).

--- a/theories/reals.v
+++ b/theories/reals.v
@@ -449,7 +449,7 @@ Implicit Types x y : R.
 Lemma has_sup_floor_set x : has_sup (floor_set x).
 Proof.
 split; [exists (- (Num.bound (-x))%:~R) | exists (Num.bound x)%:~R].
-  rewrite /floor_set rpredN rpred_int /= ler_oppl.
+  rewrite /floor_set/mkset rpredN rpred_int /= ler_oppl.
   case: (ger0P (-x)) => [/archi_boundP/ltW//|].
   by move/ltW/le_trans; apply; rewrite ler0z.
 apply/ubP=> y /andP[_] /le_trans; apply.
@@ -483,7 +483,7 @@ Proof. by rewrite /ifloor RtointK ?isint_floor. Qed.
 
 Lemma mem_rg1_floor (x : R) : (range1 (floor x)) x.
 Proof.
-rewrite /range1.
+rewrite /range1/mkset.
 have /andP[_ ->] /= := sup_in_floor_set x.
 have [|] := pselect ((floor_set x) (floor x + 1)); last first.
   rewrite /floor_set => /negP.
@@ -509,14 +509,14 @@ exact/(le_lt_trans m1x).
 Qed.
 
 Lemma range1rr (x : R) : (range1 x) x.
-Proof. by rewrite /range1 lexx /= ltr_addl ltr01. Qed.
+Proof. by rewrite /range1/mkset lexx /= ltr_addl ltr01. Qed.
 
 Lemma range1zP (m : int) (x : R) :
   floor x = m%:~R <-> (range1 m%:~R) x.
 Proof.
 split=> [<-|h]; first exact/mem_rg1_floor.
 apply/eqP; rewrite floorE eqr_int; apply/eqP/(@range1z_inj x) => //.
-by rewrite /range1 -floorE mem_rg1_floor.
+by rewrite /range1/mkset -floorE mem_rg1_floor.
 Qed.
 
 Lemma floor_natz (x : int) : floor x%:~R = x%:~R :> R.

--- a/theories/sequences.v
+++ b/theories/sequences.v
@@ -204,7 +204,7 @@ rewrite !near_simpl [\forall x \near _, P _](near_map _ \oo);
 have [|/=n _]:= u_cvg (fun x => P (- x)); do ?by [exists n
   | exists (- l); split; rewrite ?rpredN// => x;
     rewrite (ltr_oppl, ltr_oppr); apply: Pl].
-by under [X in _ `<=` X]funext do rewrite opprK; exists n.
+by under [X in _ `<=` X]funext do rewrite /= opprK; exists n.
 Qed.
 
 Lemma cvgNminfty (u_ : R^o ^nat) : (- u_ --> -oo) = (u_ --> +oo).
@@ -413,7 +413,8 @@ move=> u_nd u_M; set S := _ @` _; set M0 := sup S.
 have supS : has_sup S.
   split; first by exists (u_ 0%N), 0%N.
   by exists M; apply/ubP => x -[n _ <-{x}].
-apply: cvg_distW => _/posnumP[e]; rewrite near_map.
+apply: cvg_distW; first exact: fmap_filter.
+move=> _/posnumP[e]; rewrite near_map.
 have [p /andP[M0u_p u_pM0]] : exists p, M0 - e%:num <= u_ p <= M0.
   have [x] := sup_adherent supS (posnum_gt0 e).
   move=> -[p _] <-{x} => /ltW M0u_p.
@@ -437,8 +438,8 @@ Proof.
 move=> [k _ u_nd] [k' _ u_M]; suff : cvg [sequence u_ (n + maxn k k')%N]_n.
   by case/cvg_ex => /= l; rewrite cvg_shiftn => ul; apply/cvg_ex; exists l.
 apply (@nondecreasing_is_cvg _ M) => [/= ? ? ? | ?].
-  by rewrite u_nd ?leq_add2r ?(leq_trans (leq_maxl _ _) (leq_addl _ _))//.
-by rewrite u_M // (leq_trans (leq_maxr _ _) (leq_addl _ _)).
+  by rewrite u_nd ?leq_add2r//= (leq_trans (leq_maxl _ _) (leq_addl _ _)).
+by rewrite u_M //= (leq_trans (leq_maxr _ _) (leq_addl _ _)).
 Qed.
 
 Lemma nonincreasing_cvg (u_ : (R^o) ^nat) (m : R) :
@@ -495,7 +496,8 @@ Proof. exact/ltW/harmonic_gt0. Qed.
 
 Lemma cvg_harmonic {R : archiFieldType} : harmonic --> (0 : R^o).
 Proof.
-apply: cvg_distW => _/posnumP[e]; rewrite near_map; near=> i.
+apply: cvg_distW; first exact: fmap_filter.
+move=> _/posnumP[e]; rewrite near_map; near=> i.
 rewrite distrC subr0 ger0_norm//= -lef_pinv ?qualifE// invrK.
 rewrite (le_trans (ltW (archi_boundP _)))// ler_nat -add1n -leq_subLR.
 by near: i; apply: nbhs_infty_ge.
@@ -527,7 +529,8 @@ move=> u0_cvg; have ssplit v_ m n : (m <= n)%N -> `|n%:R^-1 * series v_ n| <=
     n%:R^-1 * `|series v_ m| + n%:R^-1 * `|\sum_(m <= i < n) v_ i|.
   move=> /subnK<-; rewrite series_addn mulrDr (le_trans (ler_norm_add _ _))//.
   by rewrite !normrM ger0_norm ?invr_ge0 ?ler0n.
-apply/cvg_distP => _/posnumP[e]; rewrite near_simpl; near \oo => m; near=> n.
+apply/cvg_distP; first exact: fmap_filter.
+move=> _/posnumP[e]; rewrite near_simpl; near \oo => m; near=> n.
 have {}/ssplit -/(_ _ [sequence l - u_ n]_n) : (m.+1 <= n.+1)%nat by near: n; exists m.
 rewrite /series /= big_split/= sumrN mulrBr sumr_const card_ord -(mulr_natl l) mulKf//.
 move=> /le_lt_trans->//; rewrite [e%:num]splitr ltr_add//.
@@ -544,7 +547,7 @@ move=> i /andP[mi _]; move: i mi; near: m.
 have : \forall x \near \oo, `|l - u_ x| < e%:num / 2.
   by move/cvg_distP : u0_cvg; apply; rewrite divr_gt0.
 move=> -[N _ Nu]; exists N => // k Nk i ki.
-by rewrite ltW// Nu// (leq_trans Nk)// ltnW.
+by rewrite ltW// Nu//= (leq_trans Nk)// ltnW.
 Grab Existential Variables. all: end_near. Qed.
 
 End cesaro.
@@ -556,7 +559,8 @@ Let cesaro_converse_off_by_one (u_ : R^o ^nat) :
   [sequence n.+1%:R^-1 * series u_ n.+1]_ n --> (0 : R^o) ->
   [sequence n.+1%:R^-1 * series u_ n]_ n --> (0 : R^o).
 Proof.
-move=> H; apply/cvg_distP => _/posnumP[e]; rewrite near_map.
+move=> H; apply/cvg_distP; first exact: fmap_filter.
+move=> _/posnumP[e]; rewrite near_map.
 move/cvg_distP : H => /(_ e%:num (posnum_gt0 e)); rewrite near_map => -[m _ mu].
 near=> n; rewrite sub0r normrN /=.
 have /andP[n0] : ((0 < n) && (m <= n.-1))%N.
@@ -768,7 +772,8 @@ Lemma normed_cvg {R : realType} (V : completeNormedModType R) (u_ : V ^nat) :
   cvg [normed series u_] -> cvg (series u_).
 Proof.
 move=> /cauchy_cvgP/cauchy_seriesP u_ncvg.
-apply/cauchy_cvgP/cauchy_seriesP => e /u_ncvg.
+apply/cauchy_cvgP; first exact: fmap_proper_filter.
+apply/cauchy_seriesP => e /u_ncvg.
 apply: filterS => n /=; rewrite ger0_norm ?sumr_ge0//.
 by apply: le_lt_trans; apply: ler_norm_sum.
 Qed.
@@ -823,7 +828,8 @@ Qed.
 Lemma dvg_ereal_cvg (R : realFieldType) (u_ : (R^o) ^nat) :
   u_ --> +oo -> (fun n => (u_ n)%:E) --> +oo%E.
 Proof.
-move/cvgPpinfty_lt => uoo; apply/cvg_ballP => _/posnumP[e]; rewrite near_map.
+move/cvgPpinfty_lt => uoo; apply/cvg_ballP; first exact: fmap_filter.
+move=> _/posnumP[e]; rewrite near_map.
 have [e1|e1] := lerP 1 e%:num.
   case: (uoo _ ltr01) => k _ k1un; near=> n.
   rewrite /ball /= /ereal_ball [contract +oo]/= ger0_norm ?subr_ge0; last first.
@@ -856,7 +862,7 @@ split=> [[[N _ foo] fa]|fa].
     by rewrite (@cvg_shiftn _ _ (real_of_er \o f : _ -> R^o)).
   move/(@cvg_app _ _ _ _ (@ERFin R)).
   apply: cvg_trans; apply: near_eq_cvg; near=> n => /=.
-  by rewrite -ERFin_real_of_er //; apply foo; rewrite leq_addl.
+  by rewrite -ERFin_real_of_er // foo//= leq_addl.
 split; last first.
   by move/(@cvg_app _ _ _ _ real_of_er) : fa; apply: cvg_trans; exact: cvg_id.
 move/cvg_ballP : fa.
@@ -894,7 +900,8 @@ have [/eqP|lnoo] := boolP (l == -oo%E).
   move/ereal_sup_ninfty => loo.
   suff : u_ = (fun=> -oo%E) by [].
   by rewrite funeqE => m; apply (loo (u_ m)); exists m.
-apply/cvg_ballP => _/posnumP[e].
+apply/cvg_ballP; first exact: fmap_filter.
+move=> _/posnumP[e].
 have [/eqP {lnoo}loo|lpoo] := boolP (l == +oo%E).
   rewrite near_map; near=> n; rewrite /ball /= /ereal_ball.
   have unoo : u_ n != -oo%E.
@@ -1174,7 +1181,7 @@ move: a b => [a| |] [b| |] // _.
 - case/ereal_cvg_real => [[na _ foo] fa].
   case/ereal_cvg_real => [[nb _ goo] gb].
   apply/ereal_cvg_real; split.
-    exists (maxn na nb) => // n; rewrite geq_max => /andP[nan nbn].
+    exists (maxn na nb) => // n; rewrite /= geq_max => /andP[nan nbn].
     by rewrite /= is_realD; apply/andP; split; [exact: foo | exact: goo].
   rewrite -(@cvg_shiftn (maxn na nb) [topologicalType of R^o]).
   rewrite (_ : (fun n => _) = (fun n => real_of_er (f (n + maxn na nb)%N)
@@ -1202,6 +1209,9 @@ Qed.
 Lemma ereal_limD (R : realType) (f g : nat -> {ereal R}) :
   cvg f -> cvg g -> ~~ adde_undef (lim f) (lim g) ->
   (lim (f \+ g) = lim f + lim g)%E.
-Proof. by move=> cf cg fg; apply/cvg_lim => //; apply ereal_cvgD. Qed.
+Proof. 
+move=> cf cg fg; apply/(@cvg_lim _ _ ((f \+ g)%E @ \oo)) => //=. (* BUG *)
+exact: ereal_cvgD.
+Qed.
 
 End sequences_of_extended_real_numbers.

--- a/theories/summability.v
+++ b/theories/summability.v
@@ -31,7 +31,7 @@ Canonical totally_filter_source {I : choiceType} X :=
 
 Instance totally_filter {I : choiceType} : ProperFilter (@totally I).
 Proof.
-eapply filter_from_proper; last by move=> A _; exists A; rewrite fsubset_refl.
+eapply filter_from_proper; last by move=> A _; exists A; rewrite /= fsubset_refl.
 apply: filter_fromT_filter; first by exists fset0.
 by move=> A B /=; exists (A `|` B) => P /=; rewrite fsubUset => /andP[].
 Qed.

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -1070,7 +1070,7 @@ Lemma filter_forall T (I : finType) (f : I -> set T) (F : set (set T)) :
   \forall x \near F, forall i, f i x.
 Proof.
 move=> FF fIF; apply: filterS (@filter_bigI T I [fset x in I]%fset f F FF _).
-  by move=> x fIx i; have := fIx i; rewrite inE/=; apply.
+  by move=> x fIx i; have := fIx i; rewrite /= inE/=; apply.
 by move=> i; rewrite inE/= => _; apply: (fIF i).
 Qed.
 
@@ -1122,12 +1122,12 @@ Global Instance fmapi_filter T U (f : T -> set U) (F : set (set T)) :
 Proof.
 move=> f_totalfun FF; rewrite /fmapi; apply: Build_Filter. (* bug *)
 - by apply: filterS f_totalfun => x [[y Hy] H]; exists y.
-- move=> P Q FP FQ; near=> x.
+- move=> /= P Q FP FQ; near=> x.
     have [//|y [fxy Py]] := near FP x.
     have [//|z [fxz Qz]] := near FQ x.
     have [//|_ fx_prop] := near f_totalfun x.
     by exists y; split => //; split => //; rewrite [y](fx_prop _ z).
-- move=> P Q subPQ FP; near=> x.
+- move=> /= P Q subPQ FP; near=> x.
   by have [//|y [fxy /subPQ Qy]] := near FP x; exists y.
 Grab Existential Variables. all: end_near. Qed.
 
@@ -1139,7 +1139,7 @@ Global Instance fmapi_proper_filter
   ProperFilter F -> ProperFilter (f `@ F).
 Proof.
 move=> f_totalfun FF; apply: Build_ProperFilter.
-by move=> P; rewrite /fmapi => /filter_ex [x [y [??]]]; exists y.
+by move=> P; rewrite /fmapi/= => /filter_ex [x [y [??]]]; exists y.
 Qed.
 Definition filter_map_proper_filter' := fmapi_proper_filter.
 
@@ -1171,7 +1171,7 @@ Proof. by move=> fFG gGH; apply: cvg_trans gGH => P /fFG. Qed.
 
 Lemma near_eq_cvg {T U} {F : set (set T)} {FF : Filter F} (f g : T -> U) :
   {near F, f =1 g} -> g @ F `=>` f @ F.
-Proof. by move=> eq_fg P /=; apply: filterS2 eq_fg => x <-. Qed.
+Proof. by move=> eq_fg P /=; apply: filterS2 eq_fg => x /= <-. Qed.
 
 Lemma neari_eq_loc {T U} {F : set (set T)} {FF : Filter F} (f g : T -> set U) :
   {near F, f =2 g} -> g `@ F `=>` f `@ F.
@@ -1410,7 +1410,7 @@ Arguments subset_filter {T} F D _.
 Global Instance subset_filter_filter T F (D : set T) :
   Filter F -> Filter (subset_filter F D).
 Proof.
-move=> FF; constructor; rewrite /subset_filter.
+move=> FF; constructor; rewrite /subset_filter/=.
 - exact: filterE.
 - by move=> P Q; apply: filterS2=> x PD QD Dx; split.
 - by move=> P Q subPQ; apply: filterS => R PD Dx; apply: subPQ.
@@ -1730,10 +1730,10 @@ Grab Existential Variables. all: end_near. Qed.
 
 (* [locally P] replaces a (globally A) in P by a within A (nbhs x)      *)
 (* Can be combined with a notation taking a filter as its last argument *)
-Definition nbhs_of (T : topologicalType) (A : set T)
+Definition locally_of (T : topologicalType) (A : set T)
   (P : set (set T) -> Prop) of phantom Prop (P (globally A)) :=
   forall x, A x -> P (within A (nbhs x)).
-Notation "[ 'locally' P ]" := (@nbhs_of _ _ _ (Phantom _ P))
+Notation "[ 'locally' P ]" := (@locally_of _ _ _ (Phantom _ P))
   (at level 0, format "[ 'locally'  P ]").
 (* e.g. [locally [bounded f x | x in A]]  *)
 (* see lemmas bounded_locally for example *)
@@ -1867,8 +1867,8 @@ Lemma finI_from1 (I : choiceType) T (D : set I) (f : I -> set T) i :
 Proof.
 move=> Di; exists [fset i]%fset.
   by move=> ?; rewrite !inE => /eqP->.
-rewrite predeqE => t; split=> [|fit]; first by apply; rewrite inE.
-by move=> ?; rewrite inE => /eqP->.
+rewrite predeqE => t; split=> [|fit]; first by apply; rewrite /= inE.
+by move=> ?; rewrite /= inE => /eqP->.
 Qed.
 
 Section TopologyOfSubbase.
@@ -1882,8 +1882,8 @@ move: i j t H H0 H1 H2 => A B t [DA sDAD AeIbA] [DB sDBD BeIbB] At Bt.
 exists (A `&` B); split; last by split.
 exists (DA `|` DB)%fset; first by move=> i /fsetUP [/sDAD|/sDBD].
 rewrite predeqE => s; split=> [Ifs|[As Bs] i /fsetUP].
-  split; first by rewrite -AeIbA => i DAi; apply: Ifs; rewrite inE DAi.
-  by rewrite -BeIbB => i DBi; apply: Ifs; rewrite inE DBi orbC.
+  split; first by rewrite -AeIbA => i DAi; apply: Ifs; rewrite /= inE DAi.
+  by rewrite -BeIbB => i DBi; apply: Ifs; rewrite /= inE DBi orbC.
 by move=> [DAi|DBi];
   [have := As; rewrite -AeIbA; apply|have := Bs; rewrite -BeIbB; apply].
 Qed.
@@ -1918,7 +1918,7 @@ Canonical eventually_filter_source X :=
 
 Global Instance eventually_filter : ProperFilter eventually.
 Proof.
-eapply @filter_from_proper; last by move=> i _; exists i.
+eapply @filter_from_proper; last by move=> i _; exists i => /=.
 apply: filter_fromT_filter; first by exists 0%N.
 move=> i j; exists (maxn i j) => n //=.
 by rewrite geq_max => /andP[ltin ltjn].
@@ -1936,7 +1936,7 @@ Proof. by exists N. Qed.
 
 Lemma cvg_addnl N : addn N @ \oo --> \oo.
 Proof.
-by move=> P [n _ Pn]; exists (n - N)%N => // m; rewrite leq_subLR => /Pn.
+by move=> P [n _ Pn]; exists (n - N)%N => // m; rewrite /= leq_subLR => /Pn.
 Qed.
 
 Lemma cvg_addnr N : addn^~ N --> \oo.
@@ -1945,13 +1945,13 @@ Proof. by under [addn^~ N]funext => n do rewrite addnC; apply: cvg_addnl. Qed.
 Lemma cvg_subnr N : subn^~ N --> \oo.
 Proof.
 move=> P [n _ Pn]; exists (N + n)%N => //= m le_m.
-by apply: Pn; rewrite leq_subRL// (leq_trans _ le_m)// leq_addr.
+by apply: Pn; rewrite /= leq_subRL// (leq_trans _ le_m)// leq_addr.
 Qed.
 
 Lemma cvg_mulnl N : (N > 0)%N -> muln N --> \oo.
 Proof.
-case: N => N // _ P [n _ Pn]; exists (n %/ N.+1).+1 => //= m.
-by rewrite ltn_divLR// => n_lt; apply: Pn; rewrite mulnC ltnW.
+case: N => N // _ P [n _ Pn]; exists (n %/ N.+1).+1 => // m.
+by rewrite /= ltn_divLR// => n_lt; apply: Pn; rewrite mulnC /= ltnW.
 Qed.
 
 Lemma cvg_mulnr N :(N > 0)%N -> muln^~ N --> \oo.
@@ -1962,7 +1962,7 @@ Qed.
 Lemma cvg_divnr N : (N > 0)%N -> divn^~ N --> \oo.
 Proof.
 move=> N_gt0 P [n _ Pn]; exists (n * N)%N => //= m.
-by rewrite -leq_divRL//; apply: Pn.
+by rewrite /= -leq_divRL//; apply: Pn.
 Qed.
 
 (** ** Topology on the product of two spaces *)
@@ -2114,7 +2114,7 @@ move=> Ffilt; split=> cvFt.
     by rewrite predeqE => ?; split=> [[_ ->]|] //; exists B.
   move=> _ ->; exists [fset B]%fset.
     by move=> ?; rewrite inE inE => /eqP->; exists i.
-  by rewrite predeqE=> ?; split=> [|??]; [apply|]; rewrite inE // =>/eqP->.
+  by rewrite predeqE=> ?; split=> [|??]; [apply|]; rewrite /= inE // =>/eqP->.
 move=> A /=; rewrite (@nbhsE sup_topologicalType).
 move=> [_ [[[B sB <-] [C BC Ct]] sUBA]].
 rewrite nbhs_filterE; apply: filterS sUBA _; apply: (@filterS _ _ _ C).
@@ -2516,7 +2516,7 @@ rewrite predeqE => A; split=> Aco F FF FA.
   by have /Aco [p [?]] := FA; rewrite ultra_cvg_clusterE; exists p.
 have [G [GU sFG]] := ultraFilterLemma FF.
 have /Aco [p [Ap]] : G A by apply: sFG.
-rewrite -[_ --> p]/([set _ | _] p) -ultra_cvg_clusterE.
+rewrite /= -[_ --> p]/([set _ | _] p) -ultra_cvg_clusterE.
 by move=> /(cvg_cluster sFG); exists p.
 Qed.
 
@@ -2629,8 +2629,8 @@ move=> finIf; apply: (filter_from_proper (filter_from_filter _ _)).
   exists (DA `|` DB)%fset.
     by move=> ?; rewrite inE => /orP [/sDA|/sDB].
   rewrite -IfA -IfB predeqE => p; split=> [Ifp|[IfAp IfBp] i].
-    by split=> i Di; apply: Ifp; rewrite inE Di // orbC.
-  by rewrite inE => /orP []; [apply: IfAp|apply: IfBp].
+    by split=> i Di; apply: Ifp; rewrite /= inE Di // orbC.
+  by rewrite /= inE => /orP []; [apply: IfAp|apply: IfBp].
 - by move=> _ [?? <-]; apply: finIf.
 Qed.
 
@@ -2743,7 +2743,7 @@ have [D' sD sAnfcov] := Aco _ _ _ Anfop Anfcov.
 wlog [k D'k] : D' sD sAnfcov / exists i, i \in D'.
   move=> /(_ (D' `|` [fset j])%fset); apply.
   - by move=> k; rewrite !inE => /orP [/sD|/eqP->] //; rewrite inE.
-  - by move=> p /sAnfcov [i D'i Anfip]; exists i => //; rewrite !inE D'i.
+  - by move=> p /sAnfcov [i D'i Anfip]; exists i => //=; rewrite !inE D'i.
   - by exists j; rewrite !inE orbC eq_refl.
 exists D' => /(_ sD) [p Ifp].
 have /Ifp := D'k; rewrite feAg; last by have /sD := D'k; rewrite inE.
@@ -2765,7 +2765,7 @@ transitivity (cluster (open_nbhs x)); last first.
   by rewrite /cluster; under eq_fun do rewrite -meets_openl.
 rewrite clusterEonbhs /close funeqE => y /=; rewrite meetsC /meets.
 apply/eq_forall => A; rewrite forall_swap.
-by rewrite closureEonbhs meets_globallyl.
+by rewrite closureEonbhs/= meets_globallyl.
 Qed.
 
 Lemma closeEonbhs x : close x = [set y | open_nbhs x `#` open_nbhs y].
@@ -2774,7 +2774,7 @@ by rewrite closeEnbhs; under eq_fun do rewrite -meets_openl -meets_openr.
 Qed.
 
 Lemma close_sym (x y : T) : close x y -> close y x.
-Proof. by rewrite !closeEnbhs /cluster meetsC. Qed.
+Proof. by rewrite !closeEnbhs /cluster/= meetsC. Qed.
 
 Lemma cvg_close {F} {FF : ProperFilter F} (x y : T) :
   F --> x -> F --> y -> close x y.
@@ -2935,7 +2935,7 @@ suff sAfE : separated (AfE false) (AfE true).
   move: cA; apply/connectedPn; exists AfE; split => //.
   - move=> b; case: (E0 b) => /= u Ebu.
     have [t Et ftu] : (f @` A) u by rewrite fAE; case: b Ebu; [right|left].
-    by exists t; split => //; rewrite /preimage ftu.
+    by exists t; split => //=; rewrite /preimage ftu.
   - by rewrite -setIUr -preimage_setU -fAE; exact/esym/setIidPl/preimage_image.
 suff cI0 : forall b, closure (AfE b) `&` AfE (~~ b) = set0.
   by rewrite /separated cI0 setIC cI0.
@@ -2950,7 +2950,7 @@ have [fAfE cEIE] :
   have [t [At ftu]] : exists t, A t /\ f t = u.
     suff [t At ftu] : (f @` A) u by exists t.
     by rewrite fAE; case: b Ebu; [left|right].
-  by exists t => //; split => //; rewrite /preimage ftu.
+  by exists t => //; split => //=; rewrite /preimage ftu.
 have ? : f @` closure (AfE b) `<=` closure (E b).
   have /(@image_subset _ _ f) : closure (AfE b) `<=` f @^-1` closure (E b).
     have /closure_id -> : closed (f @^-1` closure (E b)).
@@ -3241,16 +3241,16 @@ Lemma prod_entP (A : set (U * U)) (B : set (V * V)) :
   prod_ent [set xy | A (xy.1.1, xy.2.1) /\ B (xy.1.2, xy.2.2)].
 Proof.
 move=> entA entB; exists (A,B) => // xy ABxy.
-by exists ((xy.1.1, xy.2.1),(xy.1.2,xy.2.2)); rewrite -!surjective_pairing.
+by exists ((xy.1.1, xy.2.1),(xy.1.2,xy.2.2)); rewrite /= -!surjective_pairing.
 Qed.
 
 Lemma prod_ent_filter : Filter prod_ent.
 Proof.
 have prodF := filter_prod_filter (@entourage_filter U) (@entourage_filter V).
 split; rewrite /prod_ent; last 1 first.
-- by move=> A B sAB; apply: filterS => ? [xy /sAB ??]; exists xy.
+- by move=> A B sAB /=; apply: filterS => ? [xy /sAB ??]; exists xy.
 - rewrite -setMT; apply: prod_entP filterT filterT.
-move=> A B entA entB; apply: filterS (filterI entA entB) => xy [].
+move=> A B /= entA entB; apply: filterS (filterI entA entB) => xy [].
 move=> [zt Azt ztexy] [zt' Bzt' zt'exy]; exists zt => //; split=> //.
 move/eqP: ztexy; rewrite -zt'exy !xpair_eqE.
 by rewrite andbACA -!xpair_eqE -!surjective_pairing => /eqP->.
@@ -3270,8 +3270,8 @@ Qed.
 Lemma prod_ent_inv A : prod_ent A -> prod_ent (A^-1)%classic.
 Proof.
 move=> [B [/entourage_inv entB1 /entourage_inv entB2] sBA].
-have:= prod_entP entB1 entB2; rewrite /prod_ent; apply: filterS.
-move=> _ [p /(sBA (_,_)) [[x y] ? xyE] <-]; exists (y,x) => //=; move/eqP: xyE.
+have:= prod_entP entB1 entB2; rewrite /prod_ent/=; apply: filterS.
+move=> _ [p /(sBA (_,_)) [[x y] ? xyE] <-]; exists (y,x) => //; move/eqP: xyE.
 by rewrite !xpair_eqE => /andP[/andP[/eqP-> /eqP->] /andP[/eqP-> /eqP->]].
 Qed.
 
@@ -3299,7 +3299,7 @@ exists (to_set (C.1) (xy.1), to_set (C.2) (xy.2)).
 move=> uv [/= Cxyuv1 Cxyuv2]; apply: sBA.
 have /sCB : (C.1 `*` C.2) ((xy.1,uv.1),(xy.2,uv.2)) by [].
 move=> [zt Bzt /eqP]; rewrite !xpair_eqE andbACA -!xpair_eqE.
-by rewrite -!surjective_pairing => /eqP<-.
+by rewrite /= -!surjective_pairing => /eqP<-.
 Qed.
 
 Definition prod_uniformType_mixin :=
@@ -3398,7 +3398,7 @@ apply: sPA => /=; near: N; set Q := \bigcap_ij P ij.1 ij.2.
 apply: filterS (FM Q _); first by move=> N QN i j; apply: (QN _ _ (i, j)).
 have -> : Q =
   \bigcap_(ij in [set k | k \in [fset x in predT]%fset]) P ij.1 ij.2.
-  by rewrite predeqE => t; split=> Qt ij _; apply: Qt => //; rewrite !inE.
+  by rewrite predeqE => t; split=> Qt ij _; apply: Qt => //=; rewrite !inE.
 by apply: filter_bigI => ??; apply: entP.
 Grab Existential Variables. all: end_near. Qed.
 
@@ -3587,7 +3587,7 @@ Qed.
 Next Obligation.
 move=> R T ent nbhs nbhsE m A; rewrite (PseudoMetric.ax4 m).
 move=> [e egt0 sbeA] xy xey.
-apply: sbeA; rewrite xey; exact: PseudoMetric.ax1.
+apply: sbeA; rewrite /= xey; exact: PseudoMetric.ax1.
 Qed.
 Next Obligation.
 move=> R T ent nbhs nbhsE m A; rewrite (PseudoMetric.ax4 m) => - [e egt0 sbeA].
@@ -3753,7 +3753,7 @@ Lemma ball_close (x y : M) :
 Proof.
 rewrite propeqE; split => [cxy eps|cxy].
   have := cxy _ (open_nbhs_ball _ (eps%:num/2)%:pos).
-  rewrite closureEonbhs meetsC meets_globallyr.
+  rewrite closureEonbhs/= meetsC meets_globallyr.
   move/(_ _ (open_nbhs_ball _ (eps%:num/2)%:pos)) => [z [zx zy]].
   by apply: (@ball_splitl z); apply: interior_subset.
 rewrite closeEnbhs => B A /nbhs_ballP[_/posnumP[e2 e2B]]
@@ -4118,7 +4118,7 @@ Lemma cauchy_ballP (R : numDomainType) (T  : pseudoMetricType R)
   cauchy_ball F <-> cauchy F.
 Proof.
 split=> cauchyF; last first.
-  by move=> _/posnumP[eps]; apply: cauchyF; rewrite nbhs_simpl.
+  by move=> _/posnumP[eps]; apply/cauchyF/entourage_ball.
 move=> U; rewrite -entourage_ballE => - [_/posnumP[eps] xyepsU].
 by near=> x; apply: xyepsU; near: x; apply: cauchyF.
 Grab Existential Variables. all: end_near. Qed.
@@ -4140,7 +4140,7 @@ Lemma cauchyP (R : numFieldType) (T : pseudoMetricType R)
 Proof.
 split=> [Fcauchy _/posnumP[e] |/cauchy_exP//].
 near F => x; exists x; near: x; apply: (@nearP_dep _ _ F F).
-by apply: Fcauchy; rewrite nbhs_simpl.
+exact/Fcauchy/entourage_ball.
 Grab Existential Variables. all: end_near. Qed.
 Arguments cauchyP {R T} F {PF}.
 


### PR DESCRIPTION
- unless applied, where `/=` will simplify.
- unless one uses `rewrite /mkset`.