### PR TITLE
remove company-coq-local-symbols

### DIFF
--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -1,4 +1,3 @@
-(* -*- company-coq-local-symbols: (("`&`" . ?∩) ("`|`" . ?∪) ("set0" . ?∅)); -*- *)
 (* mathcomp analysis (c) 2017 Inria and AIST. License: CeCILL-C.              *)
 From mathcomp Require Import all_ssreflect ssralg ssrnum ssrint interval.
 From mathcomp Require Import finmap fingroup perm rat.

--- a/theories/set_interval.v
+++ b/theories/set_interval.v
@@ -1,4 +1,3 @@
-(* -*- company-coq-local-symbols: (("`&`" . ?∩) ("`|`" . ?∪) ("set0" . ?∅)); -*- *)
 (* mathcomp analysis (c) 2017 Inria and AIST. License: CeCILL-C.              *)
 From mathcomp Require Import all_ssreflect ssralg ssrnum ssrint interval.
 From mathcomp Require Import finmap fingroup perm rat.


### PR DESCRIPTION
##### Motivation for this change

- they are redundant with `.dir-locals.el`
- there are still a few symbols defined in
  `lebesgue_integral.v` but they might disappear
  with an anticipated change of ASCII notation
  (see PR #644 )

Note that the few symbols left in `.dir-locals.el` correspond
to ASCII notations that should not be immediately followed by
characters, so that they should be rendered consistently with
emacs+company-coq and can be ignored otherwise.

##### Things done/to do

<!-- please fill in the following checklist -->
~~- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`~~
~~- [ ] added corresponding documentation in the headers~~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
