### PR TITLE
Rename num_abs_{lt,le} lemmas to num_abse_{lt,le}

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -8,6 +8,10 @@
 
 ### Renamed
 
+- in `ereal.v`:
+  + `num_abs_le` -> `num_abse_le`
+  + `num_abs_lt` -> `num_abse_lt`
+
 ### Removed
 
 ### Infrastructure

--- a/theories/ereal.v
+++ b/theories/ereal.v
@@ -3253,10 +3253,10 @@ Local Notation nR := {compare (0 : \bar R) & ?=0 & >=0}.
 Implicit Type x y : nR.
 Local Notation num := (@num _ _ (0 : \bar R) ?=0 >=0).
 
-Lemma num_abs_le a x : 0 <= a -> (`|a|%:nng <= x)%O = (a <= x%:num).
+Lemma num_abse_le a x : 0 <= a -> (`|a|%:nng <= x)%O = (a <= x%:num).
 Proof. by move=> a0; rewrite -num_le//= gee0_abs. Qed.
 
-Lemma num_abs_lt a x : 0 <= a -> (`|a|%:nng < x)%O = (a < x%:num).
+Lemma num_abse_lt a x : 0 <= a -> (`|a|%:nng < x)%O = (a < x%:num).
 Proof. by move=> a0; rewrite -num_lt/= gee0_abs. Qed.
 End MorphGe0.
 


### PR DESCRIPTION
There were homonym lemmas in signed.v.
I got the names wrong in #375 sorry about that.