### PR TITLE
describe \bar R in the header of ereal.v

### DIFF
--- a/theories/ereal.v
+++ b/theories/ereal.v
@@ -18,6 +18,8 @@ Require Import boolp classical_sets reals posnum topology.
 (* and operations for addition/opposite. When R is a realDomainType, \bar R   *)
 (* is equipped with a Canonical orderType.                                    *)
 (*                                                                            *)
+(*                  \bar R == coproduct of R and {+oo, -oo};                  *)
+(*                            notation for extended (R:Type)                  *)
 (*                    r%:E == injects real numbers into \bar R                *)
 (*           +%E, -%E, *%E == addition/opposite/multiplication for extended   *)
 (*                            reals                                           *)


### PR DESCRIPTION
As a user, I want to see what the primary type of ereal.v is, which is however not present in the header comment.
This PR adds two lines describing it.
