### PR TITLE
Countable additivity

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -79,6 +79,7 @@
   + lemmas `integrable_neg_fin_num`, `integrable_pos_fin_num`
   + lemma `integral_measure_series`
   + lemmas `counting_dirac`, `summable_integral_dirac`, `integral_count`
+  + lemmas `integrable_abse`, `integrable_summable`, `integral_bigcup`
 
 ### Changed
 


### PR DESCRIPTION
##### Motivation for this change

countable additivity for integrable functions

~~depends on countable additivity for non-negative functions (based on PR #574) and~~ MERGED
assumes PR #628 using admitteds to avoid branches of branches, hence the draft status

fyi: @hoheinzollern @t6s 

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
  (do not edit former entries, only append new ones, be careful:
   merge and rebase have a tendency to mess up `CHANGELOG_UNRELEASED.md`)
- [x] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
