### PR TITLE
Function instances for iter

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -3,6 +3,12 @@
 ## [Unreleased]
 
 ### Added
+- in file `boolp.v`:
+  + lemmas `iter_compl`, `iter_compr`, `iter0`
+- in file `functions.v`:
+  + lemmas `oinv_iter`, `some_iter_inv`, `inv_iter`,
+  + Instances for functions interfaces for `iter` (partial inverse up to 
+      bijective function) 
 
 - in `ereal.v`:
   + notations `_ < _ :> _` and `_ <= _ :> _`

--- a/theories/boolp.v
+++ b/theories/boolp.v
@@ -779,3 +779,13 @@ Proof. by []. Qed.
 Lemma joinfE (aT : Type) d (T : latticeType d) (f g : aT -> T) x :
   ((f `|` g) x = f x `|` g x)%O.
 Proof. by []. Qed.
+
+Lemma iterfS {T} (f : T -> T) (n : nat) : iter n.+1 f = f \o iter n f.
+Proof. by []. Qed.
+
+Lemma iterfSr {T} (f : T -> T) (n : nat) : iter n.+1 f = iter n f \o f.
+Proof. by apply/funeqP => ?; rewrite iterSr. Qed.
+
+Lemma iter0 {T} (f : T -> T) : iter 0 f = id.
+Proof. by []. Qed.
+

--- a/theories/functions.v
+++ b/theories/functions.v
@@ -1167,7 +1167,7 @@ Proof.
 split; first exact: funS.
 elim: n=> // n IH; rewrite oinv_iter iterfSr iterfS.
 apply: (@ocan_in_comp _ _ _ (mem A)) => //; last exact: oinvK.
-elim: n {IH} => // n IH x Ax; move: (IH _ Ax); rewrite pred_omap_set ?inE.
+elim: n {IH} => // n IH x Ax; move: (IH _ Ax); rewrite pred_oapp_set ?inE.
 case=> y Ay /= ynf; case: (@oinvS _ _ _ _ f _ Ay) => z ? zfinv; exists z => //.
 by rewrite zfinv /= -ynf.
 Qed.

--- a/theories/functions.v
+++ b/theories/functions.v
@@ -1113,6 +1113,75 @@ Qed.
 HB.instance Definition _ T A := @Can2.Build T T A A idfun idfun
    (fun x y => y) (fun x y => y) (fun _ _ => erefl) (fun _ _ => erefl).
 
+(**********************************************************)
+(* Iteration preserves Fun, Injectivity, and Surjectivity *)
+(**********************************************************)
+Section iter_inv.
+
+Context {aT} {A : set aT}.
+
+Local Lemma iter_fun_subproof n (f : {fun A >-> A}) : IsFun _ _ A A (iter n f).
+Proof. 
+split => x; elim: n => // n /[apply] ?; apply/(fun_image_sub f).
+by exists (iter n f x).
+Qed.
+
+HB.instance Definition _ n f := iter_fun_subproof n f.
+
+Section OInv.
+Context {f : {oinv aT >-> aT}}.
+HB.instance Definition _ n := OInv.Build _ _ (iter n f) 
+  (iter n (obind 'oinv_f) \o some).
+Lemma oinv_iter n : 'oinv_(iter n f) = iter n (obind 'oinv_f) \o some.
+Proof. by []. Qed.
+End OInv.
+
+Section OInv.
+Context {f : {inv aT >-> aT}}.
+Lemma some_iter_inv n : olift (iter n f^-1) = 'oinv_(iter n f).
+Proof.
+elim: n => // n IH; rewrite iterfSr olift_comp IH ?oinv_iter -compA.
+rewrite (_ : Some \o f^-1 = 'oinv_f); first by rewrite iterfSr; congr (_ \o _).
+by apply/funeqP => ? /=; rewrite some_inv.
+Qed.
+HB.instance Definition _ n := OInv_Inv.Build _ _ (iter n f) (some_iter_inv n).
+Lemma inv_iter n : (iter n f)^-1 = iter n f^-1. Proof. by []. Qed.
+End OInv.
+
+Lemma iter_can_subproof n (f : {injfun A >-> A}) : OInv_Can aT aT A (iter n f).
+Proof. 
+split=> x Ax; rewrite oinv_iter /=; elim: n=> // n IH.
+rewrite iterfSr /= funoK //; exact: mem_fun. 
+Qed.
+
+HB.instance Definition _ f g := iter_can_subproof f g.
+HB.instance Definition _ n (f : {injfun A >-> A}) := Inject.on (iter n f).
+HB.instance Definition _ n (f : {splitinjfun A >-> A}) := Inject.on (iter n f).
+End iter_inv.
+
+Section iter_surj.
+Context {aT} {A : set aT}.
+
+Lemma iter_surj_subproof n (f : {surj A >-> A}) : OInv_CanV _ _ A A (iter n f).
+Proof.
+split; first exact: funS.
+elim: n=> // n IH; rewrite oinv_iter iterfSr iterfS.
+apply: (@ocan_in_comp _ _ _ (mem A)) => //; last exact: oinvK.
+elim: n {IH} => // n IH x Ax; move: (IH _ Ax); rewrite pred_omap_set ?inE.
+case=> y Ay /= ynf; case: (@oinvS _ _ _ _ f _ Ay) => z ? zfinv; exists z => //.
+by rewrite zfinv /= -ynf.
+Qed.
+
+HB.instance Definition _ n f := iter_surj_subproof n f.
+HB.instance Definition _ n (f : {splitsurj A >-> A}) := Surject.on (iter n f).
+HB.instance Definition _ n (f : {surjfun A >-> A}) := Surject.on (iter n f).
+HB.instance Definition _ n (f : {splitsurjfun A >-> A}) :=
+  Surject.on (iter n f).
+HB.instance Definition _ n (f : {bij A >-> A}) := Surject.on (iter n f).
+HB.instance Definition _ n (f : {splitbij A >-> A}) := Surject.on (iter n f).
+
+End iter_surj.
+
 (**********)
 (* Unbind *)
 (**********)


### PR DESCRIPTION
##### Motivation for this change
The banach fixed point theorem change included some proofs about `iter`. Rather than handling them ad-hoc, it's more useful to plug in to the existing infrastructure from `functions.v`. So this follows the pattern of composition proofs, and adds instances for `OCan`, `Inv`, and `Oinv_Can`. The proofs go as you might expect: some induction, and some applications of the composition facts. 

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
  (do not edit former entries, only append new ones, be careful:
   merge and rebase have a tendency to mess up `CHANGELOG_UNRELEASED.md`)
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
