### PR TITLE
Arzela final

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -4,7 +4,24 @@
 
 ### Added
 
+- in `topology.v`:
+  + definition `powerset_filter_from`
+  + globals `powerset_filter_from_filter`, 
+  + lemmas `near_small_set`, `small_set_sub`, `near_powerset_filter_fromP`
+  + lemmas `withinET`, `closureEcvg`, `entourage_sym`, `fam_nbhs`
+  + definition `near_covering`
+  + lemma `compact_near_coveringP`
+  + lemma `continuous_localP`, `equicontinuous_subset_id`
+  + lemmas `ptws_cvg_entourage`, `equicontinuous_closure`, `ptws_compact_cvg`
+    `ptws_compact_closed`, `ascoli_forward`
+  + lemmas `precompact_pointwise_precompact`, `precompact_equicontinuous`,
+    `ascoli_theorem`
+
 ### Changed
+
+- in `topology.v`:
+  + generalize `cluster_cvgE`, `fam_cvgE`, `ptws_cvg_compact_family`
+  + rewrite `equicontinuous` and `pointwise_precompact` to use index 
 
 ### Renamed
 


### PR DESCRIPTION
##### Motivation for this change
Final part of arzela ascoli. This finishes the reverse direction, and phrases the full version for locally compact domains. I also slightly changed the phrasing of `ptws_compact_cvg` so you only have to prove that there is _some_ equicontinuous set in F.

This also cleans up the `near_compact_covering` interface.
- Simplify the previous property to use only one predicate (no loss of generality)
- Introduce a property `near_covering` which says a set has the nice property
- Prove that this is equivalent to compactness

In a separate change, it would be nice to prove R (and C) are locally compact. so ascoli's theorem is actually applicable.

One small detail is that `compact_equicontinuous` is a necessary step to prove `precompact_equicontinuous`. But the latter is strictly stronger. Perhaps this could be compressed into a single proof with a WLOG to split the cases?

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
  (do not edit former entries, only append new ones, be careful:
   merge and rebase have a tendency to mess up `CHANGELOG_UNRELEASED.md`)
- [x] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
