### PR TITLE
Fix boundary conditions with subspace

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -31,19 +31,21 @@
 - in `topology.v`:
   + `closedC` renamed `open_closedC`
   + `openC` renamed `closed_openC`
+- in `topology.v`:
   + lemmas `closedC`, `openC` 
   + notation `'{within A, continuous f}`
-  + lemmas `continuous_subspace_in`, `nbhs_subspace_interior`
+  + lemmas `continuous_subspace_in`
   + lemmas`closed_subspaceP`, `closed_subspaceW`, `closure_subspaceW`
   + lemmas `nbhs_subspace_subset`, `continuous_subspaceW`, `nbhs_subspaceT`,
-      `continuous_subspaceT_for`, `continuous_subspaceT`, `continuous_open_subspace`
-  + generalized `connected_continuous_connected`, `continuous_compact`
+    `continuous_subspaceT_for`, `continuous_subspaceT`, `continuous_open_subspace`
+  + globals `subspace_filter`, `subspace_proper_filter`
+  + notation `{within ..., continuous ...}`
 - in `derive.v`
   + lemma `MVT_segment`
-  + generalized `EVT_max`, `EVT_min`, `Rolle`, `MVT`, `ler0_derive1_nincr`, 
-        `le0r_derive1_ndecr` with subspace topology
 - in `normedtype.v`
-  + generalized `IVT` with subspace topology
+  + generalize `IVT` with subspace topology
+- in `realfun.v`:
+  + lemma `continuous_subspace_itv`
 
 ### Changed
 
@@ -58,6 +60,22 @@
 - in `ereal.v`:
   + lemmas `esum_fset_ninfty`, `esum_fset_pinfty`
   + lemmas `desum_fset_pinfty`, `desum_fset_ninfty`
+
+- in `topology.v`:
+  + generalize `connected_continuous_connected`, `continuous_compact`
+  + arguments of `subspace`
+- in `derive.v`:
+  + generalize `EVT_max`, `EVT_min`, `Rolle`, `MVT`, `ler0_derive1_nincr`,
+    `le0r_derive1_ndecr` with subspace topology
+  + implicits of `cvg_at_rightE`, `cvg_at_leftE`
+
+### Renamed
+
+- in `topology.v`:
+  + `closedC` -> `open_closedC`
+  + `openC` -> `closed_openC`
+
+### Removed
 
 ### Infrastructure
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -8,6 +8,42 @@
   + lemmas `esum_ninftyP`, `esum_pinftyP`
   + lemmas `addeoo`, `daddeoo`
   + lemmas `desum_pinftyP`, `desum_ninftyP`
+  + lemmas `lee_pemull`, `lee_nemul`, `lee_pemulr`, `lee_nemulr`
+- in `sequences.v`:
+  + lemmas `ereal_cvgM_gt0_pinfty`, `ereal_cvgM_lt0_pinfty`, `ereal_cvgM_gt0_ninfty`,
+    `ereal_cvgM_lt0_ninfty`, `ereal_cvgM`
+- in `ereal.v`:
+  + lemma `fin_numM`
+  + definition `mule_def`, notation `x *? y`
+  + lemma `mule_defC`
+  + notations `\*` in `ereal_scope`, and `ereal_dual_scope`
+- in `ereal.v`:
+  + lemmas `mule_def_fin`, `mule_def_neq0_infty`, `mule_def_infty_neq0`, `neq0_mule_def`
+  + notation `\-` in `ereal_scope` and `ereal_dual_scope`
+  + lemma `fin_numB`
+  + lemmas `mule_eq_pinfty`, `mule_eq_ninfty`
+  + lemmas `fine_eq0`, `abse_eq0`
+- in `topology.v`:
+  + lemma `filter_pair_set`
+- in `topology.v`:
+  + definition `prod_topo_apply`
+  + lemmas `prod_topo_applyE`, `prod_topo_apply_continuous`, `hausdorff_product`
+- in `topology.v`:
+  + `closedC` renamed `open_closedC`
+  + `openC` renamed `closed_openC`
+  + lemmas `closedC`, `openC` 
+  + notation `'{within A, continuous f}`
+  + lemmas `continuous_subspace_in`, `nbhs_subspace_interior`
+  + lemmas`closed_subspaceP`, `closed_subspaceW`, `closure_subspaceW`
+  + lemmas `nbhs_subspace_subset`, `continuous_subspaceW`, `nbhs_subspaceT`,
+      `continuous_subspaceT_for`, `continuous_subspaceT`, `continuous_open_subspace`
+  + generalized `connected_continuous_connected`, `continuous_compact`
+- in `derive.v`
+  + lemma `MVT_segment`
+  + generalized `EVT_max`, `EVT_min`, `Rolle`, `MVT`, `ler0_derive1_nincr`, 
+        `le0r_derive1_ndecr` with subspace topology
+- in `normedtype.v`
+  + generalized `IVT` with subspace topology
 
 ### Changed
 

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -1304,39 +1304,34 @@ Lemma EVT_max (R : realType) (f : R -> R) (a b : R) : (* TODO : Filter not infer
   a <= b -> {within `[a, b], continuous f} -> exists2 c, c \in `[a, b]%R &
   forall t, t \in `[a, b]%R -> f t <= f c.
 Proof.
-move=> leab fcont; set imf := [set t | (f @` `[a, b]) t].
+move=> leab fcont; set imf := f @` `[a, b].
 have imf_sup : has_sup imf.
   split; first by exists (f a); apply/imageP; rewrite /= in_itv /= lexx.
-  have [M [Mreal imfltM]] : bounded_set (f @` `[a, b]). 
-    apply/compact_bounded/continuous_compact =>//. 
-    by exact: segment_compact.
-  exists (M + 1); apply/ubP => y /imfltM yleM.
-  apply: le_trans (yleM _ _); last by rewrite ltr_addl.
-  by rewrite ler_norm.
-case: (pselect (exists2 c, c \in `[a, b]%R & f c = sup imf)) => [|imf_ltsup].
+  have [M [Mreal imfltM]] : bounded_set (f @` `[a, b]).
+    by apply/compact_bounded/continuous_compact => //; exact: segment_compact.
+  exists (M + 1) => y /imfltM yleM.
+  by rewrite (le_trans _ (yleM _ _)) ?ler_norm ?ltr_addl.
+have [|imf_ltsup] := pselect (exists2 c, c \in `[a, b]%R & f c = sup imf).
   move=> [c cab fceqsup]; exists c => // t tab; rewrite fceqsup.
-  by move/ubP : (sup_upper_bound imf_sup); apply; exact: imageP.
-have {}imf_ltsup : forall t, t \in `[a, b]%R -> f t < sup imf.
-  move=> t tab; case: (ltrP (f t) (sup imf))=> // supleft.
-  rewrite falseE; apply: imf_ltsup; exists t => //.
-  apply/eqP; rewrite eq_le supleft andbT.
-  by move/ubP : (sup_upper_bound imf_sup); apply; exact: imageP.
-set g := (fun t => (sup imf - f t)^-1 : R).
+  by apply/sup_upper_bound => //; exact/imageP.
+have {}imf_ltsup t : t \in `[a, b]%R -> f t < sup imf.
+  move=> tab; case: (ltrP (f t) (sup imf)) => // supleft.
+  rewrite falseE; apply: imf_ltsup; exists t => //; apply/eqP.
+  by rewrite eq_le supleft andbT sup_upper_bound//; exact/imageP.
+pose g t : R := (sup imf - f t)^-1.
 have invf_continuous : {within `[a, b], continuous g}.
-  rewrite continuous_subspace_in=> t tab; apply: cvgV => //=.
-    rewrite subr_eq0 gt_eqF // imf_ltsup // in_itv //=.
-    by rewrite inE in tab; exact tab.
-  by apply: cvgD; [apply: cst_continuous | apply: cvgN; apply (fcont t)].
+  rewrite continuous_subspace_in => t tab; apply: cvgV => //=.
+    by rewrite subr_eq0 gt_eqF // imf_ltsup //; rewrite inE in tab.
+  by apply: cvgD; [exact: cst_continuous | apply: cvgN; exact: (fcont t)].
 have /ex_strict_bound_gt0 [k k_gt0 /= imVfltk] : bounded_set (g @` `[a, b]).
   apply/compact_bounded/continuous_compact; last exact: segment_compact.
   exact: invf_continuous.
-have : exists2 y, imf y & sup imf - k^-1 < y.
+have [_ [t tab <-]] : exists2 y, imf y & sup imf - k^-1 < y.
   by apply: sup_adherent => //; rewrite invr_gt0.
-move=> [y] -[t tab <-] {y}.
 rewrite ltr_subl_addr -ltr_subl_addl.
 suff : sup imf - f t > k^-1 by move=> /ltW; rewrite leNgt => /negbTE ->.
-rewrite -[X in _ < X]invrK ltf_pinv ?qualifE ?invr_gt0 ?subr_gt0 ?imf_ltsup//.
-by rewrite (le_lt_trans (ler_norm _) _) ?imVfltk//; apply: imageP.
+rewrite -[X in _ < X]invrK ltf_pinv// ?qualifE ?invr_gt0 ?subr_gt0 ?imf_ltsup//.
+by rewrite (le_lt_trans (ler_norm _) _) ?imVfltk//; exact: imageP.
 Qed.
 
 Lemma EVT_min (R : realType) (f : R -> R) (a b : R) :
@@ -1345,7 +1340,7 @@ Lemma EVT_min (R : realType) (f : R -> R) (a b : R) :
 Proof.
 move=> leab fcont.
 have /(EVT_max leab) [c clr fcmax] : {within `[a, b], continuous (- f)}.
-  move=> ?; apply: continuousN => ?; exact: fcont.
+  by move=> ?; apply: continuousN => ?; exact: fcont.
 by exists c => // ? /fcmax; rewrite ler_opp2.
 Qed.
 
@@ -1358,6 +1353,7 @@ have atrF := at_right_proper_filter x.
 apply: (@cvg_map_lim _ _ _ (at_right _)) => // A /cvfx /nbhs_ballP [_ /posnumP[e] xe_A].
 by exists e%:num => // y xe_y; rewrite lt_def => /andP [xney _]; apply: xe_A.
 Qed.
+Arguments cvg_at_rightE {R V} f x.
 
 Lemma cvg_at_leftE (R : numFieldType) (V : normedModType R) (f : R -> V) x :
   cvg (f @ x^') -> lim (f @ x^') = lim (f @ at_left x).
@@ -1369,6 +1365,7 @@ apply: (@cvg_map_lim _ _ _ (at_left _)) => // A /cvfx /nbhs_ballP [_ /posnumP[e]
 exists e%:num => // y xe_y; rewrite lt_def => /andP [xney _].
 by apply: xe_A => //; rewrite eq_sym.
 Qed.
+Arguments cvg_at_leftE {R V} f x.
 
 Lemma le0r_cvg_map (R : realFieldType) (T : topologicalType) (F : set (set T))
   (FF : ProperFilter F) (f : T -> R) :
@@ -1396,8 +1393,8 @@ rewrite limopp; apply: le0r_cvg_map; last by rewrite -limopp; apply: cvgN.
 by move: fle0; apply: filterS => x; rewrite oppr_ge0.
 Qed.
 
-Lemma ler_cvg_map (R : realFieldType) (T : topologicalType) (F : set (set T)) (FF : ProperFilter F)
-  (f g : T -> R) :
+Lemma ler_cvg_map (R : realFieldType) (T : topologicalType) (F : set (set T))
+    (FF : ProperFilter F) (f g : T -> R) :
   (\forall x \near F, f x <= g x) -> cvg (f @ F) -> cvg (g @ F) ->
   lim (f @ F) <= lim (g @ F).
 Proof.
@@ -1418,7 +1415,7 @@ apply/eqP; rewrite eq_le; apply/andP; split.
   rewrite ['D_1 f c]cvg_at_rightE; last exact: fdrvbl.
   apply: ler0_cvg_map; last first.
     have /fdrvbl dfc := cab.
-    rewrite -(@cvg_at_rightE _ _ (fun h : R => h^-1 *: ((f \o shift c) _ - f c))) //.
+    rewrite -(cvg_at_rightE (fun h : R => h^-1 *: ((f \o shift c) _ - f c))) //.
     apply: cvg_trans dfc; apply: cvg_app.
     move=> A [e egt0 Ae]; exists e => // x xe xgt0; apply: Ae => //.
     exact/lt0r_neq0.
@@ -1431,7 +1428,7 @@ apply/eqP; rewrite eq_le; apply/andP; split.
   by rewrite (itvP cab).
 rewrite ['D_1 f c]cvg_at_leftE; last exact: fdrvbl.
 apply: le0r_cvg_map; last first.
-  have /fdrvbl dfc := cab; rewrite -(@cvg_at_leftE _ _ (fun h => h^-1 *: ((f \o shift c) _ - f c))) //.
+  have /fdrvbl dfc := cab; rewrite -(cvg_at_leftE (fun h => h^-1 *: ((f \o shift c) _ - f c))) //.
   apply: cvg_trans dfc; apply: cvg_app.
   move=> A [e egt0 Ae]; exists e => // x xe xgt0; apply: Ae => //.
   exact/ltr0_neq0.
@@ -1463,17 +1460,15 @@ Lemma Rolle (R : realType) (f : R -> R) (a b : R) :
 Proof.
 move=> ltab fdrvbl fcont faefb.
 have [cmax cmaxab fcmax] := EVT_max (ltW ltab) fcont.
-case: (pselect ([set a; b] cmax))=> [cmaxeaVb|]; last first.
-  move=> /asboolPn; rewrite asbool_or => /norP.
-  move=> [/asboolPn/eqP cnea /asboolPn/eqP cneb].
+have [cmaxeaVb|] := boolP (cmax \in [set a; b]); last first.
+  rewrite notin_set => /not_orP[/eqP cnea /eqP cneb].
   have {}cmaxab : cmax \in `]a, b[%R.
     by rewrite in_itv /= !lt_def !(itvP cmaxab) cnea eq_sym cneb.
   exists cmax => //; apply: derive1_at_max (ltW ltab) fdrvbl cmaxab _ => t tab.
   by apply: fcmax; rewrite in_itv /= !ltW // (itvP tab).
 have [cmin cminab fcmin] := EVT_min (ltW ltab) fcont.
-case: (pselect ([set a; b] cmin))=> [cmineaVb|]; last first.
-  move=> /asboolPn; rewrite asbool_or => /norP.
-  move=> [/asboolPn/eqP cnea /asboolPn/eqP cneb].
+have [cmineaVb|] := boolP (cmin \in [set a; b]); last first.
+  rewrite notin_set => /not_orP[/eqP cnea /eqP cneb].
   have {}cminab : cmin \in `]a, b[%R.
     by rewrite in_itv /= !lt_def !(itvP cminab) cnea eq_sym cneb.
   exists cmin => //; apply: derive1_at_min (ltW ltab) fdrvbl cminab _ => t tab.
@@ -1481,11 +1476,11 @@ case: (pselect ([set a; b] cmin))=> [cmineaVb|]; last first.
 have midab : (a + b) / 2 \in `]a, b[%R by apply: mid_in_itvoo.
 exists ((a + b) / 2) => //; apply: derive1_at_max (ltW ltab) fdrvbl (midab) _.
 move=> t tab.
-suff fcst : forall s, s \in `]a, b[%R -> f s = f cmax by rewrite !fcst.
-move=> s sab.
+suff fcst s : s \in `]a, b[%R -> f s = f cmax by rewrite !fcst.
+move=> sab.
 apply/eqP; rewrite eq_le fcmax; last by rewrite in_itv /= !ltW ?(itvP sab).
 suff -> : f cmax = f cmin by rewrite fcmin // in_itv /= !ltW ?(itvP sab).
-by case: cmaxeaVb => ->; case: cmineaVb => ->.
+by move: cmaxeaVb cmineaVb; rewrite 2!inE => -[|] -> [|] ->.
 Qed.
 
 Lemma MVT (R : realType) (f df : R -> R) (a b : R) :
@@ -1495,11 +1490,11 @@ Lemma MVT (R : realType) (f df : R -> R) (a b : R) :
 Proof.
 move=> altb fdrvbl fcont.
 set g := f + (- ( *:%R^~ ((f b - f a) / (b - a)) : R -> R)).
-have gdrvbl : forall x, x \in `]a, b[%R -> derivable g x 1.
-  by move=> x /fdrvbl dfx; apply: derivableB => //; apply/derivable1_diffP.
+have gdrvbl x : x \in `]a, b[%R -> derivable g x 1.
+  by move=> /fdrvbl dfx; apply: derivableB => //; exact/derivable1_diffP.
 have gcont : {within `[a, b], continuous g}.
-  move=> x; apply: continuousD _ ; first (move=>?; exact: fcont). 
-  by apply/continuousN/continuous_subspaceT => ? ?; apply: scalel_continuous.
+  move=> x; apply: continuousD _ ; first by move=>?; exact: fcont.
+  by apply/continuousN/continuous_subspaceT => ? ?; exact: scalel_continuous.
 have gaegb : g a = g b.
   rewrite /g -![(_ - _ : _ -> _) _]/(_ - _).
   apply/eqP; rewrite -subr_eq /= opprK addrAC -addrA -scalerBl.
@@ -1507,7 +1502,7 @@ have gaegb : g a = g b.
     by rewrite mul1r addrCA subrr addr0.
   by apply: lt0r_neq0; rewrite subr_gt0.
 have [c cab dgc0] := Rolle altb gdrvbl gcont gaegb.
-exists c; first exact: cab. 
+exists c; first exact: cab.
 have /fdrvbl dfc := cab; move/@derive_val: dgc0; rewrite deriveB //; last first.
   exact/derivable1_diffP.
 move/eqP; rewrite [X in _ - X]deriveE // derive_val diff_val scale1r subr_eq0.
@@ -1534,24 +1529,19 @@ Lemma ler0_derive1_nincr (R : realType) (f : R -> R) (a b : R) :
   forall x y, a <= x -> x <= y -> y <= b -> f y <= f x.
 Proof.
 move=> fdrvbl dfle0 ctsf x y leax lexy leyb; rewrite -subr_ge0.
-case: ltgtP lexy => // [xlty|xyb]; last first.
-  by rewrite xyb subrr.
+case: ltgtP lexy => // [xlty|->]; last by rewrite subrr.
 have itvW : {subset `[x, y]%R <= `[a, b]%R}.
   by apply/subitvP; rewrite /<=%O /= /<=%O /= leyb leax.
 have itvWlt : {subset `]x, y[%R <= `]a, b[%R}.
   by apply subitvP; rewrite /<=%O /= /<=%O /= leyb leax.
 have fdrv z : z \in `]x, y[%R -> is_derive z 1 f (f^`()z).
-  rewrite inE => /andP [lexz lezy].
-  apply: DeriveDef; last by rewrite derive1E.
-  apply: fdrvbl; rewrite inE; apply/andP.
-  split; [exact: le_trans lexz | apply: le_trans]; first exact: lezy.
-  by rewrite /Order.le; exact: leyb.
-have [] := @MVT _ f (f^`()) x y xlty fdrv. 
-  apply: (@continuous_subspaceW _ _ _ `[a,b]); first exact: itvW. 
+  rewrite in_itv/= => /andP[xz zy]; apply: DeriveDef; last by rewrite derive1E.
+  by apply: fdrvbl; rewrite in_itv/= (le_lt_trans _ xz)// (lt_le_trans zy).
+have [] := @MVT _ f (f^`()) x y xlty fdrv.
+  apply: (@continuous_subspaceW _ _ _ `[a,b]); first exact: itvW.
   by rewrite continuous_subspace_in.
-move=> t /itvWlt dft dftxy _; rewrite -oppr_le0 opprB dftxy. 
-apply: mulr_le0_ge0 => //; last by rewrite subr_ge0 ltW.
-exact: dfle0.
+move=> t /itvWlt dft dftxy _; rewrite -oppr_le0 opprB dftxy.
+by apply: mulr_le0_ge0 => //; [exact: dfle0|by rewrite subr_ge0 ltW].
 Qed.
 
 Lemma le0r_derive1_ndecr (R : realType) (f : R -> R) (a b : R) :

--- a/theories/exp.v
+++ b/theories/exp.v
@@ -443,8 +443,9 @@ Lemma expR_total_gt1 x :
 Proof.
 move=> x_ge1; have x_ge0 : 0 <= x by apply: le_trans x_ge1.
 case: (@IVT _ (fun y => expR y - x) 0 x 0) => //.
-- by move=> x1 x1Ix; apply: continuousB => // y1;
-    [exact: continuous_expR|exact: cst_continuous].
+- move=> x1 x1Ix; apply: continuousB => // y1.
+  + by apply/continuous_subspaceT=> ? _; exact: continuous_expR.
+  + exact: cst_continuous.
 - rewrite expR0; case: (ltrgtP (1- x) (expR x - x)) => [_| |].
   + rewrite subr_le0 x_ge1 subr_ge0.
     by apply: le_trans (expR_ge1Dx _); rewrite ?ler_addr.

--- a/theories/exp.v
+++ b/theories/exp.v
@@ -442,19 +442,17 @@ Lemma expR_total_gt1 x :
   1 <= x -> exists y, [/\ 0 <= y, 1 + y <= x & expR y = x].
 Proof.
 move=> x_ge1; have x_ge0 : 0 <= x by apply: le_trans x_ge1.
-case: (@IVT _ (fun y => expR y - x) 0 x 0) => //.
-- move=> x1 x1Ix; apply: continuousB => // y1.
-  + by apply/continuous_subspaceT=> ? _; exact: continuous_expR.
-  + exact: cst_continuous.
-- rewrite expR0; case: (ltrgtP (1- x) (expR x - x)) => [_| |].
-  + rewrite subr_le0 x_ge1 subr_ge0.
-    by apply: le_trans (expR_ge1Dx _); rewrite ?ler_addr.
+have [x1 x1Ix| |x1 _ /eqP] := @IVT _ (fun y => expR y - x) _ _ 0 x_ge0.
+- apply: continuousB => // y1; last exact: cst_continuous.
+  by apply/continuous_subspaceT=> ? _; exact: continuous_expR.
+- rewrite expR0; have [_| |] := ltrgtP (1- x) (expR x - x).
+  + by rewrite subr_le0 x_ge1 subr_ge0 (le_trans _ (expR_ge1Dx _)) ?ler_addr.
   + by rewrite ltr_add2r expR_lt1 ltNge x_ge0.
   + rewrite subr_le0 x_ge1 => -> /=; rewrite subr_ge0.
-    by apply: le_trans (expR_ge1Dx x_ge0); rewrite ler_addr.
-- move=> x1 _ /eqP; rewrite subr_eq0 => /eqP x1_x.
-  exists x1; split => //; first by rewrite -ler_expR expR0 x1_x.
-  by rewrite -x1_x expR_ge1Dx // -ler_expR x1_x expR0.
+    by rewrite (le_trans _ (expR_ge1Dx x_ge0)) ?ler_addr.
+- rewrite subr_eq0 => /eqP x1_x; exists x1; split => //.
+  + by rewrite -ler_expR expR0 x1_x.
+  + by rewrite -x1_x expR_ge1Dx // -ler_expR x1_x expR0.
 Qed.
 
 Lemma expR_total x : 0 < x -> exists y, expR y = x.

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -3183,13 +3183,13 @@ Proof.
 move=> leab fcont; gen have ivt : f v fcont / f a <= v <= f b ->
     exists2 c, c \in `[a, b] & f c = v; last first.
   case: (leP (f a) (f b)) => [] _ fabv; first exact: ivt.
-  have [||c cab /oppr_inj] := ivt (- f) (- v); last by exists c.
-    by move=> x; apply: continuousN; apply: fcont.
-  by rewrite ler_oppr opprK ler_oppr opprK andbC.
-move=> favfb; suff: (is_interval (f @` `[a,b])).
-  apply; last by exact: favfb. 
-    by exists a => //=; rewrite inE /<=%O /=; apply/andP.
-  by exists b => //=; rewrite inE /<=%O /=; apply/andP.
+  have [| |c cab /oppr_inj] := ivt (- f) (- v); last by exists c.
+  - by move=> x; apply: continuousN; apply: fcont.
+  - by rewrite ler_oppr opprK ler_oppr opprK andbC.
+move=> favfb; suff: is_interval (f @` `[a,b]).
+  apply; last exact: favfb.
+  - by exists a => //=; rewrite in_itv/= lexx.
+  - by exists b => //=; rewrite in_itv/= leab lexx.
 apply/connected_intervalP/connected_continuous_connected => //.
 exact: segment_connected.
 Qed.

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -2784,20 +2784,20 @@ Qed.
 
 Lemma closed_le (y : R) : closed [set x : R | x <= y].
 Proof.
-rewrite (_ : mkset _ = ~` [set x | x > y]); first exact: closedC.
+rewrite (_ : mkset _ = ~` [set x | x > y]); first exact: open_closedC.
 by rewrite predeqE => x /=; rewrite leNgt; split => /negP.
 Qed.
 
 Lemma closed_ge (y : R) : closed [set x : R | y <= x].
 Proof.
-rewrite (_ : mkset _ = ~` [set x | x < y]); first exact: closedC.
+rewrite (_ : mkset _ = ~` [set x | x < y]); first exact: open_closedC.
 by rewrite predeqE => x /=; rewrite leNgt; split => /negP.
 Qed.
 
 Lemma closed_eq (y : R) : closed [set x : R | x = y].
 Proof.
 rewrite [X in closed X](_ : (eq^~ _) = ~` (xpredC (eq_op^~ y))).
-  by apply: closedC; exact: open_neq.
+  by apply: open_closedC; exact: open_neq.
 by rewrite predeqE /setC => x /=; rewrite (rwP eqP); case: eqP; split.
 Qed.
 
@@ -3084,7 +3084,7 @@ split => [cE x y Ex Ey z /andP[xz zy]|].
   have [r zcA1] : {r:{posnum R}| ball z r%:num `<=` ~` closure (A true)}.
     have ? : ~ closure (A true) z.
       by move: sepA; rewrite /separated => -[] _ /disjoints_subset; apply.
-    have ? : open (~` closure (A true)) by exact/openC/closed_closure.
+    have ? : open (~` closure (A true)) by exact/closed_openC/closed_closure.
     exact/nbhsC_ball/open_nbhs_nbhs.
   pose z1 : R := z + r%:num / 2; exists z1.
   have z1y : z1 <= y.
@@ -3176,7 +3176,7 @@ rewrite {1}(splitr x) ger_addl pmulr_lle0 // => /(lt_le_trans x0);
 Qed.
 
 Lemma IVT (R : realType) (f : R -> R) (a b v : R) :
-  a <= b -> {in `[a, b], continuous f} ->
+  a <= b -> {within `[a, b], continuous f} ->
   minr (f a) (f b) <= v <= maxr (f a) (f b) ->
   exists2 c, c \in `[a, b] & f c = v.
 Proof.
@@ -3184,50 +3184,15 @@ move=> leab fcont; gen have ivt : f v fcont / f a <= v <= f b ->
     exists2 c, c \in `[a, b] & f c = v; last first.
   case: (leP (f a) (f b)) => [] _ fabv; first exact: ivt.
   have [||c cab /oppr_inj] := ivt (- f) (- v); last by exists c.
-    by move=> x /fcont; apply: continuousN.
+    by move=> x; apply: continuousN; apply: fcont.
   by rewrite ler_oppr opprK ler_oppr opprK andbC.
-move=> /andP[]; rewrite le_eqVlt => /orP [/eqP<- _|ltfav].
-  by exists a => //; rewrite in_itv /= lexx leab.
-rewrite le_eqVlt => /orP [/eqP->|ltvfb].
-  by exists b => //; rewrite in_itv /= lexx leab.
-set A := [set c | (c <= b) && (f c <= v)].
-have An0 : nonempty A by exists a; apply/andP; split=> //; apply: ltW.
-have supA : has_sup A by split=> //; exists b; apply/ubP => ? /andP [].
-have supAab : sup A \in `[a, b].
-  rewrite inE; apply/andP; split; last first.
-    by apply: sup_le_ub => //; apply/ubP => ? /andP [].
-  by move/ubP : (sup_upper_bound supA); apply; rewrite /A/= leab andTb ltW.
-exists (sup A) => //; have lefsupv : f (sup A) <= v.
-  rewrite leNgt; apply/negP => ltvfsup.
-  have vltfsup : 0 < f (sup A) - v by rewrite subr_gt0.
-  have /fcont /(_ _ (nbhsx_ballx _ (PosNum vltfsup))) [_/posnumP[d] supdfe]
-    := supAab.
-  have [t At supd_t] := sup_adherent supA [gt0 of d%:num].
-  suff /supdfe : ball (sup A) d%:num t.
-    rewrite /= /ball /= ltr_norml => /andP [_].
-    by rewrite ltr_add2l ltr_oppr opprK ltNge; have /andP [_ ->] := At.
-  rewrite /= /ball /= ger0_norm.
-    by rewrite ltr_subl_addr -ltr_subl_addl.
-  by rewrite subr_ge0; move/ubP : (sup_upper_bound supA); exact.
-apply/eqP; rewrite eq_le; apply/andP; split=> //.
-rewrite -subr_le0; apply/ler0_addgt0P => _/posnumP[e].
-rewrite ler_subl_addr -ler_subl_addl ltW //.
-have /fcont /(_ _ (nbhsx_ballx _ e)) [_/posnumP[d] supdfe] := supAab.
-have atrF := at_right_proper_filter (sup A); near (at_right (sup A)) => x.
-have /supdfe /= : ball (sup A) d%:num x.
-  by near: x; rewrite /= nbhs_simpl; exists d%:num => //.
-rewrite /= => /ltr_distlC_subl; apply: le_lt_trans.
-rewrite ler_add2r ltW //; suff : forall t, t \in `](sup A), b] -> v < f t.
-  apply; rewrite inE; apply/andP; split; first by near: x; exists 1.
-  near: x; exists (b - sup A) => /=.
-    rewrite subr_gt0 lt_def (itvP supAab) andbT; apply/negP => /eqP besup.
-    by move: lefsupv; rewrite leNgt -besup ltvfb.
-  move=> t lttb ltsupt; move: lttb; rewrite /= distrC.
-  by rewrite gtr0_norm ?subr_gt0 // ltr_add2r; apply: ltW.
-move=> t; rewrite in_itv /=; case/andP => ltsupt letb.
-apply/contra_lt: ltsupt => leftv.
-by move/ubP : (sup_upper_bound supA); apply; rewrite /A/= leftv letb.
-Unshelve. all: by end_near. Qed.
+move=> favfb; suff: (is_interval (f @` `[a,b])).
+  apply; last by exact: favfb. 
+    by exists a => //=; rewrite inE /<=%O /=; apply/andP.
+  by exists b => //=; rewrite inE /<=%O /=; apply/andP.
+apply/connected_intervalP/connected_continuous_connected => //.
+exact: segment_connected.
+Qed.
 
 (** Local properties in [R] *)
 
@@ -3558,14 +3523,14 @@ Lemma closed_ereal_le_ereal y : closed [set x | y <= x].
 Proof.
 rewrite (_ : [set x | y <= x] = ~` [set x | y > x]); last first.
   by rewrite predeqE=> x; split=> [rx|/negP]; [apply/negP|]; rewrite -leNgt.
-exact/closedC/open_ereal_lt_ereal.
+exact/open_closedC/open_ereal_lt_ereal.
 Qed.
 
 Lemma closed_ereal_ge_ereal y : closed [set x | y >= x].
 Proof.
 rewrite (_ : [set x | y >= x] = ~` [set x | y < x]); last first.
   by rewrite predeqE=> x; split=> [rx|/negP]; [apply/negP|]; rewrite -leNgt.
-exact/closedC/open_ereal_gt_ereal.
+exact/open_closedC/open_ereal_gt_ereal.
 Qed.
 
 End open_closed_sets_ereal.

--- a/theories/realfun.v
+++ b/theories/realfun.v
@@ -27,15 +27,14 @@ Section real_inverse_functions.
 Variable R : realType.
 Implicit Types (a b : R) (f g : R -> R).
 
-(* TODO: this is a workaround to weaken {in I, continuous f} to use IVT. 
+(* TODO: this is a workaround to weaken {in I, continuous f} to use IVT.
    Updating this whole file to use {within [set` I], continuous f} is the
-   better, but more labor intensive approach 
-*)
-Lemma continuous_subspace_itv ( I : interval R) (f : R -> R) : 
-  {in I, continuous f} -> {within [set` I], continuous f}. 
+   better, but more labor intensive approach *)
+Lemma continuous_subspace_itv (I : interval R) (f : R -> R) :
+  {in I, continuous f} -> {within [set` I], continuous f}.
 Proof.
 move=> ctsf; apply: continuous_subspaceT => x Ix; apply: ctsf.
-by move: Ix; rewrite inE /=.
+by move: Ix; rewrite inE.
 Qed.
 
 Lemma itv_continuous_inj_le f (I : interval R) :
@@ -52,17 +51,12 @@ gen have main : f / forall c, {in I, continuous f} -> {in I &, injective f} ->
   move=> c fC fI a b aI bI faLfb aLc cLb.
   have intP := interval_is_interval aI bI.
   have cI : c \in I by rewrite intP// (ltW aLc) ltW.
-  (* TODO: this is a workaround to weaken {in I, continuous f} to use IVT. 
-     Updating this whole file to use {within [set` I], continuous f} is the
-     better, but more labor intensive approach *)
-  have ctsACf : {within `[a,c], continuous f}.
-    apply: continuous_subspaceT => x axc; apply: fC.
-    move:axc; rewrite /= inE /<=%O/= => /andP [? ?].
-    by apply/intP; rewrite (le_trans _ (ltW cLb)) // Bool.andb_true_r.
+  have ctsACf : {within `[a, c], continuous f}.
+    apply: continuous_subspaceT => x; rewrite inE => /itvP axc; apply: fC.
+    by rewrite intP// axc/= (le_trans _ (ltW cLb))// axc.
   have ctsCBf : {within `[c,b], continuous f}.
-    apply: continuous_subspaceT => x axc; apply: fC.
-    move:axc; rewrite /= inE /<=%O/= => /andP [? ?].
-    by apply/intP; rewrite (le_trans (ltW aLc)).
+    apply: continuous_subspaceT => x; rewrite inE => /itvP axc; apply: fC.
+    by rewrite intP// axc andbT (le_trans (ltW aLc)) ?axc.
   have [aLb alb'] : a < b /\ a <= b by rewrite ltW (lt_trans aLc).
   have [faLfc|fcLfa|/eqP faEfc] /= := ltrgtP (f a) (f c).
   - split; rewrite // lt_neqAle fxy // leNgt; apply/negP => fbLfc.
@@ -220,9 +214,7 @@ Qed.
 
 Lemma segment_continuous_surjective a b f : a <= b ->
   {in `[a, b], continuous f} -> surjective `[a, b] (f @`[a, b]) f.
-Proof. 
-by move=> le_ab /continuous_subspace_itv fct y/= /IVT[]// x; exists x.
-Qed.
+Proof. by move=> ? /continuous_subspace_itv fct y/= /IVT[]// x; exists x. Qed.
 
 Lemma segment_continuous_le_surjective a b f : a <= b -> f a <= f b ->
   {in `[a, b], continuous f} -> surjective `[a, b] `[f a, f b] f.
@@ -498,13 +490,11 @@ Lemma is_derive_0_is_cst (f : R -> R) x y :
   (forall x, is_derive x 1 f 0) -> f x = f y.
 Proof.
 move=> Hd.
-wlog xLy : x y / x <= y.
-  by move=> H; case: (leP x y) => [/H |/ltW /H].
+wlog xLy : x y / x <= y by move=> H; case: (leP x y) => [/H |/ltW /H].
 rewrite -(subKr (f y) (f x)).
-case: (MVT_segment xLy) => [| _ _].
-  apply/continuous_subspaceT=> ? _.
-  by apply/differentiable_continuous/derivable1_diffP.
-by rewrite mul0r => ->; rewrite subr0.
+have [| _ _] := MVT_segment xLy; last by rewrite mul0r => ->; rewrite subr0.
+apply/continuous_subspaceT => r _.
+exact/differentiable_continuous/derivable1_diffP.
 Qed.
 
 Global Instance is_derive1_comp (f g : R -> R) (x a b : R) :

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -378,8 +378,8 @@ Reserved Notation "f `@ F" (at level 60, format "f  `@  F").
 Reserved Notation "A ^°" (at level 1, format "A ^°").
 Reserved Notation "[ 'locally' P ]" (at level 0, format "[ 'locally'  P ]").
 Reserved Notation "x ^'" (at level 2, format "x ^'").
-
-<<<<<<< HEAD
+Reserved Notation "'{within' A , 'continuous' f }"
+  (at level 70, A at level 69, format "'{within'  A ,  'continuous'  f }").
 Reserved Notation "{ 'uniform`' A -> V }"
   (at level 0, A at level 69, format "{ 'uniform`'  A  ->  V }").
 Reserved Notation "{ 'uniform' U -> V }"
@@ -398,29 +398,6 @@ Reserved Notation "{ 'family' fam , U -> V }"
   (at level 0, U at level 69, format "{ 'family'  fam ,  U  ->  V }").
 Reserved Notation "{ 'family' fam , F --> f }"
   (at level 0, F at level 69, format "{ 'family'  fam ,  F  -->  f }").
-=======
-Reserved Notation "'{within' A , 'continuous' f }"
-  (at level 70, A at level 69, format "'{within'  A ,  'continuous'  f }").
-
-Reserved Notation "'{uniform`' A -> V }"
-  (at level 70, A at level 69, format "'{uniform`'  A  ->  V }").
-Reserved Notation "'{uniform' U -> V }"
-  (at level 70, U at level 69, format "'{uniform'  U  ->  V }").
-Reserved Notation "'{uniform' A , F --> f }"
-  (at level 70, A at level 69, F at level 69,
-   format "'{uniform'  A ,  F  -->  f }").
-Reserved Notation "'{uniform' , F --> f }"
-  (at level 70, F at level 69,
-   format "'{uniform' ,  F  -->  f }").
-Reserved Notation "'{ptws' U -> V }"
-  (at level 70, U at level 69, format "'{ptws'  U  ->  V }").
-Reserved Notation "'{ptws' , F --> f }"
-  (at level 70, F at level 69, format "'{ptws' ,  F  -->  f }").
-Reserved Notation "'{family' fam , U -> V }"
-  (at level 70, U at level 69, format "'{family'  fam ,  U  ->  V }").
-Reserved Notation "'{family' fam , F --> f }"
-  (at level 70, F at level 69, format "'{family'  fam ,  F  -->  f }").
->>>>>>> 33a0ee0... fixed connected continuous
 
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/theories/trigo.v
+++ b/theories/trigo.v
@@ -524,7 +524,7 @@ Lemma cos_exists : exists2 pih : R, 0 <= pih <= 2 & cos pih = 0.
 Proof.
 have /IVT[]// : minr (cos 0) (cos 2) <= (0 : R) <= maxr (cos 0) (cos 2).
   by rewrite /minr /maxr cos0 ltNge cos_le1/= ler01 (ltW cos2_lt0).
-by move=> *; apply: continuous_cos.
+by move=> *; apply/continuous_subspaceT=> ? _; apply: continuous_cos.
 by move=> pih /itvP pihI chpi_eq0; exists pih; rewrite ?pihI.
 Qed.
 
@@ -562,9 +562,9 @@ wlog xLy : x y / x <= y => [H xB cx0 yB cy0|].
 move=> /andP[x_ge0 x_le2] cx0 /andP[y_ge0 y_le2] cy0.
 case: (x =P y) => // /eqP xDy.
 have xLLs : x < y by rewrite le_eqVlt (negPf xDy) in xLy.
-have /(Rolle xLLs)[x1 _|x1 _|x1 x1I [_ x1D]] : cos x = cos y by rewrite cy0.
+have /(Rolle xLLs)[x1 _|x1|x1 x1I [_ x1D]] : cos x = cos y by rewrite cy0.
 - exact: derivable_cos.
-- exact: continuous_cos.
+- by apply/continuous_subspaceT=> ? _; exact: continuous_cos.
 - have [_ /esym/eqP] := is_derive_cos x1; rewrite x1D oppr_eq0 => /eqP Hs.
   suff : 0 < sin x1 by rewrite Hs ltxx.
   apply/sin2_gt0/andP; split.
@@ -610,7 +610,7 @@ wlog : x / 0 <= x => [Hw|x_ge0].
 move=> /andP[x_gt0 xLpi2]; case: (ler0P (cos x)) => // cx_le0.
 have /IVT[]// : minr (cos 0) (cos x) <= 0 <= maxr (cos 0) (cos x).
   by rewrite cos0 /minr /maxr !ifN ?cx_le0 //= -leNgt (le_trans cx_le0).
-- by move=> *; apply: continuous_cos.
+- by move=> *; apply/continuous_subspaceT=> ? _; apply: continuous_cos.
 move=> x1 /itvP Hx1 cx1_eq0.
 suff x1E : x1 = pi/2.
   have : x1 < pi / 2 by apply: le_lt_trans xLpi2; rewrite Hx1.
@@ -700,8 +700,8 @@ move=> x y; rewrite !in_itv/= le_eqVlt; case: eqP => [<- _|_] /=.
     by rewrite cos0 !ltxx.
   rewrite y_gt0; apply/idP.
   suff : cos y != 1 by case: ltrgtP (cos_le1 y).
-  rewrite -cos0 eq_sym; apply/eqP => /Rolle [||x1 _|x1 /itvP x1I [_ x1D]] //.
-    exact: continuous_cos.
+  rewrite -cos0 eq_sym; apply/eqP => /Rolle [||x1|x1 /itvP x1I [_ x1D]] //.
+    by apply/continuous_subspaceT=> ? _; exact: continuous_cos.
   case: (is_derive_cos x1) => _ /eqP; rewrite x1D eq_sym oppr_eq0 => /eqP s_eq0.
   suff : 0 < sin x1 by rewrite s_eq0 ltxx.
   by apply: sin_gt0_pi; rewrite x1I /= (lt_le_trans (_ : _ < y)) ?x1I // yI.
@@ -715,8 +715,8 @@ rewrite le_eqVlt; case: eqP => [<- _|_] /=.
 rewrite le_eqVlt; case: eqP => /= [-> _ | _ /andP[y_gt0 y_ltpi]].
   rewrite cospi x_ltpi; apply/idP.
   suff : cos x != -1 by case: ltrgtP (cos_geN1 x).
-  rewrite -cospi; apply/eqP => /Rolle [||x1 _|x1 /itvP x1I [_ x1D]] //.
-    exact: continuous_cos.
+  rewrite -cospi; apply/eqP => /Rolle [||x1|x1 /itvP x1I [_ x1D]] //.
+    by apply/continuous_subspaceT=> ? _; exact: continuous_cos.
   case: (is_derive_cos x1) => _ /eqP; rewrite x1D eq_sym oppr_eq0 => /eqP s_eq0.
   suff : 0 < sin x1 by rewrite s_eq0 ltxx.
   by apply: sin_gt0_pi; rewrite x1I /= (lt_le_trans (_ : _ < x)) ?x1I.
@@ -726,8 +726,8 @@ wlog xLy : x y x_gt0 x_ltpi y_gt0 y_ltpi / x <= y => [H | ].
 case: (x =P y) => [->| /eqP xDy]; first by rewrite ltxx.
 have xLLs : x < y by rewrite le_eqVlt (negPf xDy) in xLy.
 rewrite xLLs -subr_gt0 -opprB; rewrite -subr_gt0 in xLLs; apply/idP.
-have [x1 _|z /itvP zI ->] := @MVT _ cos (-sin) _ _ xLy.
-  exact: continuous_cos.
+have [x1|z /itvP zI ->] := @MVT_segment _ cos (-sin) _ _ xLy.
+  by apply/continuous_subspaceT=> ? _; exact: continuous_cos.
 rewrite -mulNr opprK mulr_gt0 //; apply: sin_gt0_pi.
 by rewrite (lt_le_trans x_gt0) ?zI //= (le_lt_trans _ y_ltpi) ?zI.
 Qed.
@@ -846,13 +846,14 @@ wlog xLy : x y / x <= y => [H | ] xB yB.
 case: (x =P y) => [->| /eqP xDy]; first by rewrite ltxx.
 have xLLs : x < y by rewrite le_eqVlt (negPf xDy) in xLy.
 rewrite -subr_gt0 xLLs; rewrite -subr_gt0 in xLLs; apply/idP.
-have [x1 /itvP x1I|z /itvP zI|] := @MVT _ tan (fun x => (cos x) ^-2) _ _ xLy.
+have [x1 /itvP x1I|z |] := @MVT_segment _ tan (fun x => (cos x) ^-2) _ _ xLy.
 - apply: is_derive_tan.
   rewrite gt_eqF // cos_gt0_pihalf // (@lt_le_trans _  _ x) ?x1I ?(itvP xB)//=.
   by rewrite (@le_lt_trans _  _ y) ?x1I ?(itvP yB).
-- apply: continuous_tan.
+- apply/continuous_subspaceT=> ? inI; apply: continuous_tan.
+  rewrite /= inE /<=%O/= in inI; move/andP: inI => /= [? ?].
   rewrite gt_eqF // cos_gt0_pihalf // (@lt_le_trans _  _ x) ?zI ?(itvP xB)//=.
-  by rewrite (@le_lt_trans _  _ y) ?zI ?(itvP yB).
+  rewrite (@le_lt_trans _  _ y) ?zI ?(itvP yB) //.
 - move=> x1 /itvP x1I ->.
   rewrite mulr_gt0 // invr_gt0 // exprn_gte0 // cos_gt0_pihalf //.
   rewrite (@lt_le_trans _  _ x) ?x1I ?(itvP xB)//=.
@@ -885,7 +886,8 @@ have /(IVT (@pi_ge0 _))[] // : minr (f 0) (f pi) <= 0 <= maxr (f 0) (f pi).
   rewrite /f cos0 cospi /minr /maxr ltr_add2r -subr_lt0 opprK (_ : 1 + 1 = 2)//.
   by rewrite ltrn0 subr_le0 subr_ge0.
 - move=> y y0pi.
-  by apply: continuousB; [exact: continuous_cos|exact: cst_continuous].
+  by apply: continuousB; apply/continuous_subspaceT=> ? ?; 
+    [exact: continuous_cos|exact: cst_continuous].
 - rewrite /f => x1 /itvP x1I /eqP; rewrite subr_eq0 => /eqP cosx1E.
   by case: (He x1); rewrite !x1I.
 Qed.
@@ -982,8 +984,8 @@ have /IVT[] // :
   rewrite /f sinN sin_pihalf /minr /maxr ltr_add2r -subr_gt0 opprK.
   by rewrite (_ : 1 + 1 = 2)// ltr0n/= subr_le0 subr_ge0.
 - by rewrite -subr_ge0 opprK -splitr pi_ge0.
-- by move=> *; apply: continuousB; [exact: continuous_sin|
-                                   exact: cst_continuous].
+- by move=> *; apply: continuousB; apply/continuous_subspaceT=> ? ?; 
+   [exact: continuous_sin| exact: cst_continuous].
 - rewrite /f => x1 /itvP x1I /eqP; rewrite subr_eq0 => /eqP sinx1E.
   by case: (He x1); rewrite !x1I.
 Qed.


### PR DESCRIPTION
Fixes #408 (except in realfun.v. We should open another ticket for that, as it's a bit more work). 

This 
1. introduces a notation `{within A, continuous f}`, to indicate continuity on the subspace. This is hacky, and needs fixing (see #408) for further discussion
2. A bunch of additional lemmas about subspaces, their continuity, and closed sets
3. Fixes boundary conditions for
  a. continuous image of connected is connected
  b. continuous image of compact is compact
  c. EVT, and it's friends, including Rolle's theorem, and MVT.
  d. interval_connectedP, and IVT, including a dramatic simplification of that proof. 

  
Note that I use some scaffolding code for realfun.v to change the `{in I, continuous f}` to `{within I, continuous f}`. It's not much, but rewriting the whole thing is a lot of lines changed, and requires a couple tougher lemmas (such as letting us convert between `fmap f (nbhs {subspace A} x)`  and `nbhs {subspace (f`@A)} f a` when f is a homeomorphism). Specifically, this comes up in `segment_can_ge`, where the subspace swaps from `[a,b]` to `[-b, -a]`. 

I think the scaffolding in realfun.v is fine, and can be handled in a separate diff. The notation should be fixed, at least. 