### PR TITLE
Change the definition of is_interval to rely on large inequalities

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -11,6 +11,24 @@
   + lemmas `trivIset_seqDU`, `bigsetU_seqDU`, `seqDU_bigcup_eq`, `seqDUE`
 - in `ereal.v`:
   + notation `x +? y` for `adde_def x y`
+  + HB.mixin `AlgebraOfSets_from_RingOfSets`
+  + HB.structure `AlgebraOfSets` and notation `algebraOfSetsType`
+  + HB.instance `T_isAlgebraOfSets` in HB.builders `isAlgebraOfSets`
+  + lemma `bigcup_set_cond`
+- in `classical_sets.v`:
+  + lemmas `bigcupD1`, `bigcapD1`
+- in `normedtypes.v`:
+  + lemma `is_intervalPlt`
+
+### Changed
+
+- in `measure.v`:
+  + generalize lemma `eq_bigcupB_of`
+- in `ereal.v`, definition `adde_undef` changed to `adde_def`
+  + consequently, the following lemmas changed:
+    * in `ereal.v`, `adde_undefC` renamed to `adde_defC`,
+      `fin_num_adde_undef` renamed to `fin_num_adde_def`
+    * in `sequences.v`, `ereal_cvgD` and `ereal_limD` now use hypotheses with `adde_def`
 - in `sequences.v`:
   + lemmas `lt_lim`, `nondecreasing_dvg_lt`, `ereal_lim_sum`
 - in `ereal.v`:
@@ -45,6 +63,9 @@
 - in `normedtype.v`:
   + lemmas `ereal_is_cvgN`, `ereal_cvgZr`, `ereal_is_cvgZr`, `ereal_cvgZl`, `ereal_is_cvgZl`,
     `ereal_limZr`, `ereal_limZl`, `ereal_limN`
+  + lemma `cvg_bounded_real`
+  + lemma `pseudoMetricNormedZModType_hausdorff`
+  + definition `is_interval`
 
 ### Changed
 
@@ -119,6 +140,9 @@
       `bigmaxr_ltrP`, `bigmaxr_gerP`, `bigmaxr_gtrP`
 - in `sequences.v`:
   + lemma `closed_seq`
+
+- in `normedtype.v`:
+  + lemma `is_intervalPle`
 
 ### Infrastructure
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -11,24 +11,8 @@
   + lemmas `trivIset_seqDU`, `bigsetU_seqDU`, `seqDU_bigcup_eq`, `seqDUE`
 - in `ereal.v`:
   + notation `x +? y` for `adde_def x y`
-  + HB.mixin `AlgebraOfSets_from_RingOfSets`
-  + HB.structure `AlgebraOfSets` and notation `algebraOfSetsType`
-  + HB.instance `T_isAlgebraOfSets` in HB.builders `isAlgebraOfSets`
-  + lemma `bigcup_set_cond`
-- in `classical_sets.v`:
-  + lemmas `bigcupD1`, `bigcapD1`
 - in `normedtypes.v`:
   + lemma `is_intervalPlt`
-
-### Changed
-
-- in `measure.v`:
-  + generalize lemma `eq_bigcupB_of`
-- in `ereal.v`, definition `adde_undef` changed to `adde_def`
-  + consequently, the following lemmas changed:
-    * in `ereal.v`, `adde_undefC` renamed to `adde_defC`,
-      `fin_num_adde_undef` renamed to `fin_num_adde_def`
-    * in `sequences.v`, `ereal_cvgD` and `ereal_limD` now use hypotheses with `adde_def`
 - in `sequences.v`:
   + lemmas `lt_lim`, `nondecreasing_dvg_lt`, `ereal_lim_sum`
 - in `ereal.v`:
@@ -63,9 +47,6 @@
 - in `normedtype.v`:
   + lemmas `ereal_is_cvgN`, `ereal_cvgZr`, `ereal_is_cvgZr`, `ereal_cvgZl`, `ereal_is_cvgZl`,
     `ereal_limZr`, `ereal_limZl`, `ereal_limN`
-  + lemma `cvg_bounded_real`
-  + lemma `pseudoMetricNormedZModType_hausdorff`
-  + definition `is_interval`
 
 ### Changed
 
@@ -93,6 +74,8 @@
   + replace `closed_cvg_loc` and `closed_cvg` by a more general lemma `closed_cvg`
 - move from `sequences.v` to `normedtype.v` and generalize from `nat` to `T : topologicalType`
   + lemmas `ereal_cvgN`
+- in `normedtype.v`:
+  + definition `is_interval`
 
 ### Renamed
 - in `classical_sets.v`:
@@ -140,7 +123,6 @@
       `bigmaxr_ltrP`, `bigmaxr_gerP`, `bigmaxr_gtrP`
 - in `sequences.v`:
   + lemma `closed_seq`
-
 - in `normedtype.v`:
   + lemma `is_intervalPle`
 

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -2934,9 +2934,9 @@ Lemma is_intervalPlt (E : set R) :
   is_interval E <-> forall x y, E x -> E y -> forall z, x < z < y -> E z.
 Proof.
 split=> iE x y Ex Ey z /andP[].
-  by move=> xz zy; apply (iE _ _ Ex Ey); rewrite (ltW xz) (ltW zy).
-rewrite le_eqVlt => /orP[/eqP <-//|xz]; rewrite le_eqVlt => /orP[/eqP ->//|?].
-by apply (iE _ _ Ex Ey); rewrite xz.
+  by move=> xz zy; apply: (iE x y); rewrite ?ltW.
+rewrite !le_eqVlt => /predU1P[<-//|xz] /predU1P[->//|zy].
+by apply: (iE x y); rewrite ?xz.
 Qed.
 
 Lemma interval_is_interval (i : interval R) : is_interval [set x | x \in i].
@@ -2987,7 +2987,7 @@ Proof.
 move=> iX lX uX; rewrite predeqE => x; split => // _.
 move/has_lbPn : lX => /(_ x) [y Xy xy].
 move/has_ubPn : uX => /(_ x) [z Xz xz].
-by apply: (iX _ _ Xy Xz); rewrite (ltW xy) (ltW xz).
+by apply: (iX y z); rewrite ?ltW.
 Qed.
 
 Lemma interval_left_unbounded_interior (X : set R) : is_interval X ->
@@ -2998,8 +2998,7 @@ rewrite -(open_subsetE _ (@open_lt _ _)) => r rsupX.
 move/has_lbPn : lX => /(_ r)[y Xy yr].
 have hsX : has_sup X by split => //; exists y.
 have /(sup_adherent hsX)[e Xe] : 0 < sup X - r by rewrite subr_gt0.
-rewrite opprB addrCA subrr addr0 => re; apply (iX _ _ Xy Xe).
-by rewrite (ltW yr) (ltW re).
+by rewrite opprB addrCA subrr addr0 => re; apply: (iX y e); rewrite ?ltW.
 Qed.
 
 Lemma interval_right_unbounded_interior (X : set R) : is_interval X ->
@@ -3010,8 +3009,7 @@ rewrite -(open_subsetE _ (@open_gt _ _)) => r infXr.
 move/has_ubPn : uX => /(_ r)[y Xy yr].
 have hiX : has_inf X by split => //; exists y.
 have /(inf_adherent hiX)[e Xe] : 0 < r - inf X by rewrite subr_gt0.
-rewrite addrCA subrr addr0 => er; apply: (iX _ _ Xe Xy).
-by rewrite (ltW yr) (ltW er).
+by rewrite addrCA subrr addr0 => er; apply: (iX e y); rewrite ?ltW.
 Qed.
 
 Lemma interval_bounded_interior (X : set R) : is_interval X ->
@@ -3029,8 +3027,7 @@ have /(inf_adherent hiX)[e Xe] : 0 < r - inf X by rewrite subr_gt0.
 rewrite addrCA subrr addr0 => er.
 have hsX : has_sup X by split.
 have /(sup_adherent hsX)[f Xf] : 0 < sup X - r by rewrite subr_gt0.
-rewrite opprB addrCA subrr addr0 => rf; apply: (iX _ _ Xe Xf).
-by rewrite (ltW er) (ltW rf).
+by rewrite opprB addrCA subrr addr0 => rf; apply: (iX e f); rewrite ?ltW.
 Qed.
 
 Definition Rhull (X : set R) : interval R := Interval
@@ -3098,7 +3095,7 @@ split => [cE x y Ex Ey z /andP[xz zy]|].
   pose Az := E `&` [set x | x < z]; pose Bz := E `&` [set x | z < x].
   apply/connectedPn : cE; exists (fun b => if b then Az else Bz); split.
   + move: xz zy Ez.
-    rewrite !le_eqVlt => /orP [/eqP <- // | xz] /orP[/eqP -> // | zy] Ez.
+    rewrite !le_eqVlt => /predU1P[<-//|xz] /predU1P[->//|zy] Ez.
     by case; [exists x | exists y].
   + rewrite /Az /Bz -setIUr; apply/esym/setIidPl => u Eu.
     by apply/orP; rewrite -neq_lt; apply/negP; apply: contraPnot Eu => /eqP <-.
@@ -3155,7 +3152,7 @@ split => [cE x y Ex Ey z /andP[xz zy]|].
   have nA0z1 : ~ (A false) z1.
     move=> A0z1; have : z < z1 by rewrite /z1 ltr_addl.
     apply/negP; rewrite -leNgt.
-     apply sup_ub; first by exists y => u [_] /andP[].
+     apply: sup_ub; first by exists y => u [_] /andP[].
     by split => //; rewrite /mkset /z1 (le_trans xz) /= ?ler_addl // (ltW z1y).
   by rewrite EU => -[//|]; apply: contra_not ncA1z1; exact: subset_closure.
 Qed.

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -2928,22 +2928,22 @@ Section interval.
 Variable R : numDomainType.
 
 Definition is_interval (E : set R) :=
-  forall x y, E x -> E y -> forall z, x < z < y -> E z.
+  forall x y, E x -> E y -> forall z, x <= z <= y -> E z.
 
-Lemma is_intervalPle (E : set R) :
-  is_interval E <-> forall x y, E x -> E y -> forall z, x <= z <= y -> E z.
+Lemma is_intervalPlt (E : set R) :
+  is_interval E <-> forall x y, E x -> E y -> forall z, x < z < y -> E z.
 Proof.
 split=> iE x y Ex Ey z /andP[].
-  rewrite le_eqVlt => /orP[/eqP <-//|xz]; rewrite le_eqVlt => /orP[/eqP ->//|?].
-  by apply (iE _ _ Ex Ey); rewrite xz.
-by move=> xz zy; apply (iE _ _ Ex Ey); rewrite (ltW xz) (ltW zy).
+  by move=> xz zy; apply (iE _ _ Ex Ey); rewrite (ltW xz) (ltW zy).
+rewrite le_eqVlt => /orP[/eqP <-//|xz]; rewrite le_eqVlt => /orP[/eqP ->//|?].
+by apply (iE _ _ Ex Ey); rewrite xz.
 Qed.
 
 Lemma interval_is_interval (i : interval R) : is_interval [set x | x \in i].
 Proof.
 by case: i => -[[]a|[]] [[]b|[]] // x y /=; do ?[by rewrite ?itv_ge//];
-   move=> xi yi z; rewrite -[x < z < y]/(z \in `]x, y[); apply/subitvP;
-   rewrite subitvE /Order.le/= ?(itvP xi, itvP yi).
+  move=> xi yi z; rewrite -[x <= z <= y]/(z \in `[x, y]); apply/subitvP;
+  rewrite subitvE /Order.le/= ?(itvP xi, itvP yi).
 Qed.
 
 End interval.
@@ -2987,7 +2987,7 @@ Proof.
 move=> iX lX uX; rewrite predeqE => x; split => // _.
 move/has_lbPn : lX => /(_ x) [y Xy xy].
 move/has_ubPn : uX => /(_ x) [z Xz xz].
-by apply: (iX _ _ Xy Xz); rewrite xy xz.
+by apply: (iX _ _ Xy Xz); rewrite (ltW xy) (ltW xz).
 Qed.
 
 Lemma interval_left_unbounded_interior (X : set R) : is_interval X ->
@@ -2998,7 +2998,8 @@ rewrite -(open_subsetE _ (@open_lt _ _)) => r rsupX.
 move/has_lbPn : lX => /(_ r)[y Xy yr].
 have hsX : has_sup X by split => //; exists y.
 have /(sup_adherent hsX)[e Xe] : 0 < sup X - r by rewrite subr_gt0.
-by rewrite opprB addrCA subrr addr0 => re; apply (iX _ _ Xy Xe); rewrite yr re.
+rewrite opprB addrCA subrr addr0 => re; apply (iX _ _ Xy Xe).
+by rewrite (ltW yr) (ltW re).
 Qed.
 
 Lemma interval_right_unbounded_interior (X : set R) : is_interval X ->
@@ -3009,7 +3010,8 @@ rewrite -(open_subsetE _ (@open_gt _ _)) => r infXr.
 move/has_ubPn : uX => /(_ r)[y Xy yr].
 have hiX : has_inf X by split => //; exists y.
 have /(inf_adherent hiX)[e Xe] : 0 < r - inf X by rewrite subr_gt0.
-by rewrite addrCA subrr addr0 => er; apply: (iX _ _ Xe Xy); rewrite yr er.
+rewrite addrCA subrr addr0 => er; apply: (iX _ _ Xe Xy).
+by rewrite (ltW yr) (ltW er).
 Qed.
 
 Lemma interval_bounded_interior (X : set R) : is_interval X ->
@@ -3027,7 +3029,8 @@ have /(inf_adherent hiX)[e Xe] : 0 < r - inf X by rewrite subr_gt0.
 rewrite addrCA subrr addr0 => er.
 have hsX : has_sup X by split.
 have /(sup_adherent hsX)[f Xf] : 0 < sup X - r by rewrite subr_gt0.
-by rewrite opprB addrCA subrr addr0 => rf; apply: (iX _ _ Xe Xf); rewrite er rf.
+rewrite opprB addrCA subrr addr0 => rf; apply: (iX _ _ Xe Xf).
+by rewrite (ltW er) (ltW rf).
 Qed.
 
 Definition Rhull (X : set R) : interval R := Interval
@@ -3094,7 +3097,9 @@ split => [cE x y Ex Ey z /andP[xz zy]|].
 - apply: contrapT => Ez.
   pose Az := E `&` [set x | x < z]; pose Bz := E `&` [set x | z < x].
   apply/connectedPn : cE; exists (fun b => if b then Az else Bz); split.
-  + by case; [exists x | exists y].
+  + move: xz zy Ez.
+    rewrite !le_eqVlt => /orP [/eqP <- // | xz] /orP[/eqP -> // | zy] Ez.
+    by case; [exists x | exists y].
   + rewrite /Az /Bz -setIUr; apply/esym/setIidPl => u Eu.
     by apply/orP; rewrite -neq_lt; apply/negP; apply: contraPnot Eu => /eqP <-.
   + split; [|rewrite setIC].
@@ -3125,32 +3130,32 @@ split => [cE x y Ex Ey z /andP[xz zy]|].
       * by exists x; split => //; rewrite /mkset /= lexx /= (ltW xy).
     + by split=> //; rewrite /mkset lexx (ltW xy).
   have [A0z|A0z] := pselect ((A false) z); last first.
-    have {}xzy : x < z < y.
-      by rewrite zy lt_neqAle xz !andbT; apply/eqP; apply: contra_not A0z => <-.
+  have {}xzy : x <= z <= y by rewrite xz ltW.
     have : ~ E z by rewrite EU => -[].
     by apply; apply (intE x y) => //; rewrite EU; [left|right].
-  suff [z1 [/andP[zz1 z1y] Ez1]] : exists z1 : R, z < z1 < y /\ ~ E z1.
+  suff [z1 [/andP[zz1 z1y] Ez1]] : exists z1 : R, z <= z1 <= y /\ ~ E z1.
     apply Ez1; apply (intE x y) => //; rewrite ?EU; [by left|by right|].
-    by rewrite z1y (le_lt_trans _ zz1).
+    by rewrite z1y (le_trans _ zz1).
   have [r zcA1] : {r:{posnum R}| ball z r%:num `<=` ~` closure (A true)}.
     have ? : ~ closure (A true) z.
       by move: sepA; rewrite /separated => -[] _ /disjoints_subset; apply.
     have ? : open (~` closure (A true)) by exact/openC/closed_closure.
     exact/nbhsC_ball/open_nbhs_nbhs.
   pose z1 : R := z + r%:num / 2; exists z1.
-  have z1y : z1 < y.
-    rewrite ltNge; apply/negP => yz1.
+  have z1y : z1 <= y.
+    rewrite leNgt; apply/negP => yz1.
     suff : (~` closure (A true)) y by apply; exact: subset_closure.
     apply zcA1; rewrite /ball /= ltr_distl (lt_le_trans zy) // ?ler_addl //.
-    rewrite andbT ltr_subl_addl addrC (le_lt_trans yz1) // ltr_add2l.
+    rewrite andbT ltr_subl_addl addrC (lt_trans yz1) // ltr_add2l.
     by rewrite ltr_pdivr_mulr // ltr_pmulr // ltr1n.
-  rewrite z1y andbT ltr_addl; split => //.
+  rewrite z1y andbT ler_addl; split => //.
   have ncA1z1 : (~` closure (A true)) z1.
     apply zcA1; rewrite /ball /= /z1 opprD addrA subrr add0r normrN.
     by rewrite ger0_norm // ltr_pdivr_mulr // ltr_pmulr // ltr1n.
   have nA0z1 : ~ (A false) z1.
     move=> A0z1; have : z < z1 by rewrite /z1 ltr_addl.
-    apply/negP; rewrite -leNgt; apply sup_ub; first by exists y => u [_] /andP[].
+    apply/negP; rewrite -leNgt.
+     apply sup_ub; first by exists y => u [_] /andP[].
     by split => //; rewrite /mkset /z1 (le_trans xz) /= ?ler_addl // (ltW z1y).
   by rewrite EU => -[//|]; apply: contra_not ncA1z1; exact: subset_closure.
 Qed.


### PR DESCRIPTION
The previous definition, based on strict inequalities, is less practical

The impact of this change has been tested against two other pull requests that use the `is_interval` concept

- #385 : porting this PR leads to branch [ctinv-itv](https://github.com/ybertot/analysis/tree/ctinv-itv)
- #371 : porting this PR leads to branch [ctv-itv-meas](https://github.com/ybertot/analysis/tree/ctv-itv-meas) (actually this branch contains both 385 and 371).