### PR TITLE
remove code now available in mathcomp

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -50,6 +50,10 @@
 
 ### Removed
 
+- in `mathcomp_extra.v`:
+  + lemmas `natr_absz`, `ge_pinfty`, `le_ninfty`, `gt_pinfty`,
+    `lt_ninfty`
+
 ### Infrastructure
 
 ### Misc

--- a/theories/mathcomp_extra.v
+++ b/theories/mathcomp_extra.v
@@ -226,25 +226,6 @@ Local Open Scope order_scope.
 Local Open Scope ring_scope.
 Import GRing.Theory Order.TTheory.
 
-(* NB: in MathComp 1.13.0 *)
-Lemma natr_absz (R : numDomainType) i : `|i|%:R = `|i|%:~R :> R.
-Proof. by rewrite -abszE. Qed.
-
-Lemma ge_pinfty (R : numDomainType) (x : itv_bound R) :
-  (+oo <= x)%O = (x == +oo)%O.
-Proof. by move: x => [[]|[]]. Qed.
-
-Lemma le_ninfty (R : numDomainType) (x : itv_bound R) :
-  (x <= -oo)%O = (x == -oo%O).
-Proof. by case: x => // -[]. Qed.
-
-Lemma gt_pinfty (R : numDomainType) (x : itv_bound R) : (+oo%O < x)%O = false.
-Proof. by case: x. Qed.
-
-Lemma lt_ninfty (R : numDomainType) (x : itv_bound R) : (x < -oo%O)%O = false.
-Proof. by case: x => // -[]. Qed.
-(* /NB: in MathComp 1.13.0 *)
-
 Lemma mulr_ge0_gt0 (R : numDomainType) (x y : R) : 0 <= x -> 0 <= y ->
   (0 < x * y) = (0 < x) && (0 < y).
 Proof.


### PR DESCRIPTION
##### Motivation for this change

This should be ok to remove these lemmas now that we do not support MathComp 1.12 anymore.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
~~- [ ] added corresponding documentation in the headers~~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
