### PR TITLE
Contraction Definitions

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -4,6 +4,47 @@
 
 ### Added
 
+- in file `boolp.v`:
+  + lemmas `iter_compl`, `iter_compr`, `iter0`
+- in file `functions.v`:
+  + lemmas `oinv_iter`, `some_iter_inv`, `inv_iter`,
+  + Instances for functions interfaces for `iter` (partial inverse up to 
+      bijective function) 
+- in `ereal.v`:
+  + notations `_ < _ :> _` and `_ <= _ :> _`
+  + lemmas `lee01`, `lte01`, `lee0N1`, `lte0N1`
+  + lemmas `lee_pmul2l`, `lee_pmul2r`, `lte_pmul`, `lee_wpmul2l`
+  + lemmas `lee_lt_add`, `lee_lt_dadd`, `lee_paddl`, `lee_pdaddl`,
+    `lte_paddl`, `lte_pdaddl`, `lee_paddr`, `lee_pdaddr`,
+    `lte_paddr`, `lte_pdaddr`
+- in `lebesgue_integral.v`:
+  + lemma `ge0_emeasurable_fun_sum`
+  + lemma `integrableMr`
+- in `ereal.v`:
+  + lemmas `muleCA`, `muleAC`, `muleACA`
+- in `classical_sets.v`:
+  + lemma `preimage10P`
+- in `classical_sets.v`:
+  + lemma `setT_unit`
+- in `mathcomp_extra.v`:
+  + lemma `big_const_idem`
+  + lemma `big_id_idem`
+  + lemma `big_rem_AC`
+  + lemma `bigD1_AC`
+  + lemma `big_mkcond_idem`
+  + lemma `big_split_idem`
+  + lemma `big_id_idem_AC`
+  + lemma `bigID_idem`
+- in `mathcomp_extra.v`:
+  + lemmas `bigmax_le` and `bigmax_lt`
+  + lemma `bigmin_idr`
+  + lemma `bigmax_idr`
+- in `classical_sets.v`:
+  + lemma `subset_refl`
+- in `normedtype.v`:
+  + definitions `contraction` and `is_contraction`
+  + lemma `contraction_fixpoint_unique`
+
 ### Changed
 
 ### Renamed

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -3,44 +3,6 @@
 ## [Unreleased]
 
 ### Added
-
-- in file `boolp.v`:
-  + lemmas `iter_compl`, `iter_compr`, `iter0`
-- in file `functions.v`:
-  + lemmas `oinv_iter`, `some_iter_inv`, `inv_iter`,
-  + Instances for functions interfaces for `iter` (partial inverse up to 
-      bijective function) 
-- in `ereal.v`:
-  + notations `_ < _ :> _` and `_ <= _ :> _`
-  + lemmas `lee01`, `lte01`, `lee0N1`, `lte0N1`
-  + lemmas `lee_pmul2l`, `lee_pmul2r`, `lte_pmul`, `lee_wpmul2l`
-  + lemmas `lee_lt_add`, `lee_lt_dadd`, `lee_paddl`, `lee_pdaddl`,
-    `lte_paddl`, `lte_pdaddl`, `lee_paddr`, `lee_pdaddr`,
-    `lte_paddr`, `lte_pdaddr`
-- in `lebesgue_integral.v`:
-  + lemma `ge0_emeasurable_fun_sum`
-  + lemma `integrableMr`
-- in `ereal.v`:
-  + lemmas `muleCA`, `muleAC`, `muleACA`
-- in `classical_sets.v`:
-  + lemma `preimage10P`
-- in `classical_sets.v`:
-  + lemma `setT_unit`
-- in `mathcomp_extra.v`:
-  + lemma `big_const_idem`
-  + lemma `big_id_idem`
-  + lemma `big_rem_AC`
-  + lemma `bigD1_AC`
-  + lemma `big_mkcond_idem`
-  + lemma `big_split_idem`
-  + lemma `big_id_idem_AC`
-  + lemma `bigID_idem`
-- in `mathcomp_extra.v`:
-  + lemmas `bigmax_le` and `bigmax_lt`
-  + lemma `bigmin_idr`
-  + lemma `bigmax_idr`
-- in `classical_sets.v`:
-  + lemma `subset_refl`
 - in `normedtype.v`:
   + definitions `contraction` and `is_contraction`
   + lemma `contraction_fixpoint_unique`

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -65,6 +65,8 @@ Require Import functions.
 (*               k.-lipschitz_on f F == f is k.-lipschitz near F              *)
 (*                  k.-lipschitz_A f == f is k.-lipschitz on A                *)
 (*        [locally k.-lipschitz_A f] == f is locally k.-lipschitz on A        *)
+(*                   contraction q f == f is q.-lipschitz and q < 1           *)
+(*                  is_contraction f == exists q, f is q.-lipschitz and q < 1 *)
 (*                                                                            *)
 (*                     is_interval E == the set E is an interval              *)
 (*                bigcup_ointsub U q == union of open real interval included  *)
@@ -1525,6 +1527,27 @@ Qed.
 Lemma lipschitz_id (R : numFieldType) (V : normedModType R) : 1.-lipschitz (@id V).
 Proof. by move=> [/= x y] _; rewrite mul1r. Qed.
 Arguments lipschitz_id {R V}.
+
+Section contractions.
+Context {R : numDomainType} {X Y : normedModType R} {U : set X} {V : set Y}.
+
+Definition contraction (q : {nonneg R}) (f : {fun U >-> V}) :=
+  q%:num < 1 /\ q%:num.-lipschitz_U f.
+
+Definition is_contraction (f : {fun U >-> V}) := exists q, contraction q f.
+
+End contractions.
+
+Lemma contraction_fixpoint_unique {R : realDomainType}
+    {X : normedModType R} (U : set X) (f : {fun U >-> U}) (x y : X) :
+  is_contraction f -> U x -> U y -> x = f x -> y = f y -> x = y.
+Proof.
+case => q [q1 ctrfq] Ux Uy fixx fixy; apply/subr0_eq/normr0_eq0/eqP.
+have [->|xyneq] := eqVneq x y; first by rewrite subrr normr0.
+have xypos : 0 < `|x - y| by rewrite normr_gt0 subr_eq0.
+suff : `|x - y| <= q%:num * `|x - y| by rewrite ler_pmull // leNgt q1.
+by rewrite [in leLHS]fixx [in leLHS]fixy; exact: (ctrfq (_, _)).
+Qed.
 
 Section PseudoNormedZMod_numFieldType.
 Variables (R : numFieldType) (V : pseudoMetricNormedZmodType R).


### PR DESCRIPTION
##### Motivation for this change
Splitting out another piece of the Banach Fixed Point PR, this just defines contractions and proves a simple fact about them. 
Note that this places them in `normedtype.v` next to the lipschitz, which is a much more sensible place to define things. 

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
  (do not edit former entries, only append new ones, be careful:
   merge and rebase have a tendency to mess up `CHANGELOG_UNRELEASED.md`)
- [x] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
