### PR TITLE
move and generalize measurable_set1 hint

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -15,6 +15,8 @@
 
 - in `esumv`:
   + remove one hypothesis in lemmas `reindex_esum`, `esum_image`
+- moved from `lebesgue_integral.v` to `lebesgue_measure.v` and generalized
+  + hint `measurable_set1`/`emeasurable_set1`
 
 ### Renamed
 

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -64,8 +64,6 @@ Reserved Notation "'\int_' D f ''d' mu [ x ]" (at level 36, D at level 0,
 Reserved Notation "'\int' f ''d' mu [ x ]" (at level 36, f at level 36,
   mu at level 0, x at level 3, format "'\int'  f  ''d'  mu [ x ]").
 Reserved Notation "mu .-integrable" (at level 2, format "mu .-integrable").
-#[global]
-Hint Extern 0 (measurable [set _]) => solve [apply: measurable_set1] : core.
 
 HB.mixin Record IsMeasurableFun (aT : measurableType) (rT : realType) (f : aT -> rT) := {
   measurable_funP : measurable_fun setT f
@@ -1718,8 +1716,6 @@ Lemma emeasurable_funD D f g :
   measurable_fun D f -> measurable_fun D g -> measurable_fun D (f \+ g).
 Proof.
 move=> mf mg mD.
-have noom : measurable ([set -oo] : set (\bar R)) by apply: emeasurable_set1.
-have poom : measurable ([set +oo] : set (\bar R)) by apply: emeasurable_set1.
 have Cnoom : measurable (~` [set -oo] : set (\bar R)) by apply: measurableC.
 have Cpoom : measurable (~` [set +oo] : set (\bar R)) by apply: measurableC.
 have mfg :  measurable (D `&` [set x | f x +? g x]).
@@ -1772,10 +1768,10 @@ Lemma emeasurable_funM D f g :
   measurable_fun D f -> measurable_fun D g -> measurable_fun D (f \* g).
 Proof.
 move=> mf mg mD.
-have m0 : measurable ([set 0] : set (\bar R)) by apply: emeasurable_set1.
+have m0 : measurable ([set 0] : set (\bar R)) by [].
 have mC0 : measurable ([set~ 0] : set (\bar R)) by apply: measurableC.
 have mCoo : measurable (~` [set -oo; +oo] : set (\bar R)).
-  by apply/measurableC/measurableU; exact/emeasurable_set1.
+  exact/measurableC/measurableU.
 have mfg : measurable (D `&` [set x | f x *? g x]).
   suff -> : [set x | f x *? g x] =
               (f @^-1` (~` [set 0]) `|` g @^-1` (~` [set -oo; +oo])) `&`
@@ -2471,7 +2467,7 @@ have [muD0|muD0] := eqVneq (mu D) 0.
 pose E := [set x | `|f x| = +oo /\ D x ].
 have mE : measurable E.
   rewrite [X in measurable X](_ : _ = D `&` f @^-1` [set -oo; +oo]).
-    by apply: fint.1 => //; apply: measurableU; exact: emeasurable_set1.
+    by apply: fint.1 => //; exact: measurableU.
   rewrite predeqE => t; split=> [[/eqP ftoo Dt]|[Dt]].
     split => //.
     by move: ftoo; rewrite /preimage /= eqe_absl => /andP[/orP[|]/eqP]; tauto.
@@ -3456,8 +3452,7 @@ have -> : xsection A x = (fun y => f (x, y)) @^-1` [set 1%E].
     by rewrite /= /mindic indicE/= => ->.
   rewrite /= /mindic indicE.
   by case: (_ \in _) => //= -[] /eqP; rewrite eq_sym oner_eq0.
-rewrite -(setTI (_ @^-1` _)).
-by apply: measurable_fun_prod1 => //; exact: emeasurable_set1.
+by rewrite -(setTI (_ @^-1` _)); exact: measurable_fun_prod1.
 Qed.
 
 Lemma measurable_ysection A y : measurable A -> measurable (ysection A y).
@@ -3473,8 +3468,7 @@ have -> : ysection A y = (fun x => f (x, y)) @^-1` [set 1%E].
     by rewrite /= /mindic indicE => ->.
   rewrite /= /mindic indicE.
   by case: (_ \in _) => //= -[] /eqP; rewrite eq_sym oner_eq0.
-rewrite -(setTI (_ @^-1` _)).
-by apply: measurable_fun_prod2 => //; exact: emeasurable_set1.
+by rewrite -(setTI (_ @^-1` _)); exact: measurable_fun_prod2.
 Qed.
 
 End measurable_section.

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -773,6 +773,9 @@ Definition elebesgue_measure : {measure set \bar R -> \bar R} :=
   Measure.Pack _ elebesgue_measure_isMeasure.
 
 End salgebra_R_ssets.
+#[global]
+Hint Extern 0 (measurable [set _]) => solve [apply: measurable_set1|
+                                            apply: emeasurable_set1] : core.
 
 Section measurable_fun_measurable.
 Local Open Scope ereal_scope.
@@ -822,11 +825,10 @@ Qed.
 
 Lemma emeasurable_neq y : measurable (D `&` [set x | f x != y]).
 Proof.
-rewrite (_ : [set x | f x != y] = f @^-1` (setT `\ y)); last first.
-  rewrite predeqE => t; split.
-    by rewrite /= => ft0; rewrite /preimage /=; split => //; exact/eqP.
-  by rewrite /preimage /= => -[_ /eqP].
-by apply/mf/measurableD => //; exact/emeasurable_set1.
+rewrite (_ : [set x | f x != y] = f @^-1` (setT `\ y)).
+  exact/mf/measurableD.
+rewrite predeqE => t; split; last by rewrite /preimage /= => -[_ /eqP].
+by rewrite /= => ft0; rewrite /preimage /=; split => //; exact/eqP.
 Qed.
 
 End measurable_fun_measurable.
@@ -1481,7 +1483,7 @@ move=> /= _ [_ [x ->] <-]; move: x => [x| |].
 - rewrite [X in _ @^-1` X](punct_eitv_bnd_pinfty _ x) preimage_setU setIUr.
   apply: measurableU; last first.
     rewrite preimage_abse_pinfty.
-    by apply: measurableI => //; apply: measurableU; exact: emeasurable_set1.
+    by apply: measurableI => //; exact: measurableU.
   apply: measurableI => //; exists (normr @^-1` `]x, +oo[%classic).
     rewrite -[X in measurable X]setTI.
     by apply: measurable_fun_normr => //; exact: measurable_itv.


### PR DESCRIPTION
##### Motivation for this change

This PS is minor improvement.
It moves and generalizes a hint from `lebesgue_integral` to `lebesgue_measure` to shorten proofs a bit.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
~~- [ ] added corresponding documentation in the headers~~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
