### PR TITLE
add choice_of_Type definition

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -10,6 +10,8 @@
     `is_cvg_seriesB`, `lim_seriesB`, `lim_series_le`, `lim_series_norm`
 - in `classical_sets.v`:
   + lemmas `bigcup_image`, `bigcup_of_set1`
+- in `boolp.v`:
+  + definitions `equality_mixin_of_Type`, `choice_of_Type`
 
 ### Changed
 

--- a/theories/boolp.v
+++ b/theories/boolp.v
@@ -238,6 +238,12 @@ Proof. by case: asboolP. Qed.
 Lemma asboolF (P : Prop) : ~ P -> `[<P>] = false.
 Proof. by apply/introF/asboolP. Qed.
 
+Definition equality_mixin_of_Type (T : Type) : Equality.mixin_of T :=
+  EqMixin (fun x y : T => asboolP (x = y)).
+
+Definition choice_of_Type (T : Type) : choiceType :=
+  Choice.Pack (Choice.Class (equality_mixin_of_Type T) gen_choiceMixin).
+
 Lemma is_true_inj : injective is_true.
 Proof. by move=> [] []; rewrite ?(trueE, falseE) ?propeqE; tauto. Qed.
 


### PR DESCRIPTION
We have been using this definition in `infotheo` (https://github.com/affeldt-aist/infotheo/blob/master/probability/convex.v#L1094-L1103) and in `monae` (https://github.com/affeldt-aist/monae/blob/master/monad_model.v) and believe that it is of more general interest. @CohenCyril 