### PR TITLE
Fix level of notations like %:pos

### DIFF
--- a/theories/nngnum.v
+++ b/theories/nngnum.v
@@ -34,8 +34,8 @@ Local Open Scope ring_scope.
 Import Order.TTheory GRing.Theory Num.Theory.
 
 Reserved Notation "'{nonneg' R }" (at level 0, format "'{nonneg'  R }").
-Reserved Notation "x %:nng" (at level 0, format "x %:nng").
-Reserved Notation "x %:nngnum" (at level 0, format "x %:nngnum").
+Reserved Notation "x %:nng" (at level 2, left associativity, format "x %:nng").
+Reserved Notation "x %:nngnum" (at level 2, left associativity, format "x %:nngnum").
 Module Nonneg.
 Section nonnegative_numbers.
 

--- a/theories/posnum.v
+++ b/theories/posnum.v
@@ -31,8 +31,8 @@ Require Import boolp nngnum.
 (******************************************************************************)
 
 Reserved Notation "'{posnum' R }" (at level 0, format "'{posnum'  R }").
-Reserved Notation "x %:pos" (at level 0, format "x %:pos").
-Reserved Notation "x %:num" (at level 0, format "x %:num").
+Reserved Notation "x %:pos" (at level 2, left associativity, format "x %:pos").
+Reserved Notation "x %:num" (at level 2, left associativity, format "x %:num").
 Reserved Notation "[gt0 'of' x ]" (format "[gt0 'of'  x ]").
 
 Set Implicit Arguments.


### PR DESCRIPTION
Print 0%:pos or x%:pos instead of (0)%:pos or (x)%:pos.
This takes inspiration from %:R and the likes in MathComp.