### PR TITLE
use set instead of fset in esum

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -38,6 +38,43 @@
 
 - in `measure.v`:
   + generalize `measurable_uncurry`
+  + generalize `pushforward`
+- in `lebesgue_integral.v`
+  + change `Arguments` of `eq_integrable`
+- in `lebesgue_integral.v`:
+  + fix pretty-printing of `{mfun _ >-> _}`, `{sfun _ >-> _}`, `{nnfun _ >-> _}`
+- in `lebesgue_integral.v`
+  + minor generalization of `eq_measure_integral`
+- from `topology.v` to `mathcomp_extra.v`:
+  + generalize `ltr_bigminr` to `porderType` and rename to `bigmin_lt`
+  + generalize `bigminr_ler` to `orderType` and rename to `bigmin_le`
+- moved out of module `Bigminr` in `normedtype.v` to `mathcomp_extra.v` and generalized to `orderType`:
+  + lemma `bigminr_ler_cond`, renamed to `bigmin_le_cond`
+- moved out of module `Bigminr` in `normedtype.v` to `mathcomp_extra.v`:
+  + lemma `bigminr_maxr`
+- moved from from module `Bigminr` in `normedtype.v`
+  + to `mathcomp_extra.v` and generalized to `orderType`
+    * `bigminr_mkcond` -> `bigmin_mkcond`
+    * `bigminr_split` -> `bigmin_split`
+    * `bigminr_idl` -> `bigmin_idl`
+    * `bigminrID` -> `bigminID`
+    * `bigminrD1` -> `bigminD1`
+    * `bigminr_inf` -> `bigmin_inf`
+    * `bigminr_gerP` -> `bigmin_geP`
+    * `bigminr_gtrP` -> ``bigmin_gtP``
+    * `bigminr_eq_arg` -> `bigmin_eq_arg`
+    * `eq_bigminr` -> `eq_bigmin`
+  + to `topology.v` and generalized to `orderType`
+    * `bigminr_lerP` -> `bigmin_leP`
+    * `bigminr_ltrP` -> `bigmin_ltP`
+- moved from `topology.v` to `mathcomp_extra.v`:
+  + `bigmax_lerP` -> `bigmax_leP`
+  + `bigmax_ltrP` -> `bigmax_ltP`
+  + `ler_bigmax_cond` -> `le_bigmax_cond`
+  + `ler_bigmax` -> `le_bigmax`
+  + `le_bigmax` -> `homo_le_bigmax`
+- in `esum.v`:
+  + definition `esum`
 
 ### Renamed
 
@@ -62,6 +99,14 @@
   + `nnfun_mulem_ge0` -> `nnsfun_mulemu_ge0`
 
 ### Removed
+
+- in `normedtype.v` (module `Bigminr`)
+  + `bigminr_ler_cond`, `bigminr_ler`.
+  + `bigminr_seq1`, `bigminr_pred1_eq`, `bigminr_pred1`
+- in `topology.v`:
+  + `bigmax_seq1`, `bigmax_pred1_eq`, `bigmax_pred1`
+- in `esum.v`:
+  + lemma `fsetsP`, `sum_fset_set`
 
 ### Infrastructure
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -33,64 +33,22 @@
   + lemma `measurable_funTS`
 - in `lebesgue_measure.v`:
   + lemma `measurable_fun_indic`
-  + lemma `big_const_idem`
-  + lemma `big_id_idem`
-  + lemma `big_rem_AC`
-  + lemma `bigD1_AC`
-  + lemma `big_mkcond_idem`
-  + lemma `big_split_idem`
-  + lemma `big_id_idem_AC`
-  + lemma `bigID_idem`
-- in `mathcomp_extra.v`:
-  + lemmas `bigmax_le` and `bigmax_lt`
-  + lemma `bigmin_idr`
-  + lemma `bigmax_idr`
-- in `classical_sets.v`:
-  + lemma `subset_refl`
 - in `fsbigop.v`:
-  + lemma `lee_fsum_nneg_subset`
+  + lemmas `lee_fsum_nneg_subset`, `lee_fsum`
+- in `classical_sets.v`:
+  + lemmas `subset_fst_set`, `subset_snd_set`, `fst_set_fst`, `snd_set_snd`,
+    `fset_setM`, `snd_setM`, `fst_setMR`
+  + lemmas `xsection_snd_set`, `ysection_fst_set`
 
 ### Changed
 
 - in `measure.v`:
   + generalize `measurable_uncurry`
-  + generalize `pushforward`
-- in `lebesgue_integral.v`
-  + change `Arguments` of `eq_integrable`
-- in `lebesgue_integral.v`:
-  + fix pretty-printing of `{mfun _ >-> _}`, `{sfun _ >-> _}`, `{nnfun _ >-> _}`
-- in `lebesgue_integral.v`
-  + minor generalization of `eq_measure_integral`
-- from `topology.v` to `mathcomp_extra.v`:
-  + generalize `ltr_bigminr` to `porderType` and rename to `bigmin_lt`
-  + generalize `bigminr_ler` to `orderType` and rename to `bigmin_le`
-- moved out of module `Bigminr` in `normedtype.v` to `mathcomp_extra.v` and generalized to `orderType`:
-  + lemma `bigminr_ler_cond`, renamed to `bigmin_le_cond`
-- moved out of module `Bigminr` in `normedtype.v` to `mathcomp_extra.v`:
-  + lemma `bigminr_maxr`
-- moved from from module `Bigminr` in `normedtype.v`
-  + to `mathcomp_extra.v` and generalized to `orderType`
-    * `bigminr_mkcond` -> `bigmin_mkcond`
-    * `bigminr_split` -> `bigmin_split`
-    * `bigminr_idl` -> `bigmin_idl`
-    * `bigminrID` -> `bigminID`
-    * `bigminrD1` -> `bigminD1`
-    * `bigminr_inf` -> `bigmin_inf`
-    * `bigminr_gerP` -> `bigmin_geP`
-    * `bigminr_gtrP` -> ``bigmin_gtP``
-    * `bigminr_eq_arg` -> `bigmin_eq_arg`
-    * `eq_bigminr` -> `eq_bigmin`
-  + to `topology.v` and generalized to `orderType`
-    * `bigminr_lerP` -> `bigmin_leP`
-    * `bigminr_ltrP` -> `bigmin_ltP`
-- moved from `topology.v` to `mathcomp_extra.v`:
-  + `bigmax_lerP` -> `bigmax_leP`
-  + `bigmax_ltrP` -> `bigmax_ltP`
-  + `ler_bigmax_cond` -> `le_bigmax_cond`
-  + `ler_bigmax` -> `le_bigmax`
-  + `le_bigmax` -> `homo_le_bigmax`
 - in `esum.v`:
   + definition `esum`
+- moved from `lebesgue_integral.v` to `classical_sets.v`:
+  + `mem_set_pair1` -> `mem_xsection`
+  + `mem_set_pair2` -> `mem_ysection`
 
 ### Renamed
 
@@ -113,14 +71,11 @@
   + `muleindic_ge0` -> `nnfun_muleindic_ge0`
   + `mulem_ge0` -> `mulemu_ge0`
   + `nnfun_mulem_ge0` -> `nnsfun_mulemu_ge0`
+- in `esum.v`:
+  + `esum0` -> `esum1`
 
 ### Removed
 
-- in `normedtype.v` (module `Bigminr`)
-  + `bigminr_ler_cond`, `bigminr_ler`.
-  + `bigminr_seq1`, `bigminr_pred1_eq`, `bigminr_pred1`
-- in `topology.v`:
-  + `bigmax_seq1`, `bigmax_pred1_eq`, `bigmax_pred1`
 - in `esum.v`:
   + lemma `fsetsP`, `sum_fset_set`
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -33,6 +33,22 @@
   + lemma `measurable_funTS`
 - in `lebesgue_measure.v`:
   + lemma `measurable_fun_indic`
+  + lemma `big_const_idem`
+  + lemma `big_id_idem`
+  + lemma `big_rem_AC`
+  + lemma `bigD1_AC`
+  + lemma `big_mkcond_idem`
+  + lemma `big_split_idem`
+  + lemma `big_id_idem_AC`
+  + lemma `bigID_idem`
+- in `mathcomp_extra.v`:
+  + lemmas `bigmax_le` and `bigmax_lt`
+  + lemma `bigmin_idr`
+  + lemma `bigmax_idr`
+- in `classical_sets.v`:
+  + lemma `subset_refl`
+- in `fsbigop.v`:
+  + lemma `lee_fsum_nneg_subset`
 
 ### Changed
 

--- a/theories/classical_sets.v
+++ b/theories/classical_sets.v
@@ -2907,6 +2907,31 @@ End Exports.
 End SetOrder.
 Export SetOrder.Exports.
 
+Section product.
+Variables (T1 T2 : Type).
+Implicit Type A B : set (T1 * T2).
+
+Lemma subset_fst_set : {homo @fst_set T1 T2 : A B / A `<=` B}.
+Proof. by move=> A B AB x [y Axy]; exists y; exact/AB. Qed.
+
+Lemma subset_snd_set : {homo @snd_set T1 T2 : A B / A `<=` B}.
+Proof. by move=> A B AB x [y Axy]; exists y; exact/AB. Qed.
+
+Lemma fst_set_fst A : A `<=` A.`1 \o fst. Proof. by move=> [x y]; exists y. Qed.
+
+Lemma snd_set_snd A: A `<=` A.`2 \o snd. Proof. by move=> [x y]; exists x. Qed.
+
+Lemma fst_setM (X : set T1) (Y : set T2) : (X `*` Y).`1 `<=` X.
+Proof. by move=> x [y [//]]. Qed.
+
+Lemma snd_setM (X : set T1) (Y : set T2) : (X `*` Y).`2 `<=` Y.
+Proof. by move=> x [y [//]]. Qed.
+
+Lemma fst_setMR (X : set T1) (Y : T1 -> set T2) : (X `*`` Y).`1 `<=` X.
+Proof. by move=> x [y [//]]. Qed.
+
+End product.
+
 Section section.
 Variables (T1 T2 : Type).
 Implicit Types (A : set (T1 * T2)) (x : T1) (y : T2).
@@ -2914,6 +2939,18 @@ Implicit Types (A : set (T1 * T2)) (x : T1) (y : T2).
 Definition xsection A x := [set y | (x, y) \in A].
 
 Definition ysection A y := [set x | (x, y) \in A].
+
+Lemma xsection_snd_set A x : xsection A x `<=` A.`2.
+Proof. by move=> y Axy; exists x; rewrite /xsection/= inE in Axy. Qed.
+
+Lemma ysection_fst_set A y : ysection A y `<=` A.`1.
+Proof. by move=> x Axy; exists y; rewrite /ysection/= inE in Axy. Qed.
+
+Lemma mem_xsection x y A : (y \in xsection A x) = ((x, y) \in A).
+Proof. by apply/idP/idP => [|]; [rewrite inE|rewrite /xsection !inE /= inE]. Qed.
+
+Lemma mem_ysection x y A : (x \in ysection A y) = ((x, y) \in A).
+Proof. by apply/idP/idP => [|]; [rewrite inE|rewrite /ysection !inE /= inE]. Qed.
 
 Lemma xsection0 x : xsection set0 x = set0.
 Proof. by rewrite predeqE /xsection => y; split => //=; rewrite inE. Qed.
@@ -2923,16 +2960,14 @@ Proof. by rewrite predeqE /ysection => x; split => //=; rewrite inE. Qed.
 
 Lemma in_xsectionM X1 X2 x : x \in X1 -> xsection (X1 `*` X2) x = X2.
 Proof.
-move=> xX1; rewrite /xsection predeqE => y /=; split; rewrite inE.
-  by move=> [].
-by move=> X2y; split => //=; rewrite inE in xX1.
+move=> xX1; apply/seteqP; split=> [y /xsection_snd_set|]; first exact: snd_setM.
+by move=> y X2y; rewrite /xsection/= inE; split=> //=; rewrite inE in xX1.
 Qed.
 
 Lemma in_ysectionM X1 X2 y : y \in X2 -> ysection (X1 `*` X2) y = X1.
 Proof.
-move=> yX2; rewrite /ysection predeqE => x /=; split; rewrite inE.
-  by move=> [].
-by move=> X1x; split => //=; rewrite inE in yX2.
+move=> yX2; apply/seteqP; split=> [x /ysection_fst_set|]; first exact: fst_setM.
+by move=> x X1x; rewrite /ysection/= inE; split=> //=; rewrite inE in yX2.
 Qed.
 
 Lemma notin_xsectionM X1 X2 x : x \notin X1 -> xsection (X1 `*` X2) x = set0.

--- a/theories/esum.v
+++ b/theories/esum.v
@@ -54,15 +54,15 @@ Section esum.
 Variables (R : realFieldType) (T : choiceType).
 Implicit Types (S : set T) (a : T -> \bar R).
 
-Definition esum S a := ereal_sup [set \sum_(x <- fset_set A) a x | A in fsets S].
+Definition esum S a := ereal_sup [set \sum_(x \in A) a x | A in fsets S].
 
 Local Notation "\esum_ ( i 'in' P ) A" := (esum P (fun i => A)).
 
 Lemma esum_set0 a : \esum_(i in set0) a i = 0.
 Proof.
 rewrite /esum fsets0 [X in ereal_sup X](_ : _ = [set 0%E]) ?ereal_sup1//.
-apply/seteqP; split=> [x [_ /= ->]|x]; first by rewrite fset_set0 big_seq_fset0.
-by move=> -> /=; exists set0 => //; rewrite fset_set0 big_seq_fset0.
+apply/seteqP; split=> [x [_ /= ->]|x]; first by rewrite fsbig_set0.
+by move=> -> /=; exists set0 => //; rewrite fsbig_set0.
 Qed.
 
 End esum.
@@ -77,33 +77,33 @@ Lemma esum_ge0 (S : set T) a :
   (forall x, S x -> 0 <= a x) -> 0 <= \esum_(i in S) a i.
 Proof.
 move=> a0; apply: ereal_sup_ub.
-by exists set0; [exact: fsets_set0|rewrite fset_set0 big_nil].
+by exists set0; [exact: fsets_set0|rewrite fsbig_set0].
 Qed.
 
 Lemma esum_fset (F : set T) a : finite_set F ->
     (forall i, i \in F -> 0 <= a i) ->
-  \esum_(i in F) a i = \sum_(i <- fset_set F) a i.
+  \esum_(i in F) a i = \sum_(i \in F) a i.
 Proof.
 move=> finF f0; apply/eqP; rewrite eq_le; apply/andP; split; last first.
   by apply ereal_sup_ub; exists F => //; exact: fsets_self.
-apply ub_ereal_sup => /= ? -[F' [finF' F'F] <-]; apply/lee_sum_nneg_subfset.
-  by apply/fsubsetP; rewrite -fset_set_sub.
-by move=> t; rewrite inE/= !in_fset_set// => /andP[_] /f0.
+apply ub_ereal_sup => /= ? -[F' [finF' F'F] <-].
+apply/lee_fsum_nneg_subset => //; first exact/subsetP.
+by  move=> t; rewrite inE/= => /andP[_] /f0.
 Qed.
 
 Lemma esum_set1 t a : 0 <= a t -> \esum_(i in [set t]) a i = a t.
 Proof.
-by move=> ?; rewrite esum_fset// ?fset_set1// ?big_seq_fset1// => t' /[!inE] ->.
+by move=> ?; rewrite esum_fset// ?fset_set1// ?fsbig_set1// => t' /[!inE] ->.
 Qed.
 
 Lemma fsbig_esum (A : set T) a : finite_set A -> (forall x, 0 <= a x) ->
   \sum_(x \in A) (a x) = \esum_(x in A) a x.
-Proof. by move=> *; rewrite fsbig_finite//= -esum_fset. Qed.
+Proof. by move=> *; rewrite esum_fset. Qed.
 
 End esum_realType.
 
 Lemma esum_ge [R : realType] [T : choiceType] (I : set T) (a : T -> \bar R) x :
-  (exists2 X : set T, fsets I X & x <= \sum_(i <- fset_set X) a i) ->
+  (exists2 X : set T, fsets I X & x <= \sum_(i \in X) a i) ->
   x <= \esum_(i in I) a i.
 Proof. by move=> [X IX /le_trans->//]; apply: ereal_sup_ub => /=; exists X. Qed.
 
@@ -112,8 +112,8 @@ Lemma esum0 [R : realFieldType] [I : choiceType] (D : set I) (a : I -> \bar R) :
 Proof.
 move=> a0; rewrite /esum (_ : [set _ | _ in _] = [set 0]) ?ereal_sup1//.
 apply/seteqP; split=> x //= => [[X [finX XI]] <-|->].
-  by rewrite big_seq big1// => i; rewrite in_fset_set// inE=> /XI/a0.
-by exists set0; rewrite ?fset_set0 ?big_seq_fset0//; exact: fsets_set0.
+  by rewrite fsbig1// => i /XI/a0.
+by exists set0; rewrite ?fsbig_set0//; exact: fsets_set0.
 Qed.
 
 Lemma le_esum [R : realType] [T : choiceType] (I : set T) (a b : T -> \bar R) :
@@ -121,8 +121,8 @@ Lemma le_esum [R : realType] [T : choiceType] (I : set T) (a b : T -> \bar R) :
   \esum_(i in I) a i <= \esum_(i in I) b i.
 Proof.
 move=> le_ab; rewrite ub_ereal_sup => //= _ [X [finX XI]] <-; rewrite esum_ge//.
-exists X => //; rewrite big_seq [x in _ <= x]big_seq lee_sum => // i.
-by rewrite in_fset_set// inE => /XI /le_ab.
+exists X => //; rewrite !fsbig_finite// big_seq [x in _ <= x]big_seq lee_sum //.
+by move=> i; rewrite in_fset_set// inE => /XI/le_ab.
 Qed.
 
 Lemma eq_esum [R : realType] [T : choiceType] (I : set T) (a b : T -> \bar R) :
@@ -135,7 +135,7 @@ Lemma esumD [R : realType] [T : choiceType] (I : set T) (a b : T -> \bar R) :
   \esum_(i in I) (a i + b i) = \esum_(i in I) a i + \esum_(i in I) b i.
 Proof.
 move=> ag0 bg0; apply/eqP; rewrite eq_le; apply/andP; split.
-  rewrite ub_ereal_sup//= => x [X XI] <-; rewrite big_split/=.
+  rewrite ub_ereal_sup//= => x [X [finX XI]] <-; rewrite fsbig_split//=.
   by rewrite lee_add// ereal_sup_ub//=; exists X.
 wlog : a b ag0 bg0 / \esum_(i in I) a i \isn't a fin_num => [saoo|]; last first.
   move=> /fin_numPn[->|/[dup] aoo ->]; first by rewrite leNye.
@@ -143,28 +143,26 @@ wlog : a b ag0 bg0 / \esum_(i in I) a i \isn't a fin_num => [saoo|]; last first.
   rewrite leye_eq; apply/eqP/eq_infty => y; rewrite esum_ge//.
   have : y%:E < \esum_(i in I) a i by rewrite aoo// ltey.
   move=> /ereal_sup_gt[_ [X [finX XI]] <-] /ltW yle; exists X => //=.
-  rewrite (le_trans yle)// big_split lee_addl// big_seq sume_ge0 => // i.
-  by rewrite in_fset_set// inE => /XI; exact: bg0.
+  rewrite (le_trans yle)// fsbig_split// lee_addl// fsume_ge0// => // i.
+  by move=> /XI; exact: bg0.
 case: (boolP (\esum_(i in I) a i \is a fin_num)) => sa; last exact: saoo.
 case: (boolP (\esum_(i in I) b i \is a fin_num)) => sb; last first.
   by rewrite addeC (eq_esum (fun _ _ => addeC _ _)) saoo.
 rewrite -lee_subr_addr// ub_ereal_sup//= => _ [X [finX XI]] <-.
-have saX : \sum_(i <- fset_set X) a i \is a fin_num.
+have saX : \sum_(i \in X) a i \is a fin_num.
   apply: contraTT sa => /fin_numPn[] sa.
-    suff : \sum_(i <- fset_set X) a i >= 0 by rewrite sa.
-    by rewrite big_seq sume_ge0// => t; rewrite in_fset_set// inE => /XI/ag0.
+    suff : \sum_(i \in X) a i >= 0 by rewrite sa.
+    by rewrite fsume_ge0// => i /XI/ag0.
   apply/fin_numPn; right; apply/eqP; rewrite -leye_eq esum_ge//.
   by exists X; rewrite // sa.
 rewrite lee_subr_addr// addeC -lee_subr_addr// ub_ereal_sup//= => _ [Y [finY YI]] <-.
 rewrite lee_subr_addr// addeC esum_ge//; exists (X `|` Y).
   by split; [rewrite finite_setU|rewrite subUset].
-rewrite big_split/= lee_add//= lee_sum_nneg_subfset//=.
-- by apply/fsubsetP; rewrite -fset_set_sub// finite_setU.
-- move=> x; rewrite !inE fset_setU// in_fsetU !in_fset_set// andb_orr andNb/=.
-  by move=> /andP[_] /[!inE] /YI/ag0.
-- by apply/fsubsetP; rewrite -fset_set_sub// finite_setU.
-- move=> x; rewrite !inE fset_setU// in_fsetU !in_fset_set// andb_orr andNb/=.
-  by rewrite orbF => /andP[_] /[!inE] /XI/bg0.
+rewrite fsbig_split ?finite_setU//= lee_add// lee_fsum_nneg_subset//= ?finite_setU//.
+- exact/subsetP/subsetUl.
+- by move=> x; rewrite !inE in_setU andb_orr andNb/= => /andP[_] /[!inE] /YI/ag0.
+- exact/subsetP/subsetUr.
+- by move=> x; rewrite !inE in_setU andb_orr andNb/= orbF => /andP[_] /[!inE] /XI/bg0.
 Qed.
 
 Lemma esum_mkcond [R : realType] [T : choiceType] (I : set T)
@@ -173,11 +171,10 @@ Lemma esum_mkcond [R : realType] [T : choiceType] (I : set T)
 Proof.
 apply/eqP; rewrite eq_le !ub_ereal_sup//= => _ [X [finX XI]] <-.
   rewrite -big_mkcond/= big_fset_condE/=; set Y := [fset _ | _ in _ & _]%fset.
-  rewrite ereal_sup_ub//=; exists [set` Y]; last by rewrite set_fsetK.
+  rewrite ereal_sup_ub//=; exists [set` Y]; last by rewrite fsbig_finite// set_fsetK.
   by split => // i/=; rewrite !inE/= => /andP[_]; rewrite inE.
-rewrite ereal_sup_ub//; exists X => //; rewrite -big_mkcond/=.
-rewrite big_seq_cond [RHS]big_seq; apply: eq_bigl => i.
-by rewrite in_fset_set// andb_idr// 2!inE => /XI.
+rewrite ereal_sup_ub//; exists X => //; apply: eq_fsbigr => x; rewrite inE => Xx.
+by rewrite ifT// inE; exact: XI.
 Qed.
 
 Lemma esum_mkcondr [R : realType] [T : choiceType] (I J : set T) (a : T -> \bar R) :
@@ -227,6 +224,7 @@ Lemma esum_esum [R : realType] [T1 T2 : choiceType]
 Proof.
 move=> a_ge0; apply/eqP; rewrite eq_le; apply/andP; split.
   apply: ub_ereal_sup => /= _ [X [finX IX]] <-.
+  rewrite fsbig_finite//=.
   under eq_bigr do rewrite esum_mkcond.
   rewrite -esum_sum; last by move=> i j _ _; case: ifP.
   under eq_esum do rewrite -big_mkcond/=.
@@ -236,7 +234,8 @@ move=> a_ge0; apply/eqP; rewrite eq_le; apply/andP; split.
     by rewrite in_setM => -[/andP[] /[!inE]].
   exists [set z | z \in X `*` Y /\ z.2 \in J z.1] => /=.
     by split => //= z/=; rewrite !inE/= => -[[/IX]].
-  rewrite (exchange_big_dep xpredT)//= pair_big_dep_cond/=.
+  rewrite fsbig_finite//=.
+  rewrite [in RHS]fsbig_finite// (exchange_big_dep xpredT)//= pair_big_dep_cond/=.
   apply: eq_fbigl => -[/= k1 k2]; rewrite in_fset_set//; apply/idP/imfset2P.
     rewrite !inE/= !inE/= -andA => -[kX [kY kJ]].
     exists k1; first by rewrite !inE/= andbT/= in_fset_set// inE.
@@ -251,7 +250,7 @@ apply: (@le_trans _ _
   rewrite [leRHS](big_fsetID _ (mem X))/=.
   rewrite (_ : [fset x | x in Y & x \in X] = Y `&` fset_set X)%fset; last first.
     by apply/fsetP => x; rewrite 2!inE/= in_fset_set.
-  rewrite (fsetIidPr _); first by rewrite lee_addl// sume_ge0.
+  rewrite (fsetIidPr _); first by rewrite fsbig_finite// lee_addl// sume_ge0.
   apply/fsubsetP => -[i j]; rewrite in_fset_set// inE => Xij; apply/imfset2P.
   exists i => /=.
     rewrite !inE/= in_fset_set//; last exact: finite_set_fst.
@@ -259,12 +258,13 @@ apply: (@le_trans _ _
   exists j => //; rewrite !inE/=; have /XIJ[/= _ Jij] := Xij.
   rewrite in_fset_set; last exact: finite_set_snd.
   by apply/andP; split; rewrite ?inE//; exists i.
+rewrite fsbig_finite; last exact: finite_set_fst.
 rewrite big_mkcond [leRHS]big_mkcond.
 apply: lee_sum => i Xi; rewrite ereal_sup_ub => //=.
 have ? : finite_set (X.`2 `&` J i).
   by apply: finite_setI; left; apply: finite_set_snd.
 exists (X.`2 `&` J i) => //.
-rewrite [in RHS]big_fset_condE/=; apply eq_fbigl => j.
+rewrite [in RHS]big_fset_condE/= fsbig_finite//; apply eq_fbigl => j.
 by rewrite in_fset_set// !inE/= in_setI in_fset_set//; exact: finite_set_snd.
 Qed.
 
@@ -306,10 +306,10 @@ move=> a0; apply/eqP; rewrite eq_le; apply/andP; split.
   apply: ereal_sup_ub => /=; exists [set` [fset val i | i in 'I_n & P i]%fset].
     split; first exact: finite_fset.
     by move=> /= k /imfsetP[/= i]; rewrite inE => + ->.
-  rewrite set_fsetK big_imfset/=; last by move=> ? ? ? ? /val_inj.
+  rewrite fsbig_finite//= set_fsetK big_imfset/=; last by move=> ? ? ? ? /val_inj.
   by rewrite big_filter big_enum_cond/= big_mkord.
 apply: ub_ereal_sup => _ [/= F [finF PF] <-].
-rewrite -(big_rmcond_in P)/=; last first.
+rewrite fsbig_finite//= -(big_rmcond_in P)/=; last first.
   by move=> k; rewrite in_fset_set// inE => /PF ->.
 by apply: lee_sum_fset_lim.
 Qed.
@@ -334,9 +334,10 @@ rewrite ub_ereal_sup => //= _ [X [finX XQ] <-]; rewrite ereal_sup_ub => //=.
 exists [set` (e^-1 @` (fset_set X))%fset].
   split=> [|t /= /imfsetP[t'/=]]; first exact: finite_fset.
   by rewrite in_fset_set// inE => /XQ Qt' ->; exact: funS.
-rewrite set_fsetK big_imfset => //=; last first.
+rewrite fsbig_finite//= set_fsetK big_imfset => //=; last first.
   move=> x y/=; rewrite !in_fset_set// !inE => /XQ Qx /XQ Qy /(congr1 e).
   by rewrite !invK ?inE.
+rewrite fsbig_finite//=.
 apply: eq_big_seq => i; rewrite in_fset_set// inE => /XQ Qi.
 by rewrite invK ?inE.
 Qed.

--- a/theories/fsbigop.v
+++ b/theories/fsbigop.v
@@ -435,6 +435,15 @@ move=> finA finB AB f0; rewrite !fsbig_finite//=; apply: lee_sum_nneg_subfset.
 by move=> t; rewrite !inE !in_fset_set// => /f0.
 Qed.
 
+Lemma lee_fsum [R : realDomainType] [T : choiceType] (I : set T)
+  (a b : T -> \bar R) : finite_set I ->
+  (forall i, I i -> a i <= b i)%E -> (\sum_(i \in I) a i <= \sum_(i \in I) b i)%E.
+Proof.
+move=> finI ab.
+rewrite !fsbig_finite// big_seq [in leRHS]big_seq lee_sum //.
+by move=> i; rewrite in_fset_set// inE; exact: ab.
+Qed.
+
 Lemma ge0_mule_fsumr (T : choiceType) (R : realDomainType) (x : \bar R)
     (F : T -> \bar R) (P : set T) : (forall i : T, 0 <= F i)%E ->
   (x * (\sum_(i \in P) F i) = \sum_(i \in P) x * F i)%E.

--- a/theories/fsbigop.v
+++ b/theories/fsbigop.v
@@ -425,6 +425,16 @@ Arguments reindex_fsbigT {R idx op I J} _ _.
 #[deprecated(note="use reindex_fsbigT instead")]
 Notation reindex_inside_setT := reindex_fsbigT.
 
+Lemma lee_fsum_nneg_subset {R : realDomainType} [T : choiceType] [A B : set T]
+    [f : T -> \bar R] : finite_set A -> finite_set B ->
+    {subset A <= B} -> {in [predD B & A], forall t : T, 0 <= f t}%E ->
+  (\sum_(t \in A) f t <= \sum_(t \in B) f t)%E.
+Proof.
+move=> finA finB AB f0; rewrite !fsbig_finite//=; apply: lee_sum_nneg_subfset.
+  by apply/fsubsetP; rewrite -fset_set_sub//; apply/subsetP.
+by move=> t; rewrite !inE !in_fset_set// => /f0.
+Qed.
+
 Lemma ge0_mule_fsumr (T : choiceType) (R : realDomainType) (x : \bar R)
     (F : T -> \bar R) (P : set T) : (forall i : T, 0 <= F i)%E ->
   (x * (\sum_(i \in P) F i) = \sum_(i \in P) x * F i)%E.

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -370,7 +370,7 @@ move=> /(_ _ _ _)/Box[]//=; apply: le_le_trans.
   rewrite hlength_itv ?lte_fin -?EFinD/= -addrA -opprD.
   by case: ltP => //; rewrite lee_fin subr_le0.
 rewrite nneseries_esum//; last by move=> *; rewrite adde_ge0//= ?lee_fin.
-rewrite esum_ge//; exists X => //; rewrite fsbig_finite// ?set_fsetK//=.
+rewrite esum_ge//; exists [set` X] => //; rewrite fsbig_finite// ?set_fsetK//=.
 rewrite lee_sum // => i _; rewrite ?AE// !hlength_itv/= ?lte_fin -?EFinD/=.
 do !case: ifPn => //= ?; do ?by rewrite ?adde_ge0 ?lee_fin// ?subr_ge0// ?ltW.
   by rewrite addrAC.

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -371,6 +371,7 @@ move=> /(_ _ _ _)/Box[]//=; apply: le_le_trans.
   by case: ltP => //; rewrite lee_fin subr_le0.
 rewrite nneseries_esum//; last by move=> *; rewrite adde_ge0//= ?lee_fin.
 rewrite esum_ge//; exists [set` X] => //; rewrite fsbig_finite// ?set_fsetK//=.
+rewrite fsbig_finite//= set_fsetK//.
 rewrite lee_sum // => i _; rewrite ?AE// !hlength_itv/= ?lte_fin -?EFinD/=.
 do !case: ifPn => //= ?; do ?by rewrite ?adde_ge0 ?lee_fin// ?subr_ge0// ?ltW.
   by rewrite addrAC.

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -1536,7 +1536,7 @@ Lemma finite_card_dirac (A : set T) : finite_set A ->
   \esum_(i in A) \d_ i A = (#|` fset_set A|%:R)%:E :> \bar R.
 Proof.
 move=> finA.
-rewrite esum_fset// big_seq_cond (eq_bigr (fun=> 1)) -?big_seq_cond.
+rewrite esum_fset// fsbig_finite// big_seq_cond (eq_bigr (fun=> 1)) -?big_seq_cond.
   by rewrite card_fset_sum1// natr_sum -sumEFin.
 by move=> i; rewrite andbT in_fset_set//= /dirac indicE => ->.
 Qed.
@@ -1549,7 +1549,7 @@ have [B BA Br] := infinite_set_fset `|ceil r| infA.
 apply: esum_ge; exists [set` B] => //; apply: (@le_trans _ _ `|ceil r|%:R%:E).
   by rewrite lee_fin natr_absz gtr0_norm ?ceil_gt0// ceil_ge.
 move: Br; rewrite -(@ler_nat R) -lee_fin => /le_trans; apply.
-rewrite big_seq (eq_bigr (cst 1))/=; last first.
+rewrite fsbig_finite// big_seq (eq_bigr (cst 1))/=; last first.
   move=> i; rewrite in_fset_set// inE/= => Bi; rewrite /dirac indicE mem_set//.
   exact: BA.
 by rewrite -big_seq card_fset_sum1 sumEFin natr_sum// set_fsetK.

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -1536,7 +1536,7 @@ Lemma finite_card_dirac (A : set T) : finite_set A ->
   \esum_(i in A) \d_ i A = (#|` fset_set A|%:R)%:E :> \bar R.
 Proof.
 move=> finA.
-rewrite -sum_fset_set// big_seq_cond (eq_bigr (fun=> 1)) -?big_seq_cond.
+rewrite esum_fset// big_seq_cond (eq_bigr (fun=> 1)) -?big_seq_cond.
   by rewrite card_fset_sum1// natr_sum -sumEFin.
 by move=> i; rewrite andbT in_fset_set//= /dirac indicE => ->.
 Qed.
@@ -1546,12 +1546,13 @@ Lemma infinite_card_dirac (A : set T) : infinite_set A ->
 Proof.
 move=> infA; apply/eq_pinftyP => r r0.
 have [B BA Br] := infinite_set_fset `|ceil r| infA.
-apply: esum_ge; exists B => //; apply: (@le_trans _ _ `|ceil r|%:R%:E).
+apply: esum_ge; exists [set` B] => //; apply: (@le_trans _ _ `|ceil r|%:R%:E).
   by rewrite lee_fin natr_absz gtr0_norm ?ceil_gt0// ceil_ge.
 move: Br; rewrite -(@ler_nat R) -lee_fin => /le_trans; apply.
 rewrite big_seq (eq_bigr (cst 1))/=; last first.
-  by move=> i Bi; rewrite /dirac indicE mem_set//; exact: BA.
-by rewrite -big_seq card_fset_sum1 sumEFin natr_sum.
+  move=> i; rewrite in_fset_set// inE/= => Bi; rewrite /dirac indicE mem_set//.
+  exact: BA.
+by rewrite -big_seq card_fset_sum1 sumEFin natr_sum// set_fsetK.
 Qed.
 
 End dirac_lemmas.

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -1550,7 +1550,7 @@ apply: esum_ge; exists [set` B] => //; apply: (@le_trans _ _ `|ceil r|%:R%:E).
   by rewrite lee_fin natr_absz gtr0_norm ?ceil_gt0// ceil_ge.
 move: Br; rewrite -(@ler_nat R) -lee_fin => /le_trans; apply.
 rewrite fsbig_finite// big_seq (eq_bigr (cst 1))/=; last first.
-  move=> i; rewrite in_fset_set// inE/= => Bi; rewrite /dirac indicE mem_set//.
+  move=> i; rewrite in_fset_set// inE/= => Bi; rewrite diracE mem_set//.
   exact: BA.
 by rewrite -big_seq card_fset_sum1 sumEFin natr_sum// set_fsetK.
 Qed.


### PR DESCRIPTION
##### Motivation for this change

This PR defines `esum` using `finite_set` instead of `fset`. 

TODO:
~- rename `fsets`~ (not sure anymore... maybe `fsubsets`?)

some small proofs become useless but on the other hand
the following proofs got a bit longer
esum_esum, nneseries_esum, reindex_esum, infinite_card_dirac

fyi @CohenCyril 

also contains unrelated proofs shortenings related to {x,y}section

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
  (do not edit former entries, only append new ones, be careful:
   merge and rebase have a tendency to mess up `CHANGELOG_UNRELEASED.md`)
- [ ] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
