### PR TITLE
Comments to remember stuff backported to MC

### DIFF
--- a/theories/classical_sets.v
+++ b/theories/classical_sets.v
@@ -975,17 +975,17 @@ Lemma bigcupM1r T1 T2 (A1 : T2 -> set T1) (A2 : set T2) :
   \bigcup_(i in A2) (A1 i `*` [set i]) = A1 ``*` A2.
 Proof. by apply/predeqP => -[i j]; split=> [[? ? [? /= -> //]]|[]]; exists j. Qed.
 
-Lemma pred_omapE (D : {pred T}) : pred_omap D = mem (some @` D).
+Lemma pred_oappE (D : {pred T}) : pred_oapp D = mem (some @` D).
 Proof.
-apply/funext=> -[x|]/=; apply/idP/idP; rewrite /pred_omap/= inE //=.
+apply/funext=> -[x|]/=; apply/idP/idP; rewrite /pred_oapp/= inE //=.
 - by move=> xD; exists x.
 - by move=> [// + + [<-]].
 - by case.
 Qed.
 
-Lemma pred_omap_set (D : set T) : pred_omap (mem D) = mem (some @` D).
+Lemma pred_oapp_set (D : set T) : pred_oapp (mem D) = mem (some @` D).
 Proof.
-by rewrite pred_omapE; apply/funext => x/=; apply/idP/idP; rewrite ?inE;
+by rewrite pred_oappE; apply/funext => x/=; apply/idP/idP; rewrite ?inE;
    move=> [y/= ]; rewrite ?in_setE; exists y; rewrite ?in_setE.
 Qed.
 

--- a/theories/functions.v
+++ b/theories/functions.v
@@ -686,7 +686,7 @@ Lemma comp_surj_subproof (f : {surj A >-> B}) (g : {surj B >-> C}) :
 Proof.
 split; first exact: funS.
 apply: (@ocan_in_comp _ _ _ (mem B)) oinvK oinvK.
-by move=> ? /set_mem; rewrite pred_omap_set inE; apply: funS.
+by move=> ? /set_mem; rewrite pred_oapp_set inE; apply: funS.
 Qed.
 
 HB.instance Definition _ f g := comp_surj_subproof f g.

--- a/theories/mathcomp_extra.v
+++ b/theories/mathcomp_extra.v
@@ -2,9 +2,14 @@
 From mathcomp Require choice.
 (* Missing coercion (done before Import to avoid redeclaration error,
    thanks to KS for the trick) *)
+(* MathComp 1.15 addition *)
 Coercion choice.Choice.mixin : choice.Choice.class_of >-> choice.Choice.mixin_of.
 From mathcomp Require Import all_ssreflect finmap ssralg ssrnum ssrint rat.
 From mathcomp Require Import finset interval.
+
+(***************************)
+(* MathComp 1.15 additions *)
+(***************************)
 
 (******************************************************************************)
 (* This files contains lemmas and definitions missing from MathComp.          *)
@@ -40,7 +45,7 @@ Qed.
 Lemma enum_ord0 : enum 'I_0 = [::].
 Proof. by apply/eqP; rewrite -size_eq0 size_enum_ord. Qed.
 
-Lemma enum_ordS n : enum 'I_n.+1 =
+Lemma enum_ordSr n : enum 'I_n.+1 =
   rcons (map (widen_ord (leqnSn _)) (enum 'I_n)) ord_max.
 Proof.
 apply: (inj_map val_inj); rewrite val_enum_ord.
@@ -122,13 +127,13 @@ move=> fK hK c /=; rewrite -[RHS]hK/=; case hcE : (h c) => [b|]//=.
 by rewrite -[b in RHS]fK; case: (f b) => //=; have := hK c; rewrite hcE.
 Qed.
 
-Definition pred_omap T (D : {pred T}) : pred (option T) :=
+Definition pred_oapp T (D : {pred T}) : pred (option T) :=
   [pred x | oapp (mem D) false x].
 
 Lemma ocan_in_comp [A B C : Type] (D : {pred B}) (D' : {pred C})
     [f : B -> option A] [h : C -> option B]
     [f' : A -> B] [h' : B -> C] :
-  {homo h : x / x \in D' >-> x \in pred_omap D} ->
+  {homo h : x / x \in D' >-> x \in pred_oapp D} ->
   {in D, ocancel f f'} -> {in D', ocancel h h'} ->
   {in D', ocancel (obind f \o h) (h' \o f')}.
 Proof.
@@ -143,28 +148,9 @@ Proof. by move->. Qed.
 Lemma eqbRL (b1 b2 : bool) : b1 = b2 -> b2 -> b1.
 Proof. by move->. Qed.
 
-Lemma fset_nat_maximum (X : choiceType) (A : {fset X})
-    (f : X -> nat) : A != fset0 ->
-  (exists i, i \in A /\ forall j, j \in A -> f j <= f i)%nat.
-Proof.
-move=> /fset0Pn[x Ax].
-have [/= y _ /(_ _ isT) mf] := @arg_maxnP _ [` Ax]%fset xpredT (f \o val) isT.
-exists (val y); split; first exact: valP.
-by move=> z Az; have := mf [` Az]%fset.
-Qed.
-
-Lemma image_nat_maximum n (f : nat -> nat) :
-  (exists i, i <= n /\ forall j, j <= n -> f j <= f i)%N.
-Proof.
-have [i _ /(_ _ isT) mf] := @arg_maxnP _ (@ord0 n) xpredT f isT.
-by exists i; split; rewrite ?leq_ord// => j jn; have := mf (@Ordinal n.+1 j jn).
-Qed.
-
-Lemma card_fset_sum1 (T : choiceType) (A : {fset T}) : #|` A| = \sum_(i <- A) 1.
-Proof. by rewrite big_seq_fsetE/= sum1_card cardfE. Qed.
-
-Arguments big_rmcond {R idx op I r} P.
-Arguments big_rmcond_in {R idx op I r} P.
+(***************************)
+(* MathComp 1.15 additions *)
+(***************************)
 
 Definition opp_fun T (R : zmodType) (f : T -> R) x := (- f x)%R.
 Notation "\- f" := (opp_fun f) : ring_scope.
@@ -195,7 +181,7 @@ Notation ltLHS := (X in (X < _)%O)%pattern.
 Notation ltRHS := (X in (_ < X)%O)%pattern.
 Inductive boxed T := Box of T.
 
-Lemma eq_big_supp [R : eqType] [idx : R] [op : Monoid.law idx] [I : Type]
+Lemma eq_bigl_supp [R : eqType] [idx : R] [op : Monoid.law idx] [I : Type]
   [r : seq I] [P1 : pred I] (P2 : pred I) (F : I -> R) :
   {in [pred x | F x != idx], P1 =1 P2} ->
   \big[op/idx]_(i <- r | P1 i) F i = \big[op/idx]_(i <- r | P2 i) F i.
@@ -421,3 +407,33 @@ by symmetry; rewrite inE/= -predC_itvl -predC_itvr.
 Qed.
 
 End itv_porderType.
+
+(**********************************)
+(* End of MathComp 1.15 additions *)
+(**********************************)
+
+(* To be backported to finmap *)
+
+Lemma fset_nat_maximum (X : choiceType) (A : {fset X})
+    (f : X -> nat) : A != fset0 ->
+  (exists i, i \in A /\ forall j, j \in A -> f j <= f i)%nat.
+Proof.
+move=> /fset0Pn[x Ax].
+have [/= y _ /(_ _ isT) mf] := @arg_maxnP _ [` Ax]%fset xpredT (f \o val) isT.
+exists (val y); split; first exact: valP.
+by move=> z Az; have := mf [` Az]%fset.
+Qed.
+
+Lemma image_nat_maximum n (f : nat -> nat) :
+  (exists i, i <= n /\ forall j, j <= n -> f j <= f i)%N.
+Proof.
+have [i _ /(_ _ isT) mf] := @arg_maxnP _ (@ord0 n) xpredT f isT.
+by exists i; split; rewrite ?leq_ord// => j jn; have := mf (@Ordinal n.+1 j jn).
+Qed.
+
+Lemma card_fset_sum1 (T : choiceType) (A : {fset T}) :
+  #|` A| = (\sum_(i <- A) 1)%N.
+Proof. by rewrite big_seq_fsetE/= sum1_card cardfE. Qed.
+
+Arguments big_rmcond {R idx op I r} P.
+Arguments big_rmcond_in {R idx op I r} P.


### PR DESCRIPTION
This should ease cleaning of the `mathcomp_extra.v` file once we require MathComp >= 1.15.
