### PR TITLE
fix hb dependency version

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,7 +5,7 @@
 - [The Coq Proof Assistant version ≥ 8.13](https://coq.inria.fr)
 - [Mathematical Components version ≥ 1.13.0](https://github.com/math-comp/math-comp)
 - [Finmap library version ≥ 1.5.1](https://github.com/math-comp/finmap)
-- [Hierarchy builder version >= 1.0.0](https://github.com/math-comp/hierarchy-builder)
+- [Hierarchy builder version >= 1.2.0](https://github.com/math-comp/hierarchy-builder)
 
 These requirements can be installed in a custom way, or through
 [opam](https://opam.ocaml.org/) (the recommended way) using

--- a/README.md
+++ b/README.md
@@ -5,14 +5,10 @@ Follow the instructions on https://github.com/coq-community/templates to regener
 # Analysis library compatible with Mathematical Components
 
 [![Docker CI][docker-action-shield]][docker-action-link]
-[![Nix CI][nix-action-shield]][nix-action-link]
 [![Chat][chat-shield]][chat-link]
 
 [docker-action-shield]: https://github.com/math-comp/analysis/workflows/Docker%20CI/badge.svg?branch=master
 [docker-action-link]: https://github.com/math-comp/analysis/actions?query=workflow:"Docker%20CI"
-
-[nix-action-shield]: https://github.com/math-comp/analysis/workflows/Nix%20CI/badge.svg?branch=master
-[nix-action-link]: https://github.com/math-comp/analysis/actions?query=workflow:"Nix%20CI"
 [chat-shield]: https://img.shields.io/badge/zulip-join_chat-brightgreen.svg
 [chat-link]: https://coq.zulipchat.com/login/#narrow/stream/237666-math-comp-analysis
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ the Coq proof-assistant and using the Mathematical Components library.
   - [MathComp field 1.13 or later](https://math-comp.github.io)
   - [MathComp finmap 1.5.1](https://github.com/math-comp/finmap)
   - [MathComp bigenough 1.0.0](https://github.com/math-comp/bigenough)
-  - [Hierarchy Builder >= 1.0.0](https://github.com/math-comp/hierarchy-builder)
+  - [Hierarchy Builder >= 1.2.0](https://github.com/math-comp/hierarchy-builder)
 - Coq namespace: `mathcomp.analysis`
 - Related publication(s):
   - [Formalization Techniques for Asymptotic Reasoning in Classical Analysis](https://jfr.unibo.it/article/view/8124) doi:[10.6092/issn.1972-5787/8124](https://doi.org/10.6092/issn.1972-5787/8124)

--- a/coq-mathcomp-analysis.opam
+++ b/coq-mathcomp-analysis.opam
@@ -15,7 +15,7 @@ description: """
 This repository contains an experimental library for real analysis for
 the Coq proof-assistant and using the Mathematical Components library."""
 
-build: [make "-j%{jobs}%" ]
+build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
   "coq" { (>= "8.13" & < "8.16~") | (= "dev") }

--- a/coq-mathcomp-analysis.opam
+++ b/coq-mathcomp-analysis.opam
@@ -15,7 +15,7 @@ description: """
 This repository contains an experimental library for real analysis for
 the Coq proof-assistant and using the Mathematical Components library."""
 
-build: [make "-j%{jobs}%"]
+build: [make "-j%{jobs}%" ]
 install: [make "install"]
 depends: [
   "coq" { (>= "8.13" & < "8.16~") | (= "dev") }
@@ -26,7 +26,7 @@ depends: [
   "coq-mathcomp-field" { (>= "1.13.0" & < "1.15~") | (= "dev") }
   "coq-mathcomp-finmap" { (>= "1.5.1" & < "1.6~") | (= "dev") }
   "coq-mathcomp-bigenough" { (>= "1.0.0") }
-  "coq-hierarchy-builder" { (>= "1.0.0") }
+  "coq-hierarchy-builder" { (>= "1.2.0") }
 ]
 
 tags: [

--- a/meta.yml
+++ b/meta.yml
@@ -4,7 +4,7 @@ organization: math-comp
 opam_name: coq-mathcomp-analysis
 community: false
 action: true
-nix: true
+nix: false
 coqdoc: false
 
 synopsis: >-

--- a/meta.yml
+++ b/meta.yml
@@ -114,9 +114,9 @@ dependencies:
     [MathComp bigenough 1.0.0](https://github.com/math-comp/bigenough)
 - opam:
     name: coq-hierarchy-builder
-    version: '{ (>= "1.0.0") }'
+    version: '{ (>= "1.2.0") }'
   description: |-
-    [Hierarchy Builder >= 1.0.0](https://github.com/math-comp/hierarchy-builder)
+    [Hierarchy Builder >= 1.2.0](https://github.com/math-comp/hierarchy-builder)
 namespace: mathcomp.analysis
 
 keywords:


### PR DESCRIPTION
##### Motivation for this change

fix hb dependency version (only 1.2.0 and 1.2.1 seem ok)
problem revealed by https://github.com/coq/opam-coq-archive/pull/2127

##### Things done/to do

<!-- please fill in the following checklist -->
~- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`~
~- [ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
