### PR TITLE
fix definition of fin_num

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -41,6 +41,9 @@
   + remove one hypothesis in lemmas `reindex_esum`, `esum_image`
 - moved from `lebesgue_integral.v` to `lebesgue_measure.v` and generalized
   + hint `measurable_set1`/`emeasurable_set1`
+- in `ereal.v`:
+  + definition `fin_num` and accordingly lemmas `fin_numE`, `fin_numP`, `fin_numEn`,
+    `fin_numPn`
 
 ### Renamed
 

--- a/theories/esum.v
+++ b/theories/esum.v
@@ -142,7 +142,9 @@ move=> ag0 bg0; apply/eqP; rewrite eq_le; apply/andP; split.
   rewrite ub_ereal_sup//= => x [X XI] <-; rewrite big_split/=.
   by rewrite lee_add// ereal_sup_ub//=; exists X.
 wlog : a b ag0 bg0 / \esum_(i in I) a i \isn't a fin_num => [saoo|]; last first.
-  move=> /fin_numPn[->|/[dup] aoo ->]; first by rewrite /adde/= lee_ninfty.
+  move=> /fin_numPn/eqP.
+  rewrite eqe_absl lee_pinfty andbT=> /orP[/eqP/[dup] aoo->|/eqP->]; last first.
+    by rewrite /adde/= lee_ninfty.
   rewrite (@le_trans _ _ +oo)//; first by rewrite /adde/=; case: esum.
   rewrite lee_pinfty_eq; apply/eqP/eq_infty => y; rewrite esum_ge//.
   have : y%:E < \esum_(i in I) a i by rewrite aoo// lte_pinfty.
@@ -154,11 +156,12 @@ case: (boolP (\esum_(i in I) b i \is a fin_num)) => sb; last first.
   by rewrite addeC (eq_esum (fun _ _ => addeC _ _)) saoo.
 rewrite -lee_subr_addr// ub_ereal_sup//= => _ [X XI] <-.
 have saX : \sum_(i <- X) a i \is a fin_num.
-  apply: contraTT sa => /fin_numPn[] sa.
+  apply: contraTT sa => /fin_numPn/eqP; rewrite eqe_absl lee_pinfty andbT.
+  move=> /orP[] /eqP sa; last first.
     suff : \sum_(i <- X) a i >= 0 by rewrite sa.
     by rewrite big_seq_cond sume_ge0 => // i; rewrite ?andbT => /XI/ag0.
-  apply/fin_numPn; right; apply/eqP; rewrite -lee_pinfty_eq esum_ge//.
-  by exists X; rewrite // sa.
+  apply/fin_numPn/eqP; rewrite eqe_absl lee_pinfty andbT; apply/orP; left.
+  by rewrite -lee_pinfty_eq esum_ge//; exists X; rewrite // sa.
 rewrite lee_subr_addr// addeC -lee_subr_addr// ub_ereal_sup//= => _ [Y YI] <-.
 rewrite lee_subr_addr// addeC esum_ge//; exists (X `|` Y)%fset.
   by move=> i/=; rewrite inE => /orP[/XI|/YI].

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -1435,8 +1435,7 @@ Lemma cvg_approx x (f0 : forall x, D x -> (0 <= f x)%E) : D x ->
   (f x < +oo)%E -> (approx^~ x) --> fine (f x).
 Proof.
 move=> Dx fxoo; have fxfin : f x \is a fin_num.
-  rewrite fin_numE; apply/andP; split; last by rewrite lt_eqF.
-  by rewrite gt_eqF // (lt_le_trans _ (f0 _ Dx)) // lte_ninfty.
+  by rewrite fin_numElt fxoo andbT (lt_le_trans _ (f0 _ Dx)).
 apply/(@cvg_distP _ [normedModType R of R^o]) => _/posnumP[e].
 rewrite near_map.
 have [fx0|fx0] := eqVneq (f x) 0%E.
@@ -1663,7 +1662,7 @@ have := gh1 t.
 have := lee_pinfty (h1 t); rewrite le_eqVlt => /predU1P[->|ftoo].
   by rewrite lee_pinfty.
 have h1tfin : h1 t \is a fin_num.
-  by rewrite fin_numE gt_eqF/= ?lt_eqF// (lt_le_trans _ (h10 t))// lte_ninfty.
+  by rewrite fin_numElt ftoo andbT (lt_le_trans _ (h10 t)).
 have := gh1 t.
 rewrite -(fineK h1tfin) => /ereal_cvg_real[ft_near].
 set u_ := (X in X --> _) => u_h1 g1h1.
@@ -2153,8 +2152,9 @@ Proof.
 have [f_fin _|] := boolP (\int_ D (f^\- x) 'd mu[x] \is a fin_num).
   rewrite integralE// [in RHS]integralE// oppeD ?fin_numN// oppeK addeC.
   by rewrite funennpN.
-rewrite fin_numE negb_and 2!negbK => /orP[nfoo|/eqP nfoo].
-  exfalso; move/negP : nfoo; apply; rewrite -lee_ninfty_eq; apply/negP.
+rewrite fin_numE negbK eqe_absl lee_pinfty andbT => /orP[|]/eqP nfoo; last first.
+  exfalso; move: nfoo; apply/eqP.
+  rewrite -lee_ninfty_eq.
   by rewrite -ltNge (lt_le_trans _ (integral_ge0 _ _))// ?lte_ninfty.
 rewrite nfoo adde_defEninfty.
 rewrite -lee_pinfty_eq -ltNge lte_pinfty_eq => /orP[f_fin|/eqP pfoo].
@@ -2480,8 +2480,7 @@ have [ET|ET] := eqVneq E setT.
   by rewrite funeqE => t; rewrite /= foo.
 suff: mu E = 0.
   move=> muE0; exists E; split => // t /= /not_implyP[Dt ftfin]; split => //.
-  apply/eqP; rewrite eqe_absl lee_pinfty andbT.
-  by move/negP : ftfin; rewrite fin_numE negb_and 2!negbK orbC.
+  by move: ftfin; rewrite fin_numE => /negP; rewrite negbK => /eqP.
 have [->|/set0P E0] := eqVneq E set0; first by rewrite measure0.
 have [M M0 muM] : exists2 M, (0 <= M)%R &
                     (forall n, n%:R%:E * mu (E `&` D) <= M%:E).
@@ -2852,8 +2851,7 @@ move=> mf; split=> [iDf0|Df0].
       have [ftoo|ftoo] := eqVneq `|f t| +oo%E.
         by exists 0%N => //; split => //=; rewrite ftoo /= lee_pinfty.
       pose m := `|ceil (fine `|f t|)^-1|%N.
-      have ftfin : `|f t|%E \is a fin_num.
-        by rewrite fin_numE gt_eqF //= (lt_le_trans _ (abse_ge0 _))// lte_ninfty.
+      have ftfin : `|f t|%E \is a fin_num by rewrite fin_numE abse_id.
       exists m => //; split => //=.
       rewrite -(@fineK _ `|f t|) // lee_fin -ler_pinv; last 2 first.
         - rewrite inE unitfE fine_eq0 // abse_eq0 ft0/=; apply/lt0R.
@@ -2893,9 +2891,7 @@ have -> : (fun x => `|f x|) = (fun x => lim (f_^~ x)).
     rewrite natr_absz ger0_norm ?ceil_ge ?ceil_ge0//.
     by rewrite (lt_le_trans _ (ceil_ge _))// ltr_addr.
   have fxn : `|f x| <= n%:R%:E.
-    rewrite -(@fineK _ `|f x|); last first.
-      rewrite fin_numE fxoo andbT gt_eqF//.
-      by rewrite (lt_le_trans _ (abse_ge0 _))// ?lte_ninfty.
+    rewrite -(@fineK _ `|f x|); last by rewrite fin_numE abse_id.
     rewrite lee_fin.
     near: n.
     exists `|ceil (fine (`|f x|))|%N => // n /=.

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -2015,10 +2015,8 @@ Lemma measureD A B : measurable A -> measurable B ->
   mu A < +oo -> mu (A `\` B) = mu A - mu (A `&` B).
 Proof.
 move=> mA mB mAoo.
-rewrite (measureDI mA mB) addeK// fin_numE 1?gt_eqF 1?lt_eqF//.
-- rewrite (le_lt_trans _ mAoo)// le_measure // ?inE//.
-  + exact: measurableI.
-- by rewrite (lt_le_trans _ (measure_ge0 _ _))// ?lte_ninfty.
+rewrite (measureDI mA mB) addeK// fin_numE gee0_abs// lt_eqF//.
+by rewrite (le_lt_trans _ mAoo)// le_measure// ?inE//; exact: measurableI.
 Qed.
 
 End measureD.

--- a/theories/sequences.v
+++ b/theories/sequences.v
@@ -1418,7 +1418,8 @@ have [{lnoo}loo|lpoo] := eqVneq l +oo.
     have [e1|e1] := ltrP 1 e%:num.
       by rewrite ler_subl_addr (le_trans (ltW e2)).
     by rewrite ler_subl_addr ler_addl.
-have l_fin_num : l \is a fin_num by rewrite fin_numE lpoo lnoo.
+have l_fin_num : l \is a fin_num.
+  by rewrite fin_numE eqe_absl (negbTE lnoo) (negbTE lpoo).
 have [le1|le1] := (ltrP (`|contract l - e%:num|) 1)%R; last first.
   rewrite near_map; near=> n; rewrite /ball /= /ereal_ball /=.
   have unoo : u_ n != -oo.


### PR DESCRIPTION
##### Motivation for this change

It seems a bit more natural to define `fin_num` using `abse`.
This PR shows that this change impacts the proofs rather positively.
This is however a minor improvement.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
~~- [ ] added corresponding documentation in the headers~~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
