### PR TITLE
add seqDU with a few theorems

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -6,6 +6,9 @@
 
 - in `boolp.v`:
   + lemmas `orA`, `andA`
+- in `measure.v`:
+  + definition `seqDU`
+  + lemmas `trivIset_seqDU`, `bigsetU_seqDU`, `seqDU_bigcup_eq`, `seqDUE`
 
 ### Changed
 


### PR DESCRIPTION
- slight generalization of `seqD`

`seqDU` is used in the formalization of Dynkin systems in the Lebesgue measure development

also uses `nondecreasing_seq` instead of unfolded `homo` definitions
