### PR TITLE
change the use of scopes in ereal notations

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -77,6 +77,8 @@
     `countably_infinite_prod_nat`
 - in `measure.v`:
   + definition `measure_is_complete`
+- in `ereal.v`:
+  + notation `0`/`1` for `0%R%:E`/`1%R:%E` in `ereal_scope`
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -96,6 +96,10 @@
 - in `topology.v`:
   + change implicits of lemma `cvg_app`
 
+- in `ereal.v`:
+  + argument of `%:E` in `%R` by default
+  + `F` argument of `\sum` in `%E` by default
+
 ### Renamed
 
 - in `sequences,v`:

--- a/theories/csum.v
+++ b/theories/csum.v
@@ -37,9 +37,9 @@ Local Open Scope ereal_scope.
 
 (* TODO: move to sequences.v *)
 Lemma ereal_pseries_pred0 (R : realType) (P : pred nat) (f : nat -> \bar R) :
-  P =1 xpred0 -> \sum_(i <oo | P i) f i = 0%:E.
+  P =1 xpred0 -> \sum_(i <oo | P i) f i = 0.
 Proof.
-move=> P0; rewrite (_ : (fun _ => _) = fun=> 0%:E) ?lim_cst// funeqE => n.
+move=> P0; rewrite (_ : (fun _ => _) = fun=> 0) ?lim_cst// funeqE => n.
 by rewrite big1 // => i; rewrite P0.
 Qed.
 
@@ -106,12 +106,12 @@ Section csum.
 Variables (R : realFieldType) (T : choiceType).
 Implicit Types (S : set T) (a : T -> \bar R).
 
-Definition csum S a := if S == set0 then 0%:E else
+Definition csum S a := if S == set0 then 0 else
   ereal_sup [set \sum_(i <- F) a i | F in fsets S].
 
 Local Notation "\csum_ ( i 'in' P ) F" := (csum P (fun i => F)).
 
-Lemma csum0 a : \csum_(i in set0) a i = 0%:E.
+Lemma csum0 a : \csum_(i in set0) a i = 0.
 Proof. by rewrite /csum eqxx. Qed.
 
 Lemma csumE S a : S !=set0 ->
@@ -126,14 +126,13 @@ Section csum_realType.
 Variables (R : realType) (T : choiceType).
 Implicit Types (a : T -> \bar R).
 
-Lemma csum_ge0 (S : set T) a : (forall x, 0%:E <= a x) ->
-  0%:E <= \csum_(i in S) a i.
+Lemma csum_ge0 (S : set T) a : (forall x, 0 <= a x) -> 0 <= \csum_(i in S) a i.
 Proof.
 move=> a0; rewrite /csum; case: ifPn => // _.
 by apply: ereal_sup_ub; exists fset0; [exact: fsets_set0|rewrite big_nil].
 Qed.
 
-Lemma csum_fset (F : {fset T}) a : (forall i, i \in F -> 0%:E <= a i) ->
+Lemma csum_fset (F : {fset T}) a : (forall i, i \in F -> 0 <= a i) ->
   \csum_(i in [set x | x \in F]) a i = \sum_(i <- F) a i.
 Proof.
 move=> f0; rewrite /csum; case: ifPn => [|F0].
@@ -148,7 +147,7 @@ Qed.
 End csum_realType.
 
 Lemma csum_image (R : realType) (T : pointedType) (a : T -> \bar R)
-    (e : nat -> T) (P : pred nat) : (forall n, P n -> 0%:E <= a (e n)) ->
+    (e : nat -> T) (P : pred nat) : (forall n, P n -> 0 <= a (e n)) ->
     injective e ->
   \csum_(i in e @` P) a i = \sum_(i <oo | P i) a (e i).
 Proof.
@@ -182,7 +181,7 @@ by rewrite !inE /= => Pi' ->{i} -> _; apply a0.
 Grab Existential Variables. all: end_near. Qed.
 
 Lemma ereal_pseries_csum (R : realType) (a : nat -> \bar R) (P : pred nat) :
-  (forall n, P n -> 0%:E <= a n) ->
+  (forall n, P n -> 0 <= a n) ->
   \sum_(i <oo | P i) a i = \csum_(i in [set x | P x]) a i.
 Proof.
 move=> a0; rewrite -(@csum_image _ _ _ id) //; congr csum.
@@ -194,7 +193,7 @@ Variables (R : realType) (T : pointedType) (K : set nat) (J : nat -> set T).
 Hypotheses (J0 : forall k, J k !=set0) (tJ : trivIset setT J).
 Let KJ := \bigcup_(k in K) (J k).
 Variable a : T -> \bar R.
-Hypothesis a0 : forall x, 0%:E <= a x.
+Hypothesis a0 : forall x, 0 <= a x.
 
 Let tJ' : forall i j : nat, i != j -> J i `&` J j = set0.
 Proof. by move=> i j ij; move: tJ => /trivIsetP; apply. Qed.
@@ -220,7 +219,7 @@ have [L LKFJ] : set_finite KFJ.
   by rewrite predeqE => /(_ t)[+ _]; apply; rewrite /= !inE in tJi tJj.
 have LK : [set i | i \in L] `<=` K.
   by move=> /= i iL; move/predeqP : LKFJ => /(_ i) /iffRL /(_ iL) [].
-have -> : \sum_(i <- F) a i = \sum_(k <- L) (\sum_(i <- FJ k) a i)%E.
+have -> : \sum_(i <- F) a i = \sum_(k <- L) \sum_(i <- FJ k) a i.
   suff -> : F = (\big[fsetU/fset0]_(x <- L) FJ x)%fset.
     by apply/partition_disjoint_bigfcup; exact: dFJ.
   apply/fsetP => t; apply/idP/idP => [tF|/bigfcupP[i]]; last first.
@@ -258,7 +257,7 @@ have [Fj csumFj] : exists F, forall j, P (F j) j.
     by case/(@choice _ _ (fun i F => P F i)) => Fj ?; exists Fj.
   move=> j; rewrite /P csumE //; set es := ereal_sup _.
   have [esoo|[c c0 esc]] : es = +oo \/ exists2 r : R, (r >= 0)%R & es = r%:E.
-    suff : 0%:E <= es by move/gee0P.
+    suff : 0 <= es by move/gee0P.
     by apply ereal_sup_ub; exists fset0; [exact: fsets_set0|rewrite big_nil].
   - move: csumIar; rewrite csumE //; set es' := ereal_sup _ => es'r.
     suff : es <= es' by rewrite esoo es'r.
@@ -275,7 +274,7 @@ apply: (@le_trans _ _ (\sum_(i <- F) a i)); last first.
   apply/fsetsP => t /bigfcupP[/= i _] /(proj1 (csumFj i)) Jt.
   by exists (L \_ i) => //; apply: LK; rewrite /mkset mem_nth.
 rewrite (_ : \sum_(_ <- _) _ =
-             \sum_(i < #|`L|) (\sum_(j <- Fj i) a j)%E); last first.
+             \sum_(i < #|`L|) \sum_(j <- Fj i) a j); last first.
   have tFj : (forall i j : 'I_#|`L|, i != j -> [disjoint Fj i & Fj j])%fset.
     move=> i j ij; rewrite -fsetI_eq0.
     suff : (Fj i `&` Fj j)%fset == fset0 by [].
@@ -287,14 +286,14 @@ rewrite (_ : \sum_(_ <- _) _ =
     by move=> /(proj1 (csumFj i)) ? /(proj1 (csumFj j)) ?; rewrite -Jij; split.
   pose IL := [fset i | i in 'I_#|`L|]%fset.
   have -> : F = (\bigcup_(i <- IL) Fj i)%fset by rewrite big_imfset // big_enum.
-  transitivity (\sum_(i <- IL) (\sum_(j <- Fj i) a j)%E); last first.
+  transitivity (\sum_(i <- IL) \sum_(j <- Fj i) a j); last first.
     by rewrite /IL big_imfset //= big_enum.
   by apply partition_disjoint_bigfcup; exact: tFj.
 rewrite (_ : e%:num = \sum_(i < #|`L|) (e%:num / #|`L|%:R))%R; last first.
   rewrite big_const iter_addr addr0 card_ord -mulr_natr.
   by rewrite -mulrA mulVr ?mulr1 // unitfE pnatr_eq0 cardfs_eq0.
-rewrite -NEFin (@big_morph _ _ _ 0 _ _ _ (@opprD R)) ?oppr0 //.
-rewrite (@big_morph _ _ _ 0%:E _ _ _ addEFin) // -big_split /=.
+rewrite -NEFin (@big_morph _ _ _ 0%R _ _ _ (@opprD R)) ?oppr0 //.
+rewrite (@big_morph _ _ _ 0 _ _ _ addEFin) // -big_split /=.
 by apply: lee_sum => /= i _; exact: (ltW (proj2 (csumFj i))).
 Qed.
 

--- a/theories/ereal.v
+++ b/theories/ereal.v
@@ -93,7 +93,7 @@ Inductive extended (R : Type) := EFin of R | EPInf | ENInf.
 
 Notation "+oo" := (@EPInf _) : ereal_scope.
 Notation "-oo" := (@ENInf _) : ereal_scope.
-Notation "x %:E" := (@EFin _ x).
+Notation "x %:E" := (@EFin _ x%R).
 Notation "'\bar' R" := (extended R) : type_scope.
 
 Bind    Scope ereal_scope with extended.
@@ -342,29 +342,29 @@ Notation "`| x |" := (abse x) : ereal_scope.
 Notation "f \+ g" := (fun x => f x + g x)%E : ereal_scope.
 
 Notation "\sum_ ( i <- r | P ) F" :=
-  (\big[+%E/0%:E]_(i <- r | P%B) F%R) : ereal_scope.
+  (\big[+%E/0%:E]_(i <- r | P%B) F%E) : ereal_scope.
 Notation "\sum_ ( i <- r ) F" :=
-  (\big[+%E/0%:E]_(i <- r) F%R) : ereal_scope.
+  (\big[+%E/0%:E]_(i <- r) F%E) : ereal_scope.
 Notation "\sum_ ( m <= i < n | P ) F" :=
-  (\big[+%E/0%:E]_(m <= i < n | P%B) F%R) : ereal_scope.
+  (\big[+%E/0%:E]_(m <= i < n | P%B) F%E) : ereal_scope.
 Notation "\sum_ ( m <= i < n ) F" :=
-  (\big[+%E/0%:E]_(m <= i < n) F%R) : ereal_scope.
+  (\big[+%E/0%:E]_(m <= i < n) F%E) : ereal_scope.
 Notation "\sum_ ( i | P ) F" :=
-  (\big[+%E/0%:E]_(i | P%B) F%R) : ereal_scope.
+  (\big[+%E/0%:E]_(i | P%B) F%E) : ereal_scope.
 Notation "\sum_ i F" :=
-  (\big[+%E/0%:E]_i F%R) : ereal_scope.
+  (\big[+%E/0%:E]_i F%E) : ereal_scope.
 Notation "\sum_ ( i : t | P ) F" :=
-  (\big[+%E/0%:E]_(i : t | P%B) F%R) (only parsing) : ereal_scope.
+  (\big[+%E/0%:E]_(i : t | P%B) F%E) (only parsing) : ereal_scope.
 Notation "\sum_ ( i : t ) F" :=
-  (\big[+%E/0%:E]_(i : t) F%R) (only parsing) : ereal_scope.
+  (\big[+%E/0%:E]_(i : t) F%E) (only parsing) : ereal_scope.
 Notation "\sum_ ( i < n | P ) F" :=
-  (\big[+%E/0%:E]_(i < n | P%B) F%R) : ereal_scope.
+  (\big[+%E/0%:E]_(i < n | P%B) F%E) : ereal_scope.
 Notation "\sum_ ( i < n ) F" :=
-  (\big[+%E/0%:E]_(i < n) F%R) : ereal_scope.
+  (\big[+%E/0%:E]_(i < n) F%E) : ereal_scope.
 Notation "\sum_ ( i 'in' A | P ) F" :=
-  (\big[+%E/0%:E]_(i in A | P%B) F%R) : ereal_scope.
+  (\big[+%E/0%:E]_(i in A | P%B) F%E) : ereal_scope.
 Notation "\sum_ ( i 'in' A ) F" :=
-  (\big[+%E/0%:E]_(i in A) F%R) : ereal_scope.
+  (\big[+%E/0%:E]_(i in A) F%E) : ereal_scope.
 
 Section ERealOrderTheory.
 Context {R : numDomainType}.
@@ -1055,7 +1055,7 @@ case=> [x||].
   move=> P Q lP lQ; exact: xI.
   by move=> P Q PQ /xS; apply => y /PQ.
 - apply Build_ProperFilter.
-    move=> P [x [xr xP]] //; exists (x + 1)%R%:E; apply xP => /=.
+    move=> P [x [xr xP]] //; exists (x + 1)%:E; apply xP => /=.
     by rewrite lte_fin ltr_addl.
   split=> /= [|P Q [MP [MPr gtMP]] [MQ [MQr gtMQ]] |P Q sPQ [M [Mr gtM]]].
   + by exists 0; rewrite real0.
@@ -1081,7 +1081,7 @@ case=> [x||].
     * by move=> _; split; [apply/gtMP | apply/gtMQ].
   + by exists M; split => // ? /gtM /sPQ.
 - apply Build_ProperFilter.
-  + move=> P [M [Mr ltMP]]; exists (M - 1)%R%:E.
+  + move=> P [M [Mr ltMP]]; exists (M - 1)%:E.
     by apply: ltMP; rewrite lte_fin gtr_addl oppr_lt0.
   + split=> /= [|P Q [MP [MPr ltMP]] [MQ [MQr ltMQ]] |P Q sPQ [M [Mr ltM]]].
     * by exists 0; rewrite real0.
@@ -1968,7 +1968,7 @@ Qed.
 
 Definition ereal_loc_seq (R : numDomainType) (x : \bar R) (n : nat) :=
   match x with
-    | x%:E => (x + (n%:R + 1)^-1)%R%:E
+    | x%:E => (x + (n%:R + 1)^-1)%:E
     | +oo => n%:R%:E
     | -oo => - n%:R%:E
   end.

--- a/theories/ereal.v
+++ b/theories/ereal.v
@@ -55,6 +55,8 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
+Reserved Notation "x %:E" (at level 2, format "x %:E").
+
 (* TODO: add to bigop.v *)
 Lemma big_nat_widenl (R : Type) (idx : R) (op : Monoid.law idx) (m1 m2 n : nat)
     (P : pred nat) (F : nat -> R) :
@@ -95,6 +97,8 @@ Notation "+oo" := (@EPInf _) : ereal_scope.
 Notation "-oo" := (@ENInf _) : ereal_scope.
 Notation "x %:E" := (@EFin _ x%R).
 Notation "'\bar' R" := (extended R) : type_scope.
+Notation "0" := (0%R%:E) : ereal_scope.
+Notation "1" := (1%R%:E) : ereal_scope.
 
 Bind    Scope ereal_scope with extended.
 Delimit Scope ereal_scope with E.
@@ -266,7 +270,7 @@ Lemma lee_pinfty (R : realDomainType) (x : \bar R) : x <= +oo.
 Proof. case: x => //= r; exact: num_real. Qed.
 
 Lemma gee0P (R : realDomainType) (x : \bar R) :
-  0%:E <= x <-> x = +oo \/ exists2 r, (r >= 0)%R & x = r%:E.
+  0 <= x <-> x = +oo \/ exists2 r, (r >= 0)%R & x = r%:E.
 Proof.
 split=> [|[->|[r r0 ->//]]]; last exact: lee_pinfty.
 by case: x => [r r0 | _ |//]; [right; exists r|left].
@@ -322,8 +326,8 @@ Definition oppe x :=
 Definition mule x y :=
   match x, y with
   | x%:E , y%:E => (x * y)%:E
-  | -oo, y | y, -oo => if 0%:E <= y then -oo else +oo
-  | +oo, y | y, +oo => if 0%:E < y then +oo else -oo
+  | -oo, y | y, -oo => if 0 <= y then -oo else +oo
+  | +oo, y | y, +oo => if 0 < y then +oo else -oo
   end.
 
 Definition abse x := if x is r%:E then `|r|%:E else +oo.
@@ -380,7 +384,7 @@ Local Tactic Notation "elift" constr(lm) ":" ident(x) ident(y) ident(z) :=
   by case: x y z => [?||] [?||] [?||]; first by rewrite ?eqe; apply: lm.
 
 Lemma le0R (x : \bar R) :
-  0%:E <= x -> (0 <= real_of_extended(*TODO: coercion broken*) x)%R.
+  0 <= x -> (0 <= real_of_extended(*TODO: coercion broken*) x)%R.
 Proof. by case: x. Qed.
 
 Lemma lee_tofin (r0 r1 : R) : (r0 <= r1)%R -> r0%:E <= r1%:E.
@@ -431,10 +435,10 @@ Definition adde_undef x y :=
 Lemma adde_undefC x y : adde_undef x y = adde_undef y x.
 Proof. by rewrite /adde_undef andbC orbC andbC. Qed.
 
-Lemma adde0 : right_id (0%:E : \bar R) +%E.
+Lemma adde0 : right_id (0 : \bar R) +%E.
 Proof. by case=> //= x; rewrite addr0. Qed.
 
-Lemma add0e : left_id (0%:E : \bar R) +%E.
+Lemma add0e : left_id (0 : \bar R) +%E.
 Proof. by case=> //= x; rewrite add0r. Qed.
 
 Lemma addeC : commutative (S := \bar R) +%E.
@@ -455,7 +459,7 @@ Proof. by move=> x y z; rewrite addeC -addeA (addeC x). Qed.
 Lemma addeACA : @interchange (\bar R) +%E +%E.
 Proof. by case=> [r||] [s||] [t||] [u||]//=; rewrite addrACA. Qed.
 
-Lemma oppe0 : - 0%:E = 0%:E :> \bar R.
+Lemma oppe0 : - 0 = 0 :> \bar R.
 Proof. by rewrite /= oppr0. Qed.
 
 Lemma oppeK : involutive (A := \bar R) -%E.
@@ -467,10 +471,10 @@ Proof. by move: x => [x| |] //=; rewrite opprD. Qed.
 Lemma muleC x y : x * y = y * x.
 Proof. by case: x y => [r||] [s||]//=; rewrite mulrC. Qed.
 
-Lemma mule1 x : x * 1%:E = x.
+Lemma mule1 x : x * 1 = x.
 Proof. by case: x => [r||]/=; rewrite ?mulr1 ?lee_tofin ?lte_tofin. Qed.
 
-Lemma mul1e x : 1%:E * x = x.
+Lemma mul1e x : 1 * x = x.
 Proof. by rewrite muleC mule1. Qed.
 
 Lemma abseN x : `|- x| = `|x|.
@@ -498,7 +502,7 @@ Lemma oppe_subset (A B : set (\bar R)) :
   ((A `<=` B) <-> (-%E @` A `<=` -%E @` B))%classic.
 Proof.
 split=> [AB _ [] x ? <-|AB x Ax]; first by exists x => //; exact: AB.
-have /AB[y By] : ((-%E @` A) (- x)%E)%classic by exists x.
+have /AB[y By] : ((-%E @` A) (- x))%classic by exists x.
 by rewrite eqe_oppP => <-.
 Qed.
 
@@ -525,7 +529,7 @@ Proof. by move: x y => [x| |] [y| |] //; rewrite -addEFin /= addrK. Qed.
 Lemma subeK x y : y \is a fin_num -> x - y + y = x.
 Proof. by move: x y => [x| |] [y| |] //; rewrite -addEFin subrK. Qed.
 
-Lemma subee x : x \is a fin_num -> x - x = 0%:E.
+Lemma subee x : x \is a fin_num -> x - x = 0.
 Proof. by move: x => [r _| |] //; rewrite -subEFin subrr. Qed.
 
 Lemma adde_eq_ninfty x y : (x + y == -oo) = ((x == -oo) || (y == -oo)).
@@ -584,11 +588,11 @@ apply/idP/existsP => [/eqP /=|[/= i /eqP fioo]].
 by apply/eqP/esum_fset_pinfty => //; exists i; split => //; rewrite inE.
 Qed.
 
-Lemma adde_ge0 x y : 0%:E <= x -> 0%:E <= y -> 0%:E <= x + y.
+Lemma adde_ge0 x y : 0 <= x -> 0 <= y -> 0 <= x + y.
 Proof. by move: x y => [r0| |] [r1| |] // ? ?; rewrite !lee_fin addr_ge0. Qed.
 
 Lemma sume_ge0 T (f : T -> \bar R) (P : pred T) :
-  (forall t, P t -> 0%:E <= f t) -> forall l, 0%:E <= \sum_(i <- l | P i) f i.
+  (forall t, P t -> 0 <= f t) -> forall l, 0 <= \sum_(i <- l | P i) f i.
 Proof. by move=> f0 l; elim/big_rec : _ => // t x Pt; apply/adde_ge0/f0. Qed.
 
 End ERealArithTh_numDomainType.
@@ -598,25 +602,25 @@ Section ERealArithTh_realDomainType.
 Context {R : realDomainType}.
 Implicit Types x y z a b : \bar R.
 
-Lemma sube_gt0 x y : (0%:E < y - x) = (x < y).
+Lemma sube_gt0 x y : (0 < y - x) = (x < y).
 Proof.
 move: x y => [r | |] [r'| |] //=; rewrite ?(lte_pinfty,lte_ninfty) //.
 by rewrite !lte_fin subr_gt0.
 Qed.
 
-Lemma sube_le0 x y : (y - x <= 0%:E) = (y <= x).
+Lemma sube_le0 x y : (y - x <= 0) = (y <= x).
 Proof.
 by move: x y => [x| |] [y| |]; apply/idP/idP => //=; try
   (rewrite !(lee_pinfty,lee_ninfty) || rewrite !lee_fin subr_le0).
 Qed.
 
-Lemma suber_ge0 r x : (0%:E <= x - r%:E) = (r%:E <= x).
+Lemma suber_ge0 r x : (0 <= x - r%:E) = (r%:E <= x).
 Proof.
 move: x => [x| |] //=; rewrite ?(lee_pinfty,lee_ninfty,lee_fin) //=.
 by rewrite subr_ge0.
 Qed.
 
-Lemma subre_ge0 x r : (0%:E <= r%:E - x) = (x <= r%:E).
+Lemma subre_ge0 x r : (0 <= r%:E - x) = (x <= r%:E).
 Proof.
 move: x => [x| |] //=; rewrite ?(lee_pinfty,lee_ninfty,lee_fin) //=.
 by rewrite subr_ge0.
@@ -640,16 +644,16 @@ move: a b x y => [a| |] [b| |] [x| |] [y| |]; rewrite ?(lte_pinfty,lte_ninfty)//
 by rewrite !lte_fin; exact: ltr_add.
 Qed.
 
-Lemma lee_addl x y : 0%:E <= y -> x <= x + y.
+Lemma lee_addl x y : 0 <= y -> x <= x + y.
 Proof.
 move: x y => -[ x [y| |]//= | [| |]// | [| | ]//];
   by [rewrite !lee_fin ler_addl | move=> _; exact: lee_pinfty].
 Qed.
 
-Lemma lee_addr x y : 0%:E <= y -> x <= y + x.
+Lemma lee_addr x y : 0 <= y -> x <= y + x.
 Proof. by rewrite addeC; exact: lee_addl. Qed.
 
-Lemma lte_addl r x : 0%:E < x -> r%:E < r%:E + x.
+Lemma lte_addl r x : 0 < x -> r%:E < r%:E + x.
 Proof.
 by move: x => [x| |] //; rewrite ?lte_pinfty ?lte_ninfty // !lte_fin ltr_addl.
 Qed.
@@ -702,7 +706,7 @@ Lemma lee_sum I (f g : I -> \bar R) s (P : pred I) :
 Proof. by move=> Pfg; elim/big_ind2 : _ => // *; apply lee_add. Qed.
 
 Lemma lee_sum_nneg_subset I (s : seq I) (P Q : {pred I}) (f : I -> \bar R) :
-  {subset Q <= P} -> {in [predD P & Q], forall i, 0%:E <= f i} ->
+  {subset Q <= P} -> {in [predD P & Q], forall i, 0 <= f i} ->
   \sum_(i <- s | Q i) f i <= \sum_(i <- s | P i) f i.
 Proof.
 move=> QP PQf; rewrite big_mkcond [X in _ <= X]big_mkcond lee_sum// => i.
@@ -710,7 +714,7 @@ by move/implyP: (QP i); move: (PQf i); rewrite !inE -!topredE/=; do !case: ifP.
 Qed.
 
 Lemma lee_sum_nneg (I : eqType) (s : seq I) (P Q : pred I)
-  (f : I -> \bar R) : (forall i, P i -> ~~ Q i -> 0%:E <= f i) ->
+  (f : I -> \bar R) : (forall i, P i -> ~~ Q i -> 0 <= f i) ->
   \sum_(i <- s | P i && Q i) f i <= \sum_(i <- s | P i) f i.
 Proof.
 move=> PQf; rewrite [X in _ <= X](bigID Q) /= -[X in X <= _]adde0 lee_add //.
@@ -718,7 +722,7 @@ by rewrite sume_ge0// => i /andP[]; exact: PQf.
 Qed.
 
 Lemma lee_sum_nneg_ord (f : nat -> \bar R) (P : pred nat) :
-  (forall n, P n -> 0%:E <= f n) ->
+  (forall n, P n -> 0 <= f n) ->
   {homo (fun n => \sum_(i < n | P i) (f i)) : i j / (i <= j)%N >-> i <= j}.
 Proof.
 move=> f0 i j le_ij; rewrite (big_ord_widen_cond j) // big_mkcondr /=.
@@ -726,7 +730,7 @@ by rewrite lee_sum // => k ?; case: ifP => // _; exact: f0.
 Qed.
 
 Lemma lee_sum_nneg_natr (f : nat -> \bar R) (P : pred nat) m :
-  (forall n, (m <= n)%N -> P n -> 0%:E <= f n) ->
+  (forall n, (m <= n)%N -> P n -> 0 <= f n) ->
   {homo (fun n => \sum_(m <= i < n | P i) (f i)) : i j / (i <= j)%N >-> i <= j}.
 Proof.
 move=> f0 i j le_ij; rewrite -[m]add0n !big_addn !big_mkord.
@@ -735,7 +739,7 @@ apply: (@lee_sum_nneg_ord (fun k => f (k + m)%N) (fun k => P (k + m)%N));
 Qed.
 
 Lemma lee_sum_nneg_natl (f : nat -> \bar R) (P : pred nat) n :
-  (forall m, (m < n)%N -> P m -> 0%:E <= f m) ->
+  (forall m, (m < n)%N -> P m -> 0 <= f m) ->
   {homo (fun m => \sum_(m <= i < n | P i) (f i)) : i j / (i <= j)%N >-> j <= i}.
 Proof.
 move=> f0 i j le_ij; rewrite !big_geq_mkord/=.
@@ -745,7 +749,7 @@ Qed.
 
 Lemma lee_sum_nneg_subfset (T : choiceType) (A B : {fset T}%fset) (P : pred T)
   (f : T -> \bar R) : {subset A <= B} ->
-  {in [predD B & A], forall t, P t -> 0%:E <= f t} ->
+  {in [predD B & A], forall t, P t -> 0 <= f t} ->
   \sum_(t <- A | P t) f t <= \sum_(t <- B | P t) f t.
 Proof.
 move=> AB f0; rewrite [X in _ <= X]big_mkcond (big_fsetID _ (mem A) B) /=.
@@ -831,7 +835,7 @@ exists (PosNum xy); apply/negP; rewrite -ltNge lte_fin -ltr_subr_addl.
 by rewrite ltr_pdivr_mulr // ltr_pmulr ?subr_gt0 // ltr1n.
 Qed.
 
-Lemma lte_spaddr (r : R) x y : 0%:E < y -> r%:E <= x -> r%:E < x + y.
+Lemma lte_spaddr (r : R) x y : 0 < y -> r%:E <= x -> r%:E < x + y.
 Proof.
 move: y x => [y| |] [x| |] //=; rewrite ?lte_fin ?ltt_fin ?lte_pinfty //.
 exact: ltr_spaddr.
@@ -1058,15 +1062,15 @@ case=> [x||].
     move=> P [x [xr xP]] //; exists (x + 1)%:E; apply xP => /=.
     by rewrite lte_fin ltr_addl.
   split=> /= [|P Q [MP [MPr gtMP]] [MQ [MQr gtMQ]] |P Q sPQ [M [Mr gtM]]].
-  + by exists 0; rewrite real0.
-  + have [/eqP MP0|MP0] := boolP (MP == 0).
-      have [/eqP MQ0|MQ0] := boolP (MQ == 0).
-        by exists 0; rewrite real0; split => // x x0; split;
+  + by exists 0%R; rewrite real0.
+  + have [/eqP MP0|MP0] := boolP (MP == 0%R).
+      have [/eqP MQ0|MQ0] := boolP (MQ == 0%R).
+        by exists 0%R; rewrite real0; split => // x x0; split;
         [apply/gtMP; rewrite MP0 | apply/gtMQ; rewrite MQ0].
       exists `|MQ|%R; rewrite realE normr_ge0; split => // x Hx; split.
         by apply gtMP; rewrite (le_lt_trans _ Hx) // MP0 lee_fin.
       by apply gtMQ; rewrite (le_lt_trans _ Hx) // lee_fin real_ler_normr // lexx.
-    have [/eqP MQ0|MQ0] := boolP (MQ == 0).
+    have [/eqP MQ0|MQ0] := boolP (MQ == 0%R).
       exists `|MP|%R; rewrite realE normr_ge0; split => // x MPx; split.
       by apply gtMP; rewrite (le_lt_trans _ MPx) // lee_fin real_ler_normr // lexx.
       by apply gtMQ; rewrite (le_lt_trans _ MPx) // lee_fin MQ0.
@@ -1084,16 +1088,16 @@ case=> [x||].
   + move=> P [M [Mr ltMP]]; exists (M - 1)%:E.
     by apply: ltMP; rewrite lte_fin gtr_addl oppr_lt0.
   + split=> /= [|P Q [MP [MPr ltMP]] [MQ [MQr ltMQ]] |P Q sPQ [M [Mr ltM]]].
-    * by exists 0; rewrite real0.
-    * have [/eqP MP0|MP0] := boolP (MP == 0).
-        have [/eqP MQ0|MQ0] := boolP (MQ == 0).
-          by exists 0; rewrite real0; split => // x x0; split;
+    * by exists 0%R; rewrite real0.
+    * have [/eqP MP0|MP0] := boolP (MP == 0%R).
+        have [/eqP MQ0|MQ0] := boolP (MQ == 0%R).
+          by exists 0%R; rewrite real0; split => // x x0; split;
           [apply/ltMP; rewrite MP0 | apply/ltMQ; rewrite MQ0].
         exists (- `|MQ|)%R; rewrite realN realE normr_ge0; split => // x xMQ; split.
           by apply ltMP; rewrite (lt_le_trans xMQ) // lee_fin MP0 ler_oppl oppr0.
        apply ltMQ; rewrite (lt_le_trans xMQ) // lee_fin ler_oppl -normrN.
        by rewrite real_ler_normr ?realN // lexx.
-    * have [/eqP MQ0|MQ0] := boolP (MQ == 0).
+    * have [/eqP MQ0|MQ0] := boolP (MQ == 0%R).
         exists (- `|MP|)%R; rewrite realN realE normr_ge0; split => // x MPx; split.
           apply ltMP; rewrite (lt_le_trans MPx) // lee_fin ler_oppl -normrN.
           by rewrite real_ler_normr ?realN // lexx.
@@ -1157,7 +1161,7 @@ move: p => -[p| [M [Mreal MA]] | [M [Mreal MA]]] //=.
 - exists (M + 1)%R; split; first by rewrite realD // real1.
   move=> -[x| _ |] //=.
     rewrite lte_fin => M'x /=.
-    apply/nbhs_ballP; exists 1 => //= y x1y.
+    apply/nbhs_ballP; exists 1%R => //= y x1y.
     apply MA; rewrite lte_fin.
     rewrite addrC -ltr_subr_addl in M'x.
     rewrite (lt_le_trans M'x) // ler_subl_addl addrC -ler_subl_addl.
@@ -1171,7 +1175,7 @@ move: p => -[p| [M [Mreal MA]] | [M [Mreal MA]]] //=.
 - exists (M - 1)%R; split; first by rewrite realB // real1.
   move=> -[x| _ |] //=.
     rewrite lte_fin => M'x /=.
-    apply/nbhs_ballP; exists 1 => //= y x1y.
+    apply/nbhs_ballP; exists 1%R => //= y x1y.
     apply MA; rewrite lte_fin.
     rewrite ltr_subr_addl in M'x.
     rewrite (le_lt_trans _ M'x) // addrC -ler_subl_addl.
@@ -1268,7 +1272,7 @@ Proof.
 by case: x => [x| |] /=; rewrite ?normrN1 ?normr1 // (ltW (contract_lt1 _)).
 Qed.
 
-Lemma contract0 : contract 0%:E = 0.
+Lemma contract0 : contract 0 = 0%R.
 Proof. by rewrite /contract mul0r. Qed.
 
 Lemma contractN x : contract (- x) = (- contract x)%R.
@@ -1305,7 +1309,7 @@ Proof.
 by rewrite ler_oppr => /expand1/eqP; rewrite expandN eqe_oppLR => /eqP.
 Qed.
 
-Lemma expand0 : expand 0 = 0%:E.
+Lemma expand0 : expand 0%R = 0.
 Proof. by rewrite /expand leNgt ltr01 /= oppr_ge0 leNgt ltr01 /= mul0r. Qed.
 
 Lemma expandK : {in [pred x | `|x| <= 1]%R, cancel expand contract}.
@@ -1343,7 +1347,7 @@ apply: le_mono; move=> -[r0 | | ] [r1 | _ | _] //=.
   rewrite mulrAC ltr_pdivl_mulr ?ltr_paddr// 2?mulrDr 2?mulr1.
   have [r10|?] := ler0P r1; last first.
     rewrite ltr_le_add // mulrC; have [r00|//] := ler0P r0.
-    by rewrite (@le_trans _ _ 0) // ?pmulr_lle0 // mulr_ge0 // ?oppr_ge0 // ltW.
+    by rewrite (@le_trans _ _ 0%R) // ?pmulr_lle0// mulr_ge0// ?oppr_ge0// ltW.
   have [?|r00] := ler0P r0; first by rewrite ltr_le_add // 2!mulrN mulrC.
   by move: (le_lt_trans r10 (lt_trans r00 r0r1)); rewrite ltxx.
 - by rewrite ltr_pdivr_mulr ?ltr_paddr// mul1r ltr_spaddl // ler_norm.
@@ -1389,7 +1393,7 @@ Definition lt_expandRL := monoRL_in
 Lemma le_expand : {homo expand : x y / (x <= y)%O}.
 Proof.
 move=> x y xy; have [x1|] := lerP `|x| 1.
-  have [y_le1|/ltW /expand1->] := leP y 1; last by rewrite lee_pinfty.
+  have [y_le1|/ltW /expand1->] := leP y 1%R; last by rewrite lee_pinfty.
   rewrite le_expand_in ?inE// ler_norml y_le1 (le_trans _ xy)//.
   by rewrite ler_oppl (ler_normlP _ _ _).
 rewrite ltr_normr => /orP[|] x1; last first.
@@ -1397,13 +1401,13 @@ rewrite ltr_normr => /orP[|] x1; last first.
 by rewrite expand1; [rewrite expand1 // (le_trans _ xy) // ltW | exact: ltW].
 Qed.
 
-Lemma contract_eq0 x : (contract x == 0) = (x == 0%:E).
+Lemma contract_eq0 x : (contract x == 0%R) = (x == 0).
 Proof. by rewrite -(can_eq contractK) contract0. Qed.
 
 Lemma contract_eqN1 x : (contract x == -1) = (x == -oo).
 Proof. by rewrite -(can_eq contractK). Qed.
 
-Lemma contract_eq1 x : (contract x == 1) = (x == +oo).
+Lemma contract_eq1 x : (contract x == 1%R) = (x == +oo).
 Proof. by rewrite -(can_eq contractK). Qed.
 
 Lemma expand_eqoo (r : R) : (expand r == +oo) = (1 <= r)%R.
@@ -1430,7 +1434,7 @@ case=> x Sx; rewrite ler_norml; apply/andP; split; last first.
 rewrite (@le_trans _ _ (contract x)) //.
   by case/ler_normlP : (contract_le1 x); rewrite ler_oppl.
 apply sup_ub; last by exists x.
-by exists 1 => r [y Sy <-]; case/ler_normlP : (contract_le1 y).
+by exists 1%R => r [y Sy <-]; case/ler_normlP : (contract_le1 y).
 Qed.
 
 Lemma contract_sup S : S !=set0 -> contract (ereal_sup S) = sup (contract @` S).
@@ -1453,7 +1457,7 @@ exists ((supc + csup) / 2); split; first by rewrite midf_lt.
 split => [r [y Sy <-{r}]|].
   rewrite (@le_trans _ _ supc) ?midf_le //; last by rewrite ltW.
   apply sup_ub; last by exists y.
-  by exists 1 => r [z Sz <-]; case/ler_normlP : (contract_le1 z).
+  by exists 1%R => r [z Sz <-]; case/ler_normlP : (contract_le1 z).
 rewrite ler_norml; apply/andP; split; last first.
   rewrite ler_pdivr_mulr // mul1r (_ : 2 = 1 + 1)%R // ler_add //.
   by case/ler_normlP : (sup_contract_le1 S0).
@@ -1608,7 +1612,7 @@ Lemma nbhs_oo_up_1e (A : set (\bar R)) (e : {posnum R}) : (1 < e%:num)%R ->
   ereal_ball +oo e%:num `<=` A -> nbhs +oo A.
 Proof.
 move=> e1 reA; have [e2{e1}|e2] := ltrP 2 e%:num.
-  suff -> : A = setT by exists 0; rewrite real0.
+  suff -> : A = setT by exists 0%R; rewrite real0.
   rewrite predeqE => x; split => // _; apply reA.
   exact/ereal_ballN/ereal_ball_ninfty_oversize.
 have /andP[e10 e11] : (0 < e%:num - 1 <= 1)%R.
@@ -1625,7 +1629,7 @@ Lemma nbhs_oo_down_1e (A : set (\bar R)) (e : {posnum R}) : (1 < e%:num)%R ->
   ereal_ball -oo e%:num `<=` A -> nbhs -oo A.
 Proof.
 move=> e1 reA; have [e2{e1}|e2] := ltrP 2 e%:num.
-  suff -> : A = setT by exists 0; rewrite real0.
+  suff -> : A = setT by exists 0%R; rewrite real0.
   rewrite predeqE => x; split => // _.
   exact/reA/ereal_ball_ninfty_oversize.
 have /andP[e10 e11] : (0 < e%:num - 1 <= 1)%R.
@@ -1692,7 +1696,7 @@ case: x => [r'| |] //.
   + by apply contract_ereal_ball_fin_lt => //; exact/ltW.
 - exact/contract_ereal_ball_pinfty.
 - apply/ereal_ballN/contract_ereal_ball_pinfty.
-  by rewrite NEFin contractN -(opprK 1) ltr_oppl opprD opprK.
+  by rewrite NEFin contractN -(opprK 1%R) ltr_oppl opprD opprK.
 Qed.
 
 Lemma nbhs_fin_inbound (r : R) (e : {posnum R}) (A : set (\bar R)) :
@@ -1705,7 +1709,7 @@ have [|reN1] := boolP (contract r%:E - e%:num == -1)%R.
     move/eqP : reN1; rewrite -(eqP re1) opprD addrCA subrr addr0 -subr_eq0.
     rewrite opprK -mulr2n mulrn_eq0 orFb contract_eq0 => /eqP[r0].
     move: re1; rewrite r0 contract0 add0r => /eqP e1.
-    apply/nbhs_ballP; exists 1 => // r' /=; rewrite /ball /= sub0r normrN => r'1.
+    apply/nbhs_ballP; exists 1%R => // r'; rewrite /ball /= sub0r normrN => r'1.
     apply reA.
     by rewrite /ereal_ball r0 contract0 sub0r normrN e1 contract_lt1.
   rewrite neq_lt => /orP[re1|re1].
@@ -1724,7 +1728,7 @@ have [|reN1] := boolP (contract r%:E - e%:num == -1)%R.
       rewrite -lte_fin -(contractK r%:E) -(contractK r'%:E).
       by rewrite lt_expand // inE; exact: contract_le1.
     exact: contract_ereal_ball_pinfty.
-  have : nbhs r%:E (setT `\ -oo) by apply/nbhs_ballP; exists 1.
+  have : nbhs r%:E (setT `\ -oo) by apply/nbhs_ballP; exists 1%R.
   move=> /nbhs_ballP[_/posnumP[e']] /=; rewrite /ball /= => h.
   by apply/nbhs_ballP; exists e'%:num => // y /h; apply: Aoo.
 move: reN1; rewrite eq_sym neq_lt => /orP[reN1|reN1].
@@ -1733,7 +1737,7 @@ move: reN1; rewrite eq_sym neq_lt => /orP[reN1|reN1].
   move: re1; rewrite neq_lt => /orP[re1|re1].
     have ? : (`|contract r%:E - e%:num| < 1)%R.
       rewrite ltr_norml reN1 andTb ltr_subl_addl.
-      rewrite (@lt_le_trans _ _ 1) // ?ler_addr //.
+      rewrite (@lt_le_trans _ _ 1%R) // ?ler_addr//.
       by case/ltr_normlP : (contract_lt1 r).
     have ? : (`|contract r%:E + e%:num| < 1)%R.
       rewrite ltr_norml re1 andbT -(addr0 (-1)) ler_lt_add //.
@@ -1783,7 +1787,7 @@ move: re1; rewrite le_eqVlt => /orP[re1|re1].
       rewrite -ltr_subl_addl add0r ltr_oppl.
       by move: (contract_lt1 r); rewrite ltr_norml => /andP[].
     by rewrite re1 addrAC ltr_subl_addl ltr_add.
-   have : nbhs r%:E (setT `\ +oo) by exists 1.
+   have : nbhs r%:E (setT `\ +oo) by exists 1%R.
    case => _/posnumP[x] /=; rewrite /ball_ => h.
    by exists x%:num => // y /h; exact: Aoo.
 by apply (@nbhs_fin_out_below _ e) => //; rewrite ltW.
@@ -1813,16 +1817,14 @@ rewrite predeq2E => x A; split.
           rewrite /e' ltr_subr_addl addrC -ltr_subr_addl in Hr'1.
           by rewrite (lt_le_trans Hr'1) // opprB addrCA subrr addr0.
         have := H1; rewrite -lt_expandRL ?inE ?contract_le1 //.
-        rewrite !contractK => rer'.
-        rewrite lte_fin ltr_subl_addr addrC -ltr_subl_addr in rer'.
-        rewrite rer' /= andbT (@lt_le_trans _ _ 0) //.
-          by rewrite ltr_oppl oppr0.
+        rewrite !contractK lte_fin ltr_subl_addr addrC -ltr_subl_addr => ->.
+        rewrite andbT (@lt_le_trans _ _ 0%R)// 1?ltr_oppl 1?oppr0//.
         by rewrite subr_ge0 -lee_fin -le_contract.
       apply reA.
       rewrite /ball /= real_ltr_norml // ?num_real //.
       rewrite ltr0_norm ?subr_lt0// opprB in re'r'.
       apply/andP; split; last first.
-        by rewrite (@lt_trans _ _ 0) // subr_lt0 -lte_fin -lt_contract//.
+        by rewrite (@lt_trans _ _ 0%R) // subr_lt0 -lte_fin -lt_contract.
       rewrite ltr_oppl opprB.
       rewrite /e' in re'r'.
       have H2 : (contract r'%:E < contract (r%:E + e%:num%:E))%R.
@@ -1939,7 +1941,7 @@ move=> [:wlog]; case: a b => [a||] [b||] //= ltax ltxb.
   by exists d => y /dP /andP[->] /= /lt_le_trans; apply; rewrite lee_pinfty.
 - have [//||d dP] := wlog (x - 1)%R b; rewrite ?lte_fin ?gtr_addl ?ltrN10 //.
   by exists d => y /dP /andP[_ ->] /=; rewrite lte_ninfty.
-- by exists 1%:pos => ? ?; rewrite lte_ninfty lte_pinfty.
+- by exists 1%R%:pos => ? ?; rewrite lte_ninfty lte_pinfty.
 Qed.
 
 (* TODO: generalize to numFieldType? *)
@@ -1978,13 +1980,13 @@ Lemma cvg_ereal_loc_seq (R : realType) (x : \bar R) :
 Proof.
 move=> P; rewrite /ereal_loc_seq.
 case: x => /= [x [_/posnumP[d] Hp] |[d [dreal Hp]] |[d [dreal Hp]]]; last 2 first.
-    have /ZnatP [N Nfloor] : floor (Num.max d 0) \is a Znat.
+    have /ZnatP [N Nfloor] : floor (Num.max d 0%R) \is a Znat.
       by rewrite Znat_def floor_ge0 le_maxr lexx orbC.
     exists N.+1 => // n ltNn; apply: Hp.
     have /le_lt_trans : (d <= Num.max d 0)%R by rewrite le_maxr lexx.
     apply; apply: lt_le_trans (lt_succ_Rfloor _) _; rewrite RfloorE Nfloor.
     by rewrite -(@natrD R N 1) ler_nat addn1.
-  have /ZnatP [N Nfloor] : floor (Num.max (- d)%R 0) \is a Znat.
+  have /ZnatP [N Nfloor] : floor (Num.max (- d)%R 0%R) \is a Znat.
     by rewrite Znat_def floor_ge0 le_maxr lexx orbC.
   exists N.+1 => // n ltNn; apply: Hp; rewrite lte_fin ltr_oppl.
   have /le_lt_trans : (- d <= Num.max (- d) 0)%R by rewrite le_maxr lexx.

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -268,7 +268,7 @@ Definition sigma_additive :=
   forall A, (forall i : nat, measurable (A i)) -> trivIset setT A ->
   (fun n => \sum_(i < n) mu (A i)) --> mu (\bigcup_n A n).
 
-Lemma semi_additive2P : mu set0 = 0%:E -> semi_additive <-> semi_additive2.
+Lemma semi_additive2P : mu set0 = 0 -> semi_additive <-> semi_additive2.
 Proof.
 move=> mu0; split => [amx A B mA mB mAB AB|a2mx A mA /trivIsetP ATI mbigA n].
   set C := bigcup2 A B.
@@ -309,7 +309,7 @@ rewrite propeqE; split=> [amu A B ? ? ?|amu A B ? ? _ ?]; last by rewrite amu.
 by rewrite amu //; exact: measurableU.
 Qed.
 
-Lemma additive2P : mu set0 = 0%:E -> additive mu <-> additive2 mu.
+Lemma additive2P : mu set0 = 0 -> additive mu <-> additive2 mu.
 Proof. by rewrite -semi_additive2E -semi_additiveE; exact/semi_additive2P. Qed.
 
 End additivity.
@@ -317,7 +317,7 @@ End additivity.
 Lemma semi_sigma_additive_is_additive
   (R : realFieldType (*TODO: numFieldType if possible?*))
   (X : semiRingOfSetsType) (mu : set X -> \bar R) :
-  mu set0 = 0%:E -> semi_sigma_additive mu -> semi_additive mu.
+  mu set0 = 0 -> semi_sigma_additive mu -> semi_additive mu.
 Proof.
 move=> mu0 samu; apply/semi_additive2P => // A B mA mB mAB AB_eq0.
 pose C := bigcup2 A B.
@@ -346,7 +346,7 @@ Qed.
 
 Lemma sigma_additive_is_additive
   (R : realFieldType) (X : measurableType) (mu : set X -> \bar R) :
-  mu set0 = 0%:E -> sigma_additive mu -> additive mu.
+  mu set0 = 0 -> sigma_additive mu -> additive mu.
 Proof.
 move=> mu0; rewrite -semi_sigma_additiveE -semi_additiveE.
 exact: semi_sigma_additive_is_additive.
@@ -358,8 +358,8 @@ Section ClassDef.
 
 Variables (R : numFieldType) (T : semiRingOfSetsType).
 Record axioms (mu : set T -> \bar R) := Axioms {
-  _ : mu set0 = 0%:E ;
-  _ : forall x, measurable x -> 0%:E <= mu x ;
+  _ : mu set0 = 0 ;
+  _ : forall x, measurable x -> 0 <= mu x ;
   _ : semi_additive2 mu }.
 
 Structure map (phUV : phant (set T -> \bar R)) :=
@@ -393,11 +393,11 @@ Section additive_measure_on_semiring_of_sets.
 Variables (R : realFieldType) (T : semiRingOfSetsType)
   (mu : {additive_measure set T -> \bar R}).
 
-Lemma measure0 : mu set0 = 0%:E.
+Lemma measure0 : mu set0 = 0.
 Proof. by case: mu => ? []. Qed.
 Hint Resolve measure0.
 
-Lemma measure_ge0 : forall x, measurable x -> 0%:E <= mu x.
+Lemma measure_ge0 : forall x, measurable x -> 0 <= mu x.
 Proof. by case: mu => ? []. Qed.
 Hint Resolve measure_ge0.
 
@@ -433,8 +433,8 @@ Section ClassDef.
 
 Variables (R : numFieldType) (T : semiRingOfSetsType).
 Record axioms (mu : set T -> \bar R) := Axioms {
-  _ : mu set0 = 0%:E ;
-  _ : forall x, measurable x -> 0%:E <= mu x ;
+  _ : mu set0 = 0 ;
+  _ : forall x, measurable x -> 0 <= mu x ;
   _ : semi_sigma_additive mu }.
 
 Structure map (phUV : phant (set T -> \bar R)) :=
@@ -484,7 +484,7 @@ Qed.
 
 End measure_lemmas.
 
-Hint Extern 0 (_ set0 = 0%:E) => solve [apply: measure0] : core.
+Hint Extern 0 (_ set0 = 0) => solve [apply: measure0] : core.
 Hint Extern 0 (sigma_additive _) =>
   solve [apply: measure_sigma_additive] : core.
 
@@ -693,12 +693,12 @@ Section negligible.
 Variables (R : realFieldType) (T : ringOfSetsType).
 
 Definition negligible (mu : set T -> \bar R) (N : set T) :=
-  exists A : set T, [/\ measurable A, mu A = 0%:E & N `<=` A].
+  exists A : set T, [/\ measurable A, mu A = 0 & N `<=` A].
 
 Local Notation "mu .-negligible" := (negligible mu).
 
 Lemma negligibleP (mu : {measure _ -> _}) A :
-  measurable A -> mu.-negligible A <-> mu A = 0%:E.
+  measurable A -> mu.-negligible A <-> mu A = 0.
 Proof.
 move=> mA; split => [[B [mB mB0 AB]]|mA0]; last by exists A; split.
 apply/eqP; rewrite eq_le measure_ge0 // andbT -mB0.
@@ -738,8 +738,8 @@ Section ClassDef.
 
 Variables (R : numFieldType) (T : Type).
 Record axioms (mu : set T -> \bar R) := Axioms {
-  _ : mu set0 = 0%:E ;
-  _ : forall x, 0%:E <= mu x ;
+  _ : mu set0 = 0 ;
+  _ : forall x, 0 <= mu x ;
   _ : {homo mu : A B / A `<=` B >-> A <= B} ;
   _ : sigma_subadditive mu }.
 
@@ -774,10 +774,10 @@ Section outer_measure_lemmas.
 Variables (R : numFieldType) (T : Type).
 Variable mu : {outer_measure set T -> \bar R}.
 
-Lemma outer_measure0 : mu set0 = 0%:E.
+Lemma outer_measure0 : mu set0 = 0.
 Proof. by case: mu => ? []. Qed.
 
-Lemma outer_measure_ge0 : forall x, 0%:E <= mu x.
+Lemma outer_measure_ge0 : forall x, 0 <= mu x.
 Proof. by case: mu => ? []. Qed.
 
 Lemma le_outer_measure : {homo mu : A B / A `<=` B >-> A <= B}.
@@ -788,7 +788,7 @@ Proof. by case: mu => ? []. Qed.
 
 End outer_measure_lemmas.
 
-Hint Extern 0 (_ set0 = 0%:E) => solve [apply: outer_measure0] : core.
+Hint Extern 0 (_ set0 = 0) => solve [apply: outer_measure0] : core.
 Hint Extern 0 (sigma_subadditive _) =>
   solve [apply: outer_measure_sigma_subadditive] : core.
 
@@ -833,7 +833,7 @@ Section caratheodory_theorem_sigma_algebra.
 
 Variables (R : realType) (T : Type) (mu : {outer_measure set T -> \bar R}).
 
-Lemma outer_measure_bigcup_lim (A : (set T) ^nat)  X :
+Lemma outer_measure_bigcup_lim (A : (set T) ^nat) X :
   mu (X `&` \bigcup_k A k) <= \sum_(k <oo) mu (X `&` A k).
 Proof.
 apply: (le_trans _ (outer_measure_sigma_subadditive mu (fun n => X `&` A n))).
@@ -861,7 +861,7 @@ have /(lee_add2r (mu (X `&` ~` (A `|` B)))) :
     by move=> [_ ?|[_ ?|//]]; [left|right].
   rewrite (le_trans (outer_measure_sigma_subadditive mu Z)) //.
   suff : ((fun n => \sum_(i < n) mu (Z i)) -->
-    mu (X `&` A) + mu (X `&` B `&` ~` A)).
+      mu (X `&` A) + mu (X `&` B `&` ~` A)).
     move/cvg_lim => /=; under [in X in X <= _]eq_fun do rewrite big_mkord.
     by move=> ->.
   rewrite -(cvg_shiftn 2) /=; set l := (X in _ --> X).
@@ -1022,10 +1022,10 @@ Section caratheodory_measure.
 Variables (R : realType) (T : Type) (mu : {outer_measure set T -> \bar R}).
 Local Notation U := (caratheodory_type mu).
 
-Lemma caratheodory_measure0 : mu (set0 : set U) = 0%:E.
+Lemma caratheodory_measure0 : mu (set0 : set U) = 0.
 Proof. exact: outer_measure0. Qed.
 
-Lemma caratheodory_measure_ge0 (A : set U) : measurable A -> 0%:E <= mu A.
+Lemma caratheodory_measure_ge0 (A : set U) : measurable A -> 0 <= mu A.
 Proof. by move=> mx; apply outer_measure_ge0. Qed.
 
 Lemma caratheodory_measure_sigma_additive : semi_sigma_additive (mu : set U -> _).
@@ -1033,7 +1033,7 @@ Proof.
 move=> A mA tA mbigcupA; set B := \bigcup_k A k.
 suff : forall X, mu X = \sum_(k <oo) mu (X `&` A k) + mu (X `&` ~` B).
   move/(_ B); rewrite setICr outer_measure0 adde0.
-  rewrite (_ : (fun n => _) = (fun n => \sum_(k < n) mu (A k))); last first.
+  rewrite (_ : (fun n => _) = fun n => \sum_(k < n) mu (A k)); last first.
     rewrite funeqE => n; rewrite big_mkord; apply eq_bigr => i _; congr (mu _).
     by rewrite setIC; apply/setIidPl => t Ait; exists i.
   move=> ->; have := fun n (_ : xpredT n) => outer_measure_ge0 mu (A n).
@@ -1055,9 +1055,9 @@ Definition caratheodory_measure : {measure set U -> \bar R} :=
 Lemma measure_is_complete_caratheodory : measure_is_complete caratheodory_measure.
 Proof.
 move=> B [A [mA muA0 BA]]; apply le_caratheodory_measurable => X.
-suff -> : mu (X `&` B) = 0%:E.
+suff -> : mu (X `&` B) = 0.
   by rewrite add0e le_outer_measure //; apply subIset; left.
-have muB0 : mu B = 0%:E.
+have muB0 : mu B = 0.
   apply/eqP; rewrite eq_le outer_measure_ge0 andbT.
   by apply: (le_trans (le_outer_measure mu BA)); rewrite -muA0.
 apply/eqP; rewrite eq_le outer_measure_ge0 andbT.

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -3620,11 +3620,11 @@ Qed.
 Lemma open_ereal_lt' x y : x < y -> ereal_nbhs x (fun u => u < y).
 Proof.
 case: x => [x|//|] xy; first exact: open_ereal_lt.
-- case: y => [y||//] /= in xy *; last by exists 0.
+- case: y => [y||//] /= in xy *; last by exists 0%R.
   by exists y; rewrite num_real; split => //= x ?.
 - case: y => [y||//] /= in xy *.
   + by exists y; rewrite num_real; split => //= x ?.
-  + exists 0; rewrite real0; split => // x.
+  + exists 0%R; rewrite real0; split => // x.
     by move/lt_le_trans; apply; rewrite lee_pinfty.
 Qed.
 
@@ -3633,7 +3633,7 @@ Proof.
 case: x => [x||] //=; do ?[exact: open_ereal_gt];
   case: y => [y||] //=; do ?by exists 0; rewrite real0.
 - by exists y; rewrite num_real.
-- move=> _; exists 0; rewrite real0; split => // x.
+- move=> _; exists 0%R; rewrite real0; split => // x.
   by apply/le_lt_trans; rewrite lee_ninfty.
 Qed.
 
@@ -3652,7 +3652,7 @@ rewrite predeqE => -[r | | ]/=.
 - rewrite lte_pinfty; split => // _.
   by exists (r + 1)%R => //=; rewrite lte_fin ltr_addl.
 - by rewrite ltxx; split => // -[] x /=; rewrite ltNge lee_pinfty.
-- by split => // _; exists 0 => //=; rewrite lte_ninfty.
+- by split => // _; exists 0%R => //=; rewrite lte_ninfty.
 Qed.
 
 Let open_ereal_gt_real r : open (fun x => r%:E < x).
@@ -3669,7 +3669,7 @@ suff -> : [set y | -oo < y] = \bigcup_r [set y : \bar R | r%:E < y].
 rewrite predeqE => -[r | | ]/=.
 - rewrite lte_ninfty; split => // _.
   by exists (r - 1)%R => //=; rewrite lte_fin ltr_subl_addr ltr_addl.
-- by split => // _; exists 0 => //=; rewrite lte_pinfty.
+- by split => // _; exists 0%R => //=; rewrite lte_pinfty.
 - by rewrite ltxx; split => // -[] x _ /=; rewrite ltNge lee_ninfty.
 Qed.
 

--- a/theories/sequences.v
+++ b/theories/sequences.v
@@ -821,7 +821,7 @@ exact: oppe_continuous.
 Qed.
 
 Lemma ereal_cvg_ge0 (R : realFieldType) (f : (\bar R)^nat) (a : \bar R) :
-  (forall n, 0%:E <= f n) -> f --> a -> 0%:E <= a.
+  (forall n, 0 <= f n) -> f --> a -> 0 <= a.
 Proof.
 move=> f0 /closed_cvg_loc V; elim/V : _; last exact: closed_ereal_le_ereal.
 by exists O => // ? _; exact: f0.
@@ -869,7 +869,7 @@ have [e1|e1] := lerP 1 e%:num.
   rewrite ltr_subl_addr addrC -ltr_subl_addr.
   have /le_lt_trans->// : (contract 1%:E < contract (u_ n)%:E)%R.
     by rewrite lt_contract lte_fin k1un//; near: n; exists k.
-  by rewrite (@le_trans _ _ 0) // ?subr_le0 //= normr1 divr_ge0.
+  by rewrite (@le_trans _ _ 0%R) // ?subr_le0 //= normr1 divr_ge0.
 have onee1 : (`|1 - e%:num| < 1)%R.
   by rewrite gtr0_norm // ?subr_gt0 // ltr_subl_addl addrC -ltr_subl_addl subrr.
 have : (0 < real_of_extended (expand (1 - e%:num)))%R.
@@ -960,7 +960,7 @@ have [/eqP {lnoo}loo|lpoo] := boolP (l == +oo).
       by rewrite ler_subl_addr (le_trans (ltW e2)).
     by rewrite ler_subl_addr ler_addl.
 have [r lr] : exists r, l = r%:E by move: l lnoo lpoo => [] // r' _ _; exists r'.
-have [re1|re1] := ltrP `|contract l - e%:num|%R 1; last first.
+have [re1|re1] := (ltrP (`|contract l - e%:num|) 1)%R; last first.
   rewrite near_map; near=> n; rewrite /ball /= /ereal_ball /=.
   have unoo : u_ n != -oo.
     near: n.
@@ -1004,12 +1004,12 @@ Grab Existential Variables. all: end_near. Qed.
 
 (* NB: see also nondecreasing_series *)
 Lemma ereal_nondecreasing_series (R : realDomainType) (u_ : (\bar R)^nat)
-  (P : pred nat) : (forall n, P n -> 0%:E <= u_ n) ->
+  (P : pred nat) : (forall n, P n -> 0 <= u_ n) ->
   nondecreasing_seq (fun n => \sum_(0 <= i < n | P i) u_ i).
 Proof. by move=> u_ge0 n m le_nm; rewrite lee_sum_nneg_natr// => k _ /u_ge0. Qed.
 
 Lemma ereal_nneg_series_lim_ge (R : realType) (u_ : (\bar R)^nat)
-  (P : pred nat) k : (forall n, P n -> 0%:E <= u_ n) ->
+  (P : pred nat) k : (forall n, P n -> 0 <= u_ n) ->
   \sum_(0 <= i < k | P i) u_ i <= \sum_(i <oo | P i) u_ i.
 Proof.
 move/ereal_nondecreasing_series/nondecreasing_seq_ereal_cvg/cvg_lim => -> //.
@@ -1017,7 +1017,7 @@ by apply: ereal_sup_ub; exists k.
 Qed.
 
 Lemma is_cvg_ereal_nneg_natsum_cond (R : realType) m (u_ : (\bar R)^nat)
-  (P : pred nat) : (forall n, (m <= n)%N -> P n -> 0%:E <= u_ n) ->
+  (P : pred nat) : (forall n, (m <= n)%N -> P n -> 0 <= u_ n) ->
   cvg (fun n => \sum_(m <= i < n | P i) u_ i).
 Proof.
 move/lee_sum_nneg_natr/nondecreasing_seq_ereal_cvg => cu.
@@ -1025,31 +1025,31 @@ by apply/cvg_ex; eexists; exact: cu.
 Qed.
 
 Lemma is_cvg_ereal_nneg_series_cond (R : realType) (u_ : (\bar R)^nat)
-  (P : pred nat) : (forall n, P n -> 0%:E <= u_ n) ->
+  (P : pred nat) : (forall n, P n -> 0 <= u_ n) ->
   cvg (fun n => \sum_(0 <= i < n | P i) u_ i).
 Proof. by move=> u_ge0; apply: is_cvg_ereal_nneg_natsum_cond => n _ /u_ge0. Qed.
 
 Lemma is_cvg_ereal_nneg_natsum (R : realType) m (u_ : (\bar R)^nat)
-  (P : pred nat) : (forall n, (m <= n)%N -> 0%:E <= u_ n) ->
+  (P : pred nat) : (forall n, (m <= n)%N -> 0 <= u_ n) ->
   cvg (fun n => \sum_(m <= i < n) u_ i).
 Proof. by move=> u_ge0; apply: is_cvg_ereal_nneg_natsum_cond => n /u_ge0. Qed.
 
 Lemma is_cvg_ereal_nneg_series (R : realType) (u_ : (\bar R)^nat)
-  (P : pred nat) : (forall n, P n -> 0%:E <= u_ n) ->
+  (P : pred nat) : (forall n, P n -> 0 <= u_ n) ->
   cvg (fun n => \sum_(0 <= i < n | P i) u_ i).
 Proof. by move=> ?; exact: is_cvg_ereal_nneg_series_cond. Qed.
 Arguments is_cvg_ereal_nneg_series {R}.
 
 Lemma ereal_nneg_series_lim_ge0 (R : realType) (u_ : (\bar R)^nat)
-  (P : pred nat) : (forall n, P n -> 0%:E <= u_ n) ->
-  0%:E <= \sum_(i <oo | P i) u_ i.
+  (P : pred nat) : (forall n, P n -> 0 <= u_ n) ->
+  0 <= \sum_(i <oo | P i) u_ i.
 Proof.
 move=> u0; apply: (ereal_lim_ge (is_cvg_ereal_nneg_series _ _ u0)).
 by near=> k; rewrite sume_ge0 // => i; apply: u0.
 Grab Existential Variables. all: end_near. Qed.
 
 Lemma ereal_nneg_series_pinfty (R : realType) (u_ : (\bar R)^nat)
-  (P : pred nat) k : (forall n, P n -> 0%:E <= u_ n) -> P k ->
+  (P : pred nat) k : (forall n, P n -> 0 <= u_ n) -> P k ->
   u_ k = +oo -> \sum_(i <oo | P i) u_ i = +oo.
 Proof.
 move=> u0 Pk ukoo; apply/eqP; rewrite eq_le lee_pinfty /=.
@@ -1061,27 +1061,27 @@ by move=> /eqP; case: ifPn => // /u0 + uioo; rewrite uioo.
 Qed.
 
 Lemma ereal_cvgPpinfty (R : realFieldType) (u_ : (\bar R)^nat) :
-  u_ --> +oo <-> (forall A : R, (0 < A)%R -> \forall n \near \oo, A%:E <= u_ n).
+  u_ --> +oo <-> (forall A, (0 < A)%R -> \forall n \near \oo, A%:E <= u_ n).
 Proof.
 split => [u_cvg _/posnumP[A]|u_ge X [A [Ar AX]]].
   rewrite -(near_map u_ \oo (fun x => A%:num%:E <= x)).
   by apply: u_cvg; apply: ereal_nbhs_pinfty_ge.
 rewrite !near_simpl [\near u_, X _](near_map u_ \oo); near=> x.
 apply: AX.
-rewrite (@lt_le_trans _ _ (maxr 0 A + 1)%R%:E) //.
+rewrite (@lt_le_trans _ _ (maxr 0 A + 1)%:E) //.
   by rewrite addEFin lte_spaddr // ?lte_fin// lee_fin le_maxr lexx orbT.
 by near: x; apply: u_ge; rewrite ltr_spaddr // le_maxr lexx.
 Grab Existential Variables. all: end_near. Qed.
 
 Lemma ereal_cvgPninfty (R : realFieldType) (u_ : (\bar R)^nat) :
-  u_ --> -oo <-> (forall A : R, (A < 0)%R -> \forall n \near \oo, u_ n <= A%:E).
+  u_ --> -oo <-> (forall A, (A < 0)%R -> \forall n \near \oo, u_ n <= A%:E).
 Proof.
 split => [u_cvg A A0|u_le X [A [Ar AX]]].
   rewrite -(near_map u_ \oo (fun x => x <= A%:E)).
   by apply: u_cvg; apply: ereal_nbhs_ninfty_le.
 rewrite !near_simpl [\near u_, X _](near_map u_ \oo); near=> x.
 apply: AX.
-rewrite (@le_lt_trans _ _ (minr 0 A - 1)%R%:E) //.
+rewrite (@le_lt_trans _ _ (minr 0 A - 1)%:E) //.
   by near: x; apply: u_le; rewrite ltr_subl_addl addr0 lt_minl ltr01.
 by rewrite lte_fin ltr_subl_addl lt_minl ltr_addr ltr01 orbT.
 Grab Existential Variables. all: end_near. Qed.
@@ -1109,8 +1109,8 @@ case: l k => [l| |] [k| |] // in lu kv *.
   have /ereal_cvgPninfty voo : v_ --> -oo by rewrite -kv.
   have /cvg_has_inf[uT0 [M uTM]] : cvg (real_of_extended \o u_ ).
     by apply/cvg_ex; exists l.
-  have {}/voo[n1 _ vM] : (minr (M - 1) (-1) < 0)%R.
-     by rewrite lt_minl ltrN10 orbT.
+  have {}/voo [n1 _ vM] : (minr (M - 1) (-1) < 0)%R.
+    by rewrite lt_minl ltrN10 orbT.
   move: uv realu => [n2 _ uv] [n3 _ realu].
   near \oo => n.
   have : (n >= maxn n1 (maxn n2 n3))%N by near: n; exists (maxn n1 (maxn n2 n3)).
@@ -1145,7 +1145,7 @@ case: l k => [l| |] [k| |] // in lu kv *.
   have : (n >= maxn n1 (maxn n2 n3))%N by near: n; exists (maxn n1 (maxn n2 n3)).
   rewrite 2!geq_max => /and3P[n1n n2n n3n].
   suff : v_ n < u_ n by apply/negP; rewrite -leNgt; apply uv.
-  rewrite (@lt_trans _ _ 0%:E) //.
+  rewrite (@lt_trans _ _ 0) //.
     by rewrite (le_lt_trans (voo _ n3n)) // lte_fin ltrN10.
   by rewrite (lt_le_trans _ (uoo _ n2n)) // lte_fin ltr01.
 - by rewrite lee_ninfty.
@@ -1249,20 +1249,21 @@ Lemma ereal_limD (R : realType) (f g : (\bar R)^nat) :
 Proof. by move=> cf cg fg; apply/cvg_lim => //; exact: ereal_cvgD. Qed.
 
 Lemma ereal_pseriesD (R : realType) (f g : nat -> \bar R) (P : pred nat) :
-  (forall i, P i -> 0%:E <= f i)%E ->
-  (forall i, P i -> 0%:E <= g i)%E ->
-  (\sum_(i <oo | P i) (f i + g i) = (\sum_(i <oo | P i) f i) + (\sum_(i <oo | P i) g i))%E.
+  (forall i, P i -> 0 <= f i) -> (forall i, P i -> 0 <= g i) ->
+  \sum_(i <oo | P i) (f i + g i) =
+  \sum_(i <oo | P i) f i + \sum_(i <oo | P i) g i.
 Proof.
 move=> f_eq0 g_eq0.
-transitivity (lim (fun n => \sum_(0 <= i < n | P i) f i + \sum_(0 <= i < n | P i) g i)%E).
+transitivity (lim (fun n => \sum_(0 <= i < n | P i) f i +
+                         \sum_(0 <= i < n | P i) g i)).
   by congr (lim _); apply/funext => n; rewrite big_split.
 rewrite ereal_limD /adde_undef//=; do ? exact: is_cvg_ereal_nneg_series.
-by rewrite ![_ == -oo]gt_eqF ?andbF// (@lt_le_trans _ _ 0%:E)
-           ?[(_ < _)%E]real0// ereal_nneg_series_lim_ge0.
+by rewrite ![_ == -oo]gt_eqF ?andbF// (@lt_le_trans _ _ 0)
+           ?[_ < _]real0// ereal_nneg_series_lim_ge0.
 Qed.
 
 Lemma ereal_pseries0 (R : realType) (f : (\bar R)^nat) :
-  (forall i, f i = 0%:E) -> \sum_(i <oo) f i = 0%:E.
+  (forall i, f i = 0) -> \sum_(i <oo) f i = 0.
 Proof. by move=> f0; under eq_fun do rewrite big1//; rewrite lim_cst. Qed.
 
 Lemma eq_ereal_pseries (R : realType) (f g : (\bar R)^nat) :
@@ -1272,7 +1273,7 @@ by move=> efg; congr (lim _); apply/funext => n; under eq_bigr do rewrite efg.
 Qed.
 
 Lemma ereal_pseries_sum_nat (R : realType) n (f : nat -> nat -> \bar R) :
-  (forall i j, 0%:E <= f i j) ->
+  (forall i j, 0 <= f i j) ->
   \sum_(j <oo) (\sum_(0 <= i < n) f i j) =
   \sum_(0 <= i < n) (\sum_(j <oo) (f i j)).
 Proof.
@@ -1288,7 +1289,7 @@ Lemma lte_lim (R : realFieldType) (u : (\bar R)^nat) (M : R) :
   \forall n \near \oo, M%:E <= u n.
 Proof.
 move=> ndu cu Ml; have [[n Mun]|] := pselect (exists n, M%:E <= u n).
-  near=> m; suff : (u n <= u m)%E by exact: le_trans.
+  near=> m; suff : u n <= u m by exact: le_trans.
   by near: m; exists n.+1 => // p q; apply/ndu/ltnW.
 move/forallNP => Mu.
 have {}Mu : forall x, M%:E > u x by move=> x; rewrite ltNge; apply/negP.


### PR DESCRIPTION
- to reduce nested `%E`/`%R` in `integral_sketch` in particular