### PR TITLE
release of version 0.5.4 (changelog, etc.)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,96 @@
 # Changelog
 
-Lastest releases: [[0.5.3] - 2022-08-10](#053---2022-08-10) and [[0.5.2] - 2022-06-08](#052---2022-07-08)
+Lastest releases: [[0.5.4] - 2022-09-07](#055---2022-09-07) and [[0.5.3] - 2022-08-10](#053---2022-08-10)
+
+## [0.5.4] - 2022-09-07
+
+### Added
+
+- in `mathcomp_extra.v`:
+  + defintion `onem` and notation ``` `1- ```
+  + lemmas `onem0`, `onem1`, `onemK`, `onem_gt0`, `onem_ge0`, `onem_le1`, `onem_lt1`,
+    `onemX_ge0`, `onemX_lt1`, `onemD`, `onemMr`, `onemM`
+  + lemmas `natr1`, `nat1r`
+- in `classical_sets.v`:
+  + lemmas `subset_fst_set`, `subset_snd_set`, `fst_set_fst`, `snd_set_snd`,
+    `fset_setM`, `snd_setM`, `fst_setMR`
+  + lemmas `xsection_snd_set`, `ysection_fst_set`
+- in `constructive_ereal.v`:
+  + lemmas `ltNye_eq`, `sube_lt0`, `subre_lt0`, `suber_lt0`, `sube_ge0`
+  + lemmas `dsubre_gt0`, `dsuber_gt0`, `dsube_gt0`, `dsube_le0`
+- in `signed.v`:
+  + lemmas `onem_PosNum`, `onemX_NngNum`
+- in `fsbigop.v`:
+  + lemmas `lee_fsum_nneg_subset`, `lee_fsum`
+- in `topology.v`:
+  + lemma `near_inftyS`
+  + lemma `continuous_closedP`, `closedU`, `pasting`
+  + lemma `continuous_inP`
+  + lemmas `open_setIS`, `open_setSI`, `closed_setIS`, `closed_setSI`
+- in `normedtype.v`:
+  + definitions `contraction` and `is_contraction`
+  + lemma `contraction_fixpoint_unique`
+- in `sequences.v`:
+  + lemmas `contraction_dist`, `contraction_cvg`,
+    `contraction_cvg_fixed`, `banach_fixed_point`,
+    `contraction_unique`
+- in `derive.v`:
+  + lemma `diff_derivable`
+- in `measure.v`:
+  + lemma `measurable_funTS`
+- in `lebesgue_measure.v`:
+  + lemma `measurable_fun_fine`
+  + lemma `open_measurable_subspace`
+  + lemma ``subspace_continuous_measurable_fun``
+  + corollary `open_continuous_measurable_fun`
+  + Hint about `measurable_fun_normr`
+- in `lebesgue_integral.v`:
+  + lemma `measurable_fun_indic`
+  + lemma `ge0_integral_mscale`
+  + lemma `integral_pushforward`
+
+### Changed
+
+- in `esum.v`:
+  + definition `esum`
+- moved from `lebesgue_integral.v` to `classical_sets.v`:
+  + `mem_set_pair1` -> `mem_xsection`
+  + `mem_set_pair2` -> `mem_ysection`
+- in `derive.v`:
+  + generalized `is_diff_scalel`
+- in `measure.v`:
+  + generalize `measurable_uncurry`
+- in `lebesgue_measure.v`:
+  + `pushforward` requires a proof that its argument is measurable
+- in `lebesgue_integral.v`:
+  + change implicits of `integralM_indic`
+
+### Renamed
+
+- in `constructive_ereal.v`:
+  + `lte_pinfty_eq` -> `ltey_eq`
+  + `le0R` -> `fine_ge0`
+  + `lt0R` -> `fine_gt0`
+- in `ereal.v`:
+  + `lee_pinfty_eq` -> `leye_eq`
+  + `lee_ninfty_eq` -> `leeNy_eq`
+- in `esum.v`:
+  + `esum0` -> `esum1`
+- in `sequences.v`:
+  + `nneseries_lim_ge0` -> `nneseries_ge0`
+- in `measure.v`:
+  + `ring_fsets` -> `ring_finite_set`
+  + `discrete_measurable` -> `discrete_measurable_nat`
+  + `cvg_mu_inc` -> `nondecreasing_cvg_mu`
+- in `lebesgue_integral.v`:
+  + `muleindic_ge0` -> `nnfun_muleindic_ge0`
+  + `mulem_ge0` -> `mulemu_ge0`
+  + `nnfun_mulem_ge0` -> `nnsfun_mulemu_ge0`
+
+### Removed
+
+- in `esum.v`:
+  + lemma `fsetsP`, `sum_fset_set`
 
 ## [0.5.3] - 2022-08-10
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -3,103 +3,12 @@
 ## [Unreleased]
 
 ### Added
-- in `normedtype.v`:
-  + definitions `contraction` and `is_contraction`
-  + lemma `contraction_fixpoint_unique`
-
-- in `constructive_ereal.v`:
-  + lemmas `ltNye_eq`, `sube_lt0`, `subre_lt0`, `suber_lt0`, `sube_ge0`
-  + lemmas `dsubre_gt0`, `dsuber_gt0`, `dsube_gt0`, `dsube_le0`
-
-- in `topology.v`:
-  + lemma `near_inftyS`
-  + lemma `continuous_closedP`, `closedU`, `pasting`
-
-- in `sequences.v`:
-  + lemmas `contraction_dist`, `contraction_cvg`,
-    `contraction_cvg_fixed`, `banach_fixed_point`,
-    `contraction_unique`
-- in `mathcomp_extra.v`:
-  + defintion `onem` and notation ``` `1- ```
-  + lemmas `onem0`, `onem1`, `onemK`, `onem_gt0`, `onem_ge0`, `onem_le1`, `onem_lt1`,
-    `onemX_ge0`, `onemX_lt1`, `onemD`, `onemMr`, `onemM`
-- in `signed.v`:
-  + lemmas `onem_PosNum`, `onemX_NngNum`
-- in `lebesgue_measure.v`:
-  + lemma `measurable_fun_fine`
-- in `lebesgue_integral.v`:
-  + lemma `ge0_integral_mscale`
-- in `measure.v`:
-  + lemma `measurable_funTS`
-- in `lebesgue_measure.v`:
-  + lemma `measurable_fun_indic`
-- in `fsbigop.v`:
-  + lemmas `lee_fsum_nneg_subset`, `lee_fsum`
-- in `classical_sets.v`:
-  + lemmas `subset_fst_set`, `subset_snd_set`, `fst_set_fst`, `snd_set_snd`,
-    `fset_setM`, `snd_setM`, `fst_setMR`
-  + lemmas `xsection_snd_set`, `ysection_fst_set`
-  + Hint about `measurable_fun_normr`
-- in `lebesgue_integral.v`:
-  + lemma `integral_pushforward`
-
-- in `derive.v`:
-  + lemma `diff_derivable`
-- in `topology.v`:
-  + lemma `continuous_inP`
-- in `lebesgue_measure.v`:
-  + lemma `open_measurable_subspace`
-  + lemma ``subspace_continuous_measurable_fun``
-  + corollary `open_continuous_measurable_fun`
-- in `topology.v`:
-  + lemmas `open_setIS`, `open_setSI`, `closed_setIS`, `closed_setSI`
-- in `mathcomp_extra.v`:
-  + lemmas `natr1`, `nat1r`
 
 ### Changed
 
-- in `measure.v`:
-  + generalize `measurable_uncurry`
-- in `esum.v`:
-  + definition `esum`
-- moved from `lebesgue_integral.v` to `classical_sets.v`:
-  + `mem_set_pair1` -> `mem_xsection`
-  + `mem_set_pair2` -> `mem_ysection`
-- in `lebesgue_measure.v`:
-  + `pushforward` requires a proof that its argument is measurable
-- in `lebesgue_integral.v`:
-  + change implicits of `integralM_indic`
-- in `derive.v`:
-  + generalized `is_diff_scalel`
-
 ### Renamed
 
-- in `constructive_ereal.v`:
-  + `lte_pinfty_eq` -> `ltey_eq`
-- in `sequences.v`:
-  + `nneseries_lim_ge0` -> `nneseries_ge0`
-- in `constructive_ereal.v`:
-  + `le0R` -> `fine_ge0`
-  + `lt0R` -> `fine_gt0`
-- in `measure.v`:
-  + `ring_fsets` -> `ring_finite_set`
-  + `discrete_measurable` -> `discrete_measurable_nat`
-- in `ereal.v`:
-  + `lee_pinfty_eq` -> `leye_eq`
-  + `lee_ninfty_eq` -> `leeNy_eq`
-- in `measure.v`:
-  + `cvg_mu_inc` -> `nondecreasing_cvg_mu`
-- in `lebesgue_integral.v`:
-  + `muleindic_ge0` -> `nnfun_muleindic_ge0`
-  + `mulem_ge0` -> `mulemu_ge0`
-  + `nnfun_mulem_ge0` -> `nnsfun_mulemu_ge0`
-- in `esum.v`:
-  + `esum0` -> `esum1`
-
 ### Removed
-
-- in `esum.v`:
-  + lemma `fsetsP`, `sum_fset_set`
 
 ### Infrastructure
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,7 +5,7 @@
 - [The Coq Proof Assistant version ≥ 8.13](https://coq.inria.fr)
 - [Mathematical Components version ≥ 1.13.0](https://github.com/math-comp/math-comp)
 - [Finmap library version ≥ 1.5.1](https://github.com/math-comp/finmap)
-- [Hierarchy builder version >= 1.2.0](https://github.com/math-comp/hierarchy-builder)
+- [Hierarchy builder version >= 1.3.0](https://github.com/math-comp/hierarchy-builder)
 
 These requirements can be installed in a custom way, or through
 [opam](https://opam.ocaml.org/) (the recommended way) using
@@ -47,7 +47,7 @@ $ opam install coq-mathcomp-analysis
 ```
 To install a precise version, type, say
 ```
-$ opam install coq-mathcomp-analysis.0.5.3
+$ opam install coq-mathcomp-analysis.0.5.4
 ```
 4. Everytime you want to work in this same context, you need to type
 ```

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ the Coq proof-assistant and using the Mathematical Components library.
   - Pierre-Yves Strub (initial)
   - Laurent Théry
 - License: [CeCILL-C](LICENSE)
-- Compatible Coq versions: Coq 8.14 to 8.15 (or dev)
+- Compatible Coq versions: Coq 8.14 to 8.16 (or dev)
 - Additional dependencies:
   - [MathComp ssreflect 1.13 or later](https://math-comp.github.io)
   - [MathComp fingroup 1.13 or later](https://math-comp.github.io)

--- a/coq-mathcomp-analysis.opam
+++ b/coq-mathcomp-analysis.opam
@@ -18,7 +18,7 @@ the Coq proof-assistant and using the Mathematical Components library."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" { (>= "8.14" & < "8.16~") | (= "dev") }
+  "coq" { (>= "8.14" & < "8.17~") | (= "dev") }
   "coq-mathcomp-ssreflect" { (>= "1.13.0" & < "1.16~") | (= "dev") }
   "coq-mathcomp-fingroup" { (>= "1.13.0" & < "1.16~") | (= "dev") }
   "coq-mathcomp-algebra" { (>= "1.13.0" & < "1.16~") | (= "dev") }

--- a/meta.yml
+++ b/meta.yml
@@ -49,8 +49,8 @@ license:
   file: LICENSE
 
 supported_coq_versions:
-  text: Coq 8.14 to 8.15 (or dev)
-  opam: '{ (>= "8.14" & < "8.16~") | (= "dev") }'
+  text: Coq 8.14 to 8.16 (or dev)
+  opam: '{ (>= "8.14" & < "8.17~") | (= "dev") }'
 
 tested_coq_opam_versions:
 - version: '1.13.0-coq-8.14'


### PR DESCRIPTION
##### Motivation for this change

PR for the release of MathComp-Analysis version 0.5.4

It looks that we have to use HB >= 1.3.0 to accommodate Coq 8.16
(see https://github.com/math-comp/math-comp/pull/915)

##### Things done/to do

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- [ ] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
