### PR TITLE
Simplifying measurable_funrM

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -8,6 +8,7 @@
   + definition `bigcup_ointsub`
   + lemmas `bigcup_ointsub0`, `open_bigcup_ointsub`, `is_interval_bigcup_ointsub`,
     `bigcup_ointsub_sub`, `open_bigcup_rat`
+  + lemmas `mulrl_continuous` and `mulrr_continuous`.
 - in file `lebesgue_measure.v`:
   + lemmas `is_interval_measurable`, `open_measurable`, `continuous_measurable_fun`
 

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -1344,11 +1344,9 @@ Qed.
 Lemma measurable_funrM D f (k : R) : measurable_fun D f ->
   measurable_fun D (fun x => k * f x).
 Proof.
-move => mf.
-rewrite (_ : (fun x => k * f x) = (fun x => k * x) \o f).
-apply: measurable_fun_comp => //.
-apply: continuous_measurable_fun. apply: scaler_continuous.
-by apply /funext => y.
+move=> /(@measurable_fun_comp _ _ _ (GRing.mul k)); apply.
+apply: continuous_measurable_fun.
+exact/(@scaler_continuous _ [normedModType R^o of R^o]).
 Qed.
 
 Lemma measurable_funN D f : measurable_fun D f -> measurable_fun D (-%R \o f).

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -1344,9 +1344,8 @@ Qed.
 Lemma measurable_funrM D f (k : R) : measurable_fun D f ->
   measurable_fun D (fun x => k * f x).
 Proof.
-move=> /(@measurable_fun_comp _ _ _ (GRing.mul k)); apply.
-apply: continuous_measurable_fun.
-exact/(@scaler_continuous _ [normedModType R^o of R^o]).
+apply: (@measurable_fun_comp _ _ _ ( *%R k)).
+by apply: continuous_measurable_fun; apply: mulrl_continuous.
 Qed.
 
 Lemma measurable_funN D f : measurable_fun D f -> measurable_fun D (-%R \o f).

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -1344,23 +1344,11 @@ Qed.
 Lemma measurable_funrM D f (k : R) : measurable_fun D f ->
   measurable_fun D (fun x => k * f x).
 Proof.
-have [-> _|] := eqVneq k 0.
-  rewrite (_ : (fun _ => _) = cst 0); first exact: measurable_fun_cst.
-  by rewrite funeqE// => t; rewrite mul0r.
-rewrite neq_lt => /orP[k0|k0] mf mD;
-  apply: (measurability (RGenOInfty.measurableE R)) => //= A [B [a ->] <-].
-- rewrite preimage_itv_o_infty [X in measurable X](_ : _ =
-      D `&` f @^-1` `]-oo, (a / k)[); last first.
-    rewrite predeqE => t; split => [[/= akft Dtr]|[]].
-      by rewrite /= in_itv/= ltr_ndivl_mulr// mulrC.
-    by rewrite /= in_itv /= => Dt ftak; rewrite mulrC -ltr_ndivl_mulr.
-  by apply: mf =>//; rewrite -(set_itv_infty_o (a / k)); apply: measurable_itv.
-- rewrite preimage_itv_o_infty [X in measurable X](_ : _ =
-       D `&` f @^-1` `]a / k, +oo[).
-     by apply: mf => //; apply: measurable_itv.
-  rewrite predeqE => t; split => [[/= Dt akft]|[Dr]].
-    by rewrite /= in_itv/= andbT ltr_pdivr_mulr// mulrC.
-  by rewrite /= in_itv/= andbT => akft; rewrite mulrC -ltr_pdivr_mulr.
+move => mf.
+rewrite (_ : (fun x => k * f x) = (fun x => k * x) \o f).
+apply: measurable_fun_comp => //.
+apply: continuous_measurable_fun. apply: scaler_continuous.
+by apply /funext => y.
 Qed.
 
 Lemma measurable_funN D f : measurable_fun D f -> measurable_fun D (-%R \o f).

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -2168,6 +2168,12 @@ Context {K : numFieldType}.
 Lemma mul_continuous : continuous (fun z : K * K => z.1 * z.2).
 Proof. exact: scale_continuous. Qed.
 
+Lemma mulrl_continuous (x : K) : continuous ( *%R x).
+Proof. exact: scaler_continuous. Qed.
+
+Lemma mulrr_continuous (y : K) : continuous ( *%R^~ y).
+Proof. exact: scalel_continuous. Qed.
+
 Lemma inv_continuous (x : K) : x != 0 -> {for x, continuous GRing.inv}.
 Proof.
 move=> x_neq0 /=; apply/cvg_distP => _/posnumP[e]; rewrite !nearE/=; near=> y.
@@ -2175,8 +2181,7 @@ have y_gt : `|y| > `|x| / 2.
   have /(le_lt_trans (ler_sub_dist _ _)) : `|x - y| < `|x| / 2.
     by near: y; apply: cvg_dist; rewrite // divr_gt0// normr_gt0//.
   by rewrite ltr_subl_addr -ltr_subl_addl {1}[ `|x| ]splitr addrK.
-have y_neq0 : y != 0.
-  by rewrite -normr_eq0 gt_eqF// (le_lt_trans _ y_gt) ?divr_ge0.
+have y_neq0 : y != 0 by rewrite -normr_gt0 (le_lt_trans _ y_gt).
 rewrite /= -div1r -[y^-1]div1r -mulNr addf_div// mul1r mulN1r normrM normfV.
 rewrite ltr_pdivr_mulr ?normr_gt0 ?mulf_neq0//.
 apply: (@lt_le_trans _ _ (e%:num * (`|x| * (`|x| / 2)))).


### PR DESCRIPTION
In the same spirit of my other commit, I tried to simplify measurable_funrM.
Right now it fails at the application of scaler_continuous, maybe I'm missing something obvious.