### PR TITLE
sigma_finite definition from PR integral_sketch

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -25,6 +25,8 @@
 
 - in `ereal.v`, lemmas `esum_fset_ninfty`, `esum_fset_pinfty`, `esum_pinfty`
 
+- in `measure.v`, definition `sigma_finite`
+
 ### Changed
 
 - header in `normedtype.v`, precisions on `bounded_fun`

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -53,6 +53,10 @@
   + `ifloor` -> `floor`
   + `ifloor_ge0` -> `floor_ge0`
 
+- in `measure.v`:
+  + `AdditiveMeasure.Measure` -> `AdditiveMeasure.Axioms`
+  + `OuterMeasure.OuterMeasure` -> `OuterMeasure.Axioms`
+
 ### Removed
 
 - in `topology.v`:

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -419,7 +419,7 @@ Module Measure.
 Section ClassDef.
 
 Variables (R : numFieldType) (T : semiRingOfSetsType).
-Record axioms (mu : set T -> {ereal R}) := Measure {
+Record axioms (mu : set T -> {ereal R}) := Axioms {
   _ : mu set0 = 0%:E ;
   _ : forall x, measurable x -> (0%:E <= mu x)%E ;
   _ : semi_sigma_additive mu }.
@@ -721,7 +721,7 @@ Module OuterMeasure.
 Section ClassDef.
 
 Variables (R : numFieldType) (T : Type).
-Record axioms (mu : set T -> {ereal R}) := OuterMeasure {
+Record axioms (mu : set T -> {ereal R}) := Axioms {
   _ : mu set0 = 0%:E ;
   _ : forall x, (0%:E <= mu x)%E ;
   _ : {homo mu : A B / A `<=` B >-> (A <= B)%E} ;

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -12,8 +12,10 @@ From HB Require Import structures.
 (* WIP.                                                                       *)
 (*                                                                            *)
 (* semiRingOfSetsType == the type of semirings of sets                        *)
-(* ringOfSetsType == the type of rings of sets                                *)
-(* measurableType == the type of sigma-algebras                               *)
+(*     ringOfSetsType == the type of rings of sets                            *)
+(*     measurableType == the type of sigma-algebras                           *)
+(*   sigma_finite A f == the measure f is sigma-finite on A : set T with      *)
+(*                       T : ringOfSetsType.                                  *)
 (*                                                                            *)
 (* {additive_measure set T -> {ereal R}} == type of a function over sets of   *)
 (*                    elements of type T where R is expected to be a          *)
@@ -30,7 +32,7 @@ From HB Require Import structures.
 (* {ae mu, forall x, P x} == P holds almost everywhere for the measure mu     *)
 (*                                                                            *)
 (* {outer_measure set T -> {ereal R}} == type of an outer measure over sets   *)
-(*                                 of elements o ftype T where R is expected  *)
+(*                                 of elements of type T where R is expected  *)
 (*                                 to be a numFieldType                       *)
 (*                                                                            *)
 (******************************************************************************)
@@ -218,6 +220,12 @@ exact: measurableC.
 Qed.
 
 End measurable_lemmas.
+
+Definition sigma_finite (R : numDomainType) (T : ringOfSetsType) (A : set T)
+    (mu : set T -> {ereal R}) :=
+  exists2 F : (set T)^nat,
+    A = \bigcup_(i : nat) F i &
+      forall i, measurable (F i) /\ (mu (F i) < +oo)%E.
 
 Section semi_additivity.
 Variables (R : numFieldType) (T : semiRingOfSetsType) (mu : set T -> {ereal R}).


### PR DESCRIPTION
- lowered to ringOfSetsTypes

PRed because it might be needed earlier than integral.v where it was first defined

Co-authored-by: Cyril Cohen <cohen@crans.org>

Also fixes constructor names for two mixins