### PR TITLE
fixes #711

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -26,6 +26,17 @@
   + lemma `preimage10P`
 - in `classical_sets.v`:
   + lemma `setT_unit`
+- in `mathcomp_extra.v`:
+  + lemma `big_seq1E`
+  + lemma `big_pred1_eqE`
+  + lemma `big_pred1E`
+  + lemma `bigmaxmin_mkcond`
+  + lemma `bigmaxmin_split`
+  + lemma `bigmaxmin_idl`
+  + lemma `bigmaxminID`
+  + lemma `bigmaxminD1`
+- in `topogy.v`:
+  + lemmas `bigmax_le` and `bigmax_lt`
 
 ### Changed
 
@@ -41,14 +52,26 @@
 - in `lebesgue_integral.v`
   + minor generalization of `eq_measure_integral`
 - in `topology.v`:
-  + generalize `ltr_bigminr` to `porderType`
-  + generalize `bigminr_ler` to `orderType`
+  + generalize `ltr_bigminr` to `porderType` and rename to `bigmin_lt`
+  + generalize `bigminr_ler` to `orderType` and rename to `bigmin_le`
 - moved out of module `Bigminr` in `normedtype.v` to `topology.v` and generalizes to `orderType`:
-  + lemma `bigminr_ler_cond`
-- moved out of module `Bigminr` in `normedtype.v` and generalized to `orderType`:
-  + lemma `bigminr_mkcond`, `bigminr_split`, `bigminr_idl`, `bigminrID`
-
-bigminr_mkcond
+  + lemma `bigminr_ler_cond`, renamed to `bigmin_le_cond`
+- moved out of module `Bigminr` in `normedtype.v` to `mathcomp_extra.v`:
+  + lemma `bigminr_maxr`
+- moved from from module `Bigminr` in `normedtype.v` to `topology.v`
+  + and lemmas generalized to `orderType`
+    * `bigminr_mkcond` -> `bigmin_mkcond`
+    * `bigminr_split` -> `bigmin_split`
+    * `bigminr_idl` -> `bigmin_idl`
+    * `bigminrID` -> `bigminID`
+    * `bigminrD1` -> `bigminD1`
+    * `bigminr_inf` -> `bigmin_inf`
+    * `bigminr_gerP` -> `bigmin_geP`
+    * `bigminr_gtrP` -> ``bigmin_gtP``
+    * `bigminr_lerP` -> `bigmin_leP`
+    * `bigminr_ltrP` -> `bigmin_ltP`
+    * `bigminr_eq_arg` -> `bigmin_eq_arg`
+    * `eq_bigminr` -> `eq_bigmin`
 
 ### Renamed
 
@@ -57,11 +80,22 @@ bigminr_mkcond
   + `lee_ninfty_eq` -> `leeNy_eq`
 - in `classical_sets.v`:
   + `set_bool` -> `setT_bool`
+- in `topology.v`:
+  + `bigmax_lerP` -> `bigmax_leP`
+  + `bigmax_ltrP` -> `bigmax_ltP`
+  + `bigmax_gerP` -> `bigmax_geP`
+  + `bigmax_gtrP` -> `bigmax_gtP`
+  + `ler_bigmax_cond` -> `le_bigmax_cond`
+  + `ler_bigmax` -> `le_bigmax`
+  + `le_bigmax` -> `le_bigmax'`
 
 ### Removed
 
-- in `normedtype.v`
-  + `Bigminr.bigminr_ler_cond`, `Bigminr.bigminr_ler`
+- in `normedtype.v` (module `Bigminr`)
+  + `bigminr_ler_cond`, `bigminr_ler`.
+  + `bigminr_seq1`, `bigminr_pred1_eq`, `bigminr_pred1`
+- in `topology.v`:
+  + `bigmax_seq1`, `bigmax_pred1_eq`, `bigmax_pred1`
 
 ### Infrastructure
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -40,6 +40,15 @@
   + fix pretty-printing of `{mfun _ >-> _}`, `{sfun _ >-> _}`, `{nnfun _ >-> _}`
 - in `lebesgue_integral.v`
   + minor generalization of `eq_measure_integral`
+- in `topology.v`:
+  + generalize `ltr_bigminr` to `porderType`
+  + generalize `bigminr_ler` to `orderType`
+- moved out of module `Bigminr` in `normedtype.v` to `topology.v` and generalizes to `orderType`:
+  + lemma `bigminr_ler_cond`
+- moved out of module `Bigminr` in `normedtype.v` and generalized to `orderType`:
+  + lemma `bigminr_mkcond`, `bigminr_split`, `bigminr_idl`, `bigminrID`
+
+bigminr_mkcond
 
 ### Renamed
 
@@ -50,6 +59,9 @@
   + `set_bool` -> `setT_bool`
 
 ### Removed
+
+- in `normedtype.v`
+  + `Bigminr.bigminr_ler_cond`, `Bigminr.bigminr_ler`
 
 ### Infrastructure
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -27,15 +27,15 @@
 - in `classical_sets.v`:
   + lemma `setT_unit`
 - in `mathcomp_extra.v`:
-  + lemma `big_seq1E`
-  + lemma `big_pred1_eqE`
-  + lemma `big_pred1E`
-  + lemma `bigmaxmin_mkcond`
-  + lemma `bigmaxmin_split`
-  + lemma `bigmaxmin_idl`
-  + lemma `bigmaxminID`
-  + lemma `bigmaxminD1`
-- in `topogy.v`:
+  + lemma `big_idl`
+  + lemma `NoMondoiBigop.big_seq1`
+  + lemma `NoMondoiBigop.big_pred1_eq`
+  + lemma `NoMondoiBigop.big_pred1`
+  + lemma `NoMondoiBigop.big_mkcond`
+  + lemma `NoMondoiBigop.big_split`
+  + lemma `NoMondoiBigop.bigID`
+  + lemma `NoMondoiBigop.bigD1`
+- in `mathcomp_extra.v`:
   + lemmas `bigmax_le` and `bigmax_lt`
 
 ### Changed
@@ -51,15 +51,15 @@
   + fix pretty-printing of `{mfun _ >-> _}`, `{sfun _ >-> _}`, `{nnfun _ >-> _}`
 - in `lebesgue_integral.v`
   + minor generalization of `eq_measure_integral`
-- in `topology.v`:
+- from `topology.v` to `mathcomp_extra.v`:
   + generalize `ltr_bigminr` to `porderType` and rename to `bigmin_lt`
   + generalize `bigminr_ler` to `orderType` and rename to `bigmin_le`
-- moved out of module `Bigminr` in `normedtype.v` to `topology.v` and generalizes to `orderType`:
+- moved out of module `Bigminr` in `normedtype.v` to `mathcomp_extra.v` and generalized to `orderType`:
   + lemma `bigminr_ler_cond`, renamed to `bigmin_le_cond`
 - moved out of module `Bigminr` in `normedtype.v` to `mathcomp_extra.v`:
   + lemma `bigminr_maxr`
-- moved from from module `Bigminr` in `normedtype.v` to `topology.v`
-  + and lemmas generalized to `orderType`
+- moved from from module `Bigminr` in `normedtype.v`
+  + to `mathcomp_extra.v` and generalized to `orderType`
     * `bigminr_mkcond` -> `bigmin_mkcond`
     * `bigminr_split` -> `bigmin_split`
     * `bigminr_idl` -> `bigmin_idl`
@@ -68,10 +68,17 @@
     * `bigminr_inf` -> `bigmin_inf`
     * `bigminr_gerP` -> `bigmin_geP`
     * `bigminr_gtrP` -> ``bigmin_gtP``
-    * `bigminr_lerP` -> `bigmin_leP`
-    * `bigminr_ltrP` -> `bigmin_ltP`
     * `bigminr_eq_arg` -> `bigmin_eq_arg`
     * `eq_bigminr` -> `eq_bigmin`
+  + to `topology.v` and generalized to `orderType`
+    * `bigminr_lerP` -> `bigmin_leP`
+    * `bigminr_ltrP` -> `bigmin_ltP`
+- moved from `topology.v` to `mathcomp_extra.v`:
+  + `bigmax_lerP` -> `bigmax_leP`
+  + `bigmax_ltrP` -> `bigmax_ltP`
+  + `ler_bigmax_cond` -> `le_bigmax_cond`
+  + `ler_bigmax` -> `le_bigmax`
+  + `le_bigmax` -> `homo_le_bigmax`
 
 ### Renamed
 
@@ -81,13 +88,8 @@
 - in `classical_sets.v`:
   + `set_bool` -> `setT_bool`
 - in `topology.v`:
-  + `bigmax_lerP` -> `bigmax_leP`
-  + `bigmax_ltrP` -> `bigmax_ltP`
   + `bigmax_gerP` -> `bigmax_geP`
   + `bigmax_gtrP` -> `bigmax_gtP`
-  + `ler_bigmax_cond` -> `le_bigmax_cond`
-  + `ler_bigmax` -> `le_bigmax`
-  + `le_bigmax` -> `le_bigmax'`
 
 ### Removed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -37,6 +37,8 @@
   + lemma `bigID_idem`
 - in `mathcomp_extra.v`:
   + lemmas `bigmax_le` and `bigmax_lt`
+  + lemma `bigmin_idr`
+  + lemma `bigmax_idr`
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -27,14 +27,14 @@
 - in `classical_sets.v`:
   + lemma `setT_unit`
 - in `mathcomp_extra.v`:
-  + lemma `big_idl`
-  + lemma `NoMondoiBigop.big_seq1`
-  + lemma `NoMondoiBigop.big_pred1_eq`
-  + lemma `NoMondoiBigop.big_pred1`
-  + lemma `NoMondoiBigop.big_mkcond`
-  + lemma `NoMondoiBigop.big_split`
-  + lemma `NoMondoiBigop.bigID`
-  + lemma `NoMondoiBigop.bigD1`
+  + lemma `big_const_idem`
+  + lemma `big_id_idem`
+  + lemma `big_rem_AC`
+  + lemma `bigD1_AC`
+  + lemma `big_mkcond_idem`
+  + lemma `big_split_idem`
+  + lemma `big_id_idem_AC`
+  + lemma `bigID_idem`
 - in `mathcomp_extra.v`:
   + lemmas `bigmax_le` and `bigmax_lt`
 

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -1952,7 +1952,7 @@ Let nd_max_g2 : nondecreasing_seq (max_g2 : (T -> R)^nat).
 Proof.
 apply/nondecreasing_seqP => n; apply/lefP => x; rewrite 2!bigmax_nnsfunE.
 rewrite (@le_trans _ _ (\big[maxr/0]_(i < n) g2 i n.+1 x)%R) //.
-  apply: le_bigmax => i _; apply: (nondecreasing_seqP (g2 i ^~ x)).2 => a b ab.
+  apply: le_bigmax' => i _; apply: (nondecreasing_seqP (g2 i ^~ x)).2 => a b ab.
    by rewrite !nnsfun_approxE; exact/lefP/nd_approx.
 rewrite (bigmaxD1 ord_max)// le_maxr; apply/orP; right.
 rewrite [leRHS](eq_bigl (fun i => nat_of_ord i < n)%N); last first.
@@ -1971,9 +1971,9 @@ Let max_g2_g k x : ((max_g2 k x)%:E <= g k x)%O.
 Proof.
 rewrite bigmax_nnsfunE.
 apply: (@le_trans _ _ (\big[maxe/0%:E]_(i < k) g k x)); last first.
-  apply/bigmax_lerP; split => //; apply: g0D.
+  by apply/bigmax_leP; split => //; apply: g0D.
 rewrite (@big_morph _ _ EFin 0%:E maxe) //; last by move=> *; rewrite maxEFin.
-apply: le_bigmax => i _; rewrite nnsfun_approxE /=.
+apply: le_bigmax' => i _; rewrite nnsfun_approxE /=.
 by rewrite (le_trans (le_approx _ _ _)) => //; exact/nd_g/ltnW.
 Qed.
 

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -1952,7 +1952,7 @@ Let nd_max_g2 : nondecreasing_seq (max_g2 : (T -> R)^nat).
 Proof.
 apply/nondecreasing_seqP => n; apply/lefP => x; rewrite 2!bigmax_nnsfunE.
 rewrite (@le_trans _ _ (\big[maxr/0]_(i < n) g2 i n.+1 x)%R) //.
-  apply: le_bigmax' => i _; apply: (nondecreasing_seqP (g2 i ^~ x)).2 => a b ab.
+  apply: homo_le_bigmax => i _; apply: (nondecreasing_seqP (g2 i ^~ x)).2 => a b ab.
    by rewrite !nnsfun_approxE; exact/lefP/nd_approx.
 rewrite (bigmaxD1 ord_max)// le_maxr; apply/orP; right.
 rewrite [leRHS](eq_bigl (fun i => nat_of_ord i < n)%N); last first.
@@ -1973,7 +1973,7 @@ rewrite bigmax_nnsfunE.
 apply: (@le_trans _ _ (\big[maxe/0%:E]_(i < k) g k x)); last first.
   by apply/bigmax_leP; split => //; apply: g0D.
 rewrite (@big_morph _ _ EFin 0%:E maxe) //; last by move=> *; rewrite maxEFin.
-apply: le_bigmax' => i _; rewrite nnsfun_approxE /=.
+apply: homo_le_bigmax => i _; rewrite nnsfun_approxE /=.
 by rewrite (le_trans (le_approx _ _ _)) => //; exact/nd_g/ltnW.
 Qed.
 

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -1955,10 +1955,10 @@ rewrite (@le_trans _ _ (\big[maxr/0]_(i < n) g2 i n.+1 x)%R) //.
   apply: homo_le_bigmax => i _; apply: (nondecreasing_seqP (g2 i ^~ x)).2 => a b ab.
    by rewrite !nnsfun_approxE; exact/lefP/nd_approx.
 rewrite (bigmaxD1 ord_max)// le_maxr; apply/orP; right.
-rewrite [leRHS](eq_bigl (fun i => nat_of_ord i < n)%N); last first.
-   move=> i /=; rewrite neq_lt; apply/orP/idP => [[//|]|]; last by left.
-   by move=> /(leq_trans (ltn_ord i)); rewrite ltnn.
-by rewrite (big_ord_narrow (leqnSn n)).
+rewrite [leRHS](eq_bigl (fun i => nat_of_ord i < n)%N).
+  by rewrite (big_ord_narrow (leqnSn n)).
+move=> i /=; rewrite neq_lt; apply/orP/idP => [[//|]|]; last by left.
+by move=> /(leq_trans (ltn_ord i)); rewrite ltnn.
 Qed.
 
 Let is_cvg_max_g2 t : cvg (EFin \o max_g2 ^~ t).
@@ -1986,7 +1986,7 @@ Let lim_g2_max_g2 t n : lim (EFin\o g2 n ^~ t) <= lim (EFin \o max_g2 ^~ t).
 Proof.
 apply: lee_lim => //; near=> k; rewrite /= bigmax_nnsfunE lee_fin.
 have nk : (n < k)%N by near: k; exists n.+1.
-exact: (@bigmax_sup _ _ _ (Ordinal nk)).
+exact: (bigmax_sup (Ordinal nk)).
 Unshelve. all: by end_near. Qed.
 
 Let cvg_max_g2_f t : EFin \o max_g2 ^~ t --> f t.
@@ -2010,13 +2010,13 @@ have := leey (g n t); rewrite le_eqVlt => /predU1P[|] fntoo.
     by have := lim_g2_max_g2 t n; rewrite g2oo leye_eq => /eqP.
   by rewrite leey.
 - have approx_g_g := @cvg_approx _ _ _ setT _ t (fun t _ => g0 n t) Logic.I fntoo.
-  have <- : lim (EFin \o g2 n ^~ t) = g n t.
-    have /cvg_lim <- // : EFin \o (approx setT (g n)) ^~ t --> g n t.
-      move/cvg_comp : approx_g_g; apply.
-      by rewrite -(@fineK _ (g n t))// ge0_fin_numE// g0.
-    rewrite (_ : _ \o _ = EFin \o approx setT (g n) ^~ t)// funeqE => m.
-    by rewrite [in RHS]/= -nnsfun_approxE.
-  exact: (le_trans _ (lim_g2_max_g2 t n)).
+  suff : lim (EFin \o g2 n ^~ t) = g n t.
+    by move=> <-; exact: (le_trans _ (lim_g2_max_g2 t n)).
+  have /cvg_lim <- // : EFin \o (approx setT (g n)) ^~ t --> g n t.
+    move/cvg_comp : approx_g_g; apply.
+    by rewrite -(@fineK _ (g n t))// ge0_fin_numE// g0.
+  rewrite (_ : _ \o _ = EFin \o approx setT (g n) ^~ t)// funeqE => m.
+  by rewrite [in RHS]/= -nnsfun_approxE.
 Unshelve. all: by end_near. Qed.
 
 Lemma monotone_convergence :
@@ -2151,8 +2151,9 @@ End ge0_integralM.
 
 Section fatou.
 Local Open Scope ereal_scope.
-Variables (d : measure_display) (T : measurableType d) (R : realType) (mu : {measure set T -> \bar R}).
-Variables (D : set T) (mD : measurable D) (f : (T -> \bar R)^nat).
+Variables (d : measure_display) (T : measurableType d) (R : realType).
+Variables (mu : {measure set T -> \bar R}) (D : set T) (mD : measurable D).
+Variable (f : (T -> \bar R)^nat).
 Hypothesis mf : forall n, measurable_fun D (f n).
 Hypothesis f0 : forall n x, D x -> 0 <= f n x.
 
@@ -2187,7 +2188,8 @@ End fatou.
 
 Section integralN.
 Local Open Scope ereal_scope.
-Variables (d : measure_display) (T : measurableType d) (R : realType) (mu : {measure set T -> \bar R}).
+Variables (d : measure_display) (T : measurableType d) (R : realType)
+          (mu : {measure set T -> \bar R}).
 
 Lemma integralN D (f : T -> \bar R) :
   \int[mu]_(x in D) f^\+ x +? (- \int[mu]_(x in D) f^\- x) ->
@@ -2276,8 +2278,8 @@ End integral_cst.
 
 Section integral_ind.
 Local Open Scope ereal_scope.
-Variables (d : measure_display) (T : measurableType d) (R : realType) (mu : {measure set T -> \bar R}).
-Variables (D : set T) (mD : measurable D).
+Variables (d : measure_display) (T : measurableType d) (R : realType).
+Variables (mu : {measure set T -> \bar R}) (D : set T) (mD : measurable D).
 
 Lemma integral_indic (E : set T) : measurable E ->
   \int[mu]_(x in D) (\1_E x)%:E = mu (E `&` D).
@@ -2565,7 +2567,8 @@ End ge0_integral_measure_series.
 
 Section subset_integral.
 Local Open Scope ereal_scope.
-Variables (d : measure_display) (T : measurableType d) (R : realType) (mu : {measure set T -> \bar R}).
+Variables (d : measure_display) (T : measurableType d) (R : realType)
+          (mu : {measure set T -> \bar R}).
 
 Lemma integral_setU (A B : set T) (mA : measurable A) (mB : measurable B)
     (f : T -> \bar R) : measurable_fun (A `|` B) f ->
@@ -2653,7 +2656,8 @@ End subset_integral.
 
 Section Rintegral.
 Local Open Scope ereal_scope.
-Variables (d : measure_display) (T : measurableType d) (R : realType) (mu : {measure set T -> \bar R}).
+Variables (d : measure_display) (T : measurableType d) (R : realType)
+          (mu : {measure set T -> \bar R}).
 
 Definition Rintegral (D : set T) (f : T -> \bar R) :=
   fine (\int[mu]_(x in D) f x).
@@ -2873,7 +2877,8 @@ End sequence_measure.
 
 Section integrable_lemmas.
 Local Open Scope ereal_scope.
-Variables (d : measure_display) (T : measurableType d) (R : realType) (mu : {measure set T -> \bar R}).
+Variables (d : measure_display) (T : measurableType d) (R : realType)
+          (mu : {measure set T -> \bar R}).
 
 Lemma ge0_integral_bigcup (F : (set _)^nat) (f : T -> \bar R) :
   (forall k, measurable (F k)) ->
@@ -2946,8 +2951,9 @@ Arguments integrable_mkcond {d T R mu D} f.
 
 Section integrable_ae.
 Local Open Scope ereal_scope.
-Variables (d : measure_display) (T : measurableType d) (R : realType) (mu : {measure set T -> \bar R}).
-Variables (D : set T) (mD : measurable D) (f : T -> \bar R).
+Variables (d : measure_display) (T : measurableType d) (R : realType).
+Variables (mu : {measure set T -> \bar R}) (D : set T) (mD : measurable D).
+Variable (f : T -> \bar R).
 Hypotheses fint : mu.-integrable D f.
 
 Lemma integrable_ae : {ae mu, forall x, D x -> f x \is a fin_num}.
@@ -3015,8 +3021,9 @@ End integrable_ae.
 
 Section linearityM.
 Local Open Scope ereal_scope.
-Variables (d : measure_display) (T : measurableType d) (R : realType) (mu : {measure set T -> \bar R}).
-Variables (D : set T) (mD : measurable D) (f : T -> \bar R).
+Variables (d : measure_display) (T : measurableType d) (R : realType).
+Variables (mu : {measure set T -> \bar R}) (D : set T) (mD : measurable D).
+Variable (f : T -> \bar R).
 Hypothesis intf : mu.-integrable D f.
 
 Lemma integralM r :
@@ -3047,8 +3054,9 @@ End linearityM.
 
 Section linearity.
 Local Open Scope ereal_scope.
-Variables (d : measure_display) (T : measurableType d) (R : realType) (mu : {measure set T -> \bar R}).
-Variables (D : set T) (mD : measurable D) (f1 f2 : T -> R).
+Variables (d : measure_display) (T : measurableType d) (R : realType).
+Variables (mu : {measure set T -> \bar R}) (D : set T) (mD : measurable D).
+Variable (f1 f2 : T -> R).
 Let g1 := EFin \o f1.
 Let g2 := EFin \o f2.
 Hypothesis if1 : mu.-integrable D g1.
@@ -3267,7 +3275,8 @@ End ae_eq.
 
 Section ae_eq_integral.
 Local Open Scope ereal_scope.
-Variables (d : measure_display) (T : measurableType d) (R : realType) (mu : {measure set T -> \bar R}).
+Variables (d : measure_display) (T : measurableType d) (R : realType)
+          (mu : {measure set T -> \bar R}).
 
 Local Notation ae_eq := (ae_eq mu).
 
@@ -3547,7 +3556,8 @@ Qed.
 End ae_eq_integral.
 
 Section ae_measurable_fun.
-Variables (d : measure_display) (T : measurableType d) (R : realType) (mu : {measure set T -> \bar R}).
+Variables (d : measure_display) (T : measurableType d) (R : realType)
+          (mu : {measure set T -> \bar R}).
 Hypothesis cmu : measure_is_complete mu.
 Variables (D : set T) (f g : T -> \bar R).
 
@@ -3578,8 +3588,9 @@ End ae_measurable_fun.
 
 Section integralD.
 Local Open Scope ereal_scope.
-Variables (d : measure_display) (T : measurableType d) (R : realType) (mu : {measure set T -> \bar R}).
-Variables (D : set T) (mD : measurable D) (f1 f2 : T -> \bar R).
+Variables (d : measure_display) (T : measurableType d) (R : realType).
+Variables (mu : {measure set T -> \bar R}) (D : set T) (mD : measurable D).
+Variables (f1 f2 : T -> \bar R).
 Hypotheses (if1 : mu.-integrable D f1) (if2 : mu.-integrable D f2).
 
 Lemma integralD : \int[mu]_(x in D) (f1 x + f2 x) =
@@ -3796,9 +3807,9 @@ End subadditive_countable.
 
 Section dominated_convergence_lemma.
 Local Open Scope ereal_scope.
-Variables (d : measure_display) (T : measurableType d) (R : realType) (mu : {measure set T -> \bar R}).
-Variables (D : set T) (mD : measurable D) (f_ : (T -> \bar R)^nat).
-Variables (f : T -> \bar R) (g : T -> \bar R).
+Variables (d : measure_display) (T : measurableType d) (R : realType).
+Variables (mu : {measure set T -> \bar R}) (D : set T) (mD : measurable D).
+Variables (f_ : (T -> \bar R)^nat) (f : T -> \bar R) (g : T -> \bar R).
 Hypothesis mf_ : forall n, measurable_fun D (f_ n).
 Hypothesis f_f : forall x, D x -> f_ ^~ x --> f x.
 Hypothesis fing : forall x, D x -> g x \is a fin_num.

--- a/theories/mathcomp_extra.v
+++ b/theories/mathcomp_extra.v
@@ -438,6 +438,10 @@ Proof. by rewrite big_seq_fsetE/= sum1_card cardfE. Qed.
 Arguments big_rmcond {R idx op I r} P.
 Arguments big_rmcond_in {R idx op I r} P.
 
+(*******************************)
+(* MathComp > 1.15.0 additions *)
+(*******************************)
+
 Section bigminr_maxr.
 Import Num.Def.
 

--- a/theories/mathcomp_extra.v
+++ b/theories/mathcomp_extra.v
@@ -438,22 +438,45 @@ Proof. by rewrite big_seq_fsetE/= sum1_card cardfE. Qed.
 Arguments big_rmcond {R idx op I r} P.
 Arguments big_rmcond_in {R idx op I r} P.
 
-Lemma big_seq1E (T : Type) op I (i : I) (F : I -> T) x :
+Section bigminr_maxr.
+Import Num.Def.
+
+Lemma bigminr_maxr (R : realDomainType) I r (P : pred I) (F : I -> R) x :
+  \big[minr/x]_(i <- r | P i) F i = - \big[maxr/- x]_(i <- r | P i) - F i.
+Proof.
+by elim/big_rec2: _ => [|i y _ _ ->]; rewrite ?oppr_max opprK.
+Qed.
+End bigminr_maxr.
+
+Lemma big_idl (T : Type) op I r (P : pred I) (F : I -> T) x :
+  idempotent op -> left_commutative op ->
+  \big[op/x]_(i <- r | P i) F i = op x (\big[op/x]_(i <- r | P i) F i).
+Proof.
+move=> opxx opCA; rewrite -big_filter; elim: [seq i <- r | P i] => [|i l ihl].
+  by rewrite big_nil opxx.
+by rewrite big_cons opCA -ihl.
+Qed.
+
+(* this module duplicates lemmas from bigop without requiring op
+   to be of type Monoid.law idx or Monoid.com_law idx *)
+Module NoMonoidBigop.
+
+Lemma big_seq1 (T : Type) op I (i : I) (F : I -> T) x :
   \big[op/x]_(j <- [:: i]) F j = op (F i) x.
 Proof. by rewrite big_cons big_nil. Qed.
 
-Lemma big_pred1_eqE (T : Type) op (I : finType) (i : I) (F : I -> T) x :
+Lemma big_pred1_eq (T : Type) op (I : finType) (i : I) (F : I -> T) x :
   \big[op/x]_(j | j == i) F j = op (F i) x.
 Proof.
 have [e1 <- _ [e_enum _]] := big_enumP (pred1 i).
-by rewrite (perm_small_eq _ e_enum) enum1 ?big_seq1E.
+by rewrite (perm_small_eq _ e_enum) enum1 ?big_seq1.
 Qed.
 
-Lemma big_pred1E (T : Type) op (I : finType) i (P : pred I) (F : I -> T) x :
+Lemma big_pred1 (T : Type) op (I : finType) i (P : pred I) (F : I -> T) x :
   P =1 pred1 i -> \big[op/x]_(j | P j) F j = op (F i) x.
-Proof. by move/(eq_bigl _ _)->; apply: big_pred1_eqE. Qed.
+Proof. by move/(eq_bigl _ _)->; apply: big_pred1_eq. Qed.
 
-Lemma bigmaxmin_mkcond (T : Type) op I r (P : pred I) (F : I -> T) x :
+Lemma big_mkcond (T : Type) op I r (P : pred I) (F : I -> T) x :
   idempotent op -> left_commutative op ->
   \big[op/x]_(i <- r | P i) F i = \big[op/x]_(i <- r) (if P i then F i else x).
 Proof.
@@ -463,23 +486,13 @@ elim: r {ih} => [|j r ih]; first by rewrite big_nil opxx.
 by rewrite big_cons {1}ih opCA.
 Qed.
 
-Lemma bigmaxmin_split (T : Type) op I r (P : pred I) (F1 F2 : I -> T) x :
+Lemma big_split (T : Type) op I r (P : pred I) (F1 F2 : I -> T) x :
   idempotent op -> interchange op op ->
   \big[op/x]_(i <- r | P i) (op (F1 i) (F2 i)) =
   op (\big[op/x]_(i <- r | P i) F1 i) (\big[op/x]_(i <- r | P i) F2 i).
 Proof. by move=> opxx minACA; elim/big_rec3: _ => [|i y z _ _ ->]. Qed.
 
-Lemma bigmaxmin_idl (T : Type) op I r (P : pred I) (F : I -> T) x :
-  idempotent op -> left_commutative op ->
-  \big[op/x]_(i <- r | P i) F i = op x (\big[op/x]_(i <- r | P i) F i).
-Proof.
-move=> opxx opCA.
-rewrite -big_filter; elim: [seq i <- r | P i] => [|i l ihl].
-  by rewrite big_nil opxx.
-by rewrite big_cons opCA -ihl.
-Qed.
-
-Lemma bigmaxminID (T : Type) op I r (a P : pred I) (F : I -> T) x :
+Lemma bigID (T : Type) op I r (a P : pred I) (F : I -> T) x :
   idempotent op -> associative op -> commutative op ->
   \big[op/x]_(i <- r | P i) F i =
   op (\big[op/x]_(i <- r | P i && a i) F i)
@@ -492,32 +505,250 @@ have opACA : interchange op op by move=> u v w t; rewrite -opA (opCA v) opA.
 under [in X in op X _]eq_bigl do rewrite andbC.
 under [in X in op _ X]eq_bigl do rewrite andbC.
 rewrite -!(big_filter _ (fun _ => _ && _)) !filter_predI !big_filter.
-rewrite ![in RHS](bigmaxmin_mkcond _ _ F)// !big_filter -bigmaxmin_split//.
+rewrite ![in RHS](big_mkcond _ _ F)// !big_filter -big_split//.
 have eqop i : P i ->
   op (if a i then F i else x) (if ~~ a i then F i else x) = op (F i) x.
   by move=> _; case: (a i) => //=; rewrite opC.
 rewrite [RHS](eq_bigr _ eqop) -!(big_filter _ P).
 elim: [seq j <- r | P j] => [|j l ihl]; first by rewrite !big_nil.
-by rewrite !big_cons -opA -bigmaxmin_idl// ihl.
+by rewrite !big_cons -opA -big_idl// ihl.
 Qed.
 
-Lemma bigmaxminD1 (T : Type) op (I : finType) j (P : pred I) (F : I -> T) x :
+Lemma bigD1 (T : Type) op (I : finType) j (P : pred I) (F : I -> T) x :
   idempotent op -> associative op -> commutative op ->
   P j -> \big[op/x]_(i | P i) F i
     = op (F j) (\big[op/x]_(i | P i && (i != j)) F i).
 Proof.
 move=> opxx opA opC.
 have opCA : left_commutative op by move=> u v w; rewrite opA (opC u) -opA.
-move=> Pj; rewrite (bigmaxminID _ (pred1 j))// [in RHS]bigmaxmin_idl// opA.
-by congr op; apply: big_pred1E => i; rewrite /= andbC; case: eqP => //->.
+move=> Pj; rewrite (bigID _ (pred1 j))// [in RHS]big_idl// opA.
+by congr op; apply: big_pred1 => i; rewrite /= andbC; case: eqP => //->.
 Qed.
 
-Section bigminr_maxr.
-Import Num.Def.
+End NoMonoidBigop.
 
-Lemma bigminr_maxr (R : realDomainType) I r (P : pred I) (F : I -> R) x :
-  \big[minr/x]_(i <- r | P i) F i = - \big[maxr/- x]_(i <- r | P i) - F i.
+Section bigmaxmin.
+Local Notation max := Order.max.
+Local Notation min := Order.min.
+Local Open Scope order_scope.
+Variables (d : _) (R : porderType d).
+
+Lemma bigmax_le (I : finType) (f : I -> R) (x0 x : R) (P : pred I) :
+  x0 <= x -> (forall i, P i -> f i <= x) -> \big[max/x0]_(i | P i) f i <= x.
 Proof.
-by elim/big_rec2: _ => [|i y _ _ ->]; rewrite ?oppr_max opprK.
+move=> ltx0 ltxf; elim/big_ind: _ => // y z ltxy ltxz.
+by rewrite maxEle; case: ifPn.
 Qed.
-End bigminr_maxr.
+
+Lemma bigmax_lt (I : finType) (f : I -> R) (x0 x : R) (P : pred I) :
+  x0 < x -> (forall i, P i -> f i < x) -> \big[max/x0]_(i | P i) f i < x.
+Proof.
+move=> ltx0 ltxf; elim/big_ind: _ => // y z ltxy ltxz.
+by rewrite maxElt; case: ifPn.
+Qed.
+
+Lemma lt_bigmin (I : finType) (f : I -> R) (x0 x : R) (P : pred I) :
+  x < x0 -> (forall i, P i -> x < f i) -> x < \big[min/x0]_(i | P i) f i.
+Proof.
+move=> ltx0 ltxf; elim/big_ind: _ => // y z ltxy ltxz.
+by rewrite minElt; case: ifPn.
+Qed.
+
+Lemma le_bigmin (I : finType) (f : I -> R) (x0 x : R) (P : pred I) :
+  x <= x0 -> (forall i, P i -> x <= f i) -> x <= \big[min/x0]_(i | P i) f i.
+Proof.
+move=> ltx0 ltxf; elim/big_ind: _ => // y z ltxy ltxz.
+by rewrite minEle; case: ifPn.
+Qed.
+
+End bigmaxmin.
+
+Section bigmax.
+Local Notation max := Order.max.
+Local Open Scope order_scope.
+Variables (d : unit) (T : orderType d).
+
+Lemma bigmax_mkcond I r (P : pred I) (F : I -> T) x :
+  \big[max/x]_(i <- r | P i) F i =
+     \big[max/x]_(i <- r) (if P i then F i else x).
+Proof. by rewrite NoMonoidBigop.big_mkcond//; [exact: maxxx|exact: maxCA]. Qed.
+
+Lemma bigmax_split I r (P : pred I) (F1 F2 : I -> T) x :
+  \big[max/x]_(i <- r | P i) (max (F1 i) (F2 i)) =
+  max (\big[max/x]_(i <- r | P i) F1 i) (\big[max/x]_(i <- r | P i) F2 i).
+Proof. by rewrite NoMonoidBigop.big_split//; [exact: maxxx|exact: maxACA]. Qed.
+
+Lemma bigmax_idl I r (P : pred I) (F : I -> T) x :
+  \big[max/x]_(i <- r | P i) F i = max x (\big[max/x]_(i <- r | P i) F i).
+Proof. by rewrite [in LHS]big_idl//; [exact: maxxx|exact: maxCA]. Qed.
+
+Lemma bigmaxID I r (a P : pred I) (F : I -> T) x :
+  \big[max/x]_(i <- r | P i) F i =
+  max (\big[max/x]_(i <- r | P i && a i) F i)
+      (\big[max/x]_(i <- r | P i && ~~ a i) F i).
+Proof.
+by rewrite (NoMonoidBigop.bigID _ a)//; [exact: maxxx|exact: maxA|exact: maxC].
+Qed.
+
+Lemma bigmaxD1 (I : finType) j (P : pred I) (F : I -> T) x :
+  P j -> \big[max/x]_(i | P i) F i
+    = max (F j) (\big[max/x]_(i | P i && (i != j)) F i).
+Proof.
+by apply: NoMonoidBigop.bigD1; [exact: maxxx|exact: maxA|exact: maxC].
+Qed.
+
+Local Open Scope order_scope.
+
+Lemma le_bigmax_cond (I : finType) (P : pred I) (F : I -> T) x i0 :
+  P i0 -> F i0 <= \big[max/x]_(i | P i) F i.
+Proof. by move=> Pi0; rewrite (bigmaxD1 _ _ Pi0) le_maxr lexx. Qed.
+
+Lemma le_bigmax (I : finType) (F : I -> T) (i0 : I) x :
+  F i0 <= \big[max/x]_i F i.
+Proof. exact: le_bigmax_cond. Qed.
+
+(* NB: bigop.bigmax_sup already exists for nat *)
+Lemma bigmax_sup (I : finType) i0 (P : pred I) m (F : I -> T) x :
+  P i0 -> m <= F i0 -> m <= \big[max/x]_(i | P i) F i.
+Proof. by move=> Pi0 ?; apply: le_trans (le_bigmax_cond _ _ Pi0). Qed.
+
+Lemma bigmax_leP (I : finType) (P : pred I) m (F : I -> T) x :
+  reflect (x <= m /\ forall i, P i -> F i <= m)
+          (\big[max/x]_(i | P i) F i <= m).
+Proof.
+apply: (iffP idP) => [|[lexm leFm]]; last exact: bigmax_le.
+rewrite bigmax_idl le_maxl => /andP[-> leFm]; split=> // i Pi.
+by apply: le_trans leFm; apply: le_bigmax_cond.
+Qed.
+
+Lemma bigmax_ltP (I : finType) (P : pred I) m (F : I -> T) x :
+  reflect (x < m /\ forall i, P i -> F i < m)
+          (\big[max/x]_(i | P i) F i < m).
+Proof.
+apply: (iffP idP) => [|[ltxm ltFm]]; last exact: bigmax_lt.
+rewrite bigmax_idl lt_maxl => /andP[-> ltFm]; split=> // i Pi.
+by apply: le_lt_trans ltFm; apply: le_bigmax_cond.
+Qed.
+
+Lemma bigmax_eq_arg (I : finType) i0 (P : pred I) (F : I -> T) x :
+  P i0 -> (forall i, P i -> x <= F i) ->
+  \big[max/x]_(i | P i) F i = F [arg max_(i > i0 | P i) F i].
+Proof.
+move=> Pi0; case: arg_maxP => //= i Pi PF PxF.
+apply/eqP; rewrite eq_le le_bigmax_cond // andbT.
+by apply/bigmax_leP; split => //; exact: PxF.
+Qed.
+
+Lemma eq_bigmax (I : finType) i0 (P : pred I) (F : I -> T) x :
+  P i0 -> (forall i, P i -> x <= F i) ->
+  {i0 | i0 \in I & \big[max/x]_(i | P i) F i = F i0}.
+Proof. by move=> Pi0 Hx; rewrite (bigmax_eq_arg Pi0) //; eexists. Qed.
+
+Lemma homo_le_bigmax (I : finType) (P : pred I) (F G : I -> T) x :
+  (forall i, P i -> F i <= G i) ->
+  \big[max/x]_(i | P i) F i <= \big[max/x]_(i | P i) G i.
+Proof.
+move=> FG; elim/big_ind2 : _ => // a b e f ba fe.
+rewrite le_maxr 2!le_maxl ba fe /= andbT; have [//|/= af] := leP f a.
+by rewrite (le_trans ba) // (le_trans _ fe) // ltW.
+Qed.
+
+End bigmax.
+Arguments bigmax_mkcond {d T I r}.
+Arguments bigmaxID {d T I r}.
+Arguments bigmaxD1 {d T I} j {P F}.
+Arguments le_bigmax_cond {d T I P F}.
+Arguments bigmax_eq_arg {d T I} i0 {P F}.
+Arguments eq_bigmax {d T I} i0 {P F}.
+
+Section bigmin.
+Local Notation min := Order.min.
+Local Open Scope order_scope.
+Variables (d : _) (R : orderType d).
+
+Lemma bigmin_mkcond I r (P : pred I) (F : I -> R) x :
+  \big[min/x]_(i <- r | P i) F i =
+    \big[min/x]_(i <- r) (if P i then F i else x).
+Proof. by rewrite NoMonoidBigop.big_mkcond//; [exact: minxx|exact:minCA]. Qed.
+
+Lemma bigmin_split I r (P : pred I) (F1 F2 : I -> R) x :
+  \big[min/x]_(i <- r | P i) (min (F1 i) (F2 i)) =
+  min (\big[min/x]_(i <- r | P i) F1 i) (\big[min/x]_(i <- r | P i) F2 i).
+Proof. by rewrite NoMonoidBigop.big_split//; [exact: minxx|exact: minACA]. Qed.
+
+Lemma bigmin_idl I r (P : pred I) (F : I -> R) x :
+  \big[min/x]_(i <- r | P i) F i = min x (\big[min/x]_(i <- r | P i) F i).
+Proof. by rewrite [in LHS]big_idl//; [exact: minxx|exact: minCA]. Qed.
+
+Lemma bigminID I r (a P : pred I) (F : I -> R) x :
+  \big[min/x]_(i <- r | P i) F i =
+  min (\big[min/x]_(i <- r | P i && a i) F i)
+      (\big[min/x]_(i <- r | P i && ~~ a i) F i).
+Proof.
+by rewrite (NoMonoidBigop.bigID _ a)//; [exact: minxx|exact: minA|exact: minC].
+Qed.
+
+Lemma bigminD1 (I : finType) j (P : pred I) (F : I -> R) x :
+  P j -> \big[min/x]_(i | P i) F i
+    = min (F j) (\big[min/x]_(i | P i && (i != j)) F i).
+Proof.
+by apply: NoMonoidBigop.bigD1; [exact: minxx|exact: minA|exact: minC].
+Qed.
+
+Lemma bigmin_le_cond (I : finType) (P : pred I) (f : I -> R) (x0 : R) i :
+  P i -> \big[min/x0]_(j | P j) f j <= f i.
+Proof.
+have := mem_index_enum i; rewrite unlock; elim: (index_enum I) => //= j l ihl.
+rewrite inE => /orP [/eqP-> ->|/ihl leminlfi Pi]; first by rewrite le_minl lexx.
+by case: ifPn => Pj; [rewrite le_minl leminlfi// orbC|exact: leminlfi].
+Qed.
+
+Lemma bigmin_le (I : finType) (f : I -> R) (x0 : R) i :
+  \big[min/x0]_j f j <= f i.
+Proof. exact: bigmin_le_cond. Qed.
+
+Lemma bigmin_inf (I : finType) i0 (P : pred I) m (F : I -> R) x :
+  P i0 -> F i0 <= m -> \big[min/x]_(i | P i) F i <= m.
+Proof. by move=> Pi0 ?; apply: le_trans (bigmin_le_cond _ _ Pi0) _. Qed.
+
+Lemma bigmin_geP (I : finType) (P : pred I) m (F : I -> R) x :
+  reflect (m <= x /\ forall i, P i -> m <= F i)
+          (m <= \big[min/x]_(i | P i) F i).
+Proof.
+apply: (iffP idP) => [lemFi|[lemx lemPi]]; [split|exact: le_bigmin].
+- by rewrite (le_trans lemFi)// bigmin_idl le_minl lexx.
+- by move=> i Pi; rewrite (le_trans lemFi)// (bigminD1 _ _ Pi)// le_minl lexx.
+Qed.
+
+Lemma bigmin_gtP (I : finType) (P : pred I) m (F : I -> R) x :
+  reflect (m < x /\ forall i, P i -> m < F i)
+          (m < \big[min/x]_(i | P i) F i).
+Proof.
+apply: (iffP idP) => [lemFi|[lemx lemPi]]; [split|exact: lt_bigmin].
+- by rewrite (lt_le_trans lemFi)// bigmin_idl le_minl lexx.
+- by move=> i Pi; rewrite (lt_le_trans lemFi)// (bigminD1 _ _ Pi)// le_minl lexx.
+Qed.
+
+Lemma bigmin_eq_arg (I : finType) i0 (P : pred I) (F : I -> R) x :
+  P i0 -> (forall i, P i -> F i <= x) ->
+  \big[min/x]_(i | P i) F i = F [arg min_(i < i0 | P i) F i].
+Proof.
+move=> Pi0; case: arg_minP => //= i Pi PF PFx.
+apply/eqP; rewrite eq_le bigmin_le_cond //=.
+by apply/bigmin_geP; split => //; exact: PFx.
+Qed.
+
+Lemma eq_bigmin (I : finType) i0 (P : pred I) (F : I -> R) x :
+  P i0 -> (forall i, P i -> F i <= x) ->
+  {i0 | i0 \in I & \big[min/x]_(i | P i) F i = F i0}.
+Proof. by move=> Pi0 Hx; rewrite (bigmin_eq_arg Pi0) //; eexists. Qed.
+
+End bigmin.
+Arguments bigmin_le_cond {d R I P f}.
+Arguments bigmin_le {d R I f}.
+Arguments bigmin_mkcond {d R I r}.
+Arguments bigminID {d R I r}.
+Arguments bigminD1 {d R I} j {P F}.
+Arguments bigmin_inf {d R I} i0 {P m F}.
+Arguments bigmin_eq_arg {d R I} i0 {P F}.
+Arguments eq_bigmin {d R I} i0 {P F}.

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -1791,7 +1791,7 @@ rewrite /normr /ball_ predeq3E => x e y /=; rewrite mx_normE; split => xey.
   by rewrite -num_lt /=; split => // -[? ?] _; rewrite !mxE; exact: xey.
 - have e_gt0 : 0 < e by rewrite (le_lt_trans _ xey).
   move: e_gt0 (e_gt0) xey => /ltW/nonnegP[{}e] e_gt0.
-  move=> /(bigmax_ltP _ _ (fun _ => _%:sgn)) /= [e0 xey] i j.
+  move=> /(bigmax_ltP _ _ _ (fun _ => _%:sgn)) /= [e0 xey] i j.
   by move: (xey (i, j)); rewrite !mxE; exact.
 Qed.
 

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -384,7 +384,7 @@ apply Build_ProperFilter.
   by move=> P [M [Mreal MP]]; exists (M + 1); apply MP; rewrite ltr_addl.
 split=> /= [|P Q [MP [MPr gtMP]] [MQ [MQr gtMQ]] |P Q sPQ [M [Mr gtM]]].
 - by exists 0.
-- exists (Num.max MP MQ); split=> [|x]; first exact: max_real.
+- exists (maxr MP MQ); split=> [|x]; first exact: max_real.
   by rewrite comparable_lt_maxl ?real_comparable // => /andP[/gtMP ? /gtMQ].
 - by exists M; split => // ? /gtM /sPQ.
 Qed.
@@ -1694,12 +1694,6 @@ rewrite near_map => /nbhs_ballP[_/posnumP[a]] + xl; apply.
 by move/cvg_ball : xl => /(_ _ (gt0 a))/nbhs_ballP[_/posnumP[b]]; apply.
 Qed.
 
-Lemma bigminr_maxr (R : realDomainType) I r (P : pred I) (F : I -> R) x :
-  \big[minr/x]_(i <- r | P i) F i = - \big[maxr/- x]_(i <- r | P i) - F i.
-Proof.
-by elim/big_rec2: _ => [|i y _ _ ->]; rewrite ?oppr_max opprK.
-Qed.
-
 (** ** Matrices *)
 
 Section mx_norm.
@@ -1714,8 +1708,8 @@ Proof. by []. Qed.
 Lemma ler_mx_norm_add x y : mx_norm (x + y) <= mx_norm x + mx_norm y.
 Proof.
 rewrite !mx_normE [_ <= _%:num]num_le; apply/bigmax_leP.
-split; first exact: addr_ge0.
-move=> ij _; rewrite mxE; apply: le_trans (ler_norm_add _ _) _.
+split=> [|ij _]; first exact: addr_ge0.
+rewrite mxE; apply: le_trans (ler_norm_add _ _) _.
 by rewrite ler_add// -[leLHS]nngE num_le; exact: le_bigmax.
 Qed.
 
@@ -1771,7 +1765,7 @@ Lemma mx_normrE (K : realDomainType) (m n : nat) (x : 'M[K]_(m, n)) :
 Proof.
 rewrite /mx_norm; apply/esym.
 elim/big_ind2 : _ => //= a a' b b' ->{a'} ->{b'}.
-case: (leP a b) => ab; by [rewrite max_r | rewrite max_l // ltW].
+by have [ab|ab] := leP a b; [rewrite max_r | rewrite max_l // ltW].
 Qed.
 
 Definition matrix_normedZmodMixin (K : numDomainType) (m n : nat) :=


### PR DESCRIPTION
##### Motivation for this change

fixes #711

There was a section about bigmin in normedtype.v that was specialized to realDomainType
whereas there was a section about bigmax in topology.v that was using orderType.
This PR generalizes slightly the bigmin lemmas, bring them to topology.v, this highlights
a few factorizations, and this allows for simplifying the naming scheme (we can drop the `r`
that were marking numeric types).
It can still be cleaned up a bit but that's already an improvement imo.

fyi @proux01

TODO: just after merge: mathcomp issue about bigmax_sup

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- [ ] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
