### PR TITLE
Introduce T_0 and T_1 spaces and prove T_1 -> T0.

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -4,6 +4,15 @@
 
 ### Added
 
+- in `classical_sets.v`:
+  + lemma `setDIr`
+  + lemmas `setMT`, `setTM`, `setMI`
+  + lemmas `setSM`, `setM_bigcupr`, `setM_bigcupl`
+  + lemmas `setC1E`, `mem_setC_subset`
+- in `topology.v`:
+  + definitions `kolmogorov`, `accessible`
+  + lemmas `accessible_closed_set1`, `accessible_kolmogorov`
+
 ### Changed
 
 ### Renamed

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -4,20 +4,20 @@
 
 ### Added
 
-- in `classical_sets.v`:
-  + lemma `setDIr`
-  + lemmas `setMT`, `setTM`, `setMI`
-  + lemmas `setSM`, `setM_bigcupr`, `setM_bigcupl`
 - in `topology.v`:
-  + definitions `kolmogorov`, `accessible`
+  + definitions `kolmogorov_space`, `accessible_space`
   + lemmas `accessible_closed_set1`, `accessible_kolmogorov`
 
 ### Changed
+
 - in `topology.v`:
   + renamed and generalized `setC_subset_set1C` implication to
     equivalence `subsetC1`
 
 ### Renamed
+
+- in `topology.v:
+  + `hausdorff` -> `hausdorff_space`
 
 ### Removed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -8,12 +8,14 @@
   + lemma `setDIr`
   + lemmas `setMT`, `setTM`, `setMI`
   + lemmas `setSM`, `setM_bigcupr`, `setM_bigcupl`
-  + lemmas `setC1E`, `mem_setC_subset`
 - in `topology.v`:
   + definitions `kolmogorov`, `accessible`
   + lemmas `accessible_closed_set1`, `accessible_kolmogorov`
 
 ### Changed
+- in `topology.v`:
+  + renamed and generalized `setC_subset_set1C` implication to
+    equivalence `subsetC1`
 
 ### Renamed
 

--- a/theories/classical_sets.v
+++ b/theories/classical_sets.v
@@ -492,6 +492,8 @@ Proof. by rewrite subsets_disjoint setCK. Qed.
 
 Lemma setCT : ~` setT = set0 :> set T. Proof. by rewrite -setC0 setCK. Qed.
 
+Lemma set1CE (x : T) : [set y | y <> x] = [set~ x]. Proof. by []. Qed.
+
 Lemma setDE A B : A `\` B = A `&` ~` B. Proof. by []. Qed.
 
 Lemma setSD C A B : A `<=` B -> A `\` C `<=` B `\` C.
@@ -594,6 +596,14 @@ Qed.
 
 Lemma nonsubset A B : ~ (A `<=` B) -> A `&` ~` B !=set0.
 Proof. by rewrite -setD_eq0 setDE -set0P => /eqP. Qed.
+
+Lemma setC_subset_set1C (x : T) (A : set T) : x \in ~` A -> A `<=` [set ~ x].
+Proof.
+  rewrite in_setE /set1 => ? y yInH //= ; rewrite /setC => //= xEqy.
+  have: (A `&` ~` A) y.
+     rewrite /setI => //= ; split; by [rewrite xEqy|].
+  by rewrite setICr.
+Qed.
 
 Lemma setU_eq0 A B : (A `|` B = set0) = ((A = set0) /\ (B = set0)).
 Proof. by rewrite -!subset0 subUset. Qed.

--- a/theories/classical_sets.v
+++ b/theories/classical_sets.v
@@ -492,7 +492,10 @@ Proof. by rewrite subsets_disjoint setCK. Qed.
 
 Lemma setCT : ~` setT = set0 :> set T. Proof. by rewrite -setC0 setCK. Qed.
 
-Lemma set1CE (x : T) : [set y | y <> x] = [set~ x]. Proof. by []. Qed.
+Lemma setC1E (x : T) : [set ~ x] = [set y | y <> x]. Proof. by []. Qed.
+
+Lemma mem_setC_subset (x : T) A : x \in ~` A -> A `<=` [set ~ x].
+Proof. by rewrite in_setE => + y Ay; apply: contra_not => <-. Qed.
 
 Lemma setDE A B : A `\` B = A `&` ~` B. Proof. by []. Qed.
 

--- a/theories/classical_sets.v
+++ b/theories/classical_sets.v
@@ -44,7 +44,7 @@ Require Import boolp.
 (*                        A.`2 == set of points a such that there exists b so *)
 (*                                that A (b, a).                              *)
 (*                        ~` A == complement of A.                            *)
-(*                   [set ~ a] == complement of [set a].                      *)
+(*                    [set~ a] == complement of [set a].                      *)
 (*                     A `\` B == complement of B in A.                       *)
 (*                      A `\ a == A deprived of a.                            *)
 (*          \bigcup_(i in P) F == union of the elements of the family F whose *)
@@ -492,10 +492,11 @@ Proof. by rewrite subsets_disjoint setCK. Qed.
 
 Lemma setCT : ~` setT = set0 :> set T. Proof. by rewrite -setC0 setCK. Qed.
 
-Lemma setC1E (x : T) : [set ~ x] = [set y | y <> x]. Proof. by []. Qed.
-
-Lemma mem_setC_subset (x : T) A : x \in ~` A -> A `<=` [set ~ x].
-Proof. by rewrite in_setE => + y Ay; apply: contra_not => <-. Qed.
+Lemma subsetC1 x A : (A `<=` [set~ x]) = (x \in ~` A).
+Proof.
+rewrite !inE; apply/propext; split; first by move/[apply]; apply.
+by move=> NAx y; apply: contraPnot => ->.
+Qed.
 
 Lemma setDE A B : A `\` B = A `&` ~` B. Proof. by []. Qed.
 
@@ -599,14 +600,6 @@ Qed.
 
 Lemma nonsubset A B : ~ (A `<=` B) -> A `&` ~` B !=set0.
 Proof. by rewrite -setD_eq0 setDE -set0P => /eqP. Qed.
-
-Lemma setC_subset_set1C (x : T) (A : set T) : x \in ~` A -> A `<=` [set ~ x].
-Proof.
-  rewrite in_setE /set1 => ? y yInH //= ; rewrite /setC => //= xEqy.
-  have: (A `&` ~` A) y.
-     rewrite /setI => //= ; split; by [rewrite xEqy|].
-  by rewrite setICr.
-Qed.
 
 Lemma setU_eq0 A B : (A `|` B = set0) = ((A = set0) /\ (B = set0)).
 Proof. by rewrite -!subset0 subUset. Qed.

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -1,7 +1,8 @@
 (* mathcomp analysis (c) 2017 Inria and AIST. License: CeCILL-C.              *)
 From mathcomp Require Import ssreflect ssrfun ssrbool ssrnat eqtype choice.
-From mathcomp Require Import seq fintype bigop order ssralg ssrint ssrnum finmap.
-From mathcomp Require Import matrix interval zmodp vector fieldext falgebra.
+From mathcomp Require Import seq fintype bigop order ssralg ssrint ssrnum.
+From mathcomp Require Import finmap matrix interval zmodp vector fieldext.
+From mathcomp Require Import falgebra.
 Require Import boolp ereal reals cardinality.
 Require Import classical_sets posnum nngnum topology prodnormedzmodule.
 
@@ -1626,7 +1627,7 @@ Local Notation ball_norm := (ball_ (@normr R V)).
 
 Local Notation nbhs_norm := (@nbhs_ball _ V).
 
-Lemma norm_hausdorff : hausdorff V.
+Lemma norm_hausdorff : hausdorff_space V.
 Proof.
 rewrite ball_hausdorff => a b ab.
 have ab2 : 0 < `|a - b| / 2 by apply divr_gt0 => //; rewrite normr_gt0 subr_eq0.
@@ -1637,7 +1638,7 @@ move: (ltr_add acr bcr); rewrite -r22 (distrC b c).
 move/(le_lt_trans (ler_dist_add c a b)).
 by rewrite -mulrA mulVr ?mulr1 ?ltxx // unitfE.
 Qed.
-Hint Extern 0 (hausdorff _) => solve[apply: norm_hausdorff] : core.
+Hint Extern 0 (hausdorff_space _) => solve[apply: norm_hausdorff] : core.
 
 (* TODO: check if the following lemma are indeed useless *)
 (*       i.e. where the generic lemma is applied, *)
@@ -1734,7 +1735,7 @@ Proof. by move=> ?; rewrite normmZ normfV normr_id mulVf ?normr_eq0. Qed.
 
 End NormedModule_numFieldType.
 Arguments cvg_bounded {_ _ F FF}.
-Hint Extern 0 (hausdorff _) => solve[apply: norm_hausdorff] : core.
+Hint Extern 0 (hausdorff_space _) => solve[apply: norm_hausdorff] : core.
 
 Module Export NbhsNorm.
 Definition nbhs_simpl := (nbhs_simpl,@nbhs_nbhs_norm,@filter_from_norm_nbhs).
@@ -1743,7 +1744,7 @@ End NbhsNorm.
 (* TODO: generalize to R : numFieldType *)
 Section hausdorff.
 
-Lemma Rhausdorff (R : realFieldType) : hausdorff R.
+Lemma Rhausdorff (R : realFieldType) : hausdorff_space R.
 Proof.
 move=> x y clxy; apply/eqP; rewrite eq_le.
 apply/in_segment_addgt0Pr => _ /posnumP[e].
@@ -1755,7 +1756,7 @@ Qed.
 
 Lemma pseudoMetricNormedZModType_hausdorff (R : realFieldType)
     (V : pseudoMetricNormedZmodType R) :
-  hausdorff V.
+  hausdorff_space V.
 Proof.
 move=> p q clp_q; apply/subr0_eq/normr0_eq0/Rhausdorff => A B pq_A.
 rewrite -(@normr0 _ V) -(subrr p) => pp_B.
@@ -3740,7 +3741,7 @@ rewrite nbhsE /=; eexists; split; last by move=> y; exact.
 by split; [apply open_ereal_lt_ereal | rewrite /= lte_ninfty].
 Qed.
 
-Lemma ereal_hausdorff : hausdorff (ereal_topologicalType R).
+Lemma ereal_hausdorff : hausdorff_space (ereal_topologicalType R).
 Proof.
 move=> -[r| |] // [r' | |] //=.
 - move=> rr'; congr (_%:E); apply Rhausdorff => /= A B rA r'B.
@@ -3771,7 +3772,7 @@ Qed.
 
 End ereal_is_hausdorff.
 
-Hint Extern 0 (hausdorff _) => solve[apply: ereal_hausdorff] : core.
+Hint Extern 0 (hausdorff_space _) => solve[apply: ereal_hausdorff] : core.
 
 Section limit_composition_ereal.
 

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -213,6 +213,8 @@ Require Import boolp reals classical_sets posnum.
 (*                                     cover-based definition of compactness. *)
 (*                     connected A <-> the only non empty subset of A which   *)
 (*                                     is both open and closed in A is A.     *)
+(*                    kolmogorov T <-> T is a Kolmogorov space (T_0).         *)
+(*                    accessible T <-> T is an accessible space (T_1).        *)
 (*                    separated A B == the two sets A and B are separated     *)
 (*                      component x == the connected component of point x     *)
 (*                      [locally P] := forall a, A a -> G (within A (nbhs x)) *)
@@ -3007,33 +3009,31 @@ End Covers.
 
 Section separated_topologicalType.
 Variable (T : topologicalType).
+Implicit Types x y : T.
 
 Local Open Scope classical_set_scope.
 
-Definition T_0 : Prop := forall (x y : T), x != y -> exists p, (p \in (nbhs x) /\ y \in (~` p)) \/ (p \in (nbhs y) /\ x \in (~` p)).
+Definition kolmogorov := forall x y, x != y ->
+  exists A : set T, (A \in nbhs x /\ y \in ~` A) \/ (A \in nbhs y /\ x \in ~` A).
 
-Definition T_1 : Prop := forall (x y : T), x != y -> exists p, (open p /\ x \in p /\ y \in (~` p)).
+Definition accessible := forall x y, x != y ->
+  exists A : set T, open A /\ x \in A /\ y \in ~` A.
 
-Lemma T_1_singleton_closed : T_1 -> forall x:T, closed [set x].
+Lemma accessible_closed_set1 : accessible -> forall x, closed [set x].
 Proof.
-  move => T1 x; rewrite -[set1 _]setCK; apply: closedC.
-  rewrite openE -set1CE /interior => y //= /eqP xNeqY.
-  rewrite nbhsE => //=.
-  have := T1 _ _ xNeqY => -[] U [] ? [] ? ?.
-  exists U ; split.
-    by rewrite /open_nbhs ; split; by [|rewrite -in_setE].
-  by apply: setC_subset_set1C.
+move=> T1 x; rewrite -[X in closed X]setCK; apply: closedC.
+rewrite openE setC1E => y /eqP /T1 [U [oU [yU xU]]].
+rewrite /interior nbhsE /=; exists U; split; last exact: mem_setC_subset.
+by split => //; rewrite -in_setE.
 Qed.
 
-Definition T_1entailsT_0 : T_1 -> T_0.
+Definition accessible_kolmogorov : accessible -> kolmogorov.
 Proof.
-  rewrite /T_0 => T_1 x ? xneqy.
-  have:= (T_1 _ _ xneqy) => -[] p [] ? [] /asboolP ? ?.
-  have: open_nbhs x p by split; by [].
-  rewrite open_nbhsE => -[] ? H; exists p; left; split ; by [apply/asboolP|].
+move=> T1 x y /T1 [A [oA [xA yA]]]; exists A; left; split => //.
+by rewrite nbhsE inE /=; exists A; split => //; split => //; rewrite -in_setE.
 Qed.
 
-Definition close (x y : T) : Prop := forall M, open_nbhs y M -> closure M x.
+Definition close x y : Prop := forall M, open_nbhs y M -> closure M x.
 
 Lemma closeEnbhs x : close x = cluster (nbhs x).
 Proof.
@@ -3049,16 +3049,15 @@ Proof.
 by rewrite closeEnbhs; under eq_fun do rewrite -meets_openl -meets_openr.
 Qed.
 
-Lemma close_sym (x y : T) : close x y -> close y x.
+Lemma close_sym x y : close x y -> close y x.
 Proof. by rewrite !closeEnbhs /cluster/= meetsC. Qed.
 
-Lemma cvg_close {F} {FF : ProperFilter F} (x y : T) :
-  F --> x -> F --> y -> close x y.
+Lemma cvg_close {F} {FF : ProperFilter F} x y : F --> x -> F --> y -> close x y.
 Proof.
 by move=> /sub_meets sx /sx; rewrite closeEnbhs; apply; apply/proper_meetsxx.
 Qed.
 
-Lemma close_refl (x : T) : close x x.
+Lemma close_refl x : close x x.
 Proof. exact: (@cvg_close (nbhs x)). Qed.
 Hint Resolve close_refl : core.
 
@@ -3072,7 +3071,7 @@ have [/(cvg_trans F12)/cvgP//|dvgF2] := pselect (cvg F2).
 rewrite dvgP // dvgP //; exact/close_refl.
 Qed.
 
-Lemma cvgx_close (x y : T) : x --> y -> close x y.
+Lemma cvgx_close x y : x --> y -> close x y.
 Proof. exact: cvg_close. Qed.
 
 Lemma cvgi_close T' {F} {FF : ProperFilter F} (f : T' -> set T) (l l' : T) :
@@ -3087,13 +3086,13 @@ Grab Existential Variables. all: end_near. Qed.
 Definition cvg_toi_locally_close := @cvgi_close.
 
 Lemma open_hausdorff : hausdorff T =
-  (forall x y : T, x != y ->
+  forall x y, x != y ->
     exists2 AB, (x \in AB.1 /\ y \in AB.2) &
-                [/\ open AB.1, open AB.2 & AB.1 `&` AB.2 == set0]).
+                [/\ open AB.1, open AB.2 & AB.1 `&` AB.2 == set0].
 Proof.
 rewrite propeqE; split => [T_filterT2|T_openT2] x y.
-  have := contra_not _ _ (T_filterT2 x y); rewrite (rwP eqP) (rwP negP) => cl /cl.
-  rewrite [cluster _ _](rwP forallp_asboolP) => /negP.
+  have := contra_not _ _ (T_filterT2 x y); rewrite (rwP eqP) (rwP negP).
+  move=> /[apply]; rewrite [cluster _ _](rwP forallp_asboolP) => /negP.
   rewrite forallbE => /existsp_asboolPn/=[A]/negP/existsp_asboolPn/=[B].
   rewrite [nbhs _ _ -> _](rwP imply_asboolP) => /negP.
   rewrite asbool_imply !negb_imply => /andP[/asboolP xA] /andP[/asboolP yB].
@@ -3109,22 +3108,22 @@ Qed.
 
 Hypothesis sep : hausdorff T.
 
-Lemma closeE (x y : T) : close x y = (x = y).
+Lemma closeE x y : close x y = (x = y).
 Proof.
 rewrite propeqE; split; last by move=> ->; exact: close_refl.
 by rewrite closeEnbhs; exact: sep.
 Qed.
 
-Lemma close_eq (y x : T) : close x y -> x = y.
+Lemma close_eq x y : close x y -> x = y.
 Proof. by rewrite closeE. Qed.
 
 Lemma cvg_unique {F} {FF : ProperFilter F} : is_subset1 [set x : T | F --> x].
 Proof. move=> Fx Fy; rewrite -closeE //; exact: (@cvg_close F). Qed.
 
-Lemma cvg_eq (x y : T) : x --> y -> x = y.
+Lemma cvg_eq x y : x --> y -> x = y.
 Proof. by rewrite -closeE //; apply: cvg_close. Qed.
 
-Lemma lim_id (x : T) : lim x = x.
+Lemma lim_id x : lim x = x.
 Proof. by apply/esym/cvg_eq/cvg_ex; exists x. Qed.
 
 Lemma cvg_lim {F} {FF : ProperFilter F} (l : T) : F --> l -> lim F = l.

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -3010,6 +3010,29 @@ Variable (T : topologicalType).
 
 Local Open Scope classical_set_scope.
 
+Definition T_0 : Prop := forall (x y : T), x != y -> exists p, (p \in (nbhs x) /\ y \in (~` p)) \/ (p \in (nbhs y) /\ x \in (~` p)).
+
+Definition T_1 : Prop := forall (x y : T), x != y -> exists p, (open p /\ x \in p /\ y \in (~` p)).
+
+Lemma T_1_singleton_closed : T_1 -> forall x:T, closed [set x].
+Proof.
+  move => T1 x; rewrite -[set1 _]setCK; apply: closedC.
+  rewrite openE -set1CE /interior => y //= /eqP xNeqY.
+  rewrite nbhsE => //=.
+  have := T1 _ _ xNeqY => -[] U [] ? [] ? ?.
+  exists U ; split.
+    by rewrite /open_nbhs ; split; by [|rewrite -in_setE].
+  by apply: setC_subset_set1C.
+Qed.
+
+Definition T_1entailsT_0 : T_1 -> T_0.
+Proof.
+  rewrite /T_0 => T_1 x ? xneqy.
+  have:= (T_1 _ _ xneqy) => -[] p [] ? [] /asboolP ? ?.
+  have: open_nbhs x p by split; by [].
+  rewrite open_nbhsE => -[] ? H; exists p; left; split ; by [apply/asboolP|].
+Qed.
+
 Definition close (x y : T) : Prop := forall M, open_nbhs y M -> closure M x.
 
 Lemma closeEnbhs x : close x = cluster (nbhs x).

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -208,13 +208,13 @@ Require Import boolp reals classical_sets posnum.
 (*                        cluster F == set of cluster points of F.            *)
 (*                          compact == set of compact sets w.r.t. the filter- *)
 (*                                     based definition of compactness.       *)
-(*                     hausdorff T <-> T is a Hausdorff space (T_2).          *)
+(*               hausdorff_space T <-> T is a Hausdorff space (T_2).          *)
 (*                    cover_compact == set of compact sets w.r.t. the open    *)
 (*                                     cover-based definition of compactness. *)
 (*                     connected A <-> the only non empty subset of A which   *)
 (*                                     is both open and closed in A is A.     *)
-(*                    kolmogorov T <-> T is a Kolmogorov space (T_0).         *)
-(*                    accessible T <-> T is an accessible space (T_1).        *)
+(*              kolmogorov_space T <-> T is a Kolmogorov space (T_0).         *)
+(*              accessible_space T <-> T is an accessible space (T_1).        *)
 (*                    separated A B == the two sets A and B are separated     *)
 (*                      component x == the connected component of point x     *)
 (*                      [locally P] := forall a, A a -> G (within A (nbhs x)) *)
@@ -2678,7 +2678,7 @@ have [|p [Bp Fp]] := Bco F; first exact: filterS FA.
 by exists p; split=> //; apply: Acl=> C Cp; apply: Fp.
 Qed.
 
-Definition hausdorff := forall p q : T, cluster (nbhs p) q -> p = q.
+Definition hausdorff_space := forall p q : T, cluster (nbhs p) q -> p = q.
 
 Typeclasses Opaque within.
 Global Instance within_nbhs_proper (A : set T) p :
@@ -2688,7 +2688,7 @@ move=> clAp; apply: Build_ProperFilter => B.
 by move=> /clAp [q [Aq AqsoBq]]; exists q; apply: AqsoBq.
 Qed.
 
-Lemma compact_closed (A : set T) : hausdorff -> compact A -> closed A.
+Lemma compact_closed (A : set T) : hausdorff_space -> compact A -> closed A.
 Proof.
 move=> hT Aco p clAp; have pA := !! @withinT _ (nbhs p) A _.
 have [q [Aq clsAp_q]] := !! Aco _ _ pA; rewrite (hT p q) //.
@@ -2696,7 +2696,7 @@ by apply: cvg_cluster clsAp_q; apply: cvg_within.
 Qed.
 
 End Compact.
-Arguments hausdorff : clear implicits.
+Arguments hausdorff_space : clear implicits.
 
 Lemma continuous_compact (T U : topologicalType) (f : T -> U) A :
   {in A, continuous f} -> compact A -> compact (f @` A).
@@ -3013,13 +3013,13 @@ Implicit Types x y : T.
 
 Local Open Scope classical_set_scope.
 
-Definition kolmogorov := forall x y, x != y ->
+Definition kolmogorov_space := forall x y, x != y ->
   exists A : set T, (A \in nbhs x /\ y \in ~` A) \/ (A \in nbhs y /\ x \in ~` A).
 
-Definition accessible := forall x y, x != y ->
+Definition accessible_space := forall x y, x != y ->
   exists A : set T, open A /\ x \in A /\ y \in ~` A.
 
-Lemma accessible_closed_set1 : accessible -> forall x, closed [set x].
+Lemma accessible_closed_set1 : accessible_space -> forall x, closed [set x].
 Proof.
 move=> T1 x; rewrite -[X in closed X]setCK; apply: closedC.
 rewrite openE => y /eqP /T1 [U [oU [yU xU]]].
@@ -3027,7 +3027,7 @@ rewrite /interior nbhsE /=; exists U; split; last by rewrite subsetC1.
 by split=> //; rewrite inE in yU.
 Qed.
 
-Definition accessible_kolmogorov : accessible -> kolmogorov.
+Definition accessible_kolmogorov : accessible_space -> kolmogorov_space.
 Proof.
 move=> T1 x y /T1 [A [oA [xA yA]]]; exists A; left; split=> //.
 by rewrite nbhsE inE; exists A; do !split=> //; rewrite inE in xA.
@@ -3085,7 +3085,7 @@ by rewrite fmapiE; apply: filterS => x [y []]; exists y.
 Grab Existential Variables. all: end_near. Qed.
 Definition cvg_toi_locally_close := @cvgi_close.
 
-Lemma open_hausdorff : hausdorff T =
+Lemma open_hausdorff : hausdorff_space T =
   forall x y, x != y ->
     exists2 AB, (x \in AB.1 /\ y \in AB.2) &
                 [/\ open AB.1, open AB.2 & AB.1 `&` AB.2 == set0].
@@ -3106,7 +3106,7 @@ move=> /(_ A B (open_nbhs_nbhs _) (open_nbhs_nbhs _)).
 by rewrite -set0P => /(_ _ _)/negP; apply.
 Qed.
 
-Hypothesis sep : hausdorff T.
+Hypothesis sep : hausdorff_space T.
 
 Lemma closeE x y : close x y = (x = y).
 Proof.
@@ -4099,9 +4099,10 @@ End pseudoMetricType_numFieldType.
 Section ball_hausdorff.
 Variables (R : numDomainType) (T : pseudoMetricType R).
 
-Lemma ball_hausdorff : hausdorff T =
+Lemma ball_hausdorff : hausdorff_space T =
   forall (a b : T), a != b ->
-  exists r : {posnum R} * {posnum R}, ball a r.1%:num `&` ball b r.2%:num == set0.
+  exists r : {posnum R} * {posnum R},
+    ball a r.1%:num `&` ball b r.2%:num == set0.
 Proof.
 rewrite propeqE open_hausdorff; split => T2T a b /T2T[[/=]].
   move=> A B; rewrite 2!inE => [[aA bB] [oA oB /eqP ABeq0]].
@@ -5169,7 +5170,7 @@ by rewrite eqfg ?inE //; exact: entourage_refl.
 Qed.
 
 Lemma hausdorrf_close_eq_in (A : set U) (f g : {uniform` A -> V}) :
-  hausdorff V -> close f g = {in A, f =1 g}.
+  hausdorff_space V -> close f g = {in A, f =1 g}.
 Proof.
 move=> hV.
 rewrite propeqE; split; last exact: eq_in_close.
@@ -5519,7 +5520,7 @@ Lemma open_subspaceW (U : set T) :
 Proof. by move=> oU; apply/open_subspaceP; exists U. Qed.
 
 Lemma subspace_hausdorff :
-  hausdorff T -> hausdorff [topologicalType of subspace A].
+  hausdorff_space T -> hausdorff_space [topologicalType of subspace A].
 Proof.
 rewrite ?open_hausdorff => + x y xNy => /(_ x y xNy).
 move=> [[P Q]] /= [Px Qx] /= [/open_subspaceW oP /open_subspaceW oQ].

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -3022,15 +3022,15 @@ Definition accessible := forall x y, x != y ->
 Lemma accessible_closed_set1 : accessible -> forall x, closed [set x].
 Proof.
 move=> T1 x; rewrite -[X in closed X]setCK; apply: closedC.
-rewrite openE setC1E => y /eqP /T1 [U [oU [yU xU]]].
-rewrite /interior nbhsE /=; exists U; split; last exact: mem_setC_subset.
-by split => //; rewrite -in_setE.
+rewrite openE => y /eqP /T1 [U [oU [yU xU]]].
+rewrite /interior nbhsE /=; exists U; split; last by rewrite subsetC1.
+by split=> //; rewrite inE in yU.
 Qed.
 
 Definition accessible_kolmogorov : accessible -> kolmogorov.
 Proof.
-move=> T1 x y /T1 [A [oA [xA yA]]]; exists A; left; split => //.
-by rewrite nbhsE inE /=; exists A; split => //; split => //; rewrite -in_setE.
+move=> T1 x y /T1 [A [oA [xA yA]]]; exists A; left; split=> //.
+by rewrite nbhsE inE; exists A; do !split=> //; rewrite inE in xA.
 Qed.
 
 Definition close x y : Prop := forall M, open_nbhs y M -> closure M x.


### PR DESCRIPTION
This PR adds T0 and T1 spaces definitions, proof that singletons in T1 space are closed, and that T1 -> T0.

I introduced 2 lemmas in classical_sets to make easy to work with [set~ x] : setC_set1C and setC_subset_set1C. I'm not really sure about the naming convention:
- setC_set1C isn't technically an elimination so it can't be named set1C, but it's very close... I wonder if it's not better to have a Lemma proving "[y | y != x] = [set~ x]".
- setC_subset_set1C is involving a subset of set1C, but I don't know how to phrase it correctly. I'm also not sure my proof is optimal.
For "T_1_singleton_closed" I have an extra "have xNeqY:" step, I don't know if it can't be more elegantly derived using the setC_set1C lemma.