### PR TITLE
more uniform variable naming convention

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -25,6 +25,7 @@
 
 - in `ereal.v`, lemmas `esum_fset_ninfty`, `esum_fset_pinfty`, `esum_pinfty`
 - in `classical_sets.v`, lemmas `setDT`, `set0D`, `setD0`
+- in `classical_sets.v`, lemmas `setC_bigcup`, `setC_bigcap`
 
 ### Changed
 
@@ -56,6 +57,7 @@
 
 - in `topology.v`:
   + `ball_le`
+- in `classical_sets.v`, lemma `bigcapCU`
 
 ### Infrastructure
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -24,6 +24,7 @@
 - in `reals.v`, definition `ceil`, lemmas `RceilE`, `ceil_ge0`, `ceil_le0`
 
 - in `ereal.v`, lemmas `esum_fset_ninfty`, `esum_fset_pinfty`, `esum_pinfty`
+- in `classical_sets.v`, lemmas `setDT`, `set0D`, `setD0`
 
 ### Changed
 

--- a/theories/classical_sets.v
+++ b/theories/classical_sets.v
@@ -688,11 +688,16 @@ Proof. by rewrite eqEsubset; split => a // []. Qed.
 Lemma bigcup_set1 F i : \bigcup_(j in [set i]) F j = F i.
 Proof. by rewrite eqEsubset; split => ? => [[] ? -> //|]; exists i. Qed.
 
-Lemma bigcapCU F P : \bigcap_(i in P) (F i) = ~` (\bigcup_(i in P) (~` F i)).
+Lemma setC_bigcup P F : ~` (\bigcup_(i in P) F i) = \bigcap_(i in P) ~` F i.
 Proof.
-rewrite predeqE => t; split => [capF|cupF i Et].
-  by move=> -[n En]; apply; apply capF.
-by rewrite -(setCK (F i)) => CU; apply cupF; exists i.
+by rewrite eqEsubset; split => [t PFt i Pi ?|t PFt [i Pi ?]];
+  [apply PFt; exists i | exact: (PFt _ Pi)].
+Qed.
+
+Lemma setC_bigcap P F : ~` (\bigcap_(i in P) (F i)) = \bigcup_(i in P) ~` F i.
+Proof.
+rewrite eqEsubset; split=> [| t [i Pi Fit] /(_ _ Pi)//].
+by move=> t /existsNP[i /not_implyP[Pi Fit]]; exists i.
 Qed.
 
 End bigop_lemmas.

--- a/theories/classical_sets.v
+++ b/theories/classical_sets.v
@@ -486,6 +486,15 @@ rewrite propeqE; split => [|BA].
 by apply/subsets_disjoint; rewrite setCK setIC; apply/subsets_disjoint.
 Qed.
 
+Lemma setDT A : A `\` setT = set0.
+Proof. by rewrite setDE setCT setI0. Qed.
+
+Lemma set0D A : set0 `\` A = set0.
+Proof. by rewrite setDE set0I. Qed.
+
+Lemma setD0 A : A `\` set0 = A.
+Proof. by rewrite setDE setC0 setIT. Qed.
+
 Lemma setDS A B C : A `<=` B -> C `\` B `<=` C `\` A.
 Proof. by rewrite !setDE -setCS; apply: setIS. Qed.
 

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -210,11 +210,11 @@ Qed.
 Lemma measurableT : measurable (setT : set T).
 Proof. by rewrite -setC0; apply measurableC; exact: measurable0. Qed.
 
-Lemma measurable_bigcap (U : (set T)^nat) :
-  (forall i, measurable (U i)) -> measurable (\bigcap_i (U i)).
+Lemma measurable_bigcap (F : (set T)^nat) :
+  (forall i, measurable (F i)) -> measurable (\bigcap_i (F i)).
 Proof.
-move=> mU; rewrite bigcapCU; apply/measurableC/measurable_bigcup => i.
-exact: measurableC.
+move=> ?; rewrite -(setCK (\bigcap__ _)); apply/measurableC.
+by rewrite setC_bigcap; apply/measurable_bigcup => i; exact/measurableC.
 Qed.
 
 End measurable_lemmas.

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -2354,7 +2354,7 @@ Qed.
 Lemma closureC E :
   ~` closure E = \bigcup_(x in [set U | open U /\ U `<=` ~` E]) x.
 Proof.
-rewrite closureE bigcapCU setCK eqEsubset; split => t [U [? EU Ut]].
+rewrite closureE setC_bigcap eqEsubset; split => t [U [? EU Ut]].
   by exists (~` U) => //; split; [exact: openC|exact: subsetC].
 by rewrite -(setCK E); exists (~` U)=> //; split; [exact:closedC|exact:subsetC].
 Qed.


### PR DESCRIPTION
- enforce the convention of using T, U for names of variables
  in Type (or choiceType an pointedType)
  + as a consequence functions are of type T -> U
  + use I when the type corresponds to an index
- enforce the convention that sets are named A, B, C, D, etc.
  + indexed sets are rather named F
  + use X for set T and Y for set U when it makes sense when
    we are talking about images/preimages
  + keep X for sets of pairs
- small reordering of lemmas in sections (basic_lemmas,
  image_lemmas, bigop_lemmas) to take advantage of Implicit Types