### PR TITLE
Discrete topology

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -16,6 +16,19 @@
     `ptws_compact_closed`, `ascoli_forward`
   + lemmas `precompact_pointwise_precompact`, `precompact_equicontinuous`,
     `ascoli_theorem`
+- in file `classical_sets.v`
+  + lemma `set_bool`
+- in file `topology.v`:
+  + definition `principal_filter` `discrete_space`
+  + lemma `principal_filterP`, `principal_filter_proper`, 
+      `principa;_filter_ultra`
+  + canonical `bool_discrete_filter`
+  + lemma `compactU`
+  + lemma `discrete_sing`, `discrete_nbhs`, `discrete_open`, `discrete_set1`,
+      `discrete_closed`, `discrete_cvg`, `discrete_hausdorff`
+  + canonical `bool_discrete_topology`
+  + definition `discrete_topological_mixin`
+  + lemma `discrete_bool`, `bool_compact`
 
 ### Changed
 

--- a/theories/classical_sets.v
+++ b/theories/classical_sets.v
@@ -1042,6 +1042,9 @@ Proof. by move=> k; apply/val_inj. Qed.
 
 End InitialSegment.
 
+Lemma set_bool : [set: bool] = [set true; false].
+Proof. by rewrite eqEsubset; split => // [[]] // _; [left|right]. Qed.
+
 (* TODO: other lemmas that relate fset and classical sets *)
 Lemma fdisjoint_cset (T : choiceType) (A B : {fset T}) :
   [disjoint A & B]%fset = [disjoint [set` A] & [set` B]].

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -2839,7 +2839,7 @@ Proof.
 rewrite eqEsubset; split.
   by rewrite closureE; apply: smallest_sub => // ? /ltW.
 move=> v; rewrite /mkset le_eqVlt => /predU1P[<-{v}|]; last first.
-  exact: subset_closure.
+  move=> ?; exact: subset_closure.
 apply/subset_limit_point/limit_pointP; exists (fun n => z + n.+1%:R^-1); split.
 - by move=> _ [] m _ <-; rewrite ltr_addl.
 - by move=> n; rewrite -subr_eq0 addrAC subrr add0r.
@@ -2853,7 +2853,7 @@ Proof.
 rewrite eqEsubset; split.
   by rewrite closureE; apply: smallest_sub => // ? /ltW.
 move=> v; rewrite /mkset le_eqVlt => /predU1P[<-{z}|]; last first.
-  exact: subset_closure.
+  by move=> ?; exact: subset_closure.
 apply/subset_limit_point/limit_pointP; exists (fun n => v - n.+1%:R^-1); split.
 - by move=> _ [] m _ <-; rewrite ltr_subl_addl ltr_addr.
 - by move=> n; rewrite -subr_eq0 addrAC subrr add0r oppr_eq0.

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -2839,7 +2839,7 @@ Proof.
 rewrite eqEsubset; split.
   by rewrite closureE; apply: smallest_sub => // ? /ltW.
 move=> v; rewrite /mkset le_eqVlt => /predU1P[<-{v}|]; last first.
-  move=> ?; exact: subset_closure.
+  by move=> ?; exact: subset_closure.
 apply/subset_limit_point/limit_pointP; exists (fun n => z + n.+1%:R^-1); split.
 - by move=> _ [] m _ <-; rewrite ltr_addl.
 - by move=> n; rewrite -subr_eq0 addrAC subrr add0r.


### PR DESCRIPTION
##### Motivation for this change
While working on the cantor space stuff, I found an need for facts about the discrete topology. In particular, `bool` should be canonically equipped with the discrete topology, so things like `product of hausdorff is hausdorff` and tychonoff apply. I added a condition, analogous to the existing separation axioms, called `discrete_space` which says all the neighborhoods are the principle filters. Even though there is only one discrete topology in practice, this approach seems the most flexible.

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
  (do not edit former entries, only append new ones, be careful:
   merge and rebase have a tendency to mess up `CHANGELOG_UNRELEASED.md`)
- [x] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
