### PR TITLE
Arzela main lemmas

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -34,6 +34,32 @@
   + lemma `fset_set_image`, `card_fset_set`, `geq_card_fset_set`,
     `leq_card_fset_set`, `infinite_set_fset`, `infinite_set_fsetP` and
     `fcard_eq`.
+  + notations `{posnum \bar R}` and `{nonneg \bar R}`
+  + notations `%:pos` and `%:nng` in `ereal_dual_scope` and `ereal_scope`
+  + variants `posnume_spec` and `nonnege_spec`
+  + definitions `posnume`, `nonnege`, `abse_reality_subdef`,
+    `ereal_sup_reality_subdef`, `ereal_inf_reality_subdef`
+  + lemmas `ereal_comparable`, `pinfty_snum_subproof`, `ninfty_snum_subproof`,
+    `EFin_snum_subproof`, `fine_snum_subproof`, `oppe_snum_subproof`,
+    `adde_snum_subproof`, `dadde_snum_subproof`, `mule_snum_subproof`,
+    `abse_reality_subdef`, `abse_snum_subproof`, `ereal_sup_snum_subproof`,
+    `ereal_inf_snum_subproof`, `num_abse_eq0`, `num_lee_maxr`, `num_lee_maxl`,
+    `num_lee_minr`, `num_lee_minl`, `num_lte_maxr`, `num_lte_maxl`,
+    `num_lte_minr`, `num_lte_minl`, `num_abs_le`, `num_abs_lt`,
+    `posnumeP`, `nonnegeP`
+  + signed instances `pinfty_snum`, `ninfty_snum`, `EFin_snum`, `fine_snum`,
+    `oppe_snum`, `adde_snum`, `dadde_snum`, `mule_snum`, `abse_snum`,
+    `ereal_sup_snum`, `ereal_inf_snum`
+- in `topology.v`:
+  + Definition `powerset_filter_from`
+  + globals `powerset_filter_from_filter`, 
+  + lemmas `near_small_set`, `small_set_sub`
+  + lemmas `withinET`, `closureEcvg`, `entourage_sym`, `fam_nbhs`
+  + generalize `cluster_cvgE`, `ptws_cvg_compact_family`
+  + lemma `near_compact_covering`
+  + rewrite `equicontinuous` and `pointwise_precompact` to use index 
+  + lemmas `ptws_cvg_entourage`, `equicontinuous_closure`, `ptws_compact_cvg`
+    `ptws_compact_closed`, `ascoli_forward`, `compact_equicontinuous`
 
 ### Changed
 


### PR DESCRIPTION
This has the hard parts of Arzela-Ascoli. The forward direction is done, but the backwards direction still needs a little work to get it done fully. But this is an appropriate place to stop, considering the size of the change already.

1. We introduce a `sets_of` filter that, given a filter over `T`, gives a filter over `set T` which has the "small" sets. That is, it's the filter of downward closed members of `F`. The purpose of this is to let us write `near (sets_of entourage)` to get an "epsilon" without having a metric space and using posnum. This is super practical for both of the main lemmas.

2. I have a `near_compact_cover` lemma which dramatically factors out the two main lemmas. It let's us factor a quantifier out of a `\near`, turning a "global" property into two local ones. The analogy to open coverings is that if you can index an open cover by a filter (E.G. some epsilon), you can construct a filter which converges to counter-examples. 

3. The theorems themselves `compact_equicontinuous` and `ptws_compact_cvg` (names could be improved). Thanks to the two tools above, they are fairly short. But the topology is indeed tricky.

4. I still need to update the changelog. I'm also sure there's a bunch of linting I missed.

I ran into some rather frustrating trouble with the `\near` notation where the `near` lemma did not like the `g \near (nbhs f)` that was in scope. Sometimes it was conflicting stuff in the evar's context (I had to try to define everything possible before entering the `near` to avoid this. Why can't it unfold context elements it doesn't recognize to see if they're defined in terms it does know?). Other times I'm not really sure what was wrong. I can provide repros if you all want. 

The only remaining steps for Arzela Ascoli are:
- Prove uniform limits of continuous functions are continuous (I think this is easy from the cvg_switch?)
- The next meaningful lemma takes `compact_equicontinuous` and weakens the condition to only require `precompact` instead of `compact`
- Then the final step is to prove a weaker, but highly practical version that says
```
{ptws F --> f} /\ F is equicontinuous -> {family compact, F --> f}
```
