### PR TITLE
express sup with supremum

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -33,16 +33,44 @@
   + lemma `floor_natz`
 - in file `topology.v`:
   + definition `frechet_filter`, instances `frechet_properfilter`, and `frechet_properfilter_nat`
+- in `Rstruct.v`:
+  + lemmas `Rsupremums_neq0`, `Rsup_isLub`, `Rsup_ub`
+- in `classical_sets.v`:
+  + lemma `supremum_out`
+  + definition `isLub`
+  + lemma `supremum1`
+- in `reals.v`:
+  + lemma `opp_set_eq0`, `ubound0`, `lboundT`
 
 ### Changed
 
 - in `topology.v`:
   + generalize `cluster_cvgE`, `fam_cvgE`, `ptws_cvg_compact_family`
   + rewrite `equicontinuous` and `pointwise_precompact` to use index 
+- in `Rstruct.v`:
+  + statement of lemma `completeness'`, renamed to `Rcondcomplete`
+  + statement of lemma `real_sup_adherent`
+- in `ereal.v`:
+  + statements of lemmas `ub_ereal_sup_adherent`, `lb_ereal_inf_adherent`
+- in `reals.v`:
+  + definition `sup`
+  + statements of lemmas `sup_adherent`, `inf_adherent`
 
 ### Renamed
 
 ### Removed
+
+- `has_sup1`, `has_inf1` moved from `reals.v` to `classical_sets.v`
+- in `reals.v`:
+  + type generalization of `has_supPn`
+- in `classical_sets.v`:
+  + `supremums_set1` -> `supremums1`
+  + `infimums_set1` -> `infimums1`
+- in `Rstruct.v`:
+  + definition `real_sup`
+  + lemma `real_sup_is_lub`, `real_sup_ub`, `real_sup_out`
+- in `reals.v`:
+  + field `sup` from `mixin_of` in module `Real`
 
 ### Infrastructure
 

--- a/theories/altreals/realsum.v
+++ b/theories/altreals/realsum.v
@@ -180,7 +180,7 @@ case: (pselect (has_sup E)); last first.
   by apply/(lt_le_trans lt_MuK)/mono_u.
 move=> supE; exists (sup E)%:E => //; first exact: ltNye.
 elim/nbh_finW=>e /= gt0_e.
-case: (sup_adherent supE gt0_e)=> x [K ->] lt_uK.
+case: (sup_adherent gt0_e supE)=> x [K ->] lt_uK.
 exists K=> n le_Kn; rewrite inE distrC ger0_norm ?subr_ge0.
   by move/ubP: (sup_upper_bound supE); apply; exists n.
 rewrite ltr_subl_addr addrC -ltr_subl_addr.
@@ -467,7 +467,7 @@ apply/eqP; case: (x =P _) => // /eqP /lt_total /orP[]; last first.
   by apply/ler_sum=> /= i _; apply/ler_norm.
 move=> lt_xS; pose e := psum S - x.
   have ge0_e: 0 < e by rewrite subr_gt0.
-case: (sup_adherent (summable_sup smS) ge0_e) => y.
+case: (sup_adherent ge0_e (summable_sup smS)) => y.
 case=> /= J ->; rewrite /e /psum (asboolT smS).
 rewrite opprB addrCA subrr addr0 => lt_xSJ.
 pose k := \max_(j : J) (val j); have lt_x_uSk: x < u k.+1.

--- a/theories/ereal.v
+++ b/theories/ereal.v
@@ -2828,8 +2828,7 @@ End DualAddTheory.
 Section ereal_supremum.
 Variable R : realFieldType.
 Local Open Scope classical_set_scope.
-Implicit Types S : set (\bar R).
-Implicit Types x y : \bar R.
+Implicit Types (S : set (\bar R)) (x y : \bar R).
 
 Lemma ereal_ub_pinfty S : ubound S +oo.
 Proof. by apply/ubP=> x _; rewrite leey. Qed.
@@ -2860,15 +2859,9 @@ Definition ereal_sup S := supremum -oo S.
 
 Definition ereal_inf S := - ereal_sup (-%E @` S).
 
-Lemma ereal_sup0 : ereal_sup set0 = -oo.
-Proof. by rewrite /ereal_sup /supremum eqxx. Qed.
+Lemma ereal_sup0 : ereal_sup set0 = -oo. Proof. exact: supremum0. Qed.
 
-Lemma ereal_sup1 x : ereal_sup [set x] = x.
-Proof.
-rewrite /ereal_sup /supremum ifF; last first.
-  by apply/eqP; rewrite predeqE => /(_ x)[+ _]; apply.
-by rewrite supremums_set1; case: xgetP => // /(_ x) /(_ erefl).
-Qed.
+Lemma ereal_sup1 x : ereal_sup [set x] = x. Proof. exact: supremum1. Qed.
 
 Lemma ereal_inf0 : ereal_inf set0 = +oo.
 Proof. by rewrite /ereal_inf image_set0 ereal_sup0. Qed.
@@ -2888,23 +2881,21 @@ move=> SM; rewrite /ereal_inf lee_oppr; apply ub_ereal_sup => x [y Sy <-{x}].
 by rewrite lee_oppl oppeK; apply SM.
 Qed.
 
-Lemma ub_ereal_sup_adherent S (e : {posnum R}) :
-  ereal_sup S \is a fin_num -> exists x, S x /\ (ereal_sup S - e%:num%:E < x).
+Lemma ub_ereal_sup_adherent S (e : R) : (0 < e)%R ->
+  ereal_sup S \is a fin_num -> exists2 x, S x & (ereal_sup S - e%:E < x).
 Proof.
-move=> Sr.
-have : ~ ubound S (ereal_sup S - e%:num%:E).
+move=> e0 Sr; have : ~ ubound S (ereal_sup S - e%:E).
   move/ub_ereal_sup; apply/negP.
   by rewrite -ltNge lte_subl_addr // lte_addl // lte_fin.
 move/asboolP; rewrite asbool_neg; case/existsp_asboolPn => /= x.
-rewrite not_implyE => -[? ?]; exists x; split => //.
-by rewrite ltNge; apply/negP.
+by rewrite not_implyE => -[? ?]; exists x => //; rewrite ltNge; apply/negP.
 Qed.
 
-Lemma lb_ereal_inf_adherent S (e : {posnum R}) :
-  ereal_inf S \is a fin_num -> exists x, S x /\ (x < ereal_inf S + e%:num%:E).
+Lemma lb_ereal_inf_adherent S (e : R) : (0 < e)%R ->
+  ereal_inf S \is a fin_num -> exists2 x, S x & (x < ereal_inf S + e%:E).
 Proof.
-rewrite [in X in X -> _]/ereal_inf fin_numN => /(ub_ereal_sup_adherent e)[x []].
-move=> [y Sy <-]; rewrite -lte_oppr => /lt_le_trans ex; exists y; split => //.
+move=> e0; rewrite fin_numN => /(ub_ereal_sup_adherent e0)[x []].
+move=> y Sy <-; rewrite -lte_oppr => /lt_le_trans ex; exists y => //.
 by apply: ex; rewrite oppeD// oppeK.
 Qed.
 

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -1146,7 +1146,7 @@ rewrite le_eqVlt => /predU1P[|] mufoo; last first.
   have : \int[mu]_x (f x) \is a fin_num.
     by rewrite ge0_fin_numE//; exact: integral_ge0.
   rewrite ge0_integralTE// => /ub_ereal_sup_adherent h.
-  apply: lee_adde => e; have {h}[/= _ [[G Gf <-]]] := h e.
+  apply: lee_adde => e; have {h} [/= _ [G Gf <-]] := h _ [gt0 of e%:num].
   rewrite EFinN lte_subl_addr// => fGe.
   have : forall x, cvg (g^~ x) -> (G x <= lim (g ^~ x))%R.
     move=> x cg; rewrite -lee_fin -(EFin_lim cg).

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -2820,9 +2820,8 @@ have [G PG] : {G : ((set T)^nat)^nat & forall n, P n (G n)}.
   case: iS infS => [r Sr|Soo|Soo].
   - have en1 : (0 < e%:num / (2 ^ n.+1)%:R)%R.
       by rewrite divr_gt0 // ltr0n expn_gt0.
-    have /(lb_ereal_inf_adherent (PosNum en1)) : ereal_inf S \is a fin_num.
-      by rewrite Sr.
-    move=> [x [[B [mB AnB muBx]] xS]].
+    have /(lb_ereal_inf_adherent en1) : ereal_inf S \is a fin_num by rewrite Sr.
+    move=> [x [B [mB AnB muBx] xS]].
     exists B; split => //; rewrite muBx -Sr; apply/ltW.
     by rewrite (lt_le_trans xS) // lee_add2l //= lee_fin ler_pmul.
   - by have := Aoo n; rewrite /mu_ext Soo.

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -2990,7 +2990,7 @@ move=> iX lX uX; rewrite eqEsubset; split; first exact: right_bounded_interior.
 rewrite -(open_subsetE _ (@open_lt _ _)) => r rsupX.
 move/has_lbPn : lX => /(_ r)[y Xy yr].
 have hsX : has_sup X by split => //; exists y.
-have /(sup_adherent hsX)[e Xe] : 0 < sup X - r by rewrite subr_gt0.
+have /sup_adherent/(_ hsX)[e Xe] : 0 < sup X - r by rewrite subr_gt0.
 by rewrite opprB addrCA subrr addr0 => re; apply: (iX y e); rewrite ?ltW.
 Qed.
 
@@ -3001,7 +3001,7 @@ move=> iX lX uX; rewrite eqEsubset; split; first exact: left_bounded_interior.
 rewrite -(open_subsetE _ (@open_gt _ _)) => r infXr.
 move/has_ubPn : uX => /(_ r)[y Xy yr].
 have hiX : has_inf X by split => //; exists y.
-have /(inf_adherent hiX)[e Xe] : 0 < r - inf X by rewrite subr_gt0.
+have /inf_adherent/(_ hiX)[e Xe] : 0 < r - inf X by rewrite subr_gt0.
 by rewrite addrCA subrr addr0 => er; apply: (iX e y); rewrite ?ltW.
 Qed.
 
@@ -3016,10 +3016,10 @@ move=> r /andP[iXr rsX].
 have [X0|/set0P X0] := eqVneq X set0.
   by move: (lt_trans iXr rsX); rewrite X0 inf_out ?sup_out ?ltxx // => - [[]].
 have hiX : has_inf X by split.
-have /(inf_adherent hiX)[e Xe] : 0 < r - inf X by rewrite subr_gt0.
+have /inf_adherent/(_ hiX)[e Xe] : 0 < r - inf X by rewrite subr_gt0.
 rewrite addrCA subrr addr0 => er.
 have hsX : has_sup X by split.
-have /(sup_adherent hsX)[f Xf] : 0 < sup X - r by rewrite subr_gt0.
+have /sup_adherent/(_ hsX)[f Xf] : 0 < sup X - r by rewrite subr_gt0.
 by rewrite opprB addrCA subrr addr0 => rf; apply: (iX e f); rewrite ?ltW.
 Qed.
 

--- a/theories/sequences.v
+++ b/theories/sequences.v
@@ -628,7 +628,7 @@ move=> u_nd u_ub; set M := sup (range u_).
 have su_ : has_sup (range u_) by split => //; exists (u_ 0%N), 0%N.
 apply: cvg_distW => _/posnumP[e]; rewrite near_map.
 have [p /andP[Mu_p u_pM]] : exists p, M - e%:num <= u_ p <= M.
-  have [_ -[p _] <- /ltW Mu_p] := sup_adherent su_ (gt0 e).
+  have [_ -[p _] <- /ltW Mu_p] := sup_adherent (gt0 e) su_.
   by exists p; rewrite Mu_p; have /ubP := sup_upper_bound su_; apply; exists p.
 near=> n; have pn : (p <= n)%N by near: n; apply: nbhs_infty_ge.
 rewrite distrC ler_norml ler_sub_addl (le_trans Mu_p (u_nd _ _ pn)) /=.
@@ -1453,7 +1453,7 @@ have e'0 : (0 < e')%R.
   rewrite /e' subr_gt0 -lte_fin fine_expand //.
   rewrite lt_expandLR ?inE ?ltW// ltr_subl_addr fineK //.
   by rewrite ltr_addl.
-have [y [[m _] umx] Se'y] := ub_ereal_sup_adherent (PosNum e'0) l_fin_num.
+have [y [m _ umx] Se'y] := ub_ereal_sup_adherent e'0 l_fin_num.
 rewrite near_map; near=> n; rewrite /ball /= /ereal_ball /=.
 rewrite ger0_norm ?subr_ge0 ?le_contract ?ereal_sup_ub//; last by exists n.
 move: Se'y; rewrite -{}umx {y} /= => le'um.


### PR DESCRIPTION
The goal of this PR is to replace the definition of `sup` in `reals.v` by a definition using the more generic `supremum` from `classical_sets.v`. As a consequence, for example `sup_out` becomes a consequence of the properites of `supremum` and need not be axiomatized.

fixes #497 
