### PR TITLE
subspace open map

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -9,6 +9,7 @@
   + lemmas `fine_le`, `fine_lt`, `fine_abse`, `abse_fin_num`
 - in `lebesgue_integral.v`
   + lemmas `integral_fune_lt_pinfty`, `integral_fune_fin_num`
+  + lemma `weak_subspace_open`
 
 ### Changed
 


### PR DESCRIPTION
##### Motivation for this change
A simple theorem that the weak topology and the subspace topology are "the same thing". In particular, this is useful for knowing that `projT1` is an embedding of `{x : T | B x}` into `subspace B`. We'll want this for homotopy theory so we can do topology and paths of `{x : T | B x}` and do algebra in `subspace B`. 

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
  (do not edit former entries, only append new ones, be careful:
   merge and rebase have a tendency to mess up `CHANGELOG_UNRELEASED.md`)
- [x] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
