### PR TITLE
add lemma set_unit

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -3,13 +3,13 @@
 ## [Unreleased]
 
 ### Added
+
 - in file `boolp.v`:
   + lemmas `iter_compl`, `iter_compr`, `iter0`
 - in file `functions.v`:
   + lemmas `oinv_iter`, `some_iter_inv`, `inv_iter`,
   + Instances for functions interfaces for `iter` (partial inverse up to 
       bijective function) 
-
 - in `ereal.v`:
   + notations `_ < _ :> _` and `_ <= _ :> _`
   + lemmas `lee01`, `lte01`, `lee0N1`, `lte0N1`
@@ -24,6 +24,8 @@
   + lemmas `muleCA`, `muleAC`, `muleACA`
 - in `classical_sets.v`:
   + lemma `preimage10P`
+- in `classical_sets.v`:
+  + lemma `setT_unit`
 
 ### Changed
 
@@ -44,6 +46,8 @@
 - in `ereal.v`:
   + `lee_pinfty_eq` -> `leye_eq`
   + `lee_ninfty_eq` -> `leeNy_eq`
+- in `classical_sets.v`:
+  + `set_bool` -> `setT_bool`
 
 ### Removed
 

--- a/theories/classical_sets.v
+++ b/theories/classical_sets.v
@@ -1056,7 +1056,10 @@ Proof. by move=> k; apply/val_inj. Qed.
 
 End InitialSegment.
 
-Lemma set_bool : [set: bool] = [set true; false].
+Lemma setT_unit : [set: unit] = [set tt].
+Proof. by apply/seteqP; split => // -[]. Qed.
+
+Lemma setT_bool : [set: bool] = [set true; false].
 Proof. by rewrite eqEsubset; split => // [[]] // _; [left|right]. Qed.
 
 (* TODO: other lemmas that relate fset and classical sets *)

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -3566,7 +3566,7 @@ Lemma discrete_bool : discrete_space bool_discrete_topology.
 Proof. by []. Qed.
 
 Lemma bool_compact : compact [set: bool].
-Proof. by rewrite set_bool; apply/compactU; exact: compact_set1. Qed.
+Proof. by rewrite setT_bool; apply/compactU; exact: compact_set1. Qed.
 
 End DiscreteTopology.
 


### PR DESCRIPTION
##### Motivation for this change

trivial lemma that turns out to be useful

shouldn't it rather be named `setT_unit` (and similarly `set_bool` -> `setT_bool`)?

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
~~- [ ] added corresponding documentation in the headers~~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
