### PR TITLE
fixes #597 (infty -> y)

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -47,6 +47,8 @@
 - in `ereal.v`:
   + `num_abs_le` -> `num_abse_le`
   + `num_abs_lt` -> `num_abse_lt`
+  + `addooe` -> `addpinftye`
+  + `addeoo` -> `addepinfty`
 
 ### Removed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -47,8 +47,40 @@
 - in `ereal.v`:
   + `num_abs_le` -> `num_abse_le`
   + `num_abs_lt` -> `num_abse_lt`
-  + `addooe` -> `addpinftye`
-  + `addeoo` -> `addepinfty`
+  + `addooe` -> `addye`
+  + `addeoo` -> `addey`
+  + `mule_ninfty_pinfty` -> `mulNyy`
+  + `mule_pinfty_ninfty` -> `mulyNy`
+  + `mule_pinfty_pinfty` -> `mulyy`
+  + `mule_ninfty_ninfty` -> `mulNyNy`
+  + `lte_0_pinfty` -> `lt0y`
+  + `lte_ninfty_0` -> `ltNy0`
+  + `lee_0_pinfty` -> `le0y`
+  + `lee_ninfty_0` -> `leNy0`
+  + `lte_pinfty` -> `ltey`
+  + `lte_ninfty` -> `ltNye`
+  + `lee_pinfty` -> `leey`
+  + `lee_ninfty` -> `leNye`
+  + `mulrpinfty_real` -> `mulry_real`
+  + `mulpinftyr_real` -> `mulyr_real`
+  + `mulrninfty_real` -> `mulrNy_real`
+  + `mulninftyr_real` -> `mulNyr_real`
+  + `mulrpinfty` -> `mulry`
+  + `mulpinftyr` -> `mulyr`
+  + `mulrninfty` -> `mulrNy`
+  + `mulninftyr` -> `mulNyr`
+  + `gt0_mulpinfty` -> `gt0_mulye`
+  + `lt0_mulpinfty` -> `lt0_mulye`
+  + `gt0_mulninfty` -> `gt0_mulNye`
+  + `lt0_mulninfty` -> `lt0_mulNye`
+  + `maxe_pinftyl` -> `maxye`
+  + `maxe_pinftyr` -> `maxey`
+  + `maxe_ninftyl` -> `maxNye`
+  + `maxe_ninftyr` -> `maxeNy`
+  + `mine_ninftyl` -> `minNye`
+  + `mine_ninftyr` -> `mineNy`
+  + `mine_pinftyl` -> `minye`
+  + `mine_pinftyr` -> `miney`
 
 ### Removed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -61,10 +61,10 @@
   + `lte_ninfty` -> `ltNye`
   + `lee_pinfty` -> `leey`
   + `lee_ninfty` -> `leNye`
-  + `mulrpinfty_real` -> `mulry_real`
-  + `mulpinftyr_real` -> `mulyr_real`
-  + `mulrninfty_real` -> `mulrNy_real`
-  + `mulninftyr_real` -> `mulNyr_real`
+  + `mulrpinfty_real` -> `real_mulry`
+  + `mulpinftyr_real` -> `real_mulyr`
+  + `mulrninfty_real` -> `real_mulrNy`
+  + `mulninftyr_real` -> `real_mulNyr`
   + `mulrpinfty` -> `mulry`
   + `mulpinftyr` -> `mulyr`
   + `mulrninfty` -> `mulrNy`
@@ -81,6 +81,8 @@
   + `mine_ninftyr` -> `mineNy`
   + `mine_pinftyl` -> `minye`
   + `mine_pinftyr` -> `miney`
+  + `mulrinfty_real` -> `real_mulr_infty`
+  + `mulrinfty` -> `mulr_infty`
 
 ### Removed
 

--- a/theories/altreals/distr.v
+++ b/theories/altreals/distr.v
@@ -1217,7 +1217,7 @@ set c1 : R := _ / _; set c2 : R := _ / _; have eqc2: c2 = 1 - c1.
 set c := (li + l j); pose z := (c * c1 * f xi + c * c2 * f (x j)).
 apply/(@le_trans _ _ z); last by rewrite /z ![_*(_/_)]mulrC !mulfVK.
 rewrite {}/z -![c * _ * _]mulrA -mulrDr ler_wpmul2l ?addr_ge0 //.
-rewrite eqc2 cvx_f // ?lee_ninfty ?lee_pinfty // divr_ge0 ?addr_ge0 //=.
+rewrite eqc2 cvx_f // ?leNye ?leey // divr_ge0 ?addr_ge0 //=.
 by rewrite ler_pdivr_mulr ?mul1r ?ler_addl ?ltr_paddl.
 Qed.
 End Jensen.

--- a/theories/altreals/realseq.v
+++ b/theories/altreals/realseq.v
@@ -382,8 +382,8 @@ Lemma ncvg_gt (u : nat -> R) (l1 l2 : \bar R) :
     exists K, forall n, (K <= n)%N -> (l1 < (u n)%:E)%E.
 Proof.
 case: l1 l2 => [l1||] [l2||] //=; first last.
-+ by move=> _ _; exists 0%N => ? ?; exact: lte_ninfty.
-+ by move=> _ _; exists 0%N => ? ?; exact: lte_ninfty.
++ by move=> _ _; exists 0%N => ? ?; exact: ltNye.
++ by move=> _ _; exists 0%N => ? ?; exact: ltNye.
 + by move=> _ /(_ (NPInf l1)) [K cv]; exists K => n /cv.
 move=> lt_12; pose e := l2 - l1 => /(_ (B l2 e)).
 case=> K cv; exists K => n /cv; rewrite !inE eclamp_id ?subr_gt0 //.
@@ -547,3 +547,4 @@ Qed.
 End LimOp.
 
 (* -------------------------------------------------------------------- *)
+

--- a/theories/altreals/realsum.v
+++ b/theories/altreals/realsum.v
@@ -178,7 +178,7 @@ case: (pselect (has_sup E)); last first.
   move/has_supPn=> -/(_ nzE) h; exists +oo%E => //; elim/nbh_pinfW => M /=.
   case/(_ M): h=> x [K -> lt_MuK]; exists K=> n le_Kn; rewrite inE.
   by apply/(lt_le_trans lt_MuK)/mono_u.
-move=> supE; exists (sup E)%:E => //; first exact: lte_ninfty.
+move=> supE; exists (sup E)%:E => //; first exact: ltNye.
 elim/nbh_finW=>e /= gt0_e.
 case: (sup_adherent supE gt0_e)=> x [K ->] lt_uK.
 exists K=> n le_Kn; rewrite inE distrC ger0_norm ?subr_ge0.

--- a/theories/ereal.v
+++ b/theories/ereal.v
@@ -326,13 +326,13 @@ Proof. by case: x. Qed.
 Section ERealOrder_numDomainType.
 Context {R : numDomainType}.
 
-Lemma lte_0_pinfty : (0 : \bar R) < +oo. Proof. exact: real0. Qed.
+Lemma lt0y : (0 : \bar R) < +oo. Proof. exact: real0. Qed.
 
-Lemma lte_ninfty_0 : -oo < (0 : \bar R). Proof. exact: real0. Qed.
+Lemma ltNy0 : -oo < (0 : \bar R). Proof. exact: real0. Qed.
 
-Lemma lee_0_pinfty : (0 : \bar R) <= +oo. Proof. exact: real0. Qed.
+Lemma le0y : (0 : \bar R) <= +oo. Proof. exact: real0. Qed.
 
-Lemma lee_ninfty_0 : -oo <= (0 : \bar R). Proof. exact: real0. Qed.
+Lemma leNy0 : -oo <= (0 : \bar R). Proof. exact: real0. Qed.
 
 Lemma ereal_comparable (x y : \bar R) : (0%E >=< x)%O -> (0%E >=< y)%O ->
   (x >=< y)%O.
@@ -349,17 +349,17 @@ Section ERealOrder_realDomainType.
 Context {R : realDomainType}.
 Implicit Types (x y : \bar R) (r : R).
 
-Lemma lte_pinfty r : r%:E < +oo. Proof. exact: num_real. Qed.
+Lemma ltey r : r%:E < +oo. Proof. exact: num_real. Qed.
 
-Lemma lte_ninfty r : -oo < r%:E. Proof. exact: num_real. Qed.
+Lemma ltNye r : -oo < r%:E. Proof. exact: num_real. Qed.
 
-Lemma lee_pinfty x : x <= +oo. Proof. by case: x => //= r; exact: num_real. Qed.
+Lemma leey x : x <= +oo. Proof. by case: x => //= r; exact: num_real. Qed.
 
-Lemma lee_ninfty x : -oo <= x. Proof. by case: x => //= r; exact: num_real. Qed.
+Lemma leNye x : -oo <= x. Proof. by case: x => //= r; exact: num_real. Qed.
 
 Lemma gee0P x : 0 <= x <-> x = +oo \/ exists2 r, (r >= 0)%R & x = r%:E.
 Proof.
-split=> [|[->|[r r0 ->//]]]; last exact: lee_pinfty.
+split=> [|[->|[r r0 ->//]]]; last exact: leey.
 by case: x => [r r0 | _ |//]; [right; exists r|left].
 Qed.
 
@@ -840,10 +840,10 @@ Qed.
 Lemma adde_eq_ninfty x y : (x + y == -oo) = ((x == -oo) || (y == -oo)).
 Proof. by move: x y => [?| |] [?| |]. Qed.
 
-Lemma addpinftye x : x != -oo -> +oo + x = +oo.
+Lemma addye x : x != -oo -> +oo + x = +oo.
 Proof. by case: x. Qed.
 
-Lemma addepinfty x : x != -oo -> x + +oo = +oo.
+Lemma addey x : x != -oo -> x + +oo = +oo.
 Proof. by case: x. Qed.
 
 Lemma adde_Neq_pinfty x y : x != -oo -> y != -oo ->
@@ -889,9 +889,9 @@ move=> finoo; split=> [|[i [si Pi fi]]].
   by move=> i /andP[si Pi] fioo; exists i; rewrite si Pi fioo.
 elim: s i Pi fi si => // h t ih i Pi fi.
 rewrite inE => /predU1P[<-/=|it].
-  rewrite big_cons Pi fi addpinftye//.
+  rewrite big_cons Pi fi addye//.
   by apply/eqP => /esum_ninftyP[j [jt /finoo/negbTE/eqP]].
-by rewrite big_cons; case: ifPn => Ph; rewrite (ih i)// addepinfty// finoo.
+by rewrite big_cons; case: ifPn => Ph; rewrite (ih i)// addey// finoo.
 Qed.
 
 Lemma esum_pinfty (I : finType) (P : {pred I}) (f : I -> \bar R) :
@@ -932,19 +932,15 @@ Lemma sume_le0 T (f : T -> \bar R) (P : pred T) :
   (forall t, P t -> f t <= 0) -> forall l, \sum_(i <- l | P i) f i <= 0.
 Proof. by move=> f0 l; elim/big_rec : _ => // t x Pt; apply/adde_le0/f0. Qed.
 
-Lemma mule_ninfty_pinfty : -oo * +oo = -oo :> \bar R.
-Proof. by rewrite /mule /= lte_0_pinfty. Qed.
+Lemma mulNyy : -oo * +oo = -oo :> \bar R. Proof. by rewrite /mule /= lt0y. Qed.
 
-Lemma mule_pinfty_ninfty : +oo * -oo = -oo :> \bar R.
-Proof. by rewrite muleC mule_ninfty_pinfty. Qed.
+Lemma mulyNy : +oo * -oo = -oo :> \bar R. Proof. by rewrite muleC mulNyy. Qed.
 
-Lemma mule_pinfty_pinfty : +oo * +oo = +oo :> \bar R.
-Proof. by rewrite /mule /= lte_0_pinfty. Qed.
+Lemma mulyy : +oo * +oo = +oo :> \bar R. Proof. by rewrite /mule /= lt0y. Qed.
 
-Lemma mule_ninfty_ninfty : -oo * -oo = +oo :> \bar R.
-Proof. by []. Qed.
+Lemma mulNyNy : -oo * -oo = +oo :> \bar R. Proof. by []. Qed.
 
-Lemma mulrpinfty_real r : r \is Num.real -> r%:E * +oo = (Num.sg r)%:E * +oo.
+Lemma mulry_real r : r \is Num.real -> r%:E * +oo = (Num.sg r)%:E * +oo.
 Proof.
 move=> rreal; rewrite /mule/= !eqe sgr_eq0; case: ifP => [//|/negbT rn0].
 move: rreal => /orP[|]; rewrite le_eqVlt !lte_fin /Num.sg.
@@ -953,10 +949,10 @@ move: rreal => /orP[|]; rewrite le_eqVlt !lte_fin /Num.sg.
 by rewrite (negbTE rn0)/= => rlt0; rewrite lt_def lt_geF// rn0 rlt0/= ltr0N1.
 Qed.
 
-Lemma mulpinftyr_real r : r \is Num.real -> +oo * r%:E = (Num.sg r)%:E * +oo.
-Proof. by move=> rreal; rewrite muleC mulrpinfty_real. Qed.
+Lemma mulyr_real r : r \is Num.real -> +oo * r%:E = (Num.sg r)%:E * +oo.
+Proof. by move=> rreal; rewrite muleC mulry_real. Qed.
 
-Lemma mulrninfty_real r : r \is Num.real -> r%:E * -oo = (Num.sg r)%:E * -oo.
+Lemma mulrNy_real r : r \is Num.real -> r%:E * -oo = (Num.sg r)%:E * -oo.
 Proof.
 move=> rreal; rewrite /mule/= !eqe sgr_eq0; case: ifP => [//|/negbT rn0].
 move: rreal => /orP[|]; rewrite le_eqVlt !lte_fin /Num.sg.
@@ -965,11 +961,10 @@ move: rreal => /orP[|]; rewrite le_eqVlt !lte_fin /Num.sg.
 by rewrite (negbTE rn0)/= => rlt0; rewrite lt_def lt_geF// andbF rlt0 ltr0N1.
 Qed.
 
-Lemma mulninftyr_real r : r \is Num.real -> -oo * r%:E = (Num.sg r)%:E * -oo.
-Proof. by move=> rreal; rewrite muleC mulrninfty_real. Qed.
+Lemma mulNyr_real r : r \is Num.real -> -oo * r%:E = (Num.sg r)%:E * -oo.
+Proof. by move=> rreal; rewrite muleC mulrNy_real. Qed.
 
-Definition mulrinfty_real :=
-  (mulrpinfty_real, mulpinftyr_real, mulrninfty_real, mulninftyr_real).
+Definition mulrinfty_real := (mulry_real, mulyr_real, mulrNy_real, mulNyr_real).
 
 Lemma mulN1e x : - 1%E * x = - x.
 Proof.
@@ -981,7 +976,7 @@ Lemma muleN1 x : x * - 1%E = - x. Proof. by rewrite muleC mulN1e. Qed.
 
 Lemma mule_neq0 x y : x != 0 -> y != 0 -> x * y != 0.
 Proof.
-move: x y => [x||] [y||] x0 y0 //; rewrite /mule/= ?(lte_0_pinfty,mulf_neq0)//;
+move: x y => [x||] [y||] x0 y0 //; rewrite /mule/= ?(lt0y,mulf_neq0)//;
   try by (rewrite (negbTE x0); case: ifPn) ||
       by (rewrite (negbTE y0); case: ifPn).
 Qed.
@@ -994,13 +989,12 @@ Qed.
 
 Lemma mule_ge0 x y : 0 <= x -> 0 <= y -> 0 <= x * y.
 Proof.
-move: x y => [x||] [y||]//=; rewrite /mule/= ?(lee_fin,eqe,lte_fin)//.
+move: x y => [x||] [y||]//=; rewrite /mule/= ?(lee_fin, eqe, lte_fin, lt0y)//.
 - exact: mulr_ge0.
 - rewrite le_eqVlt => /predU1P[<- _|x0 _]; first by rewrite eqxx.
-  by rewrite gt_eqF // x0 lee_0_pinfty.
+  by rewrite gt_eqF // x0 le0y.
 - move=> _; rewrite le_eqVlt => /predU1P[<-|y0]; first by rewrite eqxx.
-  by rewrite gt_eqF // y0 lee_0_pinfty.
-- by rewrite lte_0_pinfty.
+  by rewrite gt_eqF // y0 le0y.
 Qed.
 
 Lemma mule_gt0 x y : 0 < x -> 0 < y -> 0 < x * y.
@@ -1010,20 +1004,20 @@ Qed.
 
 Lemma mule_le0 x y : x <= 0 -> y <= 0 -> 0 <= x * y.
 Proof.
-move: x y => [x||] [y||]//=; rewrite /mule/= ?(lee_fin,eqe,lte_fin)//.
+move: x y => [x||] [y||]//=; rewrite /mule/= ?(lee_fin, eqe, lte_fin)//.
 - exact: mulr_le0.
-- by rewrite lt_leAnge => -> _; case: ifP => _ //; rewrite andbF lee_0_pinfty.
-- by rewrite lt_leAnge => _ ->; case: ifP => _ //; rewrite andbF lee_0_pinfty.
+- by rewrite lt_leAnge => -> _; case: ifP => _ //; rewrite andbF le0y.
+- by rewrite lt_leAnge => _ ->; case: ifP => _ //; rewrite andbF le0y.
 Qed.
 
 Lemma mule_le0_ge0 x y : x <= 0 -> 0 <= y -> x * y <= 0.
 Proof.
-move: x y => [x| |] [y| |] //; rewrite /mule/= ?(lee_fin,lte_fin).
+move: x y => [x| |] [y| |] //; rewrite /mule/= ?(lee_fin, lte_fin).
 - exact: mulr_le0_ge0.
-- by move=> x0 _; case: ifP => _ //; rewrite lt_leAnge /= x0 andbF lee_ninfty_0.
+- by move=> x0 _; case: ifP => _ //; rewrite lt_leAnge /= x0 andbF leNy0.
 - move=> _; rewrite le_eqVlt => /predU1P[<-|->]; first by rewrite eqxx.
-  by case: ifP => _ //; rewrite lee_ninfty_0.
-- by rewrite lte_0_pinfty lee_ninfty_0.
+  by case: ifP => _ //; rewrite leNy0.
+- by rewrite lt0y leNy0.
 Qed.
 
 Lemma mule_ge0_le0 x y : 0 <= x -> y <= 0 -> x * y <= 0.
@@ -1050,15 +1044,15 @@ Lemma realMe x y : (0%E >=< x)%O -> (0%E >=< y)%O -> (0%E >=< x * y)%O.
 Proof.
 case: x y => [x||] [y||]// rx ry;
   do ?[exact: realM
-      |by rewrite /mule/= lte_0_pinfty
+      |by rewrite /mule/= lt0y
       |by rewrite mulrinfty_real ?realE -?lee_fin// /Num.sg;
           case: ifP; [|case: ifP]; rewrite ?mul0e /Order.comparable ?lexx;
-          rewrite ?mulN1e ?lee_ninfty_0 ?mul1e ?lee_0_pinfty
-      |by rewrite mule_ninfty_ninfty /Order.comparable lee_0_pinfty].
+          rewrite ?mulN1e ?leNy0 ?mul1e ?le0y
+      |by rewrite mulNyNy /Order.comparable le0y].
 Qed.
 
 Lemma abse_ge0 x : 0 <= `|x|.
-Proof. by move: x => [x| |] /=; rewrite ?lee_0_pinfty ?lee_fin. Qed.
+Proof. by move: x => [x| |] /=; rewrite ?le0y ?lee_fin. Qed.
 
 Lemma gee0_abs x : 0 <= x -> `|x| = x.
 Proof.
@@ -1315,15 +1309,15 @@ Lemma fin_numPlt x : reflect (-oo < x < +oo) (x \is a fin_num).
 Proof. by rewrite fin_numElt; exact: idP. Qed.
 
 Lemma lte_pinfty_eq x : (x < +oo) = (x \is a fin_num) || (x == -oo).
-Proof. by case: x => // x //=; exact: lte_pinfty. Qed.
+Proof. by case: x => // x //=; exact: ltey. Qed.
 
 Lemma ge0_fin_numE x : 0 <= x -> (x \is a fin_num) = (x < +oo).
-Proof. by move: x => [x| |] => // x0; rewrite fin_numElt lte_ninfty. Qed.
+Proof. by move: x => [x| |] => // x0; rewrite fin_numElt ltNye. Qed.
 
 Lemma eq_pinftyP x : x = +oo <-> (forall A, (0 < A)%R -> A%:E <= x).
 Proof.
-split=> [-> // A A0|Ax]; first by rewrite lee_pinfty.
-apply/eqP; rewrite eq_le lee_pinfty /= leNgt; apply/negP.
+split=> [-> // A A0|Ax]; first by rewrite leey.
+apply/eqP; rewrite eq_le leey /= leNgt; apply/negP.
 move: x Ax => [x Ax _|//|]; last by move/(_ _ ltr01).
 move/not_forallP : Ax; apply; exists (`|x| + 1)%R.
 apply/not_implyP; split; first by rewrite -(addr0 0%R) ler_lt_add.
@@ -1341,10 +1335,10 @@ move=> F0; apply/eqP/allP => PF0; last first.
 move=> i ir; apply/implyP => Pi; apply/eqP.
 have rPF : {in r, forall i, P i ==> (F i \is a fin_num)}.
   move=> j jr; apply/implyP => Pj; rewrite fin_numElt; apply/andP; split.
-    by rewrite (lt_le_trans _ (F0 _ Pj))// lte_ninfty.
+    by rewrite (lt_le_trans _ (F0 _ Pj))// ltNye.
   rewrite ltNge; apply/eqP; rewrite lee_pinfty_eq; apply/eqP/negP => /eqP Fjoo.
   have PFninfty k : P k -> F k != -oo%E.
-    by move=> Pk; rewrite gt_eqF// (lt_le_trans _ (F0 _ Pk))// lte_ninfty.
+    by move=> Pk; rewrite gt_eqF// (lt_le_trans _ (F0 _ Pk))// ltNye.
   have /esum_pinftyP : exists i, [/\ i \in r, P i & F i = +oo%E] by exists j.
   by move=> /(_ PFninfty); rewrite PF0.
 have ? : (\sum_(i <- r | P i) (fine \o F) i == 0)%R.
@@ -1361,19 +1355,18 @@ by rewrite Fi0.
 Qed.
 
 Lemma lte_add_pinfty x y : x < +oo -> y < +oo -> x + y < +oo.
-Proof. by move: x y => -[r [r'| |]| |] // ? ?; rewrite -EFinD lte_pinfty. Qed.
+Proof. by move: x y => -[r [r'| |]| |] // ? ?; rewrite -EFinD ltey. Qed.
 
 Lemma lte_sum_pinfty I (s : seq I) (P : pred I) (f : I -> \bar R) :
   (forall i, P i -> f i < +oo) -> \sum_(i <- s | P i) f i < +oo.
 Proof.
-elim/big_ind : _ => [_|x y xoo yoo foo|i ?]; [exact: lte_pinfty| |exact].
+elim/big_ind : _ => [_|x y xoo yoo foo|i ?]; [exact: ltey| |exact].
 by apply: lte_add_pinfty; [exact: xoo| exact: yoo].
 Qed.
 
 Lemma sube_gt0 x y : (0 < y - x) = (x < y).
 Proof.
-move: x y => [r | |] [r'| |] //=; rewrite ?(lte_pinfty,lte_ninfty) //.
-by rewrite !lte_fin subr_gt0.
+by move: x y => [r | |] [r'| |] //=; rewrite ?(ltey, ltNye)// !lte_fin subr_gt0.
 Qed.
 
 Lemma sube_le0 x y : (y - x <= 0) = (y <= x).
@@ -1381,42 +1374,37 @@ Proof. by rewrite !leNgt sube_gt0. Qed.
 
 Lemma suber_ge0 y x : y \is a fin_num -> (0 <= x - y) = (y <= x).
 Proof.
-by move: x y => [x| |] [y| |] //= _; rewrite ?(lee_pinfty, lee_fin, subr_ge0).
+by move: x y => [x| |] [y| |] //= _; rewrite ?(leey, lee_fin, subr_ge0).
 Qed.
 
 Lemma subre_ge0 x y : y \is a fin_num -> (0 <= y - x) = (x <= y).
 Proof.
-move: x y => [x| |] [y| |] //=; rewrite ?(lee_pinfty,lee_ninfty,lee_fin) //=.
-by rewrite subr_ge0.
+by move: x y => [x| |] [y| |] //=; rewrite ?(leey, leNye, lee_fin) //= subr_ge0.
 Qed.
 
 Lemma lte_oppl x y : (- x < y) = (- y < x).
 Proof.
-move: x y => [r| |] [r'| |] //=; rewrite ?lte_pinfty ?lte_ninfty //.
-by rewrite !lte_fin ltr_oppl.
+by move: x y => [r| |] [r'| |] //=; rewrite ?(ltey, ltNye)// !lte_fin ltr_oppl.
 Qed.
 
 Lemma lte_oppr x y : (x < - y) = (y < - x).
 Proof.
-move: x y => [r| |] [r'| |] //=; rewrite ?lte_pinfty ?lte_ninfty //.
-by rewrite !lte_fin ltr_oppr.
+by move: x y => [r| |] [r'| |] //=; rewrite ?(ltey, ltNye)// !lte_fin ltr_oppr.
 Qed.
 
 Lemma lee_oppr x y : (x <= - y) = (y <= - x).
 Proof.
-move: x y => [r0| |] [r1| |] //=; rewrite ?lee_pinfty ?lee_ninfty //.
-by rewrite !lee_fin ler_oppr.
+by move: x y => [r0| |] [r1| |] //=; rewrite ?(leey, leNye)// !lee_fin ler_oppr.
 Qed.
 
 Lemma lee_oppl x y : (- x <= y) = (- y <= x).
 Proof.
-move: x y => [r0| |] [r1| |] //=; rewrite ?lee_pinfty ?lee_ninfty //.
-by rewrite !lee_fin ler_oppl.
+by move: x y => [r0| |] [r1| |] //=; rewrite ?(leey, leNye)// !lee_fin ler_oppl.
 Qed.
 
 Lemma muleN x y : x * - y = - (x * y).
 Proof.
-move: x y => [x| |] [y| |] //=; rewrite /mule/=; try by rewrite lte_pinfty.
+move: x y => [x| |] [y| |] //=; rewrite /mule/=; try by rewrite ltey.
 - by rewrite mulrN.
 - by rewrite !eqe !lte_fin; case: ltrgtP => //; rewrite oppe0.
 - by rewrite !eqe !lte_fin; case: ltrgtP => //; rewrite oppe0.
@@ -1430,25 +1418,25 @@ Lemma mulNe x y : - x * y = - (x * y). Proof. by rewrite muleC muleN muleC. Qed.
 
 Lemma muleNN x y : - x * - y = x * y. Proof. by rewrite mulNe muleN oppeK. Qed.
 
-Lemma mulrpinfty r : r%:E * +oo%E = (Num.sg r)%:E * +oo%E.
-Proof. by rewrite [LHS]mulrpinfty_real// num_real. Qed.
+Lemma mulry r : r%:E * +oo%E = (Num.sg r)%:E * +oo%E.
+Proof. by rewrite [LHS]mulry_real// num_real. Qed.
 
-Lemma mulpinftyr r : +oo%E * r%:E = (Num.sg r)%:E * +oo%E.
-Proof. by rewrite muleC mulrpinfty. Qed.
+Lemma mulyr r : +oo%E * r%:E = (Num.sg r)%:E * +oo%E.
+Proof. by rewrite muleC mulry. Qed.
 
-Lemma mulrninfty r : r%:E * -oo%E = (Num.sg r)%:E * -oo%E.
-Proof. by rewrite [LHS]mulrninfty_real// num_real. Qed.
+Lemma mulrNy r : r%:E * -oo%E = (Num.sg r)%:E * -oo%E.
+Proof. by rewrite [LHS]mulrNy_real// num_real. Qed.
 
-Lemma mulninftyr r : -oo%E * r%:E = (Num.sg r)%:E * -oo%E.
-Proof. by rewrite muleC mulrninfty. Qed.
+Lemma mulNyr r : -oo%E * r%:E = (Num.sg r)%:E * -oo%E.
+Proof. by rewrite muleC mulrNy. Qed.
 
-Definition mulrinfty := (mulrpinfty, mulpinftyr, mulrninfty, mulninftyr).
+Definition mulrinfty := (mulry, mulyr, mulrNy, mulNyr).
 
 Lemma lte_mul_pinfty x y : 0 <= x -> x \is a fin_num -> y < +oo -> x * y < +oo.
 Proof.
-move: x y => [x| |] [y| |] // x0 xfin _; first by rewrite -EFinM lte_pinfty.
+move: x y => [x| |] [y| |] // x0 xfin _; first by rewrite -EFinM ltey.
 rewrite mulrinfty; move: x0; rewrite lee_fin le_eqVlt => /predU1P[<-|x0].
-- by rewrite sgr0 mul0e lte_pinfty.
+- by rewrite sgr0 mul0e ltey.
 - by rewrite gtr0_sg // mul1e.
 Qed.
 
@@ -1457,34 +1445,34 @@ Proof.
 move: x y => [x| |] [y| |] //; rewrite ?lee_fin.
 - by move=> x0 y0; rewrite !lte_fin; exact: mulr_ge0_gt0.
 - rewrite le_eqVlt => /predU1P[<-|x0] _; first by rewrite mul0e ltxx.
-  by rewrite lte_pinfty andbT mulrpinfty gtr0_sg// mul1e lte_fin x0 lte_pinfty.
+  by rewrite ltey andbT mulrinfty gtr0_sg// mul1e lte_fin x0 ltey.
 - move=> _; rewrite le_eqVlt => /predU1P[<-|x0].
     by rewrite mule0 ltxx andbC.
-  by rewrite lte_pinfty/= mulpinftyr gtr0_sg// mul1e lte_fin x0 lte_pinfty.
-- by move=> _ _; rewrite mule_pinfty_pinfty lte_pinfty.
+  by rewrite ltey/= mulrinfty gtr0_sg// mul1e lte_fin x0 ltey.
+- by move=> _ _; rewrite mulyy ltey.
 Qed.
 
-Lemma gt0_mulpinfty x : (0 < x -> +oo * x = +oo)%E.
+Lemma gt0_mulye x : (0 < x -> +oo * x = +oo)%E.
 Proof.
-move: x => [x|_|//]; last by rewrite mule_pinfty_pinfty.
+move: x => [x|_|//]; last by rewrite mulyy.
 by rewrite lte_fin => x0; rewrite muleC mulrinfty gtr0_sg// mul1e.
 Qed.
 
-Lemma lt0_mulpinfty x : (x < 0 -> +oo * x = -oo)%E.
+Lemma lt0_mulye x : (x < 0 -> +oo * x = -oo)%E.
 Proof.
-move: x => [x|//|_]; last by rewrite mule_pinfty_ninfty.
+move: x => [x|//|_]; last by rewrite mulyNy.
 by rewrite lte_fin => x0; rewrite muleC mulrinfty ltr0_sg// mulN1e.
 Qed.
 
-Lemma gt0_mulninfty x : (0 < x -> -oo * x = -oo)%E.
+Lemma gt0_mulNye x : (0 < x -> -oo * x = -oo)%E.
 Proof.
-move: x => [x|_|//]; last by rewrite mule_ninfty_pinfty.
+move: x => [x|_|//]; last by rewrite mulNyy.
 by rewrite lte_fin => x0; rewrite muleC mulrinfty gtr0_sg// mul1e.
 Qed.
 
-Lemma lt0_mulninfty x : (x < 0 -> -oo * x = +oo)%E.
+Lemma lt0_mulNye x : (x < 0 -> -oo * x = +oo)%E.
 Proof.
-move: x => [x|//|_]; last by rewrite mule_ninfty_ninfty.
+move: x => [x|//|_]; last by rewrite mulNyNy.
 by rewrite lte_fin => x0; rewrite muleC mulrinfty ltr0_sg// mulN1e.
 Qed.
 
@@ -1493,18 +1481,18 @@ Lemma mule_eq_pinfty x y : (x * y == +oo) =
      (x == +oo) && (y > 0) | (x == -oo) && (y < 0)].
 Proof.
 move: x y => [x| |] [y| |]; rewrite ?(lte_fin,andbF,andbT,orbF,eqxx,andbT)//=.
-- by rewrite mulrpinfty; have [/ltr0_sg|/gtr0_sg|] := ltgtP x 0%R;
+- by rewrite mulrinfty; have [/ltr0_sg|/gtr0_sg|] := ltgtP x 0%R;
     move=> ->; rewrite ?(mulN1e,mul1e,sgr0,mul0e).
-- by rewrite mulrninfty; have [/ltr0_sg|/gtr0_sg|] := ltgtP x 0%R;
+- by rewrite mulrinfty; have [/ltr0_sg|/gtr0_sg|] := ltgtP x 0%R;
     move=> ->; rewrite ?(mulN1e,mul1e,sgr0,mul0e).
-- by rewrite mulpinftyr; have [/ltr0_sg|/gtr0_sg|] := ltgtP y 0%R;
+- by rewrite mulrinfty; have [/ltr0_sg|/gtr0_sg|] := ltgtP y 0%R;
     move=> ->; rewrite ?(mulN1e,mul1e,sgr0,mul0e).
-- by rewrite mule_pinfty_pinfty lte_pinfty.
-- by rewrite mule_pinfty_ninfty.
-- by rewrite mulninftyr; have [/ltr0_sg|/gtr0_sg|] := ltgtP y 0%R;
+- by rewrite mulyy ltey.
+- by rewrite mulyNy.
+- by rewrite mulrinfty; have [/ltr0_sg|/gtr0_sg|] := ltgtP y 0%R;
     move=> ->; rewrite ?(mulN1e,mul1e,sgr0,mul0e).
-- by rewrite mule_ninfty_pinfty.
-- by rewrite lte_ninfty.
+- by rewrite mulNyy.
+- by rewrite ltNye.
 Qed.
 
 Lemma mule_eq_ninfty x y : (x * y == -oo) =
@@ -1520,14 +1508,14 @@ Proof. by rewrite lte_oppl oppeK. Qed.
 
 Lemma lte_add a b x y : a < b -> x < y -> a + x < b + y.
 Proof.
-move: a b x y=> [a| |] [b| |] [x| |] [y| |]; rewrite ?(lte_pinfty,lte_ninfty)//.
+move: a b x y=> [a| |] [b| |] [x| |] [y| |]; rewrite ?(ltey,ltNye)//.
 by rewrite !lte_fin; exact: ltr_add.
 Qed.
 
 Lemma lee_addl x y : 0 <= y -> x <= x + y.
 Proof.
 move: x y => -[ x [y| |]//= | [| |]// | [| | ]//];
-  by [rewrite !lee_fin ler_addl | move=> _; exact: lee_pinfty].
+  by [rewrite !lee_fin ler_addl | move=> _; exact: leey].
 Qed.
 
 Lemma lee_addr x y : 0 <= y -> x <= y + x.
@@ -1536,7 +1524,7 @@ Proof. by rewrite addeC; exact: lee_addl. Qed.
 Lemma gee_addl x y : y <= 0 -> x + y <= x.
 Proof.
 move: x y => -[ x [y| |]//= | [| |]// | [| | ]//];
-  by [rewrite !lee_fin ger_addl | move=> _; exact: lee_ninfty].
+  by [rewrite !lee_fin ger_addl | move=> _; exact: leNye].
 Qed.
 
 Lemma gee_addr x y : y <= 0 -> y + x <= x.
@@ -1544,8 +1532,7 @@ Proof. rewrite addeC; exact: gee_addl. Qed.
 
 Lemma lte_addl y x : y \is a fin_num -> 0 < x -> y < y + x.
 Proof.
-by move: x y => [x| |] [y| |] _ //;
-  rewrite ?lte_pinfty ?lte_ninfty // !lte_fin ltr_addl.
+by move: x y => [x| |] [y| |] _ //; rewrite ?ltey ?ltNye // !lte_fin ltr_addl.
 Qed.
 
 Lemma lte_addr y x : y \is a fin_num -> 0 < x -> y < x + y.
@@ -1553,7 +1540,7 @@ Proof. rewrite addeC; exact: lte_addl. Qed.
 
 Lemma gte_subl y x : y \is a fin_num -> 0 < x -> y - x < y.
 Proof.
-move: y x => [x| |] [y| |] _ //; rewrite addeC /= ?lte_ninfty //.
+move: y x => [x| |] [y| |] _ //; rewrite addeC /= ?ltNye //.
 by rewrite !lte_fin gtr_addr ltr_oppl oppr0.
 Qed.
 
@@ -1562,7 +1549,7 @@ Proof. rewrite addeC; exact: gte_subl. Qed.
 
 Lemma lte_add2lE x a b : x \is a fin_num -> (x + a < x + b) = (a < b).
 Proof.
-move: a b x => [a| |] [b| |] [x| |] _ //; rewrite ?(lte_pinfty, lte_ninfty) //.
+move: a b x => [a| |] [b| |] [x| |] _ //; rewrite ?(ltey, ltNye)//.
 by rewrite !lte_fin ltr_add2l.
 Qed.
 
@@ -1570,13 +1557,13 @@ Lemma lee_add2l x a b : a <= b -> x + a <= x + b.
 Proof.
 move: a b x => -[a [b [x /=|//|//] | []// |//] | []// | ].
 - by rewrite !lee_fin ler_add2l.
-- move=> r _; exact: lee_pinfty.
-- move=> -[b [|  |]// | []// | //] r oob; exact: lee_ninfty.
+- by move=> r _; exact: leey.
+- by move=> -[b [|  |]// | []// | //] r oob; exact: leNye.
 Qed.
 
 Lemma lee_add2lE x a b : x \is a fin_num -> (x + a <= x + b) = (a <= b).
 Proof.
-move: a b x => [a| |] [b| |] [x| |] _ //; rewrite ?(lee_pinfty, lee_ninfty) //.
+move: a b x => [a| |] [b| |] [x| |] _ //; rewrite ?(leey, leNye)//.
 by rewrite !lee_fin ler_add2l.
 Qed.
 
@@ -1585,22 +1572,20 @@ Proof. rewrite addeC (addeC b); exact: lee_add2l. Qed.
 
 Lemma lee_add a b x y : a <= b -> x <= y -> a + x <= b + y.
 Proof.
-move: a b x y => [a| |] [b| |] [x| |] [y| |]; rewrite ?(lee_pinfty,lee_ninfty)//.
+move: a b x y => [a| |] [b| |] [x| |] [y| |]; rewrite ?(leey, leNye)//.
 by rewrite !lee_fin; exact: ler_add.
 Qed.
 
 Lemma lte_le_add a b x y : a \is a fin_num -> b \is a fin_num ->
   a < x -> b <= y -> a + b < x + y.
 Proof.
-move: x y a b => [x| |] [y| |] [a| |] [b| |] _ _ //=;
-  rewrite ?(lte_pinfty,lte_ninfty)//.
+move: x y a b => [x| |] [y| |] [a| |] [b| |] _ _ //=; rewrite ?(ltey, ltNye)//.
 by rewrite !lte_fin; exact: ltr_le_add.
 Qed.
 
 Lemma lee_sub x y z u : x <= y -> u <= z -> x - z <= y - u.
 Proof.
-move: x y z u => -[x| |] -[y| |] -[z| |] -[u| |] //=;
-  rewrite ?(lee_pinfty,lee_ninfty)//.
+move: x y z u => -[x| |] -[y| |] -[z| |] -[u| |] //=; rewrite ?(leey,leNye)//.
 by rewrite !lee_fin; exact: ler_sub.
 Qed.
 
@@ -1608,7 +1593,7 @@ Lemma lte_le_sub z u x y : z \is a fin_num -> u \is a fin_num ->
   x < z -> u <= y -> x - y < z - u.
 Proof.
 move: z u => [z| |] [u| |] _ _ //.
-move: x y => [x| |] [y| |]; rewrite ?(lte_pinfty,lte_ninfty)//.
+move: x y => [x| |] [y| |]; rewrite ?(ltey, ltNye)//.
 by rewrite !lte_fin => xltr tley; apply: ltr_le_add; rewrite // ler_oppl opprK.
 Qed.
 
@@ -1616,11 +1601,11 @@ Lemma lte_pmul2r z : z \is a fin_num -> 0 < z -> {mono *%E^~ z : x y / x < y}.
 Proof.
 move: z => [z| |] _ // z0 [x| |] [y| |] //.
 - by rewrite !lte_fin ltr_pmul2r.
-- by rewrite mulrinfty gtr0_sg// mul1e 2!lte_pinfty.
-- by rewrite mulrinfty gtr0_sg// mul1e ltNge lee_ninfty ltNge lee_ninfty.
-- by rewrite mulrinfty gtr0_sg// mul1e ltNge lee_pinfty ltNge lee_pinfty.
+- by rewrite mulrinfty gtr0_sg// mul1e 2!ltey.
+- by rewrite mulrinfty gtr0_sg// mul1e ltNge leNye ltNge leNye.
+- by rewrite mulrinfty gtr0_sg// mul1e ltNge leey ltNge leey.
 - by rewrite mulrinfty gtr0_sg// mul1e mulrinfty gtr0_sg// mul1e.
-- by rewrite mulrinfty gtr0_sg// mul1e 2!lte_ninfty.
+- by rewrite mulrinfty gtr0_sg// mul1e 2!ltNye.
 - by rewrite mulrinfty gtr0_sg// mul1e mulrinfty gtr0_sg// mul1e.
 Qed.
 
@@ -1753,7 +1738,7 @@ Qed.
 
 Lemma lte_subl_addr x y z : y \is a fin_num -> (x - y < z) = (x < z + y).
 Proof.
-move: x y z => [x| |] [y| |] [z| |] _ //=; rewrite ?lte_pinfty ?lte_ninfty //.
+move: x y z => [x| |] [y| |] [z| |] _ //=; rewrite ?ltey ?ltNye //.
 by rewrite !lte_fin ltr_subl_addr.
 Qed.
 
@@ -1762,7 +1747,7 @@ Proof. by move=> ?; rewrite lte_subl_addr// addeC. Qed.
 
 Lemma lte_subr_addr x y z : z \is a fin_num -> (x < y - z) = (x + z < y).
 Proof.
-move: x y z => [x| |] [y| |] [z| |] _ //=; rewrite ?lte_ninfty ?lte_pinfty //.
+move: x y z => [x| |] [y| |] [z| |] _ //=; rewrite ?ltNye ?ltey //.
 by rewrite !lte_fin ltr_subr_addr.
 Qed.
 
@@ -1771,7 +1756,7 @@ Proof. by move=> ?; rewrite lte_subr_addr// addeC. Qed.
 
 Lemma lte_subel_addr x y z : x \is a fin_num -> (x - y < z) = (x < z + y).
 Proof.
-move: x y z => [x| |] [y| |] [z| |] _ //=; rewrite ?lte_ninfty ?lte_pinfty //.
+move: x y z => [x| |] [y| |] [z| |] _ //=; rewrite ?ltNye ?ltey //.
 by rewrite !lte_fin ltr_subl_addr.
 Qed.
 
@@ -1780,7 +1765,7 @@ Proof. by move=> ?; rewrite lte_subel_addr// addeC. Qed.
 
 Lemma lte_suber_addr x y z : x \is a fin_num -> (x < y - z) = (x + z < y).
 Proof.
-move: x y z => [x| |] [y| |] [z| |] _ //=; rewrite ?lte_ninfty ?lte_pinfty //.
+move: x y z => [x| |] [y| |] [z| |] _ //=; rewrite ?ltNye ?ltey //.
 by rewrite !lte_fin ltr_subr_addr.
 Qed.
 
@@ -1789,7 +1774,7 @@ Proof. by move=> ?; rewrite lte_suber_addr// addeC. Qed.
 
 Lemma lee_subl_addr x y z : y \is a fin_num -> (x - y <= z) = (x <= z + y).
 Proof.
-move: x y z => [x| |] [y| |] [z| |] _ //=; rewrite ?lee_pinfty ?lee_ninfty //.
+move: x y z => [x| |] [y| |] [z| |] _ //=; rewrite ?leey ?leNye //.
 by rewrite !lee_fin ler_subl_addr.
 Qed.
 
@@ -1798,7 +1783,7 @@ Proof. by move=> ?; rewrite lee_subl_addr// addeC. Qed.
 
 Lemma lee_subr_addr x y z : z \is a fin_num -> (x <= y - z) = (x + z <= y).
 Proof.
-move: y x z => [y| |] [x| |] [z| |] _ //=; rewrite ?lee_ninfty ?lee_pinfty //.
+move: y x z => [y| |] [x| |] [z| |] _ //=; rewrite ?leNye ?leey //.
 by rewrite !lee_fin ler_subr_addr.
 Qed.
 
@@ -1807,7 +1792,7 @@ Proof. by move=> ?; rewrite lee_subr_addr// addeC. Qed.
 
 Lemma lee_subel_addr x y z : z \is a fin_num -> (x - y <= z) = (x <= z + y).
 Proof.
-move: x y z => [x| |] [y| |] [z| |] _ //=; rewrite ?lee_pinfty ?lee_ninfty //.
+move: x y z => [x| |] [y| |] [z| |] _ //=; rewrite ?leey ?leNye //.
 by rewrite !lee_fin ler_subl_addr.
 Qed.
 
@@ -1816,7 +1801,7 @@ Proof. by move=> ?; rewrite lee_subel_addr// addeC. Qed.
 
 Lemma lee_suber_addr x y z : y \is a fin_num -> (x <= y - z) = (x + z <= y).
 Proof.
-move: y x z => [y| |] [x| |] [z| |] _ //=; rewrite ?lee_ninfty ?lee_pinfty //.
+move: y x z => [y| |] [x| |] [z| |] _ //=; rewrite ?leNye ?leey //.
 by rewrite !lee_fin ler_subr_addr.
 Qed.
 
@@ -1884,7 +1869,7 @@ Qed.
 Lemma muleA : associative ( *%E : \bar R -> \bar R -> \bar R ).
 Proof.
 move=> [x||] [y||] [z||] //;
-  rewrite /mule/mule_subdef/= ?(lte_pinfty,eqe,lte_fin,mulrA)//=.
+  rewrite /mule/mule_subdef/= ?(ltey, eqe, lte_fin, mulrA)//=.
 - case: ltrgtP => [y0|y0|<-{y}]; last by rewrite mulr0 eqxx.
     case: ltrgtP => [x0|x0|<-{x}]; last by rewrite mul0r eqxx.
       by rewrite gt_eqF mulr_gt0.
@@ -1902,12 +1887,12 @@ move=> [x||] [y||] [z||] //;
 - case: ltrgtP => [z0|z0|<-{z}]; try
     by case: ltrgtP => [x0|x0|_] //; rewrite mul0r.
   by case: ltrgtP; rewrite !mulr0.
-- by case: ltrgtP => //=; rewrite ?lte_pinfty// eqxx.
-- by case: ltrgtP => /=; rewrite ?lte_pinfty// eqxx.
+- by case: ltrgtP => //=; rewrite ?ltey// eqxx.
+- by case: ltrgtP => /=; rewrite ?ltey// eqxx.
 - case: ltrgtP => //= [z0|z0|<-{z}]; try by case: ltrgtP => //=; rewrite mul0r.
   by case: ltrgtP; rewrite !mulr0.
-- by case: ltrgtP => //=; rewrite ?lte_pinfty ?eqxx.
-- by case: ltrgtP => //=; rewrite ?lte_pinfty ?eqxx.
+- by case: ltrgtP => //=; rewrite eqxx.
+- by case: ltrgtP => //=; rewrite ?ltey ?eqxx.
 - case: (ltrgtP 0 y) => [y0/=|y0/=|<-{y}]; last by rewrite mul0r eqxx.
     case: (ltrgtP 0 z) => [z0/=|z0|<-{z}]; last by rewrite mulr0 eqxx.
       by rewrite (negbTE (mulf_neq0 _ _)) ?gt_eqF // mulr_gt0// lte_fin z0.
@@ -1915,10 +1900,10 @@ move=> [x||] [y||] [z||] //;
   case: (ltrgtP 0 z) => [z0/=|z0|<-{z}]; last by rewrite mulr0 eqxx.
     by rewrite lt_eqF ?nmulr_rlt0// ltNge nmulr_rle0// (ltW z0).
   by rewrite gt_eqF nmulr_lgt0// y0.
-- by case: ltrgtP => //=; rewrite lte_pinfty.
-- by case: ltrgtP; rewrite /= ?lte_pinfty// eqxx.
-- by case: ltrgtP; rewrite /= ?lte_pinfty// eqxx.
-- by case: ltrgtP; rewrite /= ?lte_pinfty// eqxx.
+- by case: ltrgtP => //=; rewrite ltey.
+- by case: ltrgtP; rewrite /= ?ltey// eqxx.
+- by case: ltrgtP; rewrite /= ?ltey// eqxx.
+- by case: ltrgtP; rewrite /= ?ltey// eqxx.
 - case: (ltrgtP 0 y) => [y0/=|y0/=|<-{y}]; last by rewrite mul0r eqxx.
     case: (ltrgtP 0 z) => [z0/=|z0|<-{z}]; last by rewrite mulr0 eqxx.
       by rewrite (negbTE (mulf_neq0 _ _)) ?gt_eqF // mulr_gt0// lte_fin z0.
@@ -1926,10 +1911,10 @@ move=> [x||] [y||] [z||] //;
   case: (ltrgtP 0 z) => [z0/=|z0|<-{z}]; last by rewrite mulr0 eqxx.
     by rewrite lt_eqF ?nmulr_rlt0// ltNge nmulr_rle0// (ltW z0).
   by rewrite gt_eqF nmulr_lgt0// y0.
-- by case: ltrgtP; rewrite ?eqxx// ?mul0e//= lte_pinfty.
+- by case: ltrgtP; rewrite ?eqxx// ?mul0e//= ltey.
 - by case: ltrgtP.
-- by case: ltrgtP => //= [z0|z0]; rewrite ?eqxx// lte_pinfty.
-- by case: ltrgtP; rewrite ?eqxx// lte_pinfty.
+- by case: ltrgtP => //= [z0|z0]; rewrite ?eqxx// ltey.
+- by case: ltrgtP; rewrite ?eqxx// ltey.
 Qed.
 
 Local Open Scope ereal_scope.
@@ -1963,17 +1948,17 @@ rewrite /mule/=; move: x y z => [r| |] [s| |] [t| |] //= s0 t0.
   + rewrite lte_fin -[in LHS](addr0 0%R) ltr_le_add // lte_fin s0.
     by case: ltgtP t0 => // [t0|[<-{t}]] _; [rewrite gt_eqF|rewrite eqxx].
   + by move: t0; rewrite lee_fin; case: (ltgtP t).
-- by rewrite lte_pinfty; case: ltgtP s0.
-- by rewrite lte_pinfty; case: ltgtP t0.
-- by rewrite lte_pinfty.
+- by rewrite ltey; case: ltgtP s0.
+- by rewrite ltey; case: ltgtP t0.
+- by rewrite ltey.
 - rewrite !eqe paddr_eq0 //; move: s0; rewrite lee_fin.
   case: (ltgtP s) => //= [s0|->{s}] _; rewrite ?add0e.
   + rewrite lte_fin -[in LHS](addr0 0%R) ltr_le_add // lte_fin s0.
     by case: ltgtP t0 => // [t0|[<-{t}]].
   + by move: t0; rewrite lee_fin; case: (ltgtP t).
-- by rewrite lte_pinfty; case: ltgtP s0.
-- by rewrite lte_pinfty; case: ltgtP s0.
-- by rewrite lte_pinfty; case: ltgtP s0.
+- by rewrite ltey; case: ltgtP s0.
+- by rewrite ltey; case: ltgtP s0.
+- by rewrite ltey; case: ltgtP s0.
 Qed.
 
 Lemma ge0_muleDr x y z : 0 <= y -> 0 <= z -> x * (y + z) = x * y + x * z.
@@ -1991,9 +1976,9 @@ rewrite /mule/=; move: x y z => [r| |] [s| |] [t| |] //= s0 t0.
   + rewrite !lte_fin -[in LHS](addr0 0%R) ltNge ler_add // ?ltW //=.
     by rewrite !ltNge ltW //.
   + by case: (ltgtP t).
-- by rewrite lte_pinfty; case: ltgtP s0.
-- by rewrite lte_pinfty; case: ltgtP t0.
-- by rewrite lte_pinfty.
+- by rewrite ltey; case: ltgtP s0.
+- by rewrite ltey; case: ltgtP t0.
+- by rewrite ltey.
 - rewrite !eqe naddr_eq0 //; move: s0; rewrite lee_fin.
   case: (ltgtP s) => //= [s0|->{s}] _; rewrite ?add0e.
   + rewrite !lte_fin -[in LHS](addr0 0%R) ltNge ler_add // ?ltW //=.
@@ -2010,7 +1995,7 @@ Lemma gee_pmull y x : y \is a fin_num -> 0 < x -> y <= 1 -> y * x <= x.
 Proof.
 move: x y => [x| |] [y| |] _ //=.
 - by rewrite lte_fin => x0 r0; rewrite /mule/= lee_fin ger_pmull.
-- by move=> _; rewrite /mule/= eqe => r1; rewrite lee_pinfty.
+- by move=> _; rewrite /mule/= eqe => r1; rewrite leey.
 Qed.
 
 Lemma lee_wpmul2r x : 0 <= x -> {homo *%E^~ x : y z / y <= z}.
@@ -2018,20 +2003,20 @@ Proof.
 move: x => [x|_|//].
   rewrite lee_fin le_eqVlt => /predU1P[<- y z|x0]; first by rewrite 2!mule0.
   move=> [y| |] [z| |]//; first by rewrite !lee_fin// ler_pmul2r.
-  - by move=> _; rewrite mulrinfty gtr0_sg// mul1e lee_pinfty.
-  - by move=> _; rewrite mulrinfty gtr0_sg// mul1e lee_ninfty.
+  - by move=> _; rewrite mulrinfty gtr0_sg// mul1e leey.
+  - by move=> _; rewrite mulrinfty gtr0_sg// mul1e leNye.
   - by move=> _; rewrite 2!mulrinfty gtr0_sg// 2!mul1e.
 move=> [y| |] [z| |]//.
 - rewrite lee_fin => yz.
   have [z0|z0|] := ltgtP 0%R z.
-  + by rewrite [leRHS]mulrinfty gtr0_sg// mul1e lee_pinfty.
+  + by rewrite [leRHS]mulrinfty gtr0_sg// mul1e leey.
   + by rewrite mulrinfty ltr0_sg// ?(le_lt_trans yz)// [leRHS]mulrinfty ltr0_sg.
   + move=> z0; move: yz; rewrite -z0 mul0e le_eqVlt => /predU1P[->|y0].
       by rewrite mul0e.
-    by rewrite mulrinfty ltr0_sg// mulN1e lee_ninfty.
-  + by move=> _; rewrite mule_pinfty_pinfty lee_pinfty.
-  + by move=> _; rewrite mule_ninfty_pinfty lee_ninfty.
-  + by move=> _; rewrite mule_ninfty_pinfty lee_ninfty.
+    by rewrite mulrinfty ltr0_sg// mulN1e leNye.
+  + by move=> _; rewrite mulyy leey.
+  + by move=> _; rewrite mulNyy leNye.
+  + by move=> _; rewrite mulNyy leNye.
 Qed.
 
 Lemma ge0_sume_distrl (I : Type) (s : seq I) x (P : pred I) (F : I -> \bar R) :
@@ -2090,19 +2075,17 @@ Proof. by move: x => [x| |] //=; rewrite normr_id. Qed.
 Lemma preimage_abse_ninfty : (@abse R @^-1` [set -oo])%classic = set0.
 Proof.
 rewrite predeqE => t; split => //=; apply/eqP.
-by rewrite gt_eqF// (lt_le_trans _ (abse_ge0 t))// lte_ninfty.
+by rewrite gt_eqF// (lt_le_trans _ (abse_ge0 t))// ltNye.
 Qed.
 
 Lemma lte_absl (x y : \bar R) : (`|x| < y)%E = (- y < x < y)%E.
 Proof.
-move: x y => [x| |] [y| |] //=; rewrite ?lte_fin ?lte_pinfty ?lte_ninfty//.
-by rewrite ltr_norml.
+by move: x y => [x| |] [y| |] //=; rewrite ?lte_fin ?ltey ?ltNye// ltr_norml.
 Qed.
 
 Lemma eqe_absl x y : (`|x| == y) = ((x == y) || (x == - y)) && (0 <= y).
 Proof.
-move: x y => [x| |] [y| |] //=; rewrite? lee_pinfty//.
-by rewrite !eqe eqr_norml lee_fin.
+by move: x y => [x| |] [y| |] //=; rewrite? leey// !eqe eqr_norml lee_fin.
 Qed.
 
 Lemma lee_abs_add x y : `|x + y| <= `|x| + `|y|.
@@ -2126,17 +2109,17 @@ Lemma abseM : {morph @abse R : x y / x * y}.
 Proof.
 have xoo r : `|r%:E * +oo| = `|r|%:E * +oo.
   have [r0|r0] := leP 0%R r.
-    by rewrite (ger0_norm r0)// gee0_abs// mule_ge0// lee_pinfty.
+    by rewrite (ger0_norm r0)// gee0_abs// mule_ge0// leey.
   rewrite (ltr0_norm r0)// lte0_abs// ?EFinN ?mulNe//.
   by rewrite mule_lt0 /= eqe lt_eqF//= lte_fin r0.
 move=> [x| |] [y| |] //=; first by rewrite normrM.
 - by rewrite -abseN -muleNN abseN -EFinN xoo normrN.
 - by rewrite muleC xoo muleC.
-- by rewrite mule_pinfty_pinfty.
-- by rewrite mule_pinfty_pinfty mule_pinfty_ninfty.
+- by rewrite mulyy.
+- by rewrite mulyy mulyNy.
 - by rewrite -abseN -muleNN abseN -EFinN xoo normrN.
-- by rewrite mule_pinfty_pinfty mule_ninfty_pinfty.
-- by rewrite mule_pinfty_pinfty.
+- by rewrite mulyy mulNyy.
+- by rewrite mulyy.
 Qed.
 
 Lemma maxEFin r1 r2 : maxe r1%:E r2%:E = (Num.max r1 r2)%:E.
@@ -2165,38 +2148,38 @@ by apply/esym/max_idPr; rewrite lee_add2l.
 by apply/esym/max_idPl; rewrite lee_add2l// ltW.
 Qed.
 
-Lemma maxe_pinftyl : left_zero (+oo : \bar R) maxe.
+Lemma maxye : left_zero (+oo : \bar R) maxe.
 Proof. by move=> x; have [|//] := leP +oo x; rewrite lee_pinfty_eq => /eqP. Qed.
 
-Lemma maxe_pinftyr : right_zero (+oo : \bar R) maxe.
-Proof. by move=> x; rewrite maxC maxe_pinftyl. Qed.
+Lemma maxey : right_zero (+oo : \bar R) maxe.
+Proof. by move=> x; rewrite maxC maxye. Qed.
 
-Lemma maxe_ninftyl : left_id (-oo : \bar R) maxe.
-Proof. by move=> x; have [//|] := leP -oo x; rewrite ltNge lee_ninfty. Qed.
+Lemma maxNye : left_id (-oo : \bar R) maxe.
+Proof. by move=> x; have [//|] := leP -oo x; rewrite ltNge leNye. Qed.
 
-Lemma maxe_ninftyr : right_id (-oo : \bar R) maxe.
-Proof. by move=> x; rewrite maxC maxe_ninftyl. Qed.
+Lemma maxeNy : right_id (-oo : \bar R) maxe.
+Proof. by move=> x; rewrite maxC maxNye. Qed.
 
-Lemma mine_ninftyl : left_zero (-oo : \bar R) mine.
+Lemma minNye : left_zero (-oo : \bar R) mine.
 Proof. by move=> x; have [|//] := leP x -oo; rewrite lee_ninfty_eq => /eqP. Qed.
 
-Lemma mine_ninftyr : right_zero (-oo : \bar R) mine.
-Proof. by move=> x; rewrite minC mine_ninftyl. Qed.
+Lemma mineNy : right_zero (-oo : \bar R) mine.
+Proof. by move=> x; rewrite minC minNye. Qed.
 
-Lemma mine_pinftyl : left_id (+oo : \bar R) mine.
-Proof. by move=> x; have [//|] := leP x +oo; rewrite ltNge lee_pinfty. Qed.
+Lemma minye : left_id (+oo : \bar R) mine.
+Proof. by move=> x; have [//|] := leP x +oo; rewrite ltNge leey. Qed.
 
-Lemma mine_pinftyr : right_id (+oo : \bar R) mine.
-Proof. by move=> x; rewrite minC mine_pinftyl. Qed.
+Lemma miney : right_id (+oo : \bar R) mine.
+Proof. by move=> x; rewrite minC minye. Qed.
 
 Lemma oppe_max : {morph -%E : x y / maxe x y >-> mine x y : \bar R}.
 Proof.
 move=> [x| |] [y| |] //=.
 - by rewrite maxEFin minEFin -EFinN oppr_max.
-- by rewrite maxe_pinftyr mine_ninftyr.
-- by rewrite mine_pinftyr.
-- by rewrite mine_ninftyl.
-- by rewrite maxe_ninftyl mine_pinftyl.
+- by rewrite maxey mineNy.
+- by rewrite miney.
+- by rewrite minNye.
+- by rewrite maxNye minye.
 Qed.
 
 Lemma oppe_min : {morph -%E : x y / mine x y >-> maxe x y : \bar R}.
@@ -2226,22 +2209,22 @@ Proof. by move=> zfin z0; rewrite muleC mineMr// !(muleC z). Qed.
 
 Lemma lee_pemull x y : 0 <= y -> 1 <= x -> y <= x * y.
 Proof.
-move: x y => [x| |] [y| |] //; last by rewrite mule_pinfty_pinfty.
+move: x y => [x| |] [y| |] //; last by rewrite mulyy.
 - by rewrite -EFinM 3!lee_fin; exact: ler_pemull.
 - move=> _; rewrite lee_fin => x1.
   by rewrite mulrinfty gtr0_sg ?mul1e// (lt_le_trans _ x1).
 - rewrite lee_fin le_eqVlt => /predU1P[<- _|y0 _]; first by rewrite mule0.
-  by rewrite mulrinfty gtr0_sg// mul1e lee_pinfty.
+  by rewrite mulrinfty gtr0_sg// mul1e leey.
 Qed.
 
 Lemma lee_nemull x y : y <= 0 -> 1 <= x -> x * y <= y.
 Proof.
-move: x y => [x| |] [y| |] //; last by rewrite mule_pinfty_ninfty.
+move: x y => [x| |] [y| |] //; last by rewrite mulyNy.
 - by rewrite -EFinM 3!lee_fin; exact: ler_nemull.
 - move=> _; rewrite lee_fin => x1.
   by rewrite mulrinfty gtr0_sg ?mul1e// (lt_le_trans _ x1).
 - rewrite lee_fin le_eqVlt => /predU1P[-> _|y0 _]; first by rewrite mule0.
-  by rewrite mulrinfty ltr0_sg// mulN1e lee_ninfty.
+  by rewrite mulrinfty ltr0_sg// mulN1e leNye.
 Qed.
 
 Lemma lee_pemulr x y : 0 <= y -> 1 <= x -> y <= y * x.
@@ -2255,8 +2238,8 @@ Proof.
 elim: n => [|n]; first by rewrite mul0e.
 move: x => [x| |] ih.
 - by rewrite -EFinM mulr_natl EFin_natmul.
-- by rewrite mulrpinfty gtr0_sg// mul1e enatmul_pinfty.
-- by rewrite mulrninfty gtr0_sg// mul1e enatmul_ninfty.
+- by rewrite mulry gtr0_sg// mul1e enatmul_pinfty.
+- by rewrite mulrNy gtr0_sg// mul1e enatmul_ninfty.
 Qed.
 
 End ERealArithTh_realDomainType.
@@ -2631,15 +2614,15 @@ End DualAddTheoryRealDomain.
 Lemma lee_opp2 {R : realDomainType} : {mono @oppe R : x y /~ x <= y}.
 Proof.
 move=> x y; case: x y => [?||] [?||] //; first by rewrite !lee_fin !ler_opp2.
-by rewrite lee_ninfty /Order.le /= realN num_real.
-by rewrite lee_pinfty /Order.le /= realN num_real.
+by rewrite leNye /Order.le /= realN num_real.
+by rewrite leey /Order.le /= realN num_real.
 Qed.
 
 Lemma lte_opp2 {R : realDomainType} : {mono @oppe R : x y /~ x < y}.
 Proof.
 move=> x y; case: x y => [?||] [?||] //; first by rewrite !lte_fin !ltr_opp2.
-by rewrite lte_ninfty /Order.lt /= realN num_real.
-by rewrite lte_pinfty /Order.lt /= realN num_real.
+by rewrite ltNye /Order.lt /= realN num_real.
+by rewrite ltey /Order.lt /= realN num_real.
 Qed.
 
 Section realFieldType_lemmas.
@@ -2649,7 +2632,7 @@ Implicit Types r : R.
 
 Lemma lee_adde x y : (forall e : {posnum R}, x <= y + e%:num%:E) -> x <= y.
 Proof.
-move: x y => [x| |] [y| |] //=; rewrite ?(lee_ninfty,lee_pinfty) //;
+move: x y => [x| |] [y| |] //=; rewrite ?(leNye, leey) //;
   try by move/(_ (PosNum ltr01)).
 rewrite lee_fin => abe; rewrite leNgt; apply/negP => ba; apply/existsNP : abe.
 have xy : (0 < (x - y) / 2)%R by apply divr_gt0 => //; rewrite subr_gt0.
@@ -2659,8 +2642,7 @@ Qed.
 
 Lemma lte_spaddr z x y : z \is a fin_num -> 0 < y -> z <= x -> z < x + y.
 Proof.
-move: z y x => [z| |] [y| |] [x| |] _ //=;
-  rewrite ?(lte_fin, lte_fin, lte_pinfty) //.
+move: z y x => [z| |] [y| |] [x| |] _ //=; rewrite ?(lte_fin, lte_fin, ltey) //.
 exact: ltr_spaddr.
 Qed.
 
@@ -2682,7 +2664,7 @@ move: x y => [x||] [y||] // in x0 h *.
     by rewrite ltr_pdivr_mulr ?mulr_gt0// mul1r mulr_natl mulr2n ltr_add2r.
   rewrite -(EFinM _ x) lee_fin invrM ?unitfE// ?gt_eqF// -mulrA mulrAC.
   by rewrite mulVr ?unitfE ?gt_eqF// mul1r; apply/negP; rewrite -ltNge midf_lt.
-- by rewrite lee_pinfty.
+- by rewrite leey.
 - by have := h _ h01.
 - by have := h _ h01; rewrite mulrinfty sgrV gtr0_sg // mul1e.
 - by have := h _ h01; rewrite mulrinfty sgrV gtr0_sg // mul1e.
@@ -2692,9 +2674,9 @@ Lemma lte_pdivr_mull r x y : (0 < r)%R -> (r^-1%:E * y < x) = (y < r%:E * x).
 Proof.
 move=> r0; move: x y => [x| |] [y| |] //=.
 - by rewrite 2!lte_fin ltr_pdivr_mull.
-- by rewrite mulrinfty sgrV gtr0_sg// mul1e 2!ltNge 2!lee_pinfty.
-- by rewrite mulrinfty sgrV gtr0_sg// mul1e -EFinM 2!lte_ninfty.
-- by rewrite mulrinfty gtr0_sg// mul1e 2!lte_pinfty.
+- by rewrite mulrinfty sgrV gtr0_sg// mul1e 2!ltNge 2!leey.
+- by rewrite mulrinfty sgrV gtr0_sg// mul1e -EFinM 2!ltNye.
+- by rewrite mulrinfty gtr0_sg// mul1e 2!ltey.
 - by rewrite mulrinfty [in RHS]mulrinfty sgrV gtr0_sg// mul1e ltxx.
 - by rewrite mulrinfty [in RHS]mulrinfty sgrV gtr0_sg// 2!mul1e.
 - by rewrite mulrinfty gtr0_sg// mul1e.
@@ -2709,12 +2691,12 @@ Lemma lte_pdivl_mull r y x : (0 < r)%R -> (x < r^-1%:E * y) = (r%:E * x < y).
 Proof.
 move=> r0; move: x y => [x| |] [y| |] //=.
 - by rewrite 2!lte_fin ltr_pdivl_mull.
-- by rewrite mulrinfty sgrV gtr0_sg// mul1e 2!lte_pinfty.
+- by rewrite mulrinfty sgrV gtr0_sg// mul1e 2!ltey.
 - by rewrite mulrinfty sgrV gtr0_sg// mul1e.
 - by rewrite mulrinfty gtr0_sg// mul1e.
 - by rewrite mulrinfty [in RHS]mulrinfty sgrV gtr0_sg// mul1e.
 - by rewrite mulrinfty [in RHS]mulrinfty sgrV gtr0_sg// 2!mul1e.
-- by rewrite mulrinfty gtr0_sg// mul1e 2!lte_ninfty.
+- by rewrite mulrinfty gtr0_sg// mul1e 2!ltNye.
 - by rewrite mulrinfty [in RHS]mulrinfty sgrV gtr0_sg// 2!mul1e.
 - by rewrite mulrinfty [in RHS]mulrinfty sgrV gtr0_sg// mul1e.
 Qed.
@@ -2746,26 +2728,26 @@ Proof.
 move: x1 y1 x2 y2 => [x1| |] [y1| |] [x2| |] [y2| |] //; rewrite !lee_fin.
 - exact: ler_pmul.
 - rewrite le_eqVlt => /predU1P[<- x20 y10 _|x10 x20 xy1 _].
-    by rewrite mul0e mule_ge0// lee_pinfty.
-  by rewrite mulrinfty gtr0_sg// ?mul1e ?lee_pinfty// (lt_le_trans x10).
+    by rewrite mul0e mule_ge0// leey.
+  by rewrite mulrinfty gtr0_sg// ?mul1e ?leey// (lt_le_trans x10).
 - rewrite le_eqVlt => /predU1P[<- _ y10 _|x10 _ xy1 _].
-    by rewrite mul0e mule_ge0// lee_pinfty.
+    by rewrite mul0e mule_ge0// leey.
   rewrite mulrinfty gtr0_sg// mul1e mulrinfty gtr0_sg// ?mul1e//.
   exact: (lt_le_trans x10).
 - move=> x10; rewrite le_eqVlt => /predU1P[<- _ y20|x20 _ xy2].
-    by rewrite mule0 mulrinfty mule_ge0// ?lee_pinfty// lee_fin sgr_ge0.
-  by rewrite mulrinfty gtr0_sg ?mul1e ?lee_pinfty// (lt_le_trans x20).
-- by move=> x10 x20 _ _; rewrite mule_pinfty_pinfty lee_pinfty.
+    by rewrite mule0 mulrinfty mule_ge0// ?leey// lee_fin sgr_ge0.
+  by rewrite mulrinfty gtr0_sg ?mul1e ?leey// (lt_le_trans x20).
+- by move=> x10 x20 _ _; rewrite mulyy leey.
 - rewrite le_eqVlt => /predU1P[<- _ _ _|x10 _ _ _].
-    by rewrite mule_pinfty_pinfty mul0e lee_pinfty.
-  by rewrite mule_pinfty_pinfty mulrinfty gtr0_sg// mul1e.
+    by rewrite mulyy mul0e leey.
+  by rewrite mulyy mulrinfty gtr0_sg// mul1e.
 - move=> _; rewrite le_eqVlt => /predU1P[<- _ y20|x20 _ xy2].
-    by rewrite mule0 mulrinfty mule_ge0// ?lee_pinfty// lee_fin sgr_ge0//.
+    by rewrite mule0 mulrinfty mule_ge0// ?leey// lee_fin sgr_ge0.
   rewrite mulrinfty gtr0_sg// mul1e mulrinfty gtr0_sg ?mul1e//.
   exact: (lt_le_trans x20).
 - move=> _; rewrite le_eqVlt => /predU1P[<- _ _|x20 _ _].
-    by rewrite mule0 mule_pinfty_pinfty lee_pinfty.
-  by rewrite mulrinfty gtr0_sg// mul1e// mule_pinfty_pinfty.
+    by rewrite mule0 mulyy leey.
+  by rewrite mulrinfty gtr0_sg// mul1e// mulyy.
 Qed.
 
 Lemma lee_pdivr_mull r x y : (0 < r)%R -> (r^-1%:E * y <= x) = (y <= r%:E * x).
@@ -2824,7 +2806,7 @@ Proof. by move=> xye; apply: lee_adde => e; case: x {xye} (xye e). Qed.
 
 Lemma lte_spdaddr (r : R) x y : 0 < y -> r%:E <= x -> r%:E < x + y.
 Proof.
-move: y x => [y| |] [x| |] //=; rewrite ?lte_fin ?ltt_fin ?lte_pinfty //.
+move: y x => [y| |] [x| |] //=; rewrite ?lte_fin ?ltt_fin ?ltey //.
 exact: ltr_spaddr.
 Qed.
 
@@ -2845,7 +2827,7 @@ Implicit Types S : set (\bar R).
 Implicit Types x y : \bar R.
 
 Lemma ereal_ub_pinfty S : ubound S +oo.
-Proof. by apply/ubP=> x _; rewrite lee_pinfty. Qed.
+Proof. by apply/ubP=> x _; rewrite leey. Qed.
 
 Lemma ereal_ub_ninfty S : ubound S -oo -> S = set0 \/ S = [set -oo].
 Proof.
@@ -2856,7 +2838,7 @@ by have := Snoo _ Sx; rewrite lee_ninfty_eq => /eqP <-.
 Qed.
 
 Lemma ereal_supremums_set0_ninfty : supremums (@set0 (\bar R)) -oo.
-Proof. by split; [exact/ubP | apply/lbP=> y _; rewrite lee_ninfty]. Qed.
+Proof. by split; [exact/ubP | apply/lbP=> y _; rewrite leNye]. Qed.
 
 Lemma supremum_pinfty S x0 : S +oo -> supremum x0 S = +oo.
 Proof.
@@ -2891,9 +2873,8 @@ Proof. by rewrite /ereal_inf image_set1 ereal_sup1 oppeK. Qed.
 
 Lemma ub_ereal_sup S M : ubound S M -> ereal_sup S <= M.
 Proof.
-rewrite /ereal_sup /supremum; case: ifPn => [/eqP ->|].
-- by rewrite lee_ninfty.
-- by move=> _ SM; case: xgetP => [_ -> [_]| _] /=; [exact |rewrite lee_ninfty].
+rewrite /ereal_sup /supremum; case: ifPn => [/eqP ->|]; first by rewrite leNye.
+- by move=> _ SM; case: xgetP => [_ -> [_]| _] /=; [exact |rewrite leNye].
 Qed.
 
 Lemma lb_ereal_inf S M : lbound S M -> M <= ereal_inf S.
@@ -2969,9 +2950,9 @@ exists u%:E; split; last first.
   apply/lbP=> -[r0 /ubP Sr0| |].
   - rewrite lee_fin; apply/sup_le_ub; first by exists r, r%:E.
     by apply/ubP => _ -[[r2 ? <-| // | /= _ <-]]; rewrite -lee_fin; exact: Sr0.
-  - by rewrite lee_pinfty.
+  - by rewrite leey.
   - by move/ereal_ub_ninfty=> [|/eqP //]; [move/eqP : S0|rewrite (negbTE Snoo)].
-apply/ubP => -[r0 Sr0|//|_]; last by rewrite lee_ninfty.
+apply/ubP => -[r0 Sr0|//|_]; last by rewrite leNye.
 rewrite lee_fin.
 suff : has_sup U by move/sup_upper_bound/ubP; apply; exists r0%:E.
 split; first by exists r0, r0%:E.
@@ -3014,8 +2995,7 @@ Lemma hasNub_ereal_sup (A : set (\bar R)) : ~ has_ubound A ->
   A !=set0 -> ereal_sup A = +oo%E.
 Proof.
 move=> hasNubA A0.
-apply/eqP; rewrite eq_le lee_pinfty /= leNgt.
-apply: contra_notN hasNubA => Aoo.
+apply/eqP; rewrite eq_le leey /= leNgt; apply: contra_notN hasNubA => Aoo.
 by exists (ereal_sup A); exact: ereal_sup_ub.
 Qed.
 
@@ -3024,9 +3004,9 @@ Lemma ereal_sup_EFin  (A : set R) :
 Proof.
 move=> has_ubA A0; apply/eqP; rewrite eq_le; apply/andP; split.
   by apply: ub_ereal_sup => /= y [r Ar <-{y}]; rewrite lee_fin sup_ub.
-set esup := ereal_sup _; have := lee_pinfty esup.
-rewrite le_eqVlt => /predU1P[->|esupoo]; first by rewrite lee_pinfty.
-have := lee_ninfty esup; rewrite le_eqVlt => /predU1P[/esym|ooesup].
+set esup := ereal_sup _; have := leey esup.
+rewrite le_eqVlt => /predU1P[->|esupoo]; first by rewrite leey.
+have := leNye esup; rewrite le_eqVlt => /predU1P[/esym|ooesup].
   case: A0 => i Ai.
   by move=> /ereal_sup_ninfty /(_ i%:E) /(_ (ex_intro2 A _ i Ai erefl)).
 have esup_fin_num : esup \is a fin_num.
@@ -3096,12 +3076,12 @@ Section SignedNumDomainStability.
 Context {R : numDomainType}.
 
 Lemma pinfty_snum_subproof : Signed.spec 0 !=0 >=0 (+oo : \bar R).
-Proof. by rewrite /= lee_0_pinfty. Qed.
+Proof. by rewrite /= le0y. Qed.
 
 Canonical pinfty_snum := Signed.mk (pinfty_snum_subproof).
 
 Lemma ninfty_snum_subproof : Signed.spec 0 !=0 <=0 (-oo : \bar R).
-Proof. by rewrite /= lee_ninfty_0. Qed.
+Proof. by rewrite /= leNy0. Qed.
 
 Canonical ninfty_snum := Signed.mk (ninfty_snum_subproof).
 
@@ -3257,7 +3237,7 @@ Proof.
 rewrite {}/r; move: xr S => [[[]|]|] S /=;
   do ?[by apply: ub_ereal_sup => _ [? _ <-]
       |by case: ereal_sup => [s||];
-          rewrite ?lee_pinfty ?lee_ninfty// !lee_fin -realE num_real].
+          rewrite ?leey ?leNye// !lee_fin -realE num_real].
 Qed.
 
 Canonical ereal_sup_snum (xnz : KnownSign.nullity) (xr : KnownSign.reality)
@@ -3278,7 +3258,7 @@ Proof.
 rewrite {}/r; move: xr S => [[[]|]|] S /=;
   do ?[by apply: lb_ereal_inf => _ [? _ <-]
       |by case: ereal_inf => [s||];
-          rewrite ?lee_pinfty ?lee_ninfty// !lee_fin -realE num_real].
+          rewrite ?leey ?leNye// !lee_fin -realE num_real].
 Qed.
 
 Canonical ereal_inf_snum (xnz : KnownSign.nullity) (xr : KnownSign.reality)
@@ -3360,11 +3340,10 @@ Variant posnume_spec (R : numDomainType) (x : \bar R) :
 Lemma posnumeP (R : numDomainType) (x : \bar R) : 0 < x ->
   posnume_spec x x (x == 0) (0 <= x) (0 < x).
 Proof.
-case: x => [x|_|//].
-- rewrite lte_fin lee_fin eqe => x_gt0.
-  rewrite x_gt0 (ltW x_gt0) (negbTE (lt0r_neq0 x_gt0)).
-  exact: (IsRealPosnume x%:E (PosNum x_gt0)).
-- rewrite lee_0_pinfty lte_0_pinfty; exact: IsPinftyPosnume.
+case: x => [x|_|//]; last by rewrite le0y lt0y; exact: IsPinftyPosnume.
+rewrite lte_fin lee_fin eqe => x_gt0.
+rewrite x_gt0 (ltW x_gt0) (negbTE (lt0r_neq0 x_gt0)).
+exact: IsRealPosnume (PosNum x_gt0).
 Qed.
 
 Variant nonnege_spec (R : numDomainType) (x : \bar R) :
@@ -3375,10 +3354,8 @@ Variant nonnege_spec (R : numDomainType) (x : \bar R) :
 Lemma nonnegeP (R : numDomainType) (x : \bar R) : 0 <= x ->
   nonnege_spec x x (0 <= x).
 Proof.
-case: x => [x|_|//].
-- rewrite lee_fin => /[dup] x_ge0 ->.
-  exact: (IsRealNonnege x%:E (NngNum x_ge0)).
-- rewrite lee_0_pinfty; exact: IsPinftyNonnege.
+case: x => [x|_|//]; last by rewrite le0y; exact: IsPinftyNonnege.
+by rewrite lee_fin => /[dup] x_ge0 ->; exact: IsRealNonnege (NngNum x_ge0).
 Qed.
 
 Section ereal_nbhs.
@@ -3750,11 +3727,11 @@ Definition lt_expandRL := monoRL_in
 Lemma le_expand : {homo expand : x y / (x <= y)%O}.
 Proof.
 move=> x y xy; have [x1|] := lerP `|x| 1.
-  have [y_le1|/ltW /expand1->] := leP y 1%R; last by rewrite lee_pinfty.
+  have [y_le1|/ltW /expand1->] := leP y 1%R; last by rewrite leey.
   rewrite le_expand_in ?inE// ler_norml y_le1 (le_trans _ xy)//.
   by rewrite ler_oppl (ler_normlP _ _ _).
 rewrite ltr_normr => /orP[|] x1; last first.
-  by rewrite expandN1 // ?lee_ninfty // ler_oppr ltW.
+  by rewrite expandN1 // ?leNye // ler_oppr ltW.
 by rewrite expand1; [rewrite expand1 // (le_trans _ xy) // ltW | exact: ltW].
 Qed.
 
@@ -4289,10 +4266,10 @@ move=> [:wlog]; case: a b => [a||] [b||] //= ltax ltxb.
     by rewrite divr_gt0 ?subr_gt0.
   by rewrite -subr_gt0 addrAC {1}[(r - a)%R]splitr addrK divr_gt0 ?subr_gt0.
 - have [//||d dP] := wlog a (r + 1)%R; rewrite ?lte_fin ?ltr_addl //.
-  by exists d => y /dP /andP[->] /= /lt_le_trans; apply; rewrite lee_pinfty.
+  by exists d => y /dP /andP[->] /= /lt_le_trans; apply; rewrite leey.
 - have [//||d dP] := wlog (r - 1)%R b; rewrite ?lte_fin ?gtr_addl ?ltrN10 //.
-  by exists d => y /dP /andP[_ ->] /=; rewrite lte_ninfty.
-- by exists 1%:pos%R => ? ?; rewrite lte_ninfty lte_pinfty.
+  by exists d => y /dP /andP[_ ->] /=; rewrite ltNye.
+- by exists 1%:pos%R => ? ?; rewrite ltNye ltey.
 Qed.
 
 (* TODO: generalize to numFieldType? *)

--- a/theories/ereal.v
+++ b/theories/ereal.v
@@ -940,7 +940,7 @@ Lemma mulyy : +oo * +oo = +oo :> \bar R. Proof. by rewrite /mule /= lt0y. Qed.
 
 Lemma mulNyNy : -oo * -oo = +oo :> \bar R. Proof. by []. Qed.
 
-Lemma mulry_real r : r \is Num.real -> r%:E * +oo = (Num.sg r)%:E * +oo.
+Lemma real_mulry r : r \is Num.real -> r%:E * +oo = (Num.sg r)%:E * +oo.
 Proof.
 move=> rreal; rewrite /mule/= !eqe sgr_eq0; case: ifP => [//|/negbT rn0].
 move: rreal => /orP[|]; rewrite le_eqVlt !lte_fin /Num.sg.
@@ -949,10 +949,10 @@ move: rreal => /orP[|]; rewrite le_eqVlt !lte_fin /Num.sg.
 by rewrite (negbTE rn0)/= => rlt0; rewrite lt_def lt_geF// rn0 rlt0/= ltr0N1.
 Qed.
 
-Lemma mulyr_real r : r \is Num.real -> +oo * r%:E = (Num.sg r)%:E * +oo.
-Proof. by move=> rreal; rewrite muleC mulry_real. Qed.
+Lemma real_mulyr r : r \is Num.real -> +oo * r%:E = (Num.sg r)%:E * +oo.
+Proof. by move=> rreal; rewrite muleC real_mulry. Qed.
 
-Lemma mulrNy_real r : r \is Num.real -> r%:E * -oo = (Num.sg r)%:E * -oo.
+Lemma real_mulrNy r : r \is Num.real -> r%:E * -oo = (Num.sg r)%:E * -oo.
 Proof.
 move=> rreal; rewrite /mule/= !eqe sgr_eq0; case: ifP => [//|/negbT rn0].
 move: rreal => /orP[|]; rewrite le_eqVlt !lte_fin /Num.sg.
@@ -961,10 +961,10 @@ move: rreal => /orP[|]; rewrite le_eqVlt !lte_fin /Num.sg.
 by rewrite (negbTE rn0)/= => rlt0; rewrite lt_def lt_geF// andbF rlt0 ltr0N1.
 Qed.
 
-Lemma mulNyr_real r : r \is Num.real -> -oo * r%:E = (Num.sg r)%:E * -oo.
-Proof. by move=> rreal; rewrite muleC mulrNy_real. Qed.
+Lemma real_mulNyr r : r \is Num.real -> -oo * r%:E = (Num.sg r)%:E * -oo.
+Proof. by move=> rreal; rewrite muleC real_mulrNy. Qed.
 
-Definition mulrinfty_real := (mulry_real, mulyr_real, mulrNy_real, mulNyr_real).
+Definition real_mulr_infty := (real_mulry, real_mulyr, real_mulrNy, real_mulNyr).
 
 Lemma mulN1e x : - 1%E * x = - x.
 Proof.
@@ -1045,7 +1045,7 @@ Proof.
 case: x y => [x||] [y||]// rx ry;
   do ?[exact: realM
       |by rewrite /mule/= lt0y
-      |by rewrite mulrinfty_real ?realE -?lee_fin// /Num.sg;
+      |by rewrite real_mulr_infty ?realE -?lee_fin// /Num.sg;
           case: ifP; [|case: ifP]; rewrite ?mul0e /Order.comparable ?lexx;
           rewrite ?mulN1e ?leNy0 ?mul1e ?le0y
       |by rewrite mulNyNy /Order.comparable le0y].
@@ -1419,23 +1419,23 @@ Lemma mulNe x y : - x * y = - (x * y). Proof. by rewrite muleC muleN muleC. Qed.
 Lemma muleNN x y : - x * - y = x * y. Proof. by rewrite mulNe muleN oppeK. Qed.
 
 Lemma mulry r : r%:E * +oo%E = (Num.sg r)%:E * +oo%E.
-Proof. by rewrite [LHS]mulry_real// num_real. Qed.
+Proof. by rewrite [LHS]real_mulry// num_real. Qed.
 
 Lemma mulyr r : +oo%E * r%:E = (Num.sg r)%:E * +oo%E.
 Proof. by rewrite muleC mulry. Qed.
 
 Lemma mulrNy r : r%:E * -oo%E = (Num.sg r)%:E * -oo%E.
-Proof. by rewrite [LHS]mulrNy_real// num_real. Qed.
+Proof. by rewrite [LHS]real_mulrNy// num_real. Qed.
 
 Lemma mulNyr r : -oo%E * r%:E = (Num.sg r)%:E * -oo%E.
 Proof. by rewrite muleC mulrNy. Qed.
 
-Definition mulrinfty := (mulry, mulyr, mulrNy, mulNyr).
+Definition mulr_infty := (mulry, mulyr, mulrNy, mulNyr).
 
 Lemma lte_mul_pinfty x y : 0 <= x -> x \is a fin_num -> y < +oo -> x * y < +oo.
 Proof.
 move: x y => [x| |] [y| |] // x0 xfin _; first by rewrite -EFinM ltey.
-rewrite mulrinfty; move: x0; rewrite lee_fin le_eqVlt => /predU1P[<-|x0].
+rewrite mulr_infty; move: x0; rewrite lee_fin le_eqVlt => /predU1P[<-|x0].
 - by rewrite sgr0 mul0e ltey.
 - by rewrite gtr0_sg // mul1e.
 Qed.
@@ -1445,35 +1445,35 @@ Proof.
 move: x y => [x| |] [y| |] //; rewrite ?lee_fin.
 - by move=> x0 y0; rewrite !lte_fin; exact: mulr_ge0_gt0.
 - rewrite le_eqVlt => /predU1P[<-|x0] _; first by rewrite mul0e ltxx.
-  by rewrite ltey andbT mulrinfty gtr0_sg// mul1e lte_fin x0 ltey.
+  by rewrite ltey andbT mulr_infty gtr0_sg// mul1e lte_fin x0 ltey.
 - move=> _; rewrite le_eqVlt => /predU1P[<-|x0].
     by rewrite mule0 ltxx andbC.
-  by rewrite ltey/= mulrinfty gtr0_sg// mul1e lte_fin x0 ltey.
+  by rewrite ltey/= mulr_infty gtr0_sg// mul1e lte_fin x0 ltey.
 - by move=> _ _; rewrite mulyy ltey.
 Qed.
 
 Lemma gt0_mulye x : (0 < x -> +oo * x = +oo)%E.
 Proof.
 move: x => [x|_|//]; last by rewrite mulyy.
-by rewrite lte_fin => x0; rewrite muleC mulrinfty gtr0_sg// mul1e.
+by rewrite lte_fin => x0; rewrite muleC mulr_infty gtr0_sg// mul1e.
 Qed.
 
 Lemma lt0_mulye x : (x < 0 -> +oo * x = -oo)%E.
 Proof.
 move: x => [x|//|_]; last by rewrite mulyNy.
-by rewrite lte_fin => x0; rewrite muleC mulrinfty ltr0_sg// mulN1e.
+by rewrite lte_fin => x0; rewrite muleC mulr_infty ltr0_sg// mulN1e.
 Qed.
 
 Lemma gt0_mulNye x : (0 < x -> -oo * x = -oo)%E.
 Proof.
 move: x => [x|_|//]; last by rewrite mulNyy.
-by rewrite lte_fin => x0; rewrite muleC mulrinfty gtr0_sg// mul1e.
+by rewrite lte_fin => x0; rewrite muleC mulr_infty gtr0_sg// mul1e.
 Qed.
 
 Lemma lt0_mulNye x : (x < 0 -> -oo * x = +oo)%E.
 Proof.
 move: x => [x|//|_]; last by rewrite mulNyNy.
-by rewrite lte_fin => x0; rewrite muleC mulrinfty ltr0_sg// mulN1e.
+by rewrite lte_fin => x0; rewrite muleC mulr_infty ltr0_sg// mulN1e.
 Qed.
 
 Lemma mule_eq_pinfty x y : (x * y == +oo) =
@@ -1481,15 +1481,15 @@ Lemma mule_eq_pinfty x y : (x * y == +oo) =
      (x == +oo) && (y > 0) | (x == -oo) && (y < 0)].
 Proof.
 move: x y => [x| |] [y| |]; rewrite ?(lte_fin,andbF,andbT,orbF,eqxx,andbT)//=.
-- by rewrite mulrinfty; have [/ltr0_sg|/gtr0_sg|] := ltgtP x 0%R;
+- by rewrite mulr_infty; have [/ltr0_sg|/gtr0_sg|] := ltgtP x 0%R;
     move=> ->; rewrite ?(mulN1e,mul1e,sgr0,mul0e).
-- by rewrite mulrinfty; have [/ltr0_sg|/gtr0_sg|] := ltgtP x 0%R;
+- by rewrite mulr_infty; have [/ltr0_sg|/gtr0_sg|] := ltgtP x 0%R;
     move=> ->; rewrite ?(mulN1e,mul1e,sgr0,mul0e).
-- by rewrite mulrinfty; have [/ltr0_sg|/gtr0_sg|] := ltgtP y 0%R;
+- by rewrite mulr_infty; have [/ltr0_sg|/gtr0_sg|] := ltgtP y 0%R;
     move=> ->; rewrite ?(mulN1e,mul1e,sgr0,mul0e).
 - by rewrite mulyy ltey.
 - by rewrite mulyNy.
-- by rewrite mulrinfty; have [/ltr0_sg|/gtr0_sg|] := ltgtP y 0%R;
+- by rewrite mulr_infty; have [/ltr0_sg|/gtr0_sg|] := ltgtP y 0%R;
     move=> ->; rewrite ?(mulN1e,mul1e,sgr0,mul0e).
 - by rewrite mulNyy.
 - by rewrite ltNye.
@@ -1601,12 +1601,12 @@ Lemma lte_pmul2r z : z \is a fin_num -> 0 < z -> {mono *%E^~ z : x y / x < y}.
 Proof.
 move: z => [z| |] _ // z0 [x| |] [y| |] //.
 - by rewrite !lte_fin ltr_pmul2r.
-- by rewrite mulrinfty gtr0_sg// mul1e 2!ltey.
-- by rewrite mulrinfty gtr0_sg// mul1e ltNge leNye ltNge leNye.
-- by rewrite mulrinfty gtr0_sg// mul1e ltNge leey ltNge leey.
-- by rewrite mulrinfty gtr0_sg// mul1e mulrinfty gtr0_sg// mul1e.
-- by rewrite mulrinfty gtr0_sg// mul1e 2!ltNye.
-- by rewrite mulrinfty gtr0_sg// mul1e mulrinfty gtr0_sg// mul1e.
+- by rewrite mulr_infty gtr0_sg// mul1e 2!ltey.
+- by rewrite mulr_infty gtr0_sg// mul1e ltNge leNye ltNge leNye.
+- by rewrite mulr_infty gtr0_sg// mul1e ltNge leey ltNge leey.
+- by rewrite mulr_infty gtr0_sg// mul1e mulr_infty gtr0_sg// mul1e.
+- by rewrite mulr_infty gtr0_sg// mul1e 2!ltNye.
+- by rewrite mulr_infty gtr0_sg// mul1e mulr_infty gtr0_sg// mul1e.
 Qed.
 
 Lemma lte_pmul2l z : z \is a fin_num -> 0 < z -> {mono *%E z : x y / x < y}.
@@ -2003,17 +2003,17 @@ Proof.
 move: x => [x|_|//].
   rewrite lee_fin le_eqVlt => /predU1P[<- y z|x0]; first by rewrite 2!mule0.
   move=> [y| |] [z| |]//; first by rewrite !lee_fin// ler_pmul2r.
-  - by move=> _; rewrite mulrinfty gtr0_sg// mul1e leey.
-  - by move=> _; rewrite mulrinfty gtr0_sg// mul1e leNye.
-  - by move=> _; rewrite 2!mulrinfty gtr0_sg// 2!mul1e.
+  - by move=> _; rewrite mulr_infty gtr0_sg// mul1e leey.
+  - by move=> _; rewrite mulr_infty gtr0_sg// mul1e leNye.
+  - by move=> _; rewrite 2!mulr_infty gtr0_sg// 2!mul1e.
 move=> [y| |] [z| |]//.
 - rewrite lee_fin => yz.
   have [z0|z0|] := ltgtP 0%R z.
-  + by rewrite [leRHS]mulrinfty gtr0_sg// mul1e leey.
-  + by rewrite mulrinfty ltr0_sg// ?(le_lt_trans yz)// [leRHS]mulrinfty ltr0_sg.
+  + by rewrite [leRHS]mulr_infty gtr0_sg// mul1e leey.
+  + by rewrite mulr_infty ltr0_sg// ?(le_lt_trans yz)// [leRHS]mulr_infty ltr0_sg.
   + move=> z0; move: yz; rewrite -z0 mul0e le_eqVlt => /predU1P[->|y0].
       by rewrite mul0e.
-    by rewrite mulrinfty ltr0_sg// mulN1e leNye.
+    by rewrite mulr_infty ltr0_sg// mulN1e leNye.
   + by move=> _; rewrite mulyy leey.
   + by move=> _; rewrite mulNyy leNye.
   + by move=> _; rewrite mulNyy leNye.
@@ -2212,9 +2212,9 @@ Proof.
 move: x y => [x| |] [y| |] //; last by rewrite mulyy.
 - by rewrite -EFinM 3!lee_fin; exact: ler_pemull.
 - move=> _; rewrite lee_fin => x1.
-  by rewrite mulrinfty gtr0_sg ?mul1e// (lt_le_trans _ x1).
+  by rewrite mulr_infty gtr0_sg ?mul1e// (lt_le_trans _ x1).
 - rewrite lee_fin le_eqVlt => /predU1P[<- _|y0 _]; first by rewrite mule0.
-  by rewrite mulrinfty gtr0_sg// mul1e leey.
+  by rewrite mulr_infty gtr0_sg// mul1e leey.
 Qed.
 
 Lemma lee_nemull x y : y <= 0 -> 1 <= x -> x * y <= y.
@@ -2222,9 +2222,9 @@ Proof.
 move: x y => [x| |] [y| |] //; last by rewrite mulyNy.
 - by rewrite -EFinM 3!lee_fin; exact: ler_nemull.
 - move=> _; rewrite lee_fin => x1.
-  by rewrite mulrinfty gtr0_sg ?mul1e// (lt_le_trans _ x1).
+  by rewrite mulr_infty gtr0_sg ?mul1e// (lt_le_trans _ x1).
 - rewrite lee_fin le_eqVlt => /predU1P[-> _|y0 _]; first by rewrite mule0.
-  by rewrite mulrinfty ltr0_sg// mulN1e leNye.
+  by rewrite mulr_infty ltr0_sg// mulN1e leNye.
 Qed.
 
 Lemma lee_pemulr x y : 0 <= y -> 1 <= x -> y <= y * x.
@@ -2666,22 +2666,22 @@ move: x y => [x||] [y||] // in x0 h *.
   by rewrite mulVr ?unitfE ?gt_eqF// mul1r; apply/negP; rewrite -ltNge midf_lt.
 - by rewrite leey.
 - by have := h _ h01.
-- by have := h _ h01; rewrite mulrinfty sgrV gtr0_sg // mul1e.
-- by have := h _ h01; rewrite mulrinfty sgrV gtr0_sg // mul1e.
+- by have := h _ h01; rewrite mulr_infty sgrV gtr0_sg // mul1e.
+- by have := h _ h01; rewrite mulr_infty sgrV gtr0_sg // mul1e.
 Qed.
 
 Lemma lte_pdivr_mull r x y : (0 < r)%R -> (r^-1%:E * y < x) = (y < r%:E * x).
 Proof.
 move=> r0; move: x y => [x| |] [y| |] //=.
 - by rewrite 2!lte_fin ltr_pdivr_mull.
-- by rewrite mulrinfty sgrV gtr0_sg// mul1e 2!ltNge 2!leey.
-- by rewrite mulrinfty sgrV gtr0_sg// mul1e -EFinM 2!ltNye.
-- by rewrite mulrinfty gtr0_sg// mul1e 2!ltey.
-- by rewrite mulrinfty [in RHS]mulrinfty sgrV gtr0_sg// mul1e ltxx.
-- by rewrite mulrinfty [in RHS]mulrinfty sgrV gtr0_sg// 2!mul1e.
-- by rewrite mulrinfty gtr0_sg// mul1e.
-- by rewrite mulrinfty [in RHS]mulrinfty sgrV gtr0_sg// 2!mul1e.
-- by rewrite mulrinfty [in RHS]mulrinfty sgrV gtr0_sg// mul1e.
+- by rewrite mulr_infty sgrV gtr0_sg// mul1e 2!ltNge 2!leey.
+- by rewrite mulr_infty sgrV gtr0_sg// mul1e -EFinM 2!ltNye.
+- by rewrite mulr_infty gtr0_sg// mul1e 2!ltey.
+- by rewrite mulr_infty [in RHS]mulr_infty sgrV gtr0_sg// mul1e ltxx.
+- by rewrite mulr_infty [in RHS]mulr_infty sgrV gtr0_sg// 2!mul1e.
+- by rewrite mulr_infty gtr0_sg// mul1e.
+- by rewrite mulr_infty [in RHS]mulr_infty sgrV gtr0_sg// 2!mul1e.
+- by rewrite mulr_infty [in RHS]mulr_infty sgrV gtr0_sg// mul1e.
 Qed.
 
 Lemma lte_pdivr_mulr r x y : (0 < r)%R -> (y * r^-1%:E < x) = (y < x * r%:E).
@@ -2691,14 +2691,14 @@ Lemma lte_pdivl_mull r y x : (0 < r)%R -> (x < r^-1%:E * y) = (r%:E * x < y).
 Proof.
 move=> r0; move: x y => [x| |] [y| |] //=.
 - by rewrite 2!lte_fin ltr_pdivl_mull.
-- by rewrite mulrinfty sgrV gtr0_sg// mul1e 2!ltey.
-- by rewrite mulrinfty sgrV gtr0_sg// mul1e.
-- by rewrite mulrinfty gtr0_sg// mul1e.
-- by rewrite mulrinfty [in RHS]mulrinfty sgrV gtr0_sg// mul1e.
-- by rewrite mulrinfty [in RHS]mulrinfty sgrV gtr0_sg// 2!mul1e.
-- by rewrite mulrinfty gtr0_sg// mul1e 2!ltNye.
-- by rewrite mulrinfty [in RHS]mulrinfty sgrV gtr0_sg// 2!mul1e.
-- by rewrite mulrinfty [in RHS]mulrinfty sgrV gtr0_sg// mul1e.
+- by rewrite mulr_infty sgrV gtr0_sg// mul1e 2!ltey.
+- by rewrite mulr_infty sgrV gtr0_sg// mul1e.
+- by rewrite mulr_infty gtr0_sg// mul1e.
+- by rewrite mulr_infty [in RHS]mulr_infty sgrV gtr0_sg// mul1e.
+- by rewrite mulr_infty [in RHS]mulr_infty sgrV gtr0_sg// 2!mul1e.
+- by rewrite mulr_infty gtr0_sg// mul1e 2!ltNye.
+- by rewrite mulr_infty [in RHS]mulr_infty sgrV gtr0_sg// 2!mul1e.
+- by rewrite mulr_infty [in RHS]mulr_infty sgrV gtr0_sg// mul1e.
 Qed.
 
 Lemma lte_pdivl_mulr r x y : (0 < r)%R -> (x < y * r^-1%:E) = (x * r%:E < y).
@@ -2729,25 +2729,25 @@ move: x1 y1 x2 y2 => [x1| |] [y1| |] [x2| |] [y2| |] //; rewrite !lee_fin.
 - exact: ler_pmul.
 - rewrite le_eqVlt => /predU1P[<- x20 y10 _|x10 x20 xy1 _].
     by rewrite mul0e mule_ge0// leey.
-  by rewrite mulrinfty gtr0_sg// ?mul1e ?leey// (lt_le_trans x10).
+  by rewrite mulr_infty gtr0_sg// ?mul1e ?leey// (lt_le_trans x10).
 - rewrite le_eqVlt => /predU1P[<- _ y10 _|x10 _ xy1 _].
     by rewrite mul0e mule_ge0// leey.
-  rewrite mulrinfty gtr0_sg// mul1e mulrinfty gtr0_sg// ?mul1e//.
+  rewrite mulr_infty gtr0_sg// mul1e mulr_infty gtr0_sg// ?mul1e//.
   exact: (lt_le_trans x10).
 - move=> x10; rewrite le_eqVlt => /predU1P[<- _ y20|x20 _ xy2].
-    by rewrite mule0 mulrinfty mule_ge0// ?leey// lee_fin sgr_ge0.
-  by rewrite mulrinfty gtr0_sg ?mul1e ?leey// (lt_le_trans x20).
+    by rewrite mule0 mulr_infty mule_ge0// ?leey// lee_fin sgr_ge0.
+  by rewrite mulr_infty gtr0_sg ?mul1e ?leey// (lt_le_trans x20).
 - by move=> x10 x20 _ _; rewrite mulyy leey.
 - rewrite le_eqVlt => /predU1P[<- _ _ _|x10 _ _ _].
     by rewrite mulyy mul0e leey.
-  by rewrite mulyy mulrinfty gtr0_sg// mul1e.
+  by rewrite mulyy mulr_infty gtr0_sg// mul1e.
 - move=> _; rewrite le_eqVlt => /predU1P[<- _ y20|x20 _ xy2].
-    by rewrite mule0 mulrinfty mule_ge0// ?leey// lee_fin sgr_ge0.
-  rewrite mulrinfty gtr0_sg// mul1e mulrinfty gtr0_sg ?mul1e//.
+    by rewrite mule0 mulr_infty mule_ge0// ?leey// lee_fin sgr_ge0.
+  rewrite mulr_infty gtr0_sg// mul1e mulr_infty gtr0_sg ?mul1e//.
   exact: (lt_le_trans x20).
 - move=> _; rewrite le_eqVlt => /predU1P[<- _ _|x20 _ _].
     by rewrite mule0 mulyy leey.
-  by rewrite mulrinfty gtr0_sg// mul1e// mulyy.
+  by rewrite mulr_infty gtr0_sg// mul1e// mulyy.
 Qed.
 
 Lemma lee_pdivr_mull r x y : (0 < r)%R -> (r^-1%:E * y <= x) = (y <= r%:E * x).

--- a/theories/ereal.v
+++ b/theories/ereal.v
@@ -840,10 +840,10 @@ Qed.
 Lemma adde_eq_ninfty x y : (x + y == -oo) = ((x == -oo) || (y == -oo)).
 Proof. by move: x y => [?| |] [?| |]. Qed.
 
-Lemma addooe x : x != -oo -> +oo + x = +oo.
+Lemma addpinftye x : x != -oo -> +oo + x = +oo.
 Proof. by case: x. Qed.
 
-Lemma addeoo x : x != -oo -> x + +oo = +oo.
+Lemma addepinfty x : x != -oo -> x + +oo = +oo.
 Proof. by case: x. Qed.
 
 Lemma adde_Neq_pinfty x y : x != -oo -> y != -oo ->
@@ -889,9 +889,9 @@ move=> finoo; split=> [|[i [si Pi fi]]].
   by move=> i /andP[si Pi] fioo; exists i; rewrite si Pi fioo.
 elim: s i Pi fi si => // h t ih i Pi fi.
 rewrite inE => /predU1P[<-/=|it].
-  rewrite big_cons Pi fi addooe//.
+  rewrite big_cons Pi fi addpinftye//.
   by apply/eqP => /esum_ninftyP[j [jt /finoo/negbTE/eqP]].
-by rewrite big_cons; case: ifPn => Ph; rewrite (ih i)// addeoo// finoo.
+by rewrite big_cons; case: ifPn => Ph; rewrite (ih i)// addepinfty// finoo.
 Qed.
 
 Lemma esum_pinfty (I : finType) (P : {pred I}) (f : I -> \bar R) :

--- a/theories/esum.v
+++ b/theories/esum.v
@@ -142,10 +142,10 @@ move=> ag0 bg0; apply/eqP; rewrite eq_le; apply/andP; split.
   rewrite ub_ereal_sup//= => x [X XI] <-; rewrite big_split/=.
   by rewrite lee_add// ereal_sup_ub//=; exists X.
 wlog : a b ag0 bg0 / \esum_(i in I) a i \isn't a fin_num => [saoo|]; last first.
-  move=> /fin_numPn[->|/[dup] aoo ->]; first by rewrite /adde/= lee_ninfty.
+  move=> /fin_numPn[->|/[dup] aoo ->]; first by rewrite leNye.
   rewrite (@le_trans _ _ +oo)//; first by rewrite /adde/=; case: esum.
   rewrite lee_pinfty_eq; apply/eqP/eq_infty => y; rewrite esum_ge//.
-  have : y%:E < \esum_(i in I) a i by rewrite aoo// lte_pinfty.
+  have : y%:E < \esum_(i in I) a i by rewrite aoo// ltey.
   move=> /ereal_sup_gt[_ [X XI] <-] /ltW yle; exists X => //=.
   rewrite (le_trans yle)// big_split lee_addl// big_seq_cond sume_ge0 => // i.
   by rewrite andbT => /XI; apply: bg0.

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -1085,7 +1085,7 @@ apply/eqP; rewrite eq_le; apply/andP; split; last first.
   have : (EFin \o g ^~ x) --> ereal_sup (range (EFin \o g ^~ x)).
     by apply: ereal_nondecreasing_cvg => p q pq /=; rewrite lee_fin; exact/nd_g.
   by move/cvg_lim => -> //; apply: ereal_sup_ub; exists n.
-have := lee_pinfty (\int (f x) 'd mu[x]).
+have := leey (\int (f x) 'd mu[x]).
 rewrite le_eqVlt => /predU1P[|] mufoo; last first.
   have : \int (f x) 'd mu[x] \is a fin_num.
     by rewrite ge0_fin_numE//; exact: integral_ge0.
@@ -1266,7 +1266,7 @@ Proof. exact: emeasurable_fun_c_infty. Qed.
 
 Let foo_B1 x n : D x -> f x = +oo%E -> x \in B n.
 Proof.
-by move=> Dx fxoo; rewrite /B inE /=; split => //=; rewrite /= fxoo lee_pinfty.
+by move=> Dx fxoo; rewrite /B inE /=; split => //=; rewrite /= fxoo leey.
 Qed.
 
 Let f0_B0 x n : f x = 0%:E -> n != 0%N -> (x \in B n) = false.
@@ -1472,7 +1472,7 @@ Lemma le_approx k x (f0 : forall x, (0 <= f x)%E) : D x ->
   ((approx k x)%:E <= f x)%E.
 Proof.
 move=> Dx; have [fixoo|] := ltP (f x) (+oo%E); last first.
-  by rewrite lee_pinfty_eq => /eqP ->; rewrite lee_pinfty.
+  by rewrite lee_pinfty_eq => /eqP ->; rewrite leey.
 have nd_ag : {homo approx ^~ x : n m / (n <= m)%N >-> n <= m}.
   by move=> m n mn; exact/lefP/nd_approx.
 have fi0 : forall x, D x -> (0 <= f x)%E by move=> *; exact: f0.
@@ -1490,7 +1490,7 @@ Lemma dvg_approx x : D x -> f x = +oo%E -> ~ cvg (approx^~ x : _ -> R^o).
 Proof.
 move=> Dx fxoo; have approx_x n : approx n x = n%:R.
   rewrite /approx foo_B1// mulr1 big1 ?add0r// => /= i _.
-  by rewrite fgen_A0 // ?mulr0 // fxoo lee_pinfty.
+  by rewrite fgen_A0 // ?mulr0 // fxoo leey.
 case/cvg_ex => /= l; have [l0|l0] := leP 0%R l.
 - move=> /cvg_distP/(_ _ ltr01); rewrite near_map => -[n _].
   move=> /(_ (`|ceil l|.+1 + n)%N) /= /(_ (leq_addl _ _)).
@@ -1513,7 +1513,7 @@ Qed.
 Lemma ecvg_approx (f0 : forall x, D x -> (0 <= f x)%E) x :
   D x -> EFin \o approx^~x --> f x.
 Proof.
-move=> Dx; have := lee_pinfty (f x); rewrite le_eqVlt => /predU1P[|] fxoo.
+move=> Dx; have := leey (f x); rewrite le_eqVlt => /predU1P[|] fxoo.
 have dvg_approx := dvg_approx Dx fxoo.
   have : {homo approx ^~ x : n m / (n <= m)%N >-> n <= m}.
     by move=> m n mn; have := nd_approx mn => /lefP; exact.
@@ -1660,10 +1660,10 @@ apply: ereal_lim_le.
 near=> n; rewrite ge0_integralTE//; apply: ereal_sup_ub => /=.
 exists (g1 n) => // t; rewrite (le_trans _ (h12 _)) //.
 have := gh1 t.
-have := lee_pinfty (h1 t); rewrite le_eqVlt => /predU1P[->|ftoo].
-  by rewrite lee_pinfty.
+have := leey (h1 t); rewrite le_eqVlt => /predU1P[->|ftoo].
+  by rewrite leey.
 have h1tfin : h1 t \is a fin_num.
-  by rewrite fin_numE gt_eqF/= ?lt_eqF// (lt_le_trans _ (h10 t))// lte_ninfty.
+  by rewrite fin_numE gt_eqF/= ?lt_eqF// (lt_le_trans _ (h10 t)).
 have := gh1 t.
 rewrite -(fineK h1tfin) => /ereal_cvg_real[ft_near].
 set u_ := (X in X --> _) => u_h1 g1h1.
@@ -1781,8 +1781,8 @@ have mfg : measurable (D `&` [set x | f x *? g x]).
    apply/predeqP=> x; rewrite /preimage/= /mule_def !(negb_and, negb_or).
    rewrite !(rwP2 eqP idP) !(rwP2 negP idP) !(rwP2 orP idP).
    rewrite !(rwP2 negP idP) !(rwP2 orP idP) !(rwP2 andP idP).
-   rewrite eqe_absl lee_pinfty andbT (orbC (g x == +oo)).
-   by rewrite eqe_absl lee_pinfty andbT (orbC (f x == +oo)).
+   rewrite eqe_absl leey andbT (orbC (g x == +oo)).
+   by rewrite eqe_absl leey andbT (orbC (f x == +oo)).
 wlog fg : D mD mf mg mfg / forall x, D x -> f x *? g x => [hwlogM|]; last first.
   have [f_ f_cvg] := approximation_sfun mD mf.
   have [g_ g_cvg] := approximation_sfun mD mg.
@@ -1948,11 +1948,10 @@ have /cvg_ex[l g_l] := @is_cvg_max_g2 t.
 suff : l == f t by move=> /eqP <-.
 rewrite eq_le; apply/andP; split.
   by rewrite /f (le_trans _ (lim_max_g2_f _)) // (cvg_lim _ g_l).
-have := lee_pinfty l; rewrite le_eqVlt => /predU1P[->|loo].
-  by rewrite lee_pinfty.
+have := leey l; rewrite le_eqVlt => /predU1P[->|loo]; first by rewrite leey.
 rewrite -(cvg_lim _ g_l) //= ereal_lim_le => //.
 near=> n.
-have := lee_pinfty (g n t); rewrite le_eqVlt => /predU1P[|] fntoo.
+have := leey (g n t); rewrite le_eqVlt => /predU1P[|] fntoo.
 - have h := @dvg_approx _ _ setT _ t Logic.I fntoo.
   have g2oo : lim (EFin \o g2 n ^~ t) = +oo.
     apply/cvg_lim => //; apply/dvg_ereal_cvg.
@@ -1962,7 +1961,7 @@ have := lee_pinfty (g n t); rewrite le_eqVlt => /predU1P[|] fntoo.
     by move/nondecreasing_dvg_lt => /(_ h).
   have -> : lim (EFin \o max_g2 ^~ t) = +oo.
     by have := lim_g2_max_g2 t n; rewrite g2oo lee_pinfty_eq => /eqP.
-  by rewrite lee_pinfty.
+  by rewrite leey.
 - have approx_g_g := @cvg_approx _ _ setT _ t (fun t _ => g0 n t) Logic.I fntoo.
   have <- : lim (EFin \o g2 n ^~ t) = g n t.
     have /cvg_lim <- // : EFin \o (approx setT (g n)) ^~ t --> g n t.
@@ -2058,19 +2057,19 @@ pose h := fun x => lim (g^~ x).
 transitivity (\int_ D (lim (g^~ x)) 'd mu[x]).
   apply: eq_integral => x Dx; apply/esym/cvg_lim => //.
   have [fx0|fx0|fx0] := ltgtP 0 (f x).
-  - rewrite gt0_mulpinfty//; apply/ereal_cvgPpinfty => M M0.
+  - rewrite gt0_mulye//; apply/ereal_cvgPpinfty => M M0.
     rewrite /g; case: (f x) fx0 => [r|_|//]; last first.
       exists 1%N => // m /= m0.
-      by rewrite mulrinfty gtr0_sg// ?mul1e ?lee_pinfty// ltr0n.
+      by rewrite mulrinfty gtr0_sg// ?mul1e ?leey// ltr0n.
     rewrite lte_fin => r0.
     near=> n; rewrite lee_fin -ler_pdivr_mulr//.
     near: n; exists `|ceil (M / r)|%N => // m /=.
     rewrite -(ler_nat R); apply: le_trans.
     by rewrite natr_absz ger0_norm ?ceil_ge// ceil_ge0// divr_ge0// ltW.
-  - rewrite lt0_mulpinfty//; apply/ereal_cvgPninfty => M M0.
+  - rewrite lt0_mulye//; apply/ereal_cvgPninfty => M M0.
     rewrite /g; case: (f x) fx0 => [r|//|_]; last first.
       exists 1%N => // m /= m0.
-      by rewrite mulrinfty gtr0_sg// ?ltr0n// mul1e ?lee_ninfty.
+      by rewrite mulrinfty gtr0_sg// ?ltr0n// mul1e ?leNye.
     rewrite lte_fin => r0.
     near=> n; rewrite lee_fin -ler_ndivr_mulr//.
     near: n; exists `|ceil (M / r)|%N => // m /=.
@@ -2087,13 +2086,13 @@ have : 0 <= \int_ D (f x) 'd mu[x] by apply: integral_ge0.
 rewrite le_eqVlt => /predU1P[<-|if_gt0].
   rewrite mule0 (_ : (fun _ => _) = cst 0) ?lim_cst//.
   by under eq_fun do rewrite mule0.
-rewrite gt0_mulpinfty//; apply/cvg_lim => //; apply/ereal_cvgPpinfty => M M0.
+rewrite gt0_mulye//; apply/cvg_lim => //; apply/ereal_cvgPpinfty => M M0.
 near=> n; have [ifoo|] := ltP (\int_ D (f x) 'd mu[x]) +oo; last first.
   rewrite lee_pinfty_eq => /eqP ->;  rewrite mulrinfty muleC.
-  rewrite gt0_mulpinfty ?lee_pinfty//.
+  rewrite gt0_mulye ?leey//.
   by near: n; exists 1%N => // n /= n0; rewrite gtr0_sg// ?lte_fin// ltr0n.
 rewrite -(@fineK _ (\int_ D (f x) 'd mu[x])); last first.
-  by rewrite fin_numElt ifoo andbT (le_lt_trans _ if_gt0)// lee_ninfty.
+  by rewrite fin_numElt ifoo andbT (le_lt_trans _ if_gt0).
 rewrite -lee_pdivr_mulr//; last first.
   by move: if_gt0 ifoo; case: (\int_ D (f x) 'd mu[x]).
 near: n.
@@ -2215,7 +2214,7 @@ rewrite monotone_convergence //.
   apply/cvg_lim => //; apply/ereal_cvgPpinfty => M M0.
   have [muDoo|muDoo] := ltP (mu D) +oo; last first.
     exists 1%N => // m /= m0; move: muDoo; rewrite lee_pinfty_eq => /eqP ->.
-    by rewrite mulrinfty gtr0_sg ?mul1e ?lee_pinfty// ltr0n.
+    by rewrite mulrinfty gtr0_sg ?mul1e ?leey// ltr0n.
   exists `|ceil (M / fine (mu D))|%N => // m /=.
   rewrite -(ler_nat R) => MDm.
   rewrite -(@fineK _ (mu D)); last by rewrite ge0_fin_numE// measure_ge0.
@@ -2480,7 +2479,7 @@ have [ET|ET] := eqVneq E setT.
   by rewrite funeqE => t; rewrite /= foo.
 suff: mu E = 0.
   move=> muE0; exists E; split => // t /= /not_implyP[Dt ftfin]; split => //.
-  apply/eqP; rewrite eqe_absl lee_pinfty andbT.
+  apply/eqP; rewrite eqe_absl leey andbT.
   by move/negP : ftfin; rewrite fin_numE negb_and 2!negbK orbC.
 have [->|/set0P E0] := eqVneq E set0; first by rewrite measure0.
 have [M M0 muM] : exists2 M, (0 <= M)%R &
@@ -2489,7 +2488,7 @@ have [M M0 muM] : exists2 M, (0 <= M)%R &
   move=> n.
   rewrite -integral_indic// -ge0_integralM//; last 2 first.
     - apply: measurable_fun_comp=> //; apply: (@measurable_funS _ _ setT)=>//.
-      by rewrite (_ : \1_ _ = indic_nnsfun R mE)//.
+      by rewrite (_ : \1_ _ = indic_nnsfun R mE).
     - by move=> *; rewrite lee_fin.
   rewrite fineK//; last first.
     by case: fint => _ foo; rewrite ge0_fin_numE//; exact: integral_ge0.
@@ -2502,7 +2501,7 @@ have [M M0 muM] : exists2 M, (0 <= M)%R &
   - by apply: measurable_fun_comp => //; case: fint.
   - move=> x Dx; rewrite /= indicE.
     have [|xE] := boolP (x \in E); last by rewrite mule0.
-    by rewrite /E inE /= => -[->]; rewrite lee_pinfty.
+    by rewrite /E inE /= => -[->]; rewrite leey.
 apply/eqP/negPn/negP => /eqP muED0.
 move/not_forallP : muM; apply.
 have [muEDoo|] := ltP (mu (E `&` D)) +oo; last first.
@@ -2850,10 +2849,10 @@ move=> mf; split=> [iDf0|Df0].
      \bigcup_n (D `&` [set x | `|f x| >= n.+1%:R^-1%:E])); last first.
     rewrite predeqE => t; split=> [[Dt ft0]|[n _ /= [Dt nft]]].
       have [ftoo|ftoo] := eqVneq `|f t| +oo%E.
-        by exists 0%N => //; split => //=; rewrite ftoo /= lee_pinfty.
+        by exists 0%N => //; split => //=; rewrite ftoo /= leey.
       pose m := `|ceil (fine `|f t|)^-1|%N.
       have ftfin : `|f t|%E \is a fin_num.
-        by rewrite fin_numE gt_eqF //= (lt_le_trans _ (abse_ge0 _))// lte_ninfty.
+        by rewrite fin_numE gt_eqF //= (lt_le_trans _ (abse_ge0 _)).
       exists m => //; split => //=.
       rewrite -(@fineK _ `|f t|) // lee_fin -ler_pinv; last 2 first.
         - rewrite inE unitfE fine_eq0 // abse_eq0 ft0/=; apply/lt0R.
@@ -3562,7 +3561,7 @@ have -> : phi (X `\` Y) = (fun x => phi X x - phi Y x)%E.
   - exact: measurable_xsection.
   - exact: measurable_xsection.
   - move: m2_bounded => [M m2M].
-    rewrite (lt_le_trans (m2M (xsection X x) _))// ?lee_pinfty//.
+    rewrite (lt_le_trans (m2M (xsection X x) _))// ?leey//.
     exact: measurable_xsection.
 exact: emeasurable_funB.
 Qed.
@@ -3606,7 +3605,7 @@ have -> : psi (X `\` Y) = (fun x => psi X x - psi Y x)%E.
   - exact: measurable_ysection.
   - exact: measurable_ysection.
   - move: m1_bounded => [M m1M].
-    rewrite (lt_le_trans (m1M (ysection X y) _))// ?lee_pinfty//.
+    rewrite (lt_le_trans (m1M (ysection X y) _))// ?leey//.
     exact: measurable_ysection.
 exact: emeasurable_funB.
 Qed.

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -2060,7 +2060,7 @@ transitivity (\int_ D (lim (g^~ x)) 'd mu[x]).
   - rewrite gt0_mulye//; apply/ereal_cvgPpinfty => M M0.
     rewrite /g; case: (f x) fx0 => [r|_|//]; last first.
       exists 1%N => // m /= m0.
-      by rewrite mulrinfty gtr0_sg// ?mul1e ?leey// ltr0n.
+      by rewrite mulry gtr0_sg// ?mul1e ?leey// ltr0n.
     rewrite lte_fin => r0.
     near=> n; rewrite lee_fin -ler_pdivr_mulr//.
     near: n; exists `|ceil (M / r)|%N => // m /=.
@@ -2069,7 +2069,7 @@ transitivity (\int_ D (lim (g^~ x)) 'd mu[x]).
   - rewrite lt0_mulye//; apply/ereal_cvgPninfty => M M0.
     rewrite /g; case: (f x) fx0 => [r|//|_]; last first.
       exists 1%N => // m /= m0.
-      by rewrite mulrinfty gtr0_sg// ?ltr0n// mul1e ?leNye.
+      by rewrite mulrNy gtr0_sg// ?ltr0n// mul1e ?leNye.
     rewrite lte_fin => r0.
     near=> n; rewrite lee_fin -ler_ndivr_mulr//.
     near: n; exists `|ceil (M / r)|%N => // m /=.
@@ -2088,7 +2088,7 @@ rewrite le_eqVlt => /predU1P[<-|if_gt0].
   by under eq_fun do rewrite mule0.
 rewrite gt0_mulye//; apply/cvg_lim => //; apply/ereal_cvgPpinfty => M M0.
 near=> n; have [ifoo|] := ltP (\int_ D (f x) 'd mu[x]) +oo; last first.
-  rewrite lee_pinfty_eq => /eqP ->;  rewrite mulrinfty muleC.
+  rewrite lee_pinfty_eq => /eqP ->;  rewrite mulry muleC.
   rewrite gt0_mulye ?leey//.
   by near: n; exists 1%N => // n /= n0; rewrite gtr0_sg// ?lte_fin// ltr0n.
 rewrite -(@fineK _ (\int_ D (f x) 'd mu[x])); last first.
@@ -2214,7 +2214,7 @@ rewrite monotone_convergence //.
   apply/cvg_lim => //; apply/ereal_cvgPpinfty => M M0.
   have [muDoo|muDoo] := ltP (mu D) +oo; last first.
     exists 1%N => // m /= m0; move: muDoo; rewrite lee_pinfty_eq => /eqP ->.
-    by rewrite mulrinfty gtr0_sg ?mul1e ?leey// ltr0n.
+    by rewrite mulry gtr0_sg ?mul1e ?leey// ltr0n.
   exists `|ceil (M / fine (mu D))|%N => // m /=.
   rewrite -(ler_nat R) => MDm.
   rewrite -(@fineK _ (mu D)); last by rewrite ge0_fin_numE// measure_ge0.

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -88,9 +88,9 @@ Lemma hlength_finite_fin_num i : neitv i -> hlength [set` i] < +oo ->
   ((i.1 : \bar R) \is a fin_num) /\ ((i.2 : \bar R) \is a fin_num).
 Proof.
 move: i => [[ba a|[]] [bb b|[]]] /neitvP //=; do ?by rewrite ?set_itvE ?eqxx.
-by move=> _; rewrite hlength_itv /= lte_pinfty.
-by move=> _; rewrite hlength_itv /= lte_ninfty.
-by move=> _; rewrite hlength_itv /=.
+by move=> _; rewrite hlength_itv /= ltey.
+by move=> _; rewrite hlength_itv /= ltNye.
+by move=> _; rewrite hlength_itv.
 Qed.
 
 Lemma finite_hlengthE i : neitv i -> hlength [set` i] < +oo ->
@@ -104,11 +104,11 @@ Qed.
 
 Lemma hlength_infty_bnd b r :
   hlength [set` Interval -oo%O (BSide b r)] = +oo :> \bar R.
-Proof. by rewrite hlength_itv /= lte_ninfty. Qed.
+Proof. by rewrite hlength_itv /= ltNye. Qed.
 
 Lemma hlength_bnd_infty b r :
   hlength [set` Interval (BSide b r) +oo%O] = +oo :> \bar R.
-Proof. by rewrite hlength_itv /= lte_pinfty. Qed.
+Proof. by rewrite hlength_itv /= ltey. Qed.
 
 Lemma pinfty_hlength i : hlength [set` i] = +oo ->
   (exists s r, i = Interval -oo%O (BSide s r) \/ i = Interval (BSide s r) +oo%O)
@@ -125,8 +125,8 @@ Lemma hlength_ge0 i : 0 <= hlength [set` i].
 Proof.
 rewrite hlength_itv; case: ifPn => //; case: (i.1 : \bar _) => [r| |].
 - by rewrite suber_ge0//; exact: ltW.
-- by rewrite ltNge lee_pinfty.
-- by case: (i.2 : \bar _) => //= [r _]; rewrite lee_pinfty.
+- by rewrite ltNge leey.
+- by case: (i.2 : \bar _) => //= [r _]; rewrite leey.
 Qed.
 Local Hint Extern 0 (0%:E <= hlength _) => solve[apply: hlength_ge0] : core.
 
@@ -141,11 +141,11 @@ have [J0|/set0P J0] := eqVneq J set0.
   by move/subset_itvP; rewrite -/J J0 subset0 -/I => ->.
 move=> /subset_itvP ij; apply: lee_sub => /=.
   have [ui|ui] := asboolP (has_ubound I).
-    have [uj /=|uj] := asboolP (has_ubound J); last by rewrite lee_pinfty.
+    have [uj /=|uj] := asboolP (has_ubound J); last by rewrite leey.
     by rewrite lee_fin le_sup // => r Ir; exists r; split => //; apply: ij.
   have [uj /=|//] := asboolP (has_ubound J).
   by move: ui; have := subset_has_ubound ij uj.
-have [lj /=|lj] := asboolP (has_lbound J); last by rewrite lee_ninfty.
+have [lj /=|lj] := asboolP (has_lbound J); last by rewrite leNye.
 have [li /=|li] := asboolP (has_lbound I); last first.
   by move: li; have := subset_has_lbound ij lj.
 rewrite lee_fin ler_oppl opprK le_sup// ?has_inf_supN//; last first.
@@ -380,8 +380,7 @@ exists (fun k : nat => `] (- k%:R)%R, k%:R]%classic).
   rewrite [ltRHS]ger0_norm//.
     by rewrite (le_lt_trans _ (lt_succ_Rfloor _))// ?ler_norm.
   by rewrite addr_ge0// -Rfloor0 le_Rfloor.
-move=> k; split => //.
-by rewrite hlength_itv/= -EFinB; case: ifP; rewrite lte_pinfty.
+by move=> k; split => //; rewrite hlength_itv/= -EFinB; case: ifP; rewrite ltey.
 Qed.
 
 Let gitvs := g_measurableType ocitv.
@@ -504,7 +503,7 @@ rewrite predeqE => x; split; rewrite /= in_itv andbT.
   by left; exists x => //; rewrite in_itv /= andbT; case: b yxb.
 - move=> [[r]|->].
   + by rewrite in_itv /= andbT => yxb <-; case: b yxb.
-  + by case: b => /=; rewrite ?(lte_pinfty, lee_pinfty).
+  + by case: b => /=; rewrite ?(ltey, leey).
 Qed.
 
 Lemma punct_eitv_ninfty_bnd b y : [set` Interval -oo%O (BSide b y%:E)] =
@@ -514,19 +513,19 @@ rewrite predeqE => x; split; rewrite /= in_itv.
 - move: x => [x| |] yxb; [|by case: b yxb|by left].
   by right; exists x => //; rewrite in_itv /= andbT; case: b yxb.
 - move=> [->|[r]].
-  + by case: b => /=; rewrite ?(lte_ninfty, lee_ninfty).
+  + by case: b => /=; rewrite ?(ltNye, leNye).
   + by rewrite in_itv /= => yxb <-; case: b yxb.
 Qed.
 
 Lemma punct_eitv_setTR : range (@EFin R) `|` [set +oo] = [set~ -oo].
 Proof.
-rewrite eqEsubset; split => [a [[a' _ <-]|->]|]; rewrite ?lte_ninfty//.
+rewrite eqEsubset; split => [a [[a' _ <-]|->]|] //.
 by move=> [x| |] //= _; [left; exists x|right].
 Qed.
 
 Lemma punct_eitv_setTL : range (@EFin R) `|` [set -oo] = [set~ +oo].
 Proof.
-rewrite eqEsubset; split => [a [[a' _ <-]|->]|]; rewrite ?lte_ninfty//.
+rewrite eqEsubset; split => [a [[a' _ <-]|->]|] //.
 by move=> [x| |] //= _; [left; exists x|right].
 Qed.
 
@@ -638,21 +637,18 @@ Qed.
 
 Lemma itv_opinfty_pinfty : `]+oo%E, +oo[%classic = set0 :> set (\bar R).
 Proof.
-rewrite set_itvE predeqE => t; split => //=.
-by apply/negP; rewrite -leNgt lee_pinfty.
+by rewrite set_itvE predeqE => t; split => //=; apply/negP; rewrite -leNgt leey.
 Qed.
 
 Lemma itv_cninfty_pinfty : `[-oo%E, +oo[%classic = setT :> set (\bar R).
-Proof.
-by rewrite set_itvE predeqE => t; split => //= _; rewrite lee_ninfty.
-Qed.
+Proof. by rewrite set_itvE predeqE => t; split => //= _; rewrite leNye. Qed.
 
 Lemma itv_oninfty_pinfty :
   `]-oo%E, +oo[%classic = ~` [set -oo]%E :> set (\bar R).
 Proof.
 rewrite set_itvE predeqE => x; split => /=.
 - by move: x => [x| |]; rewrite ?ltxx.
-- by move: x => [x h|//|/(_ erefl)]; rewrite ?lte_ninfty.
+- by move: x => [x h|//|/(_ erefl)]; rewrite ?ltNye.
 Qed.
 
 Lemma emeasurable_itv_bnd_pinfty b (y : \bar R) :
@@ -821,7 +817,7 @@ rewrite predeqE => t; split => [/= [Dt ft]|].
     by rewrite -{2}(fineK ft) lee_fin mulrNz opprK floor_le.
   by rewrite -(fineK ft)// lee_fin (le_trans (ltW ft0)).
 move=> [n _] [/= Dt [nft fnt]]; split => //; rewrite fin_numElt.
-by rewrite (lt_le_trans _ nft) ?lte_ninfty//= (le_lt_trans fnt)// lte_pinfty.
+by rewrite (lt_le_trans _ nft) ?ltNye//= (le_lt_trans fnt)// ltey.
 Qed.
 
 Lemma emeasurable_neq y : measurable (D `&` [set x | f x != y]).
@@ -1018,7 +1014,7 @@ rewrite eqEsubset; split => [x [s /itvP rs <-]|x []].
   split => //=; rewrite in_itv /=.
   by case: b in rs *; rewrite /= ?(lee_fin, lte_fin) rs.
 move: x => [s|_ /(_ erefl)|] //=; rewrite in_itv /= andbT; last first.
-  by case: b => /=; rewrite 1?(leNgt,ltNge) 1?(lte_ninfty,lee_ninfty).
+  by case: b => /=; rewrite 1?(leNgt,ltNge) 1?(ltNye, leNye).
 by case: b => /=; rewrite 1?(lte_fin,lee_fin) => rs _;
   exists s => //; rewrite in_itv /= rs.
 Qed.
@@ -1030,7 +1026,7 @@ Qed.
 
 Lemma preimage_EFin_setT : @EFin R @^-1` [set x | x \in `]-oo%E, +oo[] = setT.
 Proof.
-by rewrite set_itvE predeqE => r; split=> // _; rewrite /preimage /= lte_ninfty.
+by rewrite set_itvE predeqE => r; split=> // _; rewrite /preimage /= ltNye.
 Qed.
 
 Lemma eitv_c_infty r : `[r%:E, +oo[%classic =
@@ -1041,8 +1037,8 @@ rewrite predeqE => x; split=> [|].
   + rewrite in_itv /= andbT lee_fin => rs n _ /=.
     rewrite in_itv /= andbT lte_fin.
     by rewrite ltr_subl_addl (le_lt_trans rs)// ltr_addr invr_gt0.
-  + by rewrite /= in_itv /= andbT lte_pinfty.
-- move: x => [s| |/(_ 0%N Logic.I)] //=; last by rewrite in_itv /= lee_pinfty.
+  + by rewrite /= in_itv /= andbT ltey.
+- move: x => [s| |/(_ 0%N Logic.I)] //=; last by rewrite in_itv /= leey.
   move=> h; rewrite in_itv /= lee_fin leNgt andbT; apply/negP.
   move=> /ltr_add_invr[k skr]; have {h} := h k Logic.I.
   rewrite /= in_itv /= andbT lte_fin ltNge => /negP; apply.
@@ -1056,8 +1052,8 @@ rewrite predeqE => x; split=> [|].
 - move: x => [s /=|//|_ n _].
   + rewrite in_itv /= lee_fin => sr n _; rewrite /= in_itv /=.
     by rewrite -EFinD lee_fin (le_trans sr)// ler_addl invr_ge0.
-  + by rewrite /= in_itv /= -EFinD lee_ninfty.
-- move: x => [s|/(_ 0%N Logic.I)//|]/=; rewrite ?in_itv /= ?lee_ninfty//.
+  + by rewrite /= in_itv /= -EFinD leNye.
+- move: x => [s|/(_ 0%N Logic.I)//|]/=; rewrite ?in_itv /= ?leNye//.
   move=> h; rewrite lee_fin leNgt; apply/negP => /ltr_add_invr[k rks].
   have {h} := h k Logic.I; rewrite /= in_itv /=.
   by rewrite -EFinD lee_fin leNgt => /negP; apply.
@@ -1066,8 +1062,7 @@ Qed.
 Lemma eset1_ninfty :
   [set -oo] = \bigcap_k `]-oo, (-k%:R%:E)[%classic :> set (\bar R).
 Proof.
-rewrite eqEsubset; split=> [_ -> i _ |].
-  by rewrite /= in_itv /= lte_ninfty.
+rewrite eqEsubset; split=> [_ -> i _ |]; first by rewrite /= in_itv /= ltNye.
 move=> [r|/(_ O Logic.I)|]//.
 move=> /(_ `|floor r|%N Logic.I); rewrite /= in_itv/= ltNge.
 rewrite lee_fin; have [r0|r0] := leP 0%R r.
@@ -1080,7 +1075,7 @@ Qed.
 Lemma eset1_pinfty :
   [set +oo] = \bigcap_k `]k%:R%:E, +oo[%classic :> set (\bar R).
 Proof.
-rewrite eqEsubset; split=> [_ -> i _/=|]; first by rewrite in_itv /= lte_pinfty.
+rewrite eqEsubset; split=> [_ -> i _/=|]; first by rewrite in_itv /= ltey.
 move=> [r| |/(_ O Logic.I)] // /(_ `|ceil r|%N Logic.I); rewrite /= in_itv /=.
 rewrite andbT lte_fin ltNge.
 have [r0|r0] := ltP 0%R r; last by rewrite (le_trans r0).

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -1706,7 +1706,7 @@ Lemma le_measure (R : realFieldType) (T : semiRingOfSetsType)
   {in measurable &, {homo mu : A B / A `<=` B >-> (A <= B)%E}}.
 Proof.
 move=> A B; rewrite ?inE => mA mB AB; have [|muBfin] := leP +oo%E (mu B).
-  by rewrite lee_pinfty_eq => /eqP ->; rewrite lee_pinfty.
+  by rewrite lee_pinfty_eq => /eqP ->; rewrite leey.
 rewrite -[leRHS]SetRing.RmuE// -[B](setDUK AB) measureU/= ?setDIK//.
 - by rewrite SetRing.RmuE ?lee_addl// ?measure_ge0.
 - exact: sub_gen_smallest.
@@ -1714,8 +1714,8 @@ rewrite -[leRHS]SetRing.RmuE// -[B](setDUK AB) measureU/= ?setDIK//.
 Qed.
 
 Lemma measure_le0  (T : semiRingOfSetsType) (R : realFieldType)
-    (mu : {additive_measure set T -> \bar R}) (A : set T) :
-    (mu A <= 0)%E = (mu A == 0)%E.
+  (mu : {additive_measure set T -> \bar R}) (A : set T) :
+  (mu A <= 0)%E = (mu A == 0)%E.
 Proof. by case: ltgtP (measure_ge0 mu A). Qed.
 
 Section more_content_semiring_lemmas.
@@ -2415,9 +2415,9 @@ suff : forall n, \sum_(k < n) mu (X `&` A k) + mu (X `&` ~` A') <= mu X.
   move XAx : (mu (X `&` ~` A')) => [x| |].
   - rewrite -lee_subr_addr //; apply ub_ereal_sup => /= _ [n _] <-.
     by rewrite EFinN lee_subr_addr // -XAx XA.
-  - suff : mu X = +oo by move=> ->; rewrite lee_pinfty.
+  - suff : mu X = +oo by move=> ->; rewrite leey.
     by apply/eqP; rewrite -lee_pinfty_eq -XAx le_outer_measure.
-  - by rewrite addeC /= lee_ninfty.
+  - by rewrite addeC /= leNye.
 move=> n.
 apply (@le_trans _ _ (\sum_(k < n) mu (X `&` A k) + mu (X `&` ~` B n))).
   apply/lee_add2l/le_outer_measure; apply: setIS; apply: subsetC => t.
@@ -2599,7 +2599,7 @@ Proof. by case: x. Qed.
 Lemma mu_ext_sigma_subadditive : sigma_subadditive mu_ext.
 Proof.
 move=> A; have [[i ioo]|] := pselect (exists i, mu_ext (A i) = +oo).
-  rewrite (ereal_nneg_series_pinfty _ _ ioo)// ?lee_pinfty// => n _.
+  rewrite (ereal_nneg_series_pinfty _ _ ioo)// ?leey// => n _.
   exact: mu_ext_ge0.
 rewrite -forallNE => Aoo; apply: lee_adde => e.
 rewrite (le_trans _ (epsilon_trick _ _ _))//; last first.
@@ -2921,11 +2921,11 @@ have ? : cvg (eseries (Rmu \o B)).
   by apply/is_cvg_ereal_nneg_series => n _; exact: measure_ge0.
 have [def|] := boolP (adde_def (lim BA) (lim BNA)); last first.
   rewrite /adde_def negb_and !negbK=> /orP[/andP[BAoo BNAoo]|/andP[BAoo BNAoo]].
-  - suff -> : lim (eseries (Rmu \o B)) = +oo by rewrite lee_pinfty.
+  - suff -> : lim (eseries (Rmu \o B)) = +oo by rewrite leey.
     apply/eqP; rewrite -lee_pinfty_eq -(eqP BAoo); apply/lee_lim => //.
     near=> n; apply: lee_sum => m _; apply: le_measure; rewrite /mkset; by
       [rewrite inE; exact: measurableI | rewrite inE | apply: subIset; left].
-  - suff -> : lim (eseries (Rmu \o B)) = +oo by rewrite lee_pinfty.
+  - suff -> : lim (eseries (Rmu \o B)) = +oo by rewrite leey.
     apply/eqP; rewrite -lee_pinfty_eq -(eqP BNAoo); apply/lee_lim => //.
     by near=> n; apply: lee_sum => m _; rewrite -setDE; apply: le_measure;
        rewrite /mkset ?inE//; apply: measurableD.

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -3493,7 +3493,7 @@ Lemma open_ereal_lt y : open [set r : R | r%:E < y].
 Proof.
 case: y => [y||] /=; first exact: open_lt.
 - rewrite (_ : [set _ | _] = setT); first exact: openT.
-  by rewrite funeqE => ? /=; rewrite lte_pinfty trueE.
+  by rewrite funeqE => ? /=; rewrite ltey trueE.
 - rewrite (_ : [set _ | _] = set0); first exact: open0.
   by rewrite funeqE => ? /=; rewrite falseE.
 Qed.
@@ -3504,7 +3504,7 @@ case: y => [y||] /=; first exact: open_gt.
 - rewrite (_ : [set _ | _] = set0); first exact: open0.
   by rewrite funeqE => ? /=; rewrite falseE.
 - rewrite (_ : [set _ | _] = setT); first exact: openT.
-  by rewrite funeqE => ? /=; rewrite lte_ninfty trueE.
+  by rewrite funeqE => ? /=; rewrite ltNye trueE.
 Qed.
 
 Lemma open_ereal_lt' x y : x < y -> ereal_nbhs x (fun u => u < y).
@@ -3514,7 +3514,7 @@ case: x => [x|//|] xy; first exact: open_ereal_lt.
   by exists y; rewrite num_real; split => //= x ?.
 - case: y => [y||//] /= in xy *.
   + by exists y; rewrite num_real; split => //= x ?.
-  + by exists 0%R; split => // x /lt_le_trans; apply; rewrite lee_pinfty.
+  + by exists 0%R; split => // x /lt_le_trans; apply; rewrite leey.
 Qed.
 
 Lemma open_ereal_gt' x y : y < x -> ereal_nbhs x (fun u => y < u).
@@ -3522,7 +3522,7 @@ Proof.
 case: x => [x||] //=; do ?[exact: open_ereal_gt];
   case: y => [y||] //=; do ?by exists 0.
 - by exists y; rewrite num_real.
-- by move=> _; exists 0%R; split => // x; apply/le_lt_trans; rewrite lee_ninfty.
+- by move=> _; exists 0%R; split => // x; apply/le_lt_trans; rewrite leNye.
 Qed.
 
 Let open_ereal_lt_real r : open (fun x => x < r%:E).
@@ -3537,10 +3537,10 @@ case: x => [x | | [] // ] /=; first exact: open_ereal_lt_real.
 suff -> : [set y | y < +oo] = \bigcup_r [set y : \bar R | y < r%:E].
   by apply bigcup_open => x _; exact: open_ereal_lt_real.
 rewrite predeqE => -[r | | ]/=.
-- rewrite lte_pinfty; split => // _.
+- rewrite ltey; split => // _.
   by exists (r + 1)%R => //=; rewrite lte_fin ltr_addl.
-- by rewrite ltxx; split => // -[] x /=; rewrite ltNge lee_pinfty.
-- by split => // _; exists 0%R => //=; rewrite lte_ninfty.
+- by rewrite ltxx; split => // -[] x /=; rewrite ltNge leey.
+- by split => // _; exists 0%R => //=.
 Qed.
 
 Let open_ereal_gt_real r : open (fun x => r%:E < x).
@@ -3555,10 +3555,10 @@ case: x => [x | [] // | ] /=; first exact: open_ereal_gt_real.
 suff -> : [set y | -oo < y] = \bigcup_r [set y : \bar R | r%:E < y].
   by apply bigcup_open => x _; exact: open_ereal_gt_real.
 rewrite predeqE => -[r | | ]/=.
-- rewrite lte_ninfty; split => // _.
+- rewrite ltNye; split => // _.
   by exists (r - 1)%R => //=; rewrite lte_fin ltr_subl_addr ltr_addl.
-- by split => // _; exists 0%R => //=; rewrite lte_pinfty.
-- by rewrite ltxx; split => // -[] x _ /=; rewrite ltNge lee_ninfty.
+- by split => // _; exists 0%R => //=.
+- by rewrite ltxx; split => // -[] x _ /=; rewrite ltNge leNye.
 Qed.
 
 Lemma closed_ereal_le_ereal y : closed [set x | y <= x].
@@ -3605,13 +3605,13 @@ Qed.
 Lemma nbhs_open_ereal_pinfty r : (nbhs +oo [set y | r%:E < y])%E.
 Proof.
 rewrite nbhsE /=; eexists; split; last by move=> y; exact.
-by split; [apply open_ereal_gt_ereal | rewrite /= lte_pinfty].
+by split; [apply open_ereal_gt_ereal | rewrite /= ltey].
 Qed.
 
 Lemma nbhs_open_ereal_ninfty r : (nbhs -oo [set y | y < r%:E])%E.
 Proof.
 rewrite nbhsE /=; eexists; split; last by move=> y; exact.
-by split; [apply open_ereal_lt_ereal | rewrite /= lte_ninfty].
+by split; [apply open_ereal_lt_ereal | rewrite /= ltNye].
 Qed.
 
 Lemma ereal_hausdorff : hausdorff_space (ereal_topologicalType R).

--- a/theories/numfun.v
+++ b/theories/numfun.v
@@ -187,8 +187,8 @@ Lemma add_def_funennpg f x : (f^\+ x +? - f^\- x)%E.
 Proof.
 rewrite /funennp /funenng; case: (f x) => [r| |].
 - by rewrite !maxEFin.
-- by rewrite /maxe /= lte_ninfty.
-- by rewrite /maxe /= lte_ninfty.
+- by rewrite /maxe /= ltNye.
+- by rewrite /maxe /= ltNye.
 Qed.
 
 Lemma funeD_Dnng f g : f \+ g = (f \+ g)^\+ \- (f \+ g)^\-.
@@ -215,8 +215,10 @@ have [|fx0] := leP 0 (f x); last rewrite add0e.
 Qed.
 
 End funpos_lemmas.
-#[global] Hint Extern 0 (is_true (0 <= _ ^\+ _)%E) => solve [apply: funenng_ge0] : core.
-#[global] Hint Extern 0 (is_true (0 <= _ ^\- _)%E) => solve [apply: funennp_ge0] : core.
+#[global]
+Hint Extern 0 (is_true (0 <= _ ^\+ _)%E) => solve [apply: funenng_ge0] : core.
+#[global]
+Hint Extern 0 (is_true (0 <= _ ^\- _)%E) => solve [apply: funennp_ge0] : core.
 
 Definition indic {T} {R : ringType} (A : set T) (x : T) : R := (x \in A)%:R.
 Reserved Notation "'\1_' A" (at level 8, A at level 2, format "'\1_' A") .

--- a/theories/sequences.v
+++ b/theories/sequences.v
@@ -1546,7 +1546,7 @@ Proof.
 move=> u0 Pk ukoo; apply/eqP; rewrite -lee_pinfty_eq.
 apply: le_trans (ereal_nneg_series_lim_ge k.+1 u0) => //.
 rewrite lee_pinfty_eq; apply/eqP/esum_pinftyP=> [i /u0|].
- by rewrite leNgt; apply: contra => /eqP ->; rewrite lte_ninfty_0.
+ by rewrite leNgt; apply: contra => /eqP ->.
 by exists k; split => //; rewrite mem_iota subn0 add0n ltnS leqnn.
 Qed.
 
@@ -1609,7 +1609,7 @@ case: l k => [l| |] [k| |] // in lu kv *.
   + by apply/cvg_ex; eexists; exact: vk.
   + near=> n => /=; rewrite -lee_fin fineK; last by near: n; apply realu.
     by rewrite fineK; [near: n; exact: uv|near: n; apply realv].
-- by rewrite lee_pinfty.
+- by rewrite leey.
 - exfalso.
   have /ereal_cvg_real [realu ul] : u_ --> l%:E by rewrite -lu.
   have /ereal_cvgPninfty voo : v_ --> -oo by rewrite -kv.
@@ -1642,7 +1642,7 @@ case: l k => [l| |] [k| |] // in lu kv *.
     by near: n; apply: voo; exact: ltrN10.
   rewrite (@lt_le_trans _ _ 1)// ?lte_fin ?ltr10//.
   by near: n; apply: uoo; exact: ltr01.
-- by rewrite lee_ninfty.
+- by rewrite leNye.
 Unshelve. all: by end_near. Qed.
 
 Lemma ereal_cvgD_pinfty_fin (R : realFieldType) (f g : (\bar R)^nat) b :
@@ -1827,13 +1827,13 @@ move=> [:apoo] [:bnoo] [:poopoo] [:poonoo]; move: a b => [a| |] [b| |] //.
   by under eq_fun do rewrite muleC; exact: apoo.
 - move=> _; move: f g; abstract: poopoo.
   move=> {}f {}g /ereal_cvgPpinfty foo /ereal_cvgPpinfty goo.
-  rewrite mule_pinfty_pinfty; apply/ereal_cvgPpinfty => A A0; near=> n.
+  rewrite mulyy; apply/ereal_cvgPpinfty => A A0; near=> n.
   rewrite -(sqr_sqrtr (ltW A0)) expr2 EFinM lee_pmul// ?lee_fin ?sqrtr_ge0//.
     by near: n; apply: foo; rewrite sqrtr_gt0.
   by near: n; apply: goo; rewrite sqrtr_gt0.
 - move=> _; move: f g; abstract: poonoo.
   move=> {}f {}g /ereal_cvgPpinfty foo /ereal_cvgPninfty goo.
-  rewrite mule_pinfty_ninfty; apply/ereal_cvgPninfty => A A0; near=> n.
+  rewrite mulyNy; apply/ereal_cvgPninfty => A A0; near=> n.
   rewrite (@le_trans _ _ (g n))//; last by near: n; exact: goo.
   apply: lee_nemull; last by near: n; apply: foo.
   by rewrite (@le_trans _ _ (- 1)%:E)//; near: n; apply: goo; rewrite ltrN10.
@@ -1841,7 +1841,7 @@ move=> [:apoo] [:bnoo] [:poopoo] [:poonoo]; move: a b => [a| |] [b| |] //.
   by under eq_fun do rewrite muleC; exact: bnoo.
 - move=> _ foo goo.
   by under eq_fun do rewrite muleC; exact: poonoo.
-- move=> _ foo goo; rewrite mule_ninfty_ninfty -mule_pinfty_pinfty.
+- move=> _ foo goo; rewrite mulNyNy -mulyy.
   by under eq_fun do rewrite -muleNN; apply: poopoo;
     rewrite -/(- -oo); apply: ereal_cvgN.
 Unshelve. all: end_near. Qed.

--- a/theories/sequences.v
+++ b/theories/sequences.v
@@ -1811,16 +1811,16 @@ move=> [:apoo] [:bnoo] [:poopoo] [:poonoo]; move: a b => [a| |] [b| |] //.
   exact: cvgM.
 - move: f g a; abstract: apoo.
   move=> {}f {}g {}a + fa goo; have [a0 _|a0 _|->] := ltgtP a 0%R.
-  + rewrite mulrinfty ltr0_sg// ?mulN1e.
+  + rewrite mulry ltr0_sg// ?mulN1e.
     by under eq_fun do rewrite muleC; exact: (ereal_cvgM_lt0_pinfty a0).
-  + rewrite mulrinfty gtr0_sg// ?mul1e.
+  + rewrite mulry gtr0_sg// ?mul1e.
     by under eq_fun do rewrite muleC; exact: (ereal_cvgM_gt0_pinfty a0).
   + by rewrite /mule_def eqxx.
 - move: f g a; abstract: bnoo.
   move=> {}f {}g {}a + fa goo; have [a0 _|a0 _|->] := ltgtP a 0%R.
-  + rewrite mulrinfty ltr0_sg// ?mulN1e.
+  + rewrite mulrNy ltr0_sg// ?mulN1e.
     by under eq_fun do rewrite muleC; exact: (ereal_cvgM_lt0_ninfty a0).
-  + rewrite mulrinfty gtr0_sg// ?mul1e.
+  + rewrite mulrNy gtr0_sg// ?mul1e.
     by under eq_fun do rewrite muleC; exact: (ereal_cvgM_gt0_ninfty a0).
   + by rewrite /mule_def eqxx.
 - rewrite mule_defC => ? foo gb; rewrite muleC.

--- a/theories/set_interval.v
+++ b/theories/set_interval.v
@@ -657,7 +657,7 @@ Arguments ereal_of_itv_bound T !b.
 Lemma le_bnd_ereal (R : realDomainType) (a b : itv_bound R) :
   (a <= b)%O -> (a <= b)%E.
 Proof.
-move: a b => -[[] a|[]] [bb b|[]] //=; rewrite ?(lee_pinfty,lee_ninfty)//.
+move: a b => -[[] a|[]] [bb b|[]] //=; rewrite ?(leey,leNye)//.
   by rewrite bnd_simp.
 by move=> /lteifW.
 Qed.
@@ -687,8 +687,7 @@ Lemma Interval_ereal_mem (R : realDomainType) (r : R) (a b : itv_bound R) :
   r \in Interval a b -> (a <= r%:E <= b)%E.
 Proof.
 case: a b => [[] a|[]] [[] b|[]] => /[dup] rab /itvP rw//=;
-rewrite ?lee_fin ?rw//= ?lee_pinfty ?lee_ninfty//.
-by move: rab; rewrite in_itv//= andbF.
+by rewrite ?lee_fin ?rw//= ?leey ?leNye//; move: rab; rewrite in_itv//= andbF.
 Qed.
 
 Lemma ereal_mem_Interval (R : realDomainType) (r : R) (a b : itv_bound R) :


### PR DESCRIPTION
##### Motivation for this change

fixes #597 

implements this renaming:
`addeoo` -> `addepinfty`
`addooe` -> `addpinftye`

other proposal: 
add_pinfty_e
adde_pinfty

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- [x] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
