### PR TITLE
Measurable fun exprn

### DIFF
--- a/theories/esum.v
+++ b/theories/esum.v
@@ -34,7 +34,7 @@ Section set_of_fset_in_a_set.
 Variable (T : choiceType).
 Implicit Type S : set T.
 
-Definition fsets S : set {fset T} := [set F | [set` F] `<=` S].
+Definition fsets S : set {fset T} := [set F : {fset T} | [set` F] `<=` S].
 
 Lemma fsets_set0 S : fsets S fset0. Proof. by []. Qed.
 

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -1392,6 +1392,21 @@ rewrite -(addrA (f x * g x *+ 2)) -opprB opprK (addrC (g x ^+ 2)) addrK.
 by rewrite -(mulr_natr (f x * g x)) -(mulrC 2) mulrA mulVr ?mul1r// unitfE.
 Qed.
 
+Lemma measurable_fun_mulrn n D (f : T -> R) :
+  measurable_fun D f -> measurable_fun D (fun x => f x ^+ n).
+Proof.
+elim: n.
+move => _.
+apply: (@eq_measurable_fun _ _ _ (cst (1 : R))) => //.
+exact: measurable_fun_cst.
+move => n ih mf.
+apply: (@eq_measurable_fun _ _ _ (fun x => f x * f x ^+ n)).
+move => x xD.
+by rewrite exprS.
+apply measurable_funM => //.
+by apply ih => //.
+Qed.
+
 Lemma measurable_fun_max  D f g :
   measurable_fun D f -> measurable_fun D g -> measurable_fun D (f \max g).
 Proof.

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -1347,6 +1347,20 @@ Proof.
 by move=> ? ? ?; apply: measurable_funD => //; exact: measurable_funN.
 Qed.
 
+Lemma measurable_fun_exprn D n f :
+  measurable_fun D f -> measurable_fun D (fun x => f x ^+ n).
+Proof.
+move => mf.
+rewrite (_ : (fun x => f x ^+ n) = (fun x => x ^+ n) \o f).
+apply: measurable_fun_comp => //.
+apply: continuous_measurable_fun; apply: exp_continuous.
+by apply /funext => y.
+Qed.
+
+Lemma measurable_fun_sqr D f :
+  measurable_fun D f -> measurable_fun D (fun x => f x ^+ 2).
+Proof. by apply: measurable_fun_exprn. Qed.
+
 Lemma measurable_funM D f g :
   measurable_fun D f -> measurable_fun D g -> measurable_fun D (f \* g).
 Proof.
@@ -1362,20 +1376,6 @@ rewrite funeqE => x /=; rewrite -2!mulrBr sqrrD (addrC (f x ^+ 2)) -addrA.
 rewrite -(addrA (f x * g x *+ 2)) -opprB opprK (addrC (g x ^+ 2)) addrK.
 by rewrite -(mulr_natr (f x * g x)) -(mulrC 2) mulrA mulVr ?mul1r// unitfE.
 Qed.
-
-Lemma measurable_fun_exprn D n f :
-  measurable_fun D f -> measurable_fun D (fun x => f x ^+ n).
-Proof.
-move => mf.
-rewrite (_ : (fun x => f x ^+ n) = (fun x => x ^+ n) \o f).
-apply: measurable_fun_comp => //.
-apply: continuous_measurable_fun; apply: continuous_exprn.
-by apply /funext => y.
-Qed.
-
-Lemma measurable_fun_sqr D f :
-  measurable_fun D f -> measurable_fun D (fun x => f x ^+ 2).
-Proof. by apply: measurable_fun_exprn. Qed.
 
 Lemma measurable_fun_max  D f g :
   measurable_fun D f -> measurable_fun D g -> measurable_fun D (f \max g).

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -1362,16 +1362,6 @@ rewrite -(addrA (f x * g x *+ 2)) -opprB opprK (addrC (g x ^+ 2)) addrK.
 by rewrite -(mulr_natr (f x * g x)) -(mulrC 2) mulrA mulVr ?mul1r// unitfE.
 Qed.
 
-Lemma continuous_exprn n : continuous (fun x:R => x ^+ n).
-Proof.
-elim: n.
-  move => x; exact: cvg_cst.
-move => n ce x.
-set g := fun x => x ^+ n.+1; rewrite (_ : g = fun x => x * x ^+ n).
-rewrite exprS; apply: cvgM => //; exact: ce.
-by apply /funext => y; rewrite /g exprS.
-Qed.
-
 Lemma measurable_fun_exprn D n f :
   measurable_fun D f -> measurable_fun D (fun x => f x ^+ n).
 Proof.

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -6,6 +6,7 @@ Require Import boolp reals ereal classical_sets signed topology numfun.
 Require Import mathcomp_extra functions normedtype.
 From HB Require Import structures.
 Require Import sequences esum measure fsbigop cardinality set_interval.
+Require Import realfun.
 
 (******************************************************************************)
 (*                            Lebesgue Measure                                *)

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -1350,11 +1350,8 @@ Qed.
 Lemma measurable_fun_exprn D n f :
   measurable_fun D f -> measurable_fun D (fun x => f x ^+ n).
 Proof.
-move => mf.
-rewrite (_ : (fun x => f x ^+ n) = (fun x => x ^+ n) \o f).
-apply: measurable_fun_comp => //.
-apply: continuous_measurable_fun; apply: exp_continuous.
-by apply /funext => y.
+apply: measurable_fun_comp ((@GRing.exp R)^~ n) _ _ _.
+by apply: continuous_measurable_fun; apply: exp_continuous.
 Qed.
 
 Lemma measurable_fun_sqr D f :

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -1402,8 +1402,8 @@ rewrite exprS; apply: cvgM => //; exact: ce.
 by apply /funext => y; rewrite /g exprS.
 Qed.
 
-Lemma measurable_fun_exprn n (f : R -> R) :
-  measurable_fun setT f -> measurable_fun setT (fun x => f x ^+ n).
+Lemma measurable_fun_exprn D n (f : T -> R) :
+  measurable_fun D f -> measurable_fun D (fun x => f x ^+ n).
 Proof.
 move => mf.
 rewrite (_ : (fun x => f x ^+ n) = (fun x => x ^+ n) \o f).

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -1311,36 +1311,6 @@ rewrite predeqE => x; split => [|[r _] []/= [Dx rfx]] /= => [[Dx]|[_]].
 by rewrite ltr_subl_addr=> afg; rewrite (lt_le_trans afg)// addrC ler_add2r ltW.
 Qed.
 
-Lemma measurable_fun_sqr D f :
-  measurable_fun D f -> measurable_fun D (fun x => f x ^+ 2).
-Proof.
-move=> mf /= A mA mD.
-apply: (measurability (RGenOInfty.measurableE R)) => //= _ [_ [a ->] <-].
-have [a0|a0] := leP 0 a; last first.
-  rewrite (_ : _ `&` _ = D) // predeqE => x; split => [[]//|Dx]; split => //.
-  by rewrite /= in_itv /= andbT (lt_le_trans a0)// sqr_ge0.
-rewrite (_ : D `&` _ = (D `&` f @^-1` `]Num.sqrt a, +oo[) `|`
-                       (D `&` f @^-1` `]-oo, (-Num.sqrt a)[) ).
-  by apply: measurableU; apply: mf => //; apply: measurable_itv.
-rewrite predeqE => t; split=> [[]|].
-  rewrite /= in_itv /= andbT => Dt aft2.
-  have := le_lt_trans a0 aft2.
-  rewrite exprn_even_gt0 //= neq_lt => /orP[|] ft0.
-    move: aft2; rewrite -ltr_sqrt; last first.
-      by rewrite exprn_even_gt0//= lt_eqF.
-    by rewrite sqrtr_sqr ltr0_norm// ltr_oppr; tauto.
-  move: aft2; rewrite -ltr_sqrt; last first.
-    by rewrite exprn_even_gt0//= gt_eqF.
-  by rewrite sqrtr_sqr gtr0_norm// !/= !in_itv/= andbT; tauto.
-move=> [] /=; rewrite !/= !in_itv /= ?andbT => -[Dt fta]; split => //.
-  rewrite -ltr_sqrt; last first.
-    by rewrite exprn_even_gt0//= gt_eqF// (le_lt_trans _ fta).
-  by rewrite sqrtr_sqr gtr0_norm// (le_lt_trans _ fta).
-rewrite -ltr_sqrt; last first.
-  by rewrite exprn_even_gt0//= lt_eqF// (lt_le_trans fta).
-by rewrite sqrtr_sqr ltr0_norm// 1?ltr_oppr// (lt_le_trans fta).
-Qed.
-
 Lemma measurable_funrM D f (k : R) : measurable_fun D f ->
   measurable_fun D (fun x => k * f x).
 Proof.
@@ -1402,7 +1372,7 @@ rewrite exprS; apply: cvgM => //; exact: ce.
 by apply /funext => y; rewrite /g exprS.
 Qed.
 
-Lemma measurable_fun_exprn D n (f : T -> R) :
+Lemma measurable_fun_exprn D n f :
   measurable_fun D f -> measurable_fun D (fun x => f x ^+ n).
 Proof.
 move => mf.
@@ -1411,6 +1381,10 @@ apply: measurable_fun_comp => //.
 apply: continuous_measurable_fun; apply: continuous_exprn.
 by apply /funext => y.
 Qed.
+
+Lemma measurable_fun_sqr D f :
+  measurable_fun D f -> measurable_fun D (fun x => f x ^+ 2).
+Proof. by apply: measurable_fun_exprn. Qed.
 
 Lemma measurable_fun_max  D f g :
   measurable_fun D f -> measurable_fun D g -> measurable_fun D (f \max g).

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -1356,7 +1356,7 @@ Qed.
 
 Lemma measurable_fun_sqr D f :
   measurable_fun D f -> measurable_fun D (fun x => f x ^+ 2).
-Proof. by apply: measurable_fun_exprn. Qed.
+Proof. exact: measurable_fun_exprn. Qed.
 
 Lemma measurable_funM D f g :
   measurable_fun D f -> measurable_fun D g -> measurable_fun D (f \* g).

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -1392,20 +1392,24 @@ rewrite -(addrA (f x * g x *+ 2)) -opprB opprK (addrC (g x ^+ 2)) addrK.
 by rewrite -(mulr_natr (f x * g x)) -(mulrC 2) mulrA mulVr ?mul1r// unitfE.
 Qed.
 
+Lemma continuous_exprn n : continuous (fun x:R => x ^+ n).
+Proof.
+elim: n.
+  move => x; exact: cvg_cst.
+move => n ce x.
+set g := fun x => x ^+ n.+1; rewrite (_ : g = fun x => x * x ^+ n).
+rewrite exprS; apply: cvgM => //; exact: ce.
+by apply /funext => y; rewrite /g exprS.
+Qed.
+
 Lemma measurable_fun_exprn n (f : R -> R) :
-  continuous f ->
   measurable_fun setT f -> measurable_fun setT (fun x => f x ^+ n).
 Proof.
-move => cf mf.
-apply: continuous_measurable_fun.
-elim: n.
-  move => x; set g := fun x => f x ^+ 0; rewrite (_ : g = cst 1) /g.
-  exact: cvg_cst.
-  by apply /funext => y; rewrite expr0.
-move => n cm x; rewrite exprS.
-set g := fun x => f x ^+ n.+1; rewrite (_ : g = fun x => f x * f x ^+ n).
-apply: cvgM; [exact: cf | exact: cm].
-by apply /funext => y; rewrite /g exprS.
+move => mf.
+rewrite (_ : (fun x => f x ^+ n) = (fun x => x ^+ n) \o f).
+apply: measurable_fun_comp => //.
+apply: continuous_measurable_fun; apply: continuous_exprn.
+by apply /funext => y.
 Qed.
 
 Lemma measurable_fun_max  D f g :

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -1392,19 +1392,20 @@ rewrite -(addrA (f x * g x *+ 2)) -opprB opprK (addrC (g x ^+ 2)) addrK.
 by rewrite -(mulr_natr (f x * g x)) -(mulrC 2) mulrA mulVr ?mul1r// unitfE.
 Qed.
 
-Lemma measurable_fun_mulrn n D (f : T -> R) :
-  measurable_fun D f -> measurable_fun D (fun x => f x ^+ n).
+Lemma measurable_fun_exprn n (f : R -> R) :
+  continuous f ->
+  measurable_fun setT f -> measurable_fun setT (fun x => f x ^+ n).
 Proof.
+move => cf mf.
+apply: continuous_measurable_fun.
 elim: n.
-move => _.
-apply: (@eq_measurable_fun _ _ _ (cst (1 : R))) => //.
-exact: measurable_fun_cst.
-move => n ih mf.
-apply: (@eq_measurable_fun _ _ _ (fun x => f x * f x ^+ n)).
-move => x xD.
-by rewrite exprS.
-apply measurable_funM => //.
-by apply ih => //.
+  move => x; set g := fun x => f x ^+ 0; rewrite (_ : g = cst 1) /g.
+  exact: cvg_cst.
+  by apply /funext => y; rewrite expr0.
+move => n cm x; rewrite exprS.
+set g := fun x => f x ^+ n.+1; rewrite (_ : g = fun x => f x * f x ^+ n).
+apply: cvgM; [exact: cf | exact: cm].
+by apply /funext => y; rewrite /g exprS.
 Qed.
 
 Lemma measurable_fun_max  D f g :


### PR DESCRIPTION
@affeldt-aist and I have reworked the lemma `measurable_fun_mulrn`, now renamed to `measurable_fun_exprn`, following the suggestion by @CohenCyril to use the fact that continuous implies measurable.
This leaves us with an additional assumption that the function `f` from the lemma is continuous, which was not required before.