### PR TITLE
Subspace topology restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -745,7 +745,7 @@ Lastest releases: [[0.5.4] - 2022-09-07](#055---2022-09-07) and [[0.5.3] - 2022-
   + lemmas `continuous_subspace_in`
   + lemmas`closed_subspaceP`, `closed_subspaceW`, `closure_subspaceW`
   + lemmas `nbhs_subspace_subset`, `continuous_subspaceW`, `nbhs_subspaceT`,
-    `subspace_restrict_domain_for`, `subspace_restrict_domain`, `continuous_open_subspace`
+    `continuous_subspaceT_for`, `continuous_subspaceT`, `continuous_open_subspace`
   + globals `subspace_filter`, `subspace_proper_filter`
   + notation `{within ..., continuous ...}`
   + definitions `compact_near`, `precompact`, `locally_compact`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -745,7 +745,7 @@ Lastest releases: [[0.5.4] - 2022-09-07](#055---2022-09-07) and [[0.5.3] - 2022-
   + lemmas `continuous_subspace_in`
   + lemmas`closed_subspaceP`, `closed_subspaceW`, `closure_subspaceW`
   + lemmas `nbhs_subspace_subset`, `continuous_subspaceW`, `nbhs_subspaceT`,
-    `continuous_subspaceT_for`, `continuous_subspaceT`, `continuous_open_subspace`
+    `subspace_restrict_domain_for`, `subspace_restrict_domain`, `continuous_open_subspace`
   + globals `subspace_filter`, `subspace_proper_filter`
   + notation `{within ..., continuous ...}`
   + definitions `compact_near`, `precompact`, `locally_compact`

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -15,7 +15,7 @@
   + lemma `near_inftyS`
   + lemma `continuous_closedP`, `closedU`, `pasting`
   + changed `continuous_subspaceT` to `continuous_subspaceT_in`
-  + lemmas `continuous_subspaceT`, `subspace_continuous_restricted`
+  + lemmas `subspace_restrict_domain`, `subspace_restrict_range`
 
 - in `sequences.v`:
   + lemmas `contraction_dist`, `contraction_cvg`,

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -3,62 +3,16 @@
 ## [Unreleased]
 
 ### Added
-- in `normedtype.v`:
-  + definitions `contraction` and `is_contraction`
-  + lemma `contraction_fixpoint_unique`
-
-- in `constructive_ereal.v`:
-  + lemmas `ltNye_eq`, `sube_lt0`, `subre_lt0`, `suber_lt0`, `sube_ge0`
-  + lemmas `dsubre_gt0`, `dsuber_gt0`, `dsube_gt0`, `dsube_le0`
-
 - in `topology.v`:
-  + lemma `near_inftyS`
-  + lemma `continuous_closedP`, `closedU`, `pasting`
   + changed `continuous_subspaceT` to `continuous_subspaceT_in`
   + lemmas `subspace_restrict_domain`, `subspace_restrict_range`
-
-- in `sequences.v`:
-  + lemmas `contraction_dist`, `contraction_cvg`,
-    `contraction_cvg_fixed`, `banach_fixed_point`,
-    `contraction_unique`
-- in `mathcomp_extra.v`:
-  + defintion `onem` and notation ``` `1- ```
-  + lemmas `onem0`, `onem1`, `onemK`, `onem_gt0`, `onem_ge0`, `onem_le1`, `onem_lt1`,
-    `onemX_ge0`, `onemX_lt1`, `onemD`, `onemMr`, `onemM`
-- in `signed.v`:
-  + lemmas `onem_PosNum`, `onemX_NngNum`
-- in `lebesgue_measure.v`:
-  + lemma `measurable_fun_fine`
-- in `lebesgue_integral.v`:
-  + lemma `ge0_integral_mscale`
-- in `measure.v`:
-  + lemma `measurable_funTS`
-- in `lebesgue_measure.v`:
-  + lemma `measurable_fun_indic`
-- in `fsbigop.v`:
-  + lemmas `lee_fsum_nneg_subset`, `lee_fsum`
-- in `classical_sets.v`:
-  + lemmas `subset_fst_set`, `subset_snd_set`, `fst_set_fst`, `snd_set_snd`,
-    `fset_setM`, `snd_setM`, `fst_setMR`
-  + lemmas `xsection_snd_set`, `ysection_fst_set`
-  + Hint about `measurable_fun_normr`
-- in `lebesgue_integral.v`:
-  + lemma `integral_pushforward`
-
-- in `derive.v`:
-  + lemma `diff_derivable`
-- in `topology.v`:
-  + lemma `continuous_inP`
-- in `lebesgue_measure.v`:
-  + lemma `open_measurable_subspace`
-  + lemma ``subspace_continuous_measurable_fun``
-  + corollary `open_continuous_measurable_fun`
-- in `topology.v`:
-  + lemmas `open_setIS`, `open_setSI`, `closed_setIS`, `closed_setSI`
 
 ### Changed
 
 ### Renamed
+
+- in `topology.v`:
+  + renamed `continuous_subspaceT` to `continuous_subspaceT_in`
 
 ### Removed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -3,6 +3,58 @@
 ## [Unreleased]
 
 ### Added
+- in `normedtype.v`:
+  + definitions `contraction` and `is_contraction`
+  + lemma `contraction_fixpoint_unique`
+
+- in `constructive_ereal.v`:
+  + lemmas `ltNye_eq`, `sube_lt0`, `subre_lt0`, `suber_lt0`, `sube_ge0`
+  + lemmas `dsubre_gt0`, `dsuber_gt0`, `dsube_gt0`, `dsube_le0`
+
+- in `topology.v`:
+  + lemma `near_inftyS`
+  + lemma `continuous_closedP`, `closedU`, `pasting`
+  + changed `continuous_subspaceT` to `continuous_subspaceT_in`
+  + lemmas `continuous_subspaceT`, `subspace_continuous_restricted`
+
+- in `sequences.v`:
+  + lemmas `contraction_dist`, `contraction_cvg`,
+    `contraction_cvg_fixed`, `banach_fixed_point`,
+    `contraction_unique`
+- in `mathcomp_extra.v`:
+  + defintion `onem` and notation ``` `1- ```
+  + lemmas `onem0`, `onem1`, `onemK`, `onem_gt0`, `onem_ge0`, `onem_le1`, `onem_lt1`,
+    `onemX_ge0`, `onemX_lt1`, `onemD`, `onemMr`, `onemM`
+- in `signed.v`:
+  + lemmas `onem_PosNum`, `onemX_NngNum`
+- in `lebesgue_measure.v`:
+  + lemma `measurable_fun_fine`
+- in `lebesgue_integral.v`:
+  + lemma `ge0_integral_mscale`
+- in `measure.v`:
+  + lemma `measurable_funTS`
+- in `lebesgue_measure.v`:
+  + lemma `measurable_fun_indic`
+- in `fsbigop.v`:
+  + lemmas `lee_fsum_nneg_subset`, `lee_fsum`
+- in `classical_sets.v`:
+  + lemmas `subset_fst_set`, `subset_snd_set`, `fst_set_fst`, `snd_set_snd`,
+    `fset_setM`, `snd_setM`, `fst_setMR`
+  + lemmas `xsection_snd_set`, `ysection_fst_set`
+  + Hint about `measurable_fun_normr`
+- in `lebesgue_integral.v`:
+  + lemma `integral_pushforward`
+
+- in `derive.v`:
+  + lemma `diff_derivable`
+- in `topology.v`:
+  + lemma `continuous_inP`
+- in `lebesgue_measure.v`:
+  + lemma `open_measurable_subspace`
+  + lemma ``subspace_continuous_measurable_fun``
+  + corollary `open_continuous_measurable_fun`
+- in `topology.v`:
+  + lemmas `open_setIS`, `open_setSI`, `closed_setIS`, `closed_setSI`
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -4,7 +4,6 @@
 
 ### Added
 - in `topology.v`:
-  + changed `continuous_subspaceT` to `continuous_subspaceT_in`
   + lemmas `subspace_restrict_domain`, `subspace_restrict_range`
 
 ### Changed

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -4,14 +4,14 @@
 
 ### Added
 - in `topology.v`:
-  + lemmas `subspace_restrict_domain`, `subspace_restrict_range`
+  + lemmas `continuous_subspaceT`, `subspaceT_continuous`
 
 ### Changed
 
 ### Renamed
 
 - in `topology.v`:
-  + renamed `continuous_subspaceT` to `continuous_subspaceT_in`
+  + renamed `continuous_subspaceT` to `continuous_in_subspaceT`
 
 ### Removed
 

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -1507,7 +1507,7 @@ have gdrvbl x : x \in `]a, b[%R -> derivable g x 1.
   by move=> /fdrvbl dfx; apply: derivableB => //; exact/derivable1_diffP.
 have gcont : {within `[a, b], continuous g}.
   move=> x; apply: continuousD _ ; first by move=>?; exact: fcont.
-  by apply/continuousN/subspace_restrict_domain => ?; exact: scalel_continuous.
+  by apply/continuousN/continuous_subspaceT=> ?; exact: scalel_continuous.
 have gaegb : g a = g b.
   rewrite /g -![(_ - _ : _ -> _) _]/(_ - _).
   apply/eqP; rewrite -subr_eq /= opprK addrAC -addrA -scalerBl.

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -1507,7 +1507,7 @@ have gdrvbl x : x \in `]a, b[%R -> derivable g x 1.
   by move=> /fdrvbl dfx; apply: derivableB => //; exact/derivable1_diffP.
 have gcont : {within `[a, b], continuous g}.
   move=> x; apply: continuousD _ ; first by move=>?; exact: fcont.
-  by apply/continuousN/continuous_subspaceT => ? ?; exact: scalel_continuous.
+  by apply/continuousN/continuous_subspaceT => ?; exact: scalel_continuous.
 have gaegb : g a = g b.
   rewrite /g -![(_ - _ : _ -> _) _]/(_ - _).
   apply/eqP; rewrite -subr_eq /= opprK addrAC -addrA -scalerBl.

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -1507,7 +1507,7 @@ have gdrvbl x : x \in `]a, b[%R -> derivable g x 1.
   by move=> /fdrvbl dfx; apply: derivableB => //; exact/derivable1_diffP.
 have gcont : {within `[a, b], continuous g}.
   move=> x; apply: continuousD _ ; first by move=>?; exact: fcont.
-  by apply/continuousN/continuous_subspaceT => ?; exact: scalel_continuous.
+  by apply/continuousN/subspace_restrict_domain => ?; exact: scalel_continuous.
 have gaegb : g a = g b.
   rewrite /g -![(_ - _ : _ -> _) _]/(_ - _).
   apply/eqP; rewrite -subr_eq /= opprK addrAC -addrA -scalerBl.

--- a/theories/exp.v
+++ b/theories/exp.v
@@ -442,7 +442,7 @@ Proof.
 move=> x_ge1; have x_ge0 : 0 <= x by apply: le_trans x_ge1.
 have [x1 x1Ix| |x1 _ /eqP] := @IVT _ (fun y => expR y - x) _ _ 0 x_ge0.
 - apply: continuousB => // y1; last exact: cst_continuous.
-  by apply/continuous_subspaceT=> ?; exact: continuous_expR.
+  by apply/subspace_restrict_domain=> ?; exact: continuous_expR.
 - rewrite expR0; have [_| |] := ltrgtP (1- x) (expR x - x).
   + by rewrite subr_le0 x_ge1 subr_ge0 (le_trans _ (expR_ge1Dx _)) ?ler_addr.
   + by rewrite ltr_add2r expR_lt1 ltNge x_ge0.

--- a/theories/exp.v
+++ b/theories/exp.v
@@ -442,7 +442,7 @@ Proof.
 move=> x_ge1; have x_ge0 : 0 <= x by apply: le_trans x_ge1.
 have [x1 x1Ix| |x1 _ /eqP] := @IVT _ (fun y => expR y - x) _ _ 0 x_ge0.
 - apply: continuousB => // y1; last exact: cst_continuous.
-  by apply/continuous_subspaceT=> ? _; exact: continuous_expR.
+  by apply/continuous_subspaceT=> ?; exact: continuous_expR.
 - rewrite expR0; have [_| |] := ltrgtP (1- x) (expR x - x).
   + by rewrite subr_le0 x_ge1 subr_ge0 (le_trans _ (expR_ge1Dx _)) ?ler_addr.
   + by rewrite ltr_add2r expR_lt1 ltNge x_ge0.

--- a/theories/exp.v
+++ b/theories/exp.v
@@ -442,7 +442,7 @@ Proof.
 move=> x_ge1; have x_ge0 : 0 <= x by apply: le_trans x_ge1.
 have [x1 x1Ix| |x1 _ /eqP] := @IVT _ (fun y => expR y - x) _ _ 0 x_ge0.
 - apply: continuousB => // y1; last exact: cst_continuous.
-  by apply/subspace_restrict_domain=> ?; exact: continuous_expR.
+  by apply/continuous_subspaceT=> ?; exact: continuous_expR.
 - rewrite expR0; have [_| |] := ltrgtP (1- x) (expR x - x).
   + by rewrite subr_le0 x_ge1 subr_ge0 (le_trans _ (expR_ge1Dx _)) ?ler_addr.
   + by rewrite ltr_add2r expR_lt1 ltNge x_ge0.

--- a/theories/realfun.v
+++ b/theories/realfun.v
@@ -32,7 +32,7 @@ Implicit Types (a b : R) (f g : R -> R).
 Lemma continuous_subspace_itv (I : interval R) (f : R -> R) :
   {in I, continuous f} -> {within [set` I], continuous f}.
 Proof.
-move=> ctsf; apply: continuous_subspaceT => x Ix; apply: ctsf.
+move=> ctsf; apply: continuous_subspaceT_in => x Ix; apply: ctsf.
 by move: Ix; rewrite inE.
 Qed.
 
@@ -51,10 +51,10 @@ gen have main : f / forall c, {in I, continuous f} -> {in I &, injective f} ->
   have intP := interval_is_interval aI bI.
   have cI : c \in I by rewrite intP// (ltW aLc) ltW.
   have ctsACf : {within `[a, c], continuous f}.
-    apply: continuous_subspaceT => x; rewrite inE => /itvP axc; apply: fC.
+    apply: continuous_subspaceT_in => x; rewrite inE => /itvP axc; apply: fC.
     by rewrite intP// axc/= (le_trans _ (ltW cLb))// axc.
   have ctsCBf : {within `[c,b], continuous f}.
-    apply: continuous_subspaceT => x; rewrite inE => /itvP axc; apply: fC.
+    apply: continuous_subspaceT_in => x; rewrite inE => /itvP axc; apply: fC.
     by rewrite intP// axc andbT (le_trans (ltW aLc)) ?axc.
   have [aLb alb'] : a < b /\ a <= b by rewrite ltW (lt_trans aLc).
   have [faLfc|fcLfa|/eqP faEfc] /= := ltrgtP (f a) (f c).
@@ -487,7 +487,7 @@ move=> Hd.
 wlog xLy : x y / x <= y by move=> H; case: (leP x y) => [/H |/ltW /H].
 rewrite -(subKr (f y) (f x)).
 have [| _ _] := MVT_segment xLy; last by rewrite mul0r => ->; rewrite subr0.
-apply/continuous_subspaceT => r _.
+apply/continuous_subspaceT => r.
 exact/differentiable_continuous/derivable1_diffP.
 Qed.
 

--- a/theories/realfun.v
+++ b/theories/realfun.v
@@ -32,7 +32,7 @@ Implicit Types (a b : R) (f g : R -> R).
 Lemma continuous_subspace_itv (I : interval R) (f : R -> R) :
   {in I, continuous f} -> {within [set` I], continuous f}.
 Proof.
-move=> ctsf; apply: continuous_subspaceT_in => x Ix; apply: ctsf.
+move=> ctsf; apply: continuous_in_subspaceT => x Ix; apply: ctsf.
 by move: Ix; rewrite inE.
 Qed.
 
@@ -51,10 +51,10 @@ gen have main : f / forall c, {in I, continuous f} -> {in I &, injective f} ->
   have intP := interval_is_interval aI bI.
   have cI : c \in I by rewrite intP// (ltW aLc) ltW.
   have ctsACf : {within `[a, c], continuous f}.
-    apply: continuous_subspaceT_in => x; rewrite inE => /itvP axc; apply: fC.
+    apply: continuous_in_subspaceT => x; rewrite inE => /itvP axc; apply: fC.
     by rewrite intP// axc/= (le_trans _ (ltW cLb))// axc.
   have ctsCBf : {within `[c,b], continuous f}.
-    apply: continuous_subspaceT_in => x; rewrite inE => /itvP axc; apply: fC.
+    apply: continuous_in_subspaceT => x; rewrite inE => /itvP axc; apply: fC.
     by rewrite intP// axc andbT (le_trans (ltW aLc)) ?axc.
   have [aLb alb'] : a < b /\ a <= b by rewrite ltW (lt_trans aLc).
   have [faLfc|fcLfa|/eqP faEfc] /= := ltrgtP (f a) (f c).
@@ -487,7 +487,7 @@ move=> Hd.
 wlog xLy : x y / x <= y by move=> H; case: (leP x y) => [/H |/ltW /H].
 rewrite -(subKr (f y) (f x)).
 have [| _ _] := MVT_segment xLy; last by rewrite mul0r => ->; rewrite subr0.
-apply/subspace_restrict_domain => r.
+apply/continuous_subspaceT=> r.
 exact/differentiable_continuous/derivable1_diffP.
 Qed.
 

--- a/theories/realfun.v
+++ b/theories/realfun.v
@@ -487,7 +487,7 @@ move=> Hd.
 wlog xLy : x y / x <= y by move=> H; case: (leP x y) => [/H |/ltW /H].
 rewrite -(subKr (f y) (f x)).
 have [| _ _] := MVT_segment xLy; last by rewrite mul0r => ->; rewrite subr0.
-apply/continuous_subspaceT => r.
+apply/subspace_restrict_domain => r.
 exact/differentiable_continuous/derivable1_diffP.
 Qed.
 

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -5803,7 +5803,7 @@ rewrite eqEsubset withinE; split => [W [V nbhsV]|W ?]; last by exists W.
 by rewrite 2!setIT => ->.
 Qed.
 
-Lemma subspace_restrict_domain_for {U} A (f : T -> U) (x : T) :
+Lemma continuous_subspaceT_for {U} A (f : T -> U) (x : T) :
   A x -> {for x, continuous f} -> {for x, continuous (f : subspace A -> U)}.
 Proof.
 rewrite /filter_of/nbhs/=/prop_for => inA ctsf.
@@ -5816,7 +5816,7 @@ Lemma continuous_subspaceT_in {U} A (f : T -> U) :
   {in A, continuous f} -> {within A, continuous f}.
 Proof.
 rewrite continuous_subspace_in ?in_setP => ctsf t At.
-by apply subspace_restrict_domain_for => //=; apply: ctsf.
+by apply continuous_subspaceT_for => //=; apply: ctsf.
 Qed.
 
 Lemma subspace_restrict_domain {U} A (f : T -> U) :

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -5834,6 +5834,13 @@ by split => + x /[dup] Ax /oA Aox; rewrite /filter_of /= => /(_ _ Ax);
   rewrite -(nbhs_subspace_interior Aox).
 Qed.
 
+Lemma continuous_inP {U} A (f : T -> U) : open A ->
+  {in A, continuous f} <-> forall X, open X -> open (A `&` f @^-1` X).
+Proof.
+move=> oA; rewrite -continuous_open_subspace// continuousP.
+by under eq_forall do rewrite -open_setSI//.
+Qed.
+
 Lemma pasting {U} A B (f : T -> U) : closed A -> closed B ->
   {within A, continuous f} -> {within B, continuous f} ->
   {within A `|` B, continuous f}.

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -5812,18 +5812,18 @@ apply: (cvg_trans _ ctsf); apply: cvg_fmap2; apply: cvg_within.
 by rewrite /subspace; exact: nbhs_filter.
 Qed.
 
-Lemma continuous_subspaceT_in {U} A (f : T -> U) :
+Lemma continuous_in_subspaceT {U} A (f : T -> U) :
   {in A, continuous f} -> {within A, continuous f}.
 Proof.
 rewrite continuous_subspace_in ?in_setP => ctsf t At.
 by apply continuous_subspaceT_for => //=; apply: ctsf.
 Qed.
 
-Lemma subspace_restrict_domain {U} A (f : T -> U) :
+Lemma continuous_subspaceT{U} A (f : T -> U) :
   continuous f -> {within A, continuous f}.
 Proof.
 move=> ctsf; rewrite continuous_subspace_in => ? ?. 
-by apply: continuous_subspaceT_in => ? ?.
+by apply: continuous_in_subspaceT => ? ?.
 Qed.
 
 Lemma continuous_open_subspace {U} A (f : T -> U) :
@@ -5855,7 +5855,7 @@ rewrite [RHS]setIUr -V2W -V1W eqEsubset; split=> ?.
 by case=> [][] ? ?; split=> []; [left; split | left | right; split | right]. 
 Qed.
 
-Lemma subspace_restrict_range {U} A (B : set U) (f : {fun A >-> B}) :
+Lemma subspaceT_continuous {U} A (B : set U) (f : {fun A >-> B}) :
   {within A, continuous f} -> continuous (f : subspace A -> subspace B).
 Proof.
 move=> /continuousP ctsf; apply/continuousP=> O /open_subspaceP [V].
@@ -6069,7 +6069,7 @@ Lemma continuous_localP {X Y : topologicalType} (f : X -> Y) :
   forall (x : X), \forall U \near powerset_filter_from (nbhs x),
     {within U, continuous f}.
 Proof.
-split; first by move=> ? ?; near=> U; apply: subspace_restrict_domain => ?; exact.
+split; first by move=> ? ?; near=> U; apply: continuous_subspaceT=> ?; exact.
 move=> + x => /(_ x)/near_powerset_filter_fromP.
 case; first by move=> ? ?; exact: continuous_subspaceW.
 move=> U nbhsU wctsf; wlog oU : U wctsf nbhsU / open U.
@@ -6195,7 +6195,7 @@ Lemma precompact_pointwise_precompact (W : set {family compact, X -> Y}) :
 Proof.
 move=> + x; rewrite ?precompactE => pcptW.
 have : compact (prod_topo_apply x @` (closure W)).
-  apply: continuous_compact => //; apply: subspace_restrict_domain => g.
+  apply: continuous_compact => //; apply: continuous_subspaceT=> g.
   move=> E nbhsE; have := (@prod_topo_apply_continuous _ _ x g E nbhsE).
   exact: (@pointwise_cvg_compact_family _ _ (nbhs g)).
 move=> /[dup]/(compact_closed hsdf)/closure_id -> /subclosed_compact.
@@ -6326,7 +6326,7 @@ apply/continuous_localP => x'; apply/near_powerset_filter_fromP.
   by move=> ? ?; exact: continuous_subspaceW.
 case: (@lcptX x') => // U; rewrite withinET => nbhsU [cptU _].
 exists U => //; apply: (uniform_limit_continuous_subspace PG _ _).
-  by near=> g; apply: subspace_restrict_domain; near: g; exact: GW.
+  by near=> g; apply: continuous_subspaceT; near: g; exact: GW.
 by move/fam_cvgP/(_ _ cptU) : Gf.
 Unshelve. end_near. Qed.
 

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -5803,7 +5803,7 @@ rewrite eqEsubset withinE; split => [W [V nbhsV]|W ?]; last by exists W.
 by rewrite 2!setIT => ->.
 Qed.
 
-Lemma continuous_subspaceT_for {U} A (f : T -> U) (x : T) :
+Lemma subspace_restrict_domain_for {U} A (f : T -> U) (x : T) :
   A x -> {for x, continuous f} -> {for x, continuous (f : subspace A -> U)}.
 Proof.
 rewrite /filter_of/nbhs/=/prop_for => inA ctsf.
@@ -5816,10 +5816,10 @@ Lemma continuous_subspaceT_in {U} A (f : T -> U) :
   {in A, continuous f} -> {within A, continuous f}.
 Proof.
 rewrite continuous_subspace_in ?in_setP => ctsf t At.
-by apply continuous_subspaceT_for => //=; apply: ctsf.
+by apply subspace_restrict_domain_for => //=; apply: ctsf.
 Qed.
 
-Lemma continuous_subspaceT {U} A (f : T -> U) :
+Lemma subspace_restrict_domain {U} A (f : T -> U) :
   continuous f -> {within A, continuous f}.
 Proof.
 move=> ctsf; rewrite continuous_subspace_in => ? ?. 
@@ -5855,7 +5855,7 @@ rewrite [RHS]setIUr -V2W -V1W eqEsubset; split=> ?.
 by case=> [][] ? ?; split=> []; [left; split | left | right; split | right]. 
 Qed.
 
-Lemma subspace_continuous_restricted {U} A (B : set U) (f : {fun A >-> B}) :
+Lemma subspace_restrict_range {U} A (B : set U) (f : {fun A >-> B}) :
   {within A, continuous f} -> continuous (f : subspace A -> subspace B).
 Proof.
 move=> /continuousP ctsf; apply/continuousP=> O /open_subspaceP [V].
@@ -6069,7 +6069,7 @@ Lemma continuous_localP {X Y : topologicalType} (f : X -> Y) :
   forall (x : X), \forall U \near powerset_filter_from (nbhs x),
     {within U, continuous f}.
 Proof.
-split; first by move=> ? ?; near=> U; apply: continuous_subspaceT => ?; exact.
+split; first by move=> ? ?; near=> U; apply: subspace_restrict_domain => ?; exact.
 move=> + x => /(_ x)/near_powerset_filter_fromP.
 case; first by move=> ? ?; exact: continuous_subspaceW.
 move=> U nbhsU wctsf; wlog oU : U wctsf nbhsU / open U.
@@ -6195,7 +6195,7 @@ Lemma precompact_pointwise_precompact (W : set {family compact, X -> Y}) :
 Proof.
 move=> + x; rewrite ?precompactE => pcptW.
 have : compact (prod_topo_apply x @` (closure W)).
-  apply: continuous_compact => //; apply: continuous_subspaceT => g.
+  apply: continuous_compact => //; apply: subspace_restrict_domain => g.
   move=> E nbhsE; have := (@prod_topo_apply_continuous _ _ x g E nbhsE).
   exact: (@pointwise_cvg_compact_family _ _ (nbhs g)).
 move=> /[dup]/(compact_closed hsdf)/closure_id -> /subclosed_compact.
@@ -6326,7 +6326,7 @@ apply/continuous_localP => x'; apply/near_powerset_filter_fromP.
   by move=> ? ?; exact: continuous_subspaceW.
 case: (@lcptX x') => // U; rewrite withinET => nbhsU [cptU _].
 exists U => //; apply: (uniform_limit_continuous_subspace PG _ _).
-  by near=> g; apply: continuous_subspaceT; near: g; exact: GW.
+  by near=> g; apply: subspace_restrict_domain; near: g; exact: GW.
 by move/fam_cvgP/(_ _ cptU) : Gf.
 Unshelve. end_near. Qed.
 

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -5855,18 +5855,15 @@ rewrite [RHS]setIUr -V2W -V1W eqEsubset; split=> ?.
 by case=> [][] ? ?; split=> []; [left; split | left | right; split | right]. 
 Qed.
 
-Lemma subspace_continuous_restricted {U} (A : set T) (B : set U) 
-    (f : {fun A >-> B}) :
+Lemma subspace_continuous_restricted {U} A (B : set U) (f : {fun A >-> B}) :
   {within A, continuous f} -> continuous (f : subspace A -> subspace B).
 Proof.
 move=> /continuousP ctsf; apply/continuousP=> O /open_subspaceP [V].
 case=> ofV VAOA; rewrite -open_subspaceIT; apply/open_subspaceP.
-case/open_subspaceP: (ctsf _ ofV)=> W [] oW fvA; exists (W); split => //.
-rewrite fvA -setIA setIid eqEsubset; split=> x [] ? Ax; split=> //. 
-  have : ((V `&` B) (f x))  by split => //; exact: funS.
-  by rewrite VAOA => [][].
-have : ((O `&` B) (f x))  by split => //; exact: funS.
-by rewrite -VAOA => [][].
+case/open_subspaceP: (ctsf _ ofV) => W [] oW fvA; exists (W); split => //.
+rewrite fvA -setIA setIid eqEsubset; split=> x [] ? Ax; split=> //.
+  (have : (V `&` B) (f x) by split => //; exact: funS); by rewrite VAOA => [][].
+(have : (O `&` B) (f x) by split => //; exact: funS); by rewrite -VAOA => [][].
 Qed.
 
 End SubspaceRelative.

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -5812,26 +5812,26 @@ apply: (cvg_trans _ ctsf); apply: cvg_fmap2; apply: cvg_within.
 by rewrite /subspace; exact: nbhs_filter.
 Qed.
 
-Lemma continuous_subspaceT {U} A (f : T -> U) :
+Lemma continuous_subspaceT_in {U} A (f : T -> U) :
   {in A, continuous f} -> {within A, continuous f}.
 Proof.
 rewrite continuous_subspace_in ?in_setP => ctsf t At.
 by apply continuous_subspaceT_for => //=; apply: ctsf.
 Qed.
 
+Lemma continuous_subspaceT {U} A (f : T -> U) :
+  continuous f -> {within A, continuous f}.
+Proof.
+move=> ctsf; rewrite continuous_subspace_in => ? ?. 
+by apply: continuous_subspaceT_in => ? ?.
+Qed.
+
 Lemma continuous_open_subspace {U} A (f : T -> U) :
-  open A -> {within A, continuous f} = {in A, continuous f}.
+  @open T A -> {within A, continuous f} = {in A, continuous f}.
 Proof.
 rewrite openE continuous_subspace_in /= => oA; rewrite propeqE ?in_setP.
 by split => + x /[dup] Ax /oA Aox; rewrite /filter_of /= => /(_ _ Ax);
   rewrite -(nbhs_subspace_interior Aox).
-Qed.
-
-Lemma continuous_inP {U} A (f : T -> U) : open A ->
-  {in A, continuous f} <-> forall X, open X -> open (A `&` f @^-1` X).
-Proof.
-move=> oA; rewrite -continuous_open_subspace// continuousP.
-by under eq_forall do rewrite -open_setSI//.
 Qed.
 
 Lemma pasting {U} A B (f : T -> U) : closed A -> closed B ->
@@ -5845,7 +5845,21 @@ apply/closed_subspaceP; exists ((V1 `&` A) `|` (V2 `&` B)); split.
   by apply: closedU; exact: closedI.
 rewrite [RHS]setIUr -V2W -V1W eqEsubset; split=> ?.
   by case=> [[][]] ? ? [] ?; [left | left | right | right]; split.
-by case=> [][] ? ?; split=> []; [left; split | left | right; split | right].
+by case=> [][] ? ?; split=> []; [left; split | left | right; split | right]. 
+Qed.
+
+Lemma subspace_continuous_restricted {U} (A : set T) (B : set U) 
+    (f : {fun A >-> B}) :
+  {within A, continuous f} -> continuous (f : subspace A -> subspace B).
+Proof.
+move=> /continuousP ctsf; apply/continuousP=> O /open_subspaceP [V].
+case=> ofV VAOA; rewrite -open_subspaceIT; apply/open_subspaceP.
+case/open_subspaceP: (ctsf _ ofV)=> W [] oW fvA; exists (W); split => //.
+rewrite fvA -setIA setIid eqEsubset; split=> x [] ? Ax; split=> //. 
+  have : ((V `&` B) (f x))  by split => //; exact: funS.
+  by rewrite VAOA => [][].
+have : ((O `&` B) (f x))  by split => //; exact: funS.
+by rewrite -VAOA => [][].
 Qed.
 
 End SubspaceRelative.
@@ -6051,7 +6065,7 @@ Lemma continuous_localP {X Y : topologicalType} (f : X -> Y) :
   forall (x : X), \forall U \near powerset_filter_from (nbhs x),
     {within U, continuous f}.
 Proof.
-split; first by move=> ? ?; near=> U; apply: continuous_subspaceT => ? ?; exact.
+split; first by move=> ? ?; near=> U; apply: continuous_subspaceT => ?; exact.
 move=> + x => /(_ x)/near_powerset_filter_fromP.
 case; first by move=> ? ?; exact: continuous_subspaceW.
 move=> U nbhsU wctsf; wlog oU : U wctsf nbhsU / open U.
@@ -6177,7 +6191,7 @@ Lemma precompact_pointwise_precompact (W : set {family compact, X -> Y}) :
 Proof.
 move=> + x; rewrite ?precompactE => pcptW.
 have : compact (prod_topo_apply x @` (closure W)).
-  apply: continuous_compact => //; apply: continuous_subspaceT => g _.
+  apply: continuous_compact => //; apply: continuous_subspaceT => g.
   move=> E nbhsE; have := (@prod_topo_apply_continuous _ _ x g E nbhsE).
   exact: (@pointwise_cvg_compact_family _ _ (nbhs g)).
 move=> /[dup]/(compact_closed hsdf)/closure_id -> /subclosed_compact.
@@ -6308,7 +6322,7 @@ apply/continuous_localP => x'; apply/near_powerset_filter_fromP.
   by move=> ? ?; exact: continuous_subspaceW.
 case: (@lcptX x') => // U; rewrite withinET => nbhsU [cptU _].
 exists U => //; apply: (uniform_limit_continuous_subspace PG _ _).
-  by near=> g; apply: continuous_subspaceT => + _; near: g; exact: GW.
+  by near=> g; apply: continuous_subspaceT; near: g; exact: GW.
 by move/fam_cvgP/(_ _ cptU) : Gf.
 Unshelve. end_near. Qed.
 

--- a/theories/trigo.v
+++ b/theories/trigo.v
@@ -563,7 +563,7 @@ have /IVT[] : minr (cos 1) (cos 2) <= (0 : R) <= maxr (cos 1) (cos 2).
   - rewrite /minr /maxr ltNge (ltW (lt_trans cos2_lt0 cos1_gt0))/=.
     by rewrite (ltW cos2_lt0)/= (ltW cos1_gt0).
   - by rewrite ler1n.
-  - by move=> *; apply/continuous_subspaceT=> ?; exact: continuous_cos.
+  - by move=> *; apply/subspace_restrict_domain=> ?; exact: continuous_cos.
 by move=> pih /itvP pihI chpi_eq0; exists pih; rewrite ?pihI.
 Qed.
 
@@ -577,7 +577,7 @@ case: (x =P y) => // /eqP xDy.
 have xLLs : x < y by rewrite le_eqVlt (negPf xDy) in xLy.
 have /(Rolle xLLs)[x1 _|x1|x1 x1I [_ x1D]] : cos x = cos y by rewrite cy0.
 - exact: derivable_cos.
-- by apply/continuous_subspaceT=> ?; exact: continuous_cos.
+- by apply/subspace_restrict_domain=> ?; exact: continuous_cos.
 - have [_ /esym/eqP] := is_derive_cos x1; rewrite x1D oppr_eq0 => /eqP Hs.
   suff : 0 < sin x1 by rewrite Hs ltxx.
   apply/sin2_gt0/andP; split.
@@ -641,7 +641,7 @@ wlog : x / 0 <= x => [Hw|x_ge0].
 move=> /andP[x_gt0 xLpi2]; case: (ler0P (cos x)) => // cx_le0.
 have /IVT[]// : minr (cos 0) (cos x) <= 0 <= maxr (cos 0) (cos x).
   by rewrite cos0 /minr /maxr !ifN ?cx_le0 //= -leNgt (le_trans cx_le0).
-- by move=> *; apply/continuous_subspaceT=> ?; apply: continuous_cos.
+- by move=> *; apply/subspace_restrict_domain=> ?; apply: continuous_cos.
 move=> x1 /itvP Hx1 cx1_eq0.
 suff x1E : x1 = pi/2.
   have : x1 < pi / 2 by apply: le_lt_trans xLpi2; rewrite Hx1.
@@ -732,7 +732,7 @@ move=> x y; rewrite !in_itv/= le_eqVlt; case: eqP => [<- _|_] /=.
   rewrite y_gt0; apply/idP.
   suff : cos y != 1 by case: ltrgtP (cos_le1 y).
   rewrite -cos0 eq_sym; apply/eqP => /Rolle [||x1|x1 /itvP x1I [_ x1D]] //.
-    by apply/continuous_subspaceT=> ?; exact: continuous_cos.
+    by apply/subspace_restrict_domain=> ?; exact: continuous_cos.
   case: (is_derive_cos x1) => _ /eqP; rewrite x1D eq_sym oppr_eq0 => /eqP s_eq0.
   suff : 0 < sin x1 by rewrite s_eq0 ltxx.
   by apply: sin_gt0_pi; rewrite x1I /= (lt_le_trans (_ : _ < y)) ?x1I // yI.
@@ -747,7 +747,7 @@ rewrite le_eqVlt; case: eqP => /= [-> _ | _ /andP[y_gt0 y_ltpi]].
   rewrite cospi x_ltpi; apply/idP.
   suff : cos x != -1 by case: ltrgtP (cos_geN1 x).
   rewrite -cospi; apply/eqP => /Rolle [||x1|x1 /itvP x1I [_ x1D]] //.
-    by apply/continuous_subspaceT=> ?; exact: continuous_cos.
+    by apply/subspace_restrict_domain=> ?; exact: continuous_cos.
   case: (is_derive_cos x1) => _ /eqP; rewrite x1D eq_sym oppr_eq0 => /eqP s_eq0.
   suff : 0 < sin x1 by rewrite s_eq0 ltxx.
   by apply: sin_gt0_pi; rewrite x1I /= (lt_le_trans (_ : _ < x)) ?x1I.
@@ -758,7 +758,7 @@ case: (x =P y) => [->| /eqP xDy]; first by rewrite ltxx.
 have xLLs : x < y by rewrite le_eqVlt (negPf xDy) in xLy.
 rewrite xLLs -subr_gt0 -opprB; rewrite -subr_gt0 in xLLs; apply/idP.
 have [x1|z /itvP zI ->] := @MVT_segment _ cos (-sin) _ _ xLy.
-  by apply/continuous_subspaceT=> ?; exact: continuous_cos.
+  by apply/subspace_restrict_domain=> ?; exact: continuous_cos.
 rewrite -mulNr opprK mulr_gt0 //; apply: sin_gt0_pi.
 by rewrite (lt_le_trans x_gt0) ?zI //= (le_lt_trans _ y_ltpi) ?zI.
 Qed.

--- a/theories/trigo.v
+++ b/theories/trigo.v
@@ -563,7 +563,7 @@ have /IVT[] : minr (cos 1) (cos 2) <= (0 : R) <= maxr (cos 1) (cos 2).
   - rewrite /minr /maxr ltNge (ltW (lt_trans cos2_lt0 cos1_gt0))/=.
     by rewrite (ltW cos2_lt0)/= (ltW cos1_gt0).
   - by rewrite ler1n.
-  - by move=> *; apply/subspace_restrict_domain=> ?; exact: continuous_cos.
+  - by move=> *; apply/continuous_subspaceT=> ?; exact: continuous_cos.
 by move=> pih /itvP pihI chpi_eq0; exists pih; rewrite ?pihI.
 Qed.
 
@@ -577,7 +577,7 @@ case: (x =P y) => // /eqP xDy.
 have xLLs : x < y by rewrite le_eqVlt (negPf xDy) in xLy.
 have /(Rolle xLLs)[x1 _|x1|x1 x1I [_ x1D]] : cos x = cos y by rewrite cy0.
 - exact: derivable_cos.
-- by apply/subspace_restrict_domain=> ?; exact: continuous_cos.
+- by apply/continuous_subspaceT=> ?; exact: continuous_cos.
 - have [_ /esym/eqP] := is_derive_cos x1; rewrite x1D oppr_eq0 => /eqP Hs.
   suff : 0 < sin x1 by rewrite Hs ltxx.
   apply/sin2_gt0/andP; split.
@@ -641,7 +641,7 @@ wlog : x / 0 <= x => [Hw|x_ge0].
 move=> /andP[x_gt0 xLpi2]; case: (ler0P (cos x)) => // cx_le0.
 have /IVT[]// : minr (cos 0) (cos x) <= 0 <= maxr (cos 0) (cos x).
   by rewrite cos0 /minr /maxr !ifN ?cx_le0 //= -leNgt (le_trans cx_le0).
-- by move=> *; apply/subspace_restrict_domain=> ?; apply: continuous_cos.
+- by move=> *; apply/continuous_subspaceT=> ?; apply: continuous_cos.
 move=> x1 /itvP Hx1 cx1_eq0.
 suff x1E : x1 = pi/2.
   have : x1 < pi / 2 by apply: le_lt_trans xLpi2; rewrite Hx1.
@@ -732,7 +732,7 @@ move=> x y; rewrite !in_itv/= le_eqVlt; case: eqP => [<- _|_] /=.
   rewrite y_gt0; apply/idP.
   suff : cos y != 1 by case: ltrgtP (cos_le1 y).
   rewrite -cos0 eq_sym; apply/eqP => /Rolle [||x1|x1 /itvP x1I [_ x1D]] //.
-    by apply/subspace_restrict_domain=> ?; exact: continuous_cos.
+    by apply/continuous_subspaceT=> ?; exact: continuous_cos.
   case: (is_derive_cos x1) => _ /eqP; rewrite x1D eq_sym oppr_eq0 => /eqP s_eq0.
   suff : 0 < sin x1 by rewrite s_eq0 ltxx.
   by apply: sin_gt0_pi; rewrite x1I /= (lt_le_trans (_ : _ < y)) ?x1I // yI.
@@ -747,7 +747,7 @@ rewrite le_eqVlt; case: eqP => /= [-> _ | _ /andP[y_gt0 y_ltpi]].
   rewrite cospi x_ltpi; apply/idP.
   suff : cos x != -1 by case: ltrgtP (cos_geN1 x).
   rewrite -cospi; apply/eqP => /Rolle [||x1|x1 /itvP x1I [_ x1D]] //.
-    by apply/subspace_restrict_domain=> ?; exact: continuous_cos.
+    by apply/continuous_subspaceT=> ?; exact: continuous_cos.
   case: (is_derive_cos x1) => _ /eqP; rewrite x1D eq_sym oppr_eq0 => /eqP s_eq0.
   suff : 0 < sin x1 by rewrite s_eq0 ltxx.
   by apply: sin_gt0_pi; rewrite x1I /= (lt_le_trans (_ : _ < x)) ?x1I.
@@ -758,7 +758,7 @@ case: (x =P y) => [->| /eqP xDy]; first by rewrite ltxx.
 have xLLs : x < y by rewrite le_eqVlt (negPf xDy) in xLy.
 rewrite xLLs -subr_gt0 -opprB; rewrite -subr_gt0 in xLLs; apply/idP.
 have [x1|z /itvP zI ->] := @MVT_segment _ cos (-sin) _ _ xLy.
-  by apply/subspace_restrict_domain=> ?; exact: continuous_cos.
+  by apply/continuous_subspaceT=> ?; exact: continuous_cos.
 rewrite -mulNr opprK mulr_gt0 //; apply: sin_gt0_pi.
 by rewrite (lt_le_trans x_gt0) ?zI //= (le_lt_trans _ y_ltpi) ?zI.
 Qed.
@@ -881,7 +881,7 @@ have [x1 /itvP x1I|z |] := @MVT_segment _ tan (fun x => (cos x) ^-2) _ _ xLy.
 - apply: is_derive_tan.
   rewrite gt_eqF // cos_gt0_pihalf // (@lt_le_trans _  _ x) ?x1I ?(itvP xB)//=.
   by rewrite (@le_lt_trans _  _ y) ?x1I ?(itvP yB).
-- apply/continuous_subspaceT_in => ? inI; apply: continuous_tan.
+- apply/continuous_in_subspaceT => ? inI; apply: continuous_tan.
   rewrite /= inE /<=%O/= in inI; move/andP: inI => /= [? ?].
   rewrite gt_eqF // cos_gt0_pihalf // (@lt_le_trans _  _ x) ?zI ?(itvP xB)//=.
   rewrite (@le_lt_trans _  _ y) ?zI ?(itvP yB) //.
@@ -917,7 +917,7 @@ have /(IVT (@pi_ge0 _))[] // : minr (f 0) (f pi) <= 0 <= maxr (f 0) (f pi).
   rewrite /f cos0 cospi /minr /maxr ltr_add2r -subr_lt0 opprK (_ : 1 + 1 = 2)//.
   by rewrite ltrn0 subr_le0 subr_ge0.
 - move=> y y0pi.
-  by apply: continuousB; apply/continuous_subspaceT_in => ? ?;
+  by apply: continuousB; apply/continuous_in_subspaceT => ? ?;
     [exact: continuous_cos|exact: cst_continuous].
 - rewrite /f => x1 /itvP x1I /eqP; rewrite subr_eq0 => /eqP cosx1E.
   by case: (He x1); rewrite !x1I.
@@ -1043,7 +1043,7 @@ have /IVT[] // :
   rewrite /f sinN sin_pihalf /minr /maxr ltr_add2r -subr_gt0 opprK.
   by rewrite (_ : 1 + 1 = 2)// ltr0n/= subr_le0 subr_ge0.
 - by rewrite -subr_ge0 opprK -splitr pi_ge0.
-- by move=> *; apply: continuousB; apply/continuous_subspaceT_in => ? ?;
+- by move=> *; apply: continuousB; apply/continuous_in_subspaceT => ? ?;
    [exact: continuous_sin| exact: cst_continuous].
 - rewrite /f => x1 /itvP x1I /eqP; rewrite subr_eq0 => /eqP sinx1E.
   by case: (He x1); rewrite !x1I.

--- a/theories/trigo.v
+++ b/theories/trigo.v
@@ -563,7 +563,7 @@ have /IVT[] : minr (cos 1) (cos 2) <= (0 : R) <= maxr (cos 1) (cos 2).
   - rewrite /minr /maxr ltNge (ltW (lt_trans cos2_lt0 cos1_gt0))/=.
     by rewrite (ltW cos2_lt0)/= (ltW cos1_gt0).
   - by rewrite ler1n.
-  - by move=> *; apply/continuous_subspaceT=> ? _; exact: continuous_cos.
+  - by move=> *; apply/continuous_subspaceT=> ?; exact: continuous_cos.
 by move=> pih /itvP pihI chpi_eq0; exists pih; rewrite ?pihI.
 Qed.
 
@@ -577,7 +577,7 @@ case: (x =P y) => // /eqP xDy.
 have xLLs : x < y by rewrite le_eqVlt (negPf xDy) in xLy.
 have /(Rolle xLLs)[x1 _|x1|x1 x1I [_ x1D]] : cos x = cos y by rewrite cy0.
 - exact: derivable_cos.
-- by apply/continuous_subspaceT=> ? _; exact: continuous_cos.
+- by apply/continuous_subspaceT=> ?; exact: continuous_cos.
 - have [_ /esym/eqP] := is_derive_cos x1; rewrite x1D oppr_eq0 => /eqP Hs.
   suff : 0 < sin x1 by rewrite Hs ltxx.
   apply/sin2_gt0/andP; split.
@@ -641,7 +641,7 @@ wlog : x / 0 <= x => [Hw|x_ge0].
 move=> /andP[x_gt0 xLpi2]; case: (ler0P (cos x)) => // cx_le0.
 have /IVT[]// : minr (cos 0) (cos x) <= 0 <= maxr (cos 0) (cos x).
   by rewrite cos0 /minr /maxr !ifN ?cx_le0 //= -leNgt (le_trans cx_le0).
-- by move=> *; apply/continuous_subspaceT=> ? _; apply: continuous_cos.
+- by move=> *; apply/continuous_subspaceT=> ?; apply: continuous_cos.
 move=> x1 /itvP Hx1 cx1_eq0.
 suff x1E : x1 = pi/2.
   have : x1 < pi / 2 by apply: le_lt_trans xLpi2; rewrite Hx1.
@@ -732,7 +732,7 @@ move=> x y; rewrite !in_itv/= le_eqVlt; case: eqP => [<- _|_] /=.
   rewrite y_gt0; apply/idP.
   suff : cos y != 1 by case: ltrgtP (cos_le1 y).
   rewrite -cos0 eq_sym; apply/eqP => /Rolle [||x1|x1 /itvP x1I [_ x1D]] //.
-    by apply/continuous_subspaceT=> ? _; exact: continuous_cos.
+    by apply/continuous_subspaceT=> ?; exact: continuous_cos.
   case: (is_derive_cos x1) => _ /eqP; rewrite x1D eq_sym oppr_eq0 => /eqP s_eq0.
   suff : 0 < sin x1 by rewrite s_eq0 ltxx.
   by apply: sin_gt0_pi; rewrite x1I /= (lt_le_trans (_ : _ < y)) ?x1I // yI.
@@ -747,7 +747,7 @@ rewrite le_eqVlt; case: eqP => /= [-> _ | _ /andP[y_gt0 y_ltpi]].
   rewrite cospi x_ltpi; apply/idP.
   suff : cos x != -1 by case: ltrgtP (cos_geN1 x).
   rewrite -cospi; apply/eqP => /Rolle [||x1|x1 /itvP x1I [_ x1D]] //.
-    by apply/continuous_subspaceT=> ? _; exact: continuous_cos.
+    by apply/continuous_subspaceT=> ?; exact: continuous_cos.
   case: (is_derive_cos x1) => _ /eqP; rewrite x1D eq_sym oppr_eq0 => /eqP s_eq0.
   suff : 0 < sin x1 by rewrite s_eq0 ltxx.
   by apply: sin_gt0_pi; rewrite x1I /= (lt_le_trans (_ : _ < x)) ?x1I.
@@ -758,7 +758,7 @@ case: (x =P y) => [->| /eqP xDy]; first by rewrite ltxx.
 have xLLs : x < y by rewrite le_eqVlt (negPf xDy) in xLy.
 rewrite xLLs -subr_gt0 -opprB; rewrite -subr_gt0 in xLLs; apply/idP.
 have [x1|z /itvP zI ->] := @MVT_segment _ cos (-sin) _ _ xLy.
-  by apply/continuous_subspaceT=> ? _; exact: continuous_cos.
+  by apply/continuous_subspaceT=> ?; exact: continuous_cos.
 rewrite -mulNr opprK mulr_gt0 //; apply: sin_gt0_pi.
 by rewrite (lt_le_trans x_gt0) ?zI //= (le_lt_trans _ y_ltpi) ?zI.
 Qed.
@@ -881,7 +881,7 @@ have [x1 /itvP x1I|z |] := @MVT_segment _ tan (fun x => (cos x) ^-2) _ _ xLy.
 - apply: is_derive_tan.
   rewrite gt_eqF // cos_gt0_pihalf // (@lt_le_trans _  _ x) ?x1I ?(itvP xB)//=.
   by rewrite (@le_lt_trans _  _ y) ?x1I ?(itvP yB).
-- apply/continuous_subspaceT=> ? inI; apply: continuous_tan.
+- apply/continuous_subspaceT_in => ? inI; apply: continuous_tan.
   rewrite /= inE /<=%O/= in inI; move/andP: inI => /= [? ?].
   rewrite gt_eqF // cos_gt0_pihalf // (@lt_le_trans _  _ x) ?zI ?(itvP xB)//=.
   rewrite (@le_lt_trans _  _ y) ?zI ?(itvP yB) //.
@@ -917,7 +917,7 @@ have /(IVT (@pi_ge0 _))[] // : minr (f 0) (f pi) <= 0 <= maxr (f 0) (f pi).
   rewrite /f cos0 cospi /minr /maxr ltr_add2r -subr_lt0 opprK (_ : 1 + 1 = 2)//.
   by rewrite ltrn0 subr_le0 subr_ge0.
 - move=> y y0pi.
-  by apply: continuousB; apply/continuous_subspaceT=> ? ?;
+  by apply: continuousB; apply/continuous_subspaceT_in => ? ?;
     [exact: continuous_cos|exact: cst_continuous].
 - rewrite /f => x1 /itvP x1I /eqP; rewrite subr_eq0 => /eqP cosx1E.
   by case: (He x1); rewrite !x1I.
@@ -1043,7 +1043,7 @@ have /IVT[] // :
   rewrite /f sinN sin_pihalf /minr /maxr ltr_add2r -subr_gt0 opprK.
   by rewrite (_ : 1 + 1 = 2)// ltr0n/= subr_le0 subr_ge0.
 - by rewrite -subr_ge0 opprK -splitr pi_ge0.
-- by move=> *; apply: continuousB; apply/continuous_subspaceT=> ? ?;
+- by move=> *; apply: continuousB; apply/continuous_subspaceT_in => ? ?;
    [exact: continuous_sin| exact: cst_continuous].
 - rewrite /f => x1 /itvP x1I /eqP; rewrite subr_eq0 => /eqP sinx1E.
   by case: (He x1); rewrite !x1I.


### PR DESCRIPTION
##### Motivation for this change
The relationship between `subspace` topologies and `{fun A -> B}` was not well described. We had some stuff for restricting domains, but nothing for restricting ranges. This helps clarify that relationship with the `subspace_restrict_domain` and `subspace_restrict_range` lemmas, and some small renaming.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
  (do not edit former entries, only append new ones, be careful:
   merge and rebase have a tendency to mess up `CHANGELOG_UNRELEASED.md`)
- ~[ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
