### PR TITLE
preimage10 turned into an equivalence

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -22,6 +22,8 @@
   + lemma `integrableMr`
 - in `ereal.v`:
   + lemmas `muleCA`, `muleAC`, `muleACA`
+- in `classical_sets.v`:
+  + lemma `preimage10P`
 
 ### Changed
 

--- a/theories/classical_sets.v
+++ b/theories/classical_sets.v
@@ -1305,8 +1305,14 @@ Lemma preimage0 {T R} {f : T -> R} {A : set R} :
   A `&` range f `<=` set0 -> f @^-1` A = set0.
 Proof. by rewrite -subset0 => + x /= Afx => /(_ (f x))[]; split. Qed.
 
+Lemma preimage10P {T R} {f : T -> R} {x} : ~ range f x <-> f @^-1` [set x] = set0.
+Proof.
+split => [fx|]; first by rewrite preimage0// => ? [->].
+by apply: contraPnot => -[t _ <-] /seteqP[+ _] => /(_ t) /=.
+Qed.
+
 Lemma preimage10 {T R} {f : T -> R} {x} : ~ range f x -> f @^-1` [set x] = set0.
-Proof. by move=> fx; rewrite preimage0// => y [->]. Qed.
+Proof. by move/preimage10P. Qed.
 
 End image_lemmas.
 Arguments sub_image_setI {aT rT f A B} t _.

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -460,8 +460,8 @@ Proof. by rewrite -(image_comp f g) fset_set_image. Qed.
 Lemma preimage_nnfun0 T (R : realDomainType) (f : {nnfun T >-> R}) t :
   t < 0 -> f @^-1` [set t] = set0.
 Proof.
-move=> t0; rewrite preimage10//= => -[x _].
-by apply: contraPnot t0 => <-; rewrite le_gtF.
+move=> t0.
+by apply/preimage10 => -[x _]; apply: contraPnot t0 => <-; rewrite le_gtF.
 Qed.
 
 Lemma preimage_cstM T (R : realFieldType) (x y : R) (f : T -> R) :
@@ -684,7 +684,7 @@ Lemma sintegralE f :
   sintegral mu f = \sum_(x \in range f) x%:E * mu (f @^-1` [set x]).
 Proof.
 rewrite (fsbig_widen (range f) setT)//= => x [_ Nfx] /=.
-by rewrite preimage10 ?measure0 ?mule0.
+by rewrite preimage10// measure0 mule0.
 Qed.
 
 Lemma sintegral0 : sintegral mu (cst 0%R) = 0.
@@ -720,7 +720,7 @@ Qed.
 End sintegral_lemmas.
 
 Lemma eq_sintegral d (T : measurableType d) (R : numDomainType)
-   (mu : set T -> \bar R) g f :
+     (mu : set T -> \bar R) g f :
    f =1 g -> sintegral mu f = sintegral mu g.
 Proof. by move=> /funext->. Qed.
 Arguments eq_sintegral {d T R mu} g.


### PR DESCRIPTION
##### Motivation for this change

just observing the `preimage10` can be an equivalence

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
~~- [ ] added corresponding documentation in the headers~~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
