### PR TITLE
add .dir-locals.el for company-coq symbols

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,13 @@
+;;; Directory Local Variables
+;;; For more information see (info "(emacs) Directory Variables")
+
+;; see https://www.compart.com/en/unicode/U+xxxx
+
+((coq-mode
+  (company-coq-dir-local-symbols .
+   (("`&`" . 8745)  ;; ∩ U+2229
+    ("`|`" . 8746)  ;; ∪ U+222A
+    ("set0" . 8709) ;; ∅ U+2205
+    ("`<`" . 8842) ;; ⊊ U+228A
+    ("`<=`" . 8838) ;; ⊆ U+2286
+))))

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -39,4 +39,6 @@
 
 ### Infrastructure
 
+- add `.dir-locals.el` for company-coq symbols
+
 ### Misc


### PR DESCRIPTION
This PR adds a few uncontroversial unicode symbols for company-coq users.
