### PR TITLE
use floor rather than Rfloor

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -41,6 +41,8 @@
   + lemma `bigmax_idr`
 - in `classical_sets.v`:
   + lemma `subset_refl`
+- in `reals.v`:
+  + lemmas `Rfloor_lt_int`, `floor_lt_int`, `floor_ge_int`
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -43,6 +43,7 @@
   + lemma `subset_refl`
 - in `reals.v`:
   + lemmas `Rfloor_lt_int`, `floor_lt_int`, `floor_ge_int`
+  + lemmas `ceil_ge_int`, `ceil_lt_int`
 
 ### Changed
 

--- a/theories/ereal.v
+++ b/theories/ereal.v
@@ -1126,13 +1126,13 @@ case: x => /= [x [_/posnumP[d] dP] |[d [dreal dP]] |[d [dreal dP]]]; last 2 firs
       by rewrite Znat_def floor_ge0 le_maxr lexx orbC.
     exists N.+1 => // n ltNn; apply: dP.
     have /le_lt_trans : (d <= Num.max d 0)%R by rewrite le_maxr lexx.
-    apply; apply: lt_le_trans (lt_succ_Rfloor _) _; rewrite RfloorE Nfloor.
+    apply; apply: lt_le_trans (lt_succ_floor _) _; rewrite Nfloor.
     by rewrite -(@natrD R N 1) ler_nat addn1.
   have /ZnatP [N Nfloor] : floor (Num.max (- d)%R 0%R) \is a Znat.
     by rewrite Znat_def floor_ge0 le_maxr lexx orbC.
   exists N.+1 => // n ltNn; apply: dP; rewrite lte_fin ltr_oppl.
   have /le_lt_trans : (- d <= Num.max (- d) 0)%R by rewrite le_maxr lexx.
-  apply; apply: lt_le_trans (lt_succ_Rfloor _) _; rewrite RfloorE Nfloor.
+  apply; apply: lt_le_trans (lt_succ_floor _) _; rewrite Nfloor.
   by rewrite -(@natrD R N 1) ler_nat addn1.
 have /ZnatP [N Nfloor] : floor (d%:num^-1) \is a Znat.
   by rewrite Znat_def floor_ge0.
@@ -1142,5 +1142,5 @@ apply: dP; last first.
   by rewrite eq_sym addrC -subr_eq subrr eq_sym; apply/invr_neq0/lt0r_neq0.
 rewrite /= opprD addrA subrr distrC subr0 gtr0_norm; last by rewrite invr_gt0.
 rewrite -[ltLHS]mulr1 ltr_pdivr_mull // -ltr_pdivr_mulr // div1r.
-by rewrite (lt_le_trans (lt_succ_Rfloor _))// RfloorE Nfloor ler_add// ler_nat.
+by rewrite (lt_le_trans (lt_succ_floor _))// Nfloor ler_add// ler_nat.
 Qed.

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -1220,7 +1220,7 @@ rewrite predeqE => r; split => [/= /[!in_itv]/= /andP[nr rn1]|].
   rewrite /= in_itv /=; apply/andP; split.
     rewrite ler_pdivr_mulr// (le_trans _ (floor_le _))//.
     by rewrite -(@gez0_abs (floor _))// floor_ge0 mulr_ge0// (le_trans _ nr).
-  rewrite ltr_pdivl_mulr// (lt_le_trans (lt_succ_Rfloor _))// RfloorE.
+  rewrite ltr_pdivl_mulr// (lt_le_trans (lt_succ_floor _))//.
   rewrite -[in leRHS]addn1 natrD ler_add2r// -(@gez0_abs (floor _))// floor_ge0.
   by rewrite mulr_ge0// (le_trans _ nr).
 - rewrite -bigcup_set => -[/= k] /[!mem_index_iota] /andP[nk kn].
@@ -1373,7 +1373,7 @@ have xAnK : x \in A n (Ordinal K).
   rewrite in_itv /=; apply/andP; split.
     rewrite ler_pdivr_mulr// (le_trans _ (floor_le _))//.
     by rewrite -(@gez0_abs (floor _))// floor_ge0 mulr_ge0// ltW.
-  rewrite ltr_pdivl_mulr// (lt_le_trans (lt_succ_Rfloor _))// RfloorE.
+  rewrite ltr_pdivl_mulr// (lt_le_trans (lt_succ_floor _))//.
   rewrite -[in leRHS]addn1 natrD ler_add2r// -{1}(@gez0_abs (floor _))//.
   by rewrite floor_ge0// mulr_ge0// ltW.
 have /[!mem_index_enum]/(_ isT) := An0 (Ordinal K).
@@ -1492,7 +1492,7 @@ have : fine (f x) < n%:R.
   rewrite -(@ler_nat R); apply: lt_le_trans.
   rewrite -addn1 natrD (_ : `| _ |%:R  = (floor (fine (f x)))%:~R); last first.
     by rewrite -[in RHS](@gez0_abs (floor _))// floor_ge0 //; exact/le0R/f0.
-  by rewrite -RfloorE lt_succ_Rfloor.
+  by rewrite lt_succ_floor.
 rewrite -lte_fin (fineK fxfin) => fxn.
 have [approx_nx0|] := f_ub_approx fxn.
   by have := Hm _ mn; rewrite approx_nx0.

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -380,13 +380,11 @@ Qed.
 Lemma hlength_sigma_finite : sigma_finite [set: ocitv_type] hlength.
 Proof.
 exists (fun k : nat => `] (- k%:R)%R, k%:R]%classic).
-  apply/esym; rewrite -subTset => /= x _ /=.
-  exists `|(floor `|x|%R + 1)%R|%N; rewrite //= in_itv/=.
-  rewrite !natr_absz intr_norm intrD -RfloorE.
-  suff: `|x| < `|Rfloor `|x| + 1| by rewrite ltr_norml => /andP[-> /ltW->].
-  rewrite [ltRHS]ger0_norm//.
-    by rewrite (le_lt_trans _ (lt_succ_Rfloor _))// ?ler_norm.
-  by rewrite addr_ge0// -Rfloor0 le_Rfloor.
+  apply/esym; rewrite -subTset => x _ /=; exists `|(floor `|x| + 1)%R|%N => //=.
+  rewrite in_itv/= !natr_absz intr_norm intrD.
+  suff: `|x| < `|(floor `|x|)%:~R + 1| by rewrite ltr_norml => /andP[-> /ltW->].
+  rewrite [ltRHS]ger0_norm//; last by rewrite addr_ge0// ler0z floor_ge0.
+  by rewrite (le_lt_trans _ (lt_succ_floor _)) ?ler_norm.
 by move=> k; split => //; rewrite hlength_itv/= -EFinB; case: ifP; rewrite ltey.
 Qed.
 
@@ -564,7 +562,7 @@ apply/ler_addgt0Pl => e e_gt0; rewrite -ler_subl_addl ltW//.
 have := rx `|floor e^-1%R|%N I; rewrite /= in_itv => /andP[/le_lt_trans->]//.
 rewrite ler_add2l ler_opp2 -lef_pinv ?invrK//; last by rewrite qualifE.
 rewrite -addn1 natrD natr_absz ger0_norm ?floor_ge0 ?invr_ge0 1?ltW//.
-by rewrite -RfloorE lt_succ_Rfloor.
+by rewrite lt_succ_floor.
 Qed.
 
 Lemma itv_bnd_open_bigcup (R : realType) b (r s : R) :
@@ -602,9 +600,8 @@ Proof.
 apply/seteqP; split=> y; rewrite /= !in_itv/= andbT; last first.
   by move=> [k _ /=]; move: b => [|] /=; rewrite in_itv/= => /andP[//] /ltW.
 move=> xy; exists `|ceil (y - x)|%N => //=; rewrite in_itv/= xy/= -ler_subl_addl.
-rewrite !natr_absz/= ger0_norm ?ceil_ge0// ?subr_ge0//; last first.
-  by case: b xy => //= /ltW.
-by rewrite -RceilE Rceil_ge.
+rewrite !natr_absz/= ger0_norm ?ceil_ge0 ?subr_ge0 ?ceil_ge//.
+by case: b xy => //= /ltW.
 Qed.
 
 Lemma itv_infty_bnd_bigcup (R : realType) b (x : R) :

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -3258,8 +3258,7 @@ Lemma compact_bounded (K : realType) (V : normedModType K) (A : set V) :
 Proof.
 rewrite compact_cover => Aco.
 have covA : A `<=` \bigcup_(n : int) [set p | `|p| < n%:~R].
-  move=> p Ap; exists (floor `|p| + 1) => //.
-  by rewrite rmorphD /= -RfloorE lt_succ_Rfloor.
+  by move=> p _; exists (floor `|p| + 1) => //; rewrite rmorphD/= lt_succ_floor.
 have /Aco [] := covA.
   move=> n _; rewrite openE => p; rewrite /= -subr_gt0 => ltpn.
   apply/nbhs_ballP; exists (n%:~R - `|p|) => // q.

--- a/theories/reals.v
+++ b/theories/reals.v
@@ -676,6 +676,9 @@ apply/idP/idP; last by move/le_trans => /(_ _ (Rfloor_le x)).
 by move/le_Rfloor; apply le_trans; rewrite Rfloor_natz.
 Qed.
 
+Lemma Rfloor_lt_int x (z : int) : (x < z%:~R) = (Rfloor x < z%:~R).
+Proof. by rewrite ltNge Rfloor_ge_int -ltNge. Qed.
+
 Lemma Rfloor_le0 x : x <= 0 -> Rfloor x <= 0.
 Proof. by move=> ?; rewrite -Rfloor0 le_Rfloor. Qed.
 
@@ -708,6 +711,15 @@ apply/idP/orP => [|[x0|/le_floor r1]]; first rewrite neq_lt => /orP[x0|x0].
 - by rewrite lt_eqF//; apply: contra_lt x0; rewrite floor_ge0.
 - by rewrite gt_eqF// (lt_le_trans _ r1)// floor1.
 Qed.
+
+Lemma lt_succ_floor x : x < (floor x)%:~R + 1.
+Proof. by rewrite -RfloorE lt_succ_Rfloor. Qed.
+
+Lemma floor_lt_int x (z : int) : (x < z%:~R) = (floor x < z).
+Proof. by rewrite Rfloor_lt_int RfloorE ltr_int. Qed.
+
+Lemma floor_ge_int x (z : int) : (z%:~R <= x) = (z <= floor x).
+Proof. by rewrite Rfloor_ge_int RfloorE ler_int. Qed.
 
 Lemma ltr_add_invr (y x : R) : y < x -> exists k, y + k.+1%:R^-1 < x.
 Proof.

--- a/theories/reals.v
+++ b/theories/reals.v
@@ -771,6 +771,12 @@ Proof. by move=> x0; rewrite -ler_oppl oppr0 floor_ge0 -ler_oppr oppr0. Qed.
 Lemma le_ceil : {homo @ceil R : x y / x <= y}.
 Proof. by move=> x y xy; rewrite ler_oppl opprK le_floor // ler_oppl opprK. Qed.
 
+Lemma ceil_ge_int x (z : int) : (x <= z%:~R) = (ceil x <= z).
+Proof. by rewrite /ceil ler_oppl -floor_ge_int// -ler_oppr mulrNz opprK. Qed.
+
+Lemma ceil_lt_int x (z : int) : (z%:~R < x) = (z < ceil x).
+Proof. by rewrite ltNge ceil_ge_int -ltNge. Qed.
+
 End CeilTheory.
 
 (* -------------------------------------------------------------------- *)

--- a/theories/sequences.v
+++ b/theories/sequences.v
@@ -1161,9 +1161,8 @@ rewrite /series; near \oo => N; have xN : x < N%:R; last first.
   rewrite -(@is_cvg_series_restrict N.+1).
   by apply: (nondecreasing_is_cvg (incr_S1 N)); eexists; apply: S1_sup.
 near: N; exists (absz (floor x)).+1 => // m; rewrite /mkset -(@ler_nat R).
-move/lt_le_trans => -> //; rewrite (lt_le_trans (lt_succ_Rfloor x)) // -addn1.
-rewrite natrD (_ : 1%:R = 1%R) // ler_add2r RfloorE -(@gez0_abs (floor x)) //.
-by rewrite floor_ge0// ltW.
+move/lt_le_trans => -> //; rewrite (lt_le_trans (lt_succ_floor x)) // -addn1.
+by rewrite natrD ler_add2r -(@gez0_abs (floor x)) ?floor_ge0// ltW.
 Unshelve. all: by end_near. Qed.
 
 End exponential_series_cvg.

--- a/theories/set_interval.v
+++ b/theories/set_interval.v
@@ -415,8 +415,7 @@ rewrite predeqE => y; split=> /=; last first.
 rewrite in_itv /= andbT => xy; exists (`|floor y|%N.+1) => //=.
 rewrite in_itv /= xy /= -addn1 natrD.
 have [y0|y0] := ltP 0 y; last by rewrite (le_lt_trans y0)// ltr_spaddr.
-rewrite natr_absz ger0_norm; last by rewrite floor_ge0 ltW.
-by rewrite -RfloorE lt_succ_Rfloor.
+by rewrite natr_absz ger0_norm ?lt_succ_floor// floor_ge0 ltW.
 Qed.
 
 Lemma itv_o_inftyEbigcup x :


### PR DESCRIPTION
##### Motivation for this change

Use floor/ceil rather that Rfloor/Rceil leads to slightly shorter proofs.
This PR also adds a few lemmas found useful in another development.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
~- [ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
