### PR TITLE
fine lemmas

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -5,6 +5,11 @@
 ### Added
 - in `topology.v`:
   + lemmas `continuous_subspaceT`, `subspaceT_continuous`
+- in `constructive_ereal.v`
+  + lemmas `lte_oppe_pinfty`, `fine_le`, `fine_lt`, `fine_abse`, `abse_fin_num`
+- in `lebesgue_integral.v`
+  + lemmas `lte_oppe_pinfty`, `fine_le`, `fine_lt`, `fine_abse`, `abse_fin_num`
+  + lemmas `integral_fune_lt_pinfty`, `integral_fune_fin_num`, `rintegral_le`
 
 ### Changed
 

--- a/theories/constructive_ereal.v
+++ b/theories/constructive_ereal.v
@@ -1317,6 +1317,12 @@ Qed.
 Lemma lte_add_pinfty x y : x < +oo -> y < +oo -> x + y < +oo.
 Proof. by move: x y => -[r [r'| |]| |] // ? ?; rewrite -EFinD ltey. Qed.
 
+Lemma lte_oppe_pinfty x : -oo < x <-> -x < +oo.
+Proof.
+split; first by move: x => -[r | |] // ?; rewrite -EFinN ltey.
+by move: x => -[r | |] // ?; rewrite ltNye.
+Qed.
+
 Lemma lte_sum_pinfty I (s : seq I) (P : pred I) (f : I -> \bar R) :
   (forall i, P i -> f i < +oo) -> \sum_(i <- s | P i) f i < +oo.
 Proof.
@@ -3357,3 +3363,19 @@ move=> [:wlog]; case: a b => [a||] [b||] //= ltax ltxb.
   by exists d => y /dP /andP[_ ->] /=; rewrite ltNye.
 - by exists 1%:pos%R => ? ?; rewrite ltNye ltey.
 Qed.
+
+Lemma fine_le: forall {R : numDomainType},
+  {in fin_num &, {homo (@fine R) : x y / x <= y >-> (x <= y)%R}}.
+Proof. by move=> R  -[r [r'| |]| |] //. Qed.
+
+Lemma fine_lt: forall {R : numDomainType},
+  {in fin_num &, {homo (@fine R) : x y / (x < y)%E >-> (x < y)%R}}.
+Proof. by move=> R  -[r [r'| |]| |] //. Qed.
+
+Lemma fine_abse: forall {R : numDomainType},
+  {in fin_num, {morph (@fine R) : x / `|x| >-> (`|x|)%R}}.
+Proof. by move=> R -[r | |] //. Qed.
+
+Lemma abse_fin_num: forall {R : numDomainType} (x : \bar R),
+ abse x \is a fin_num <-> x \is a fin_num.
+Proof. by move=> R -[r | |] //. Qed.

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -2758,7 +2758,7 @@ move=> mg a0; have ? : measurable (D `&` [set x | (a%:E <= `|g x|)%E]).
 apply: (@le_trans _ _ (\int[mu]_(x in D `&` [set x | `|g x| >= a%:E]) `|g x|)).
   rewrite -integral_cst//; apply: ge0_le_integral => //.
   - by move=> x _ /=; rewrite ltW.
-  - exact/EFin_measurable_fun/measurable_fun_cst.
+  - exact/EFin_measurable_fun/measurbable_fun_cst.
   - by apply: measurable_fun_comp => //; exact: measurable_funS mg.
   - by move=> x /= [].
 by apply: subset_integral => //; exact: measurable_fun_comp.
@@ -3780,6 +3780,33 @@ Qed.
 
 End integralB.
 
+Section integrable_fune.
+Variables (d : measure_display) (T : measurableType d) (R : realType).
+Variables (mu : {measure set T -> \bar R}) (D : set T) (mD : measurable D).
+Local Open Scope ereal_scope.
+
+Lemma integral_fune_lt_pinfty (f : T -> \bar R) :
+  (mu.-integrable D f) -> \int[mu]_(x in D) f x < +oo.
+Proof.
+move=> intf; rewrite (funeposneg f) integralB => //; first last.
+- exact: integrable_funeneg.
+- exact: integrable_funepos.
+apply: lte_add_pinfty; first exact: integral_funepos_lt_pinfty.
+apply/lte_oppe_pinfty; rewrite ltNye_eq; apply/orP; left.
+exact: integrable_neg_fin_num.
+Qed.
+
+Lemma integral_fune_fin_num (f : T -> \bar R) :
+  (mu.-integrable D f) ->
+  \int[mu]_(x in D) f x \is a fin_num
+Proof.
+move=> int; apply/fin_numPlt/andP; split; last exact: integral_fune_lt_pinfty.
+apply/lte_oppe_pinfty; rewrite -integralN.
+  by apply: integral_fune_lt_pinfty; exact: integrableN.
+by apply: fin_num_adde_def; rewrite fin_numN; exact:integrable_neg_fin_num.
+Qed.
+End integrable_fune.
+
 Section integral_counting.
 Local Open Scope ereal_scope.
 Variables (R : realType).
@@ -3905,6 +3932,21 @@ by congr (_ - _)%E; rewrite nneseries_esum// set_true.
 Qed.
 
 End subadditive_countable.
+
+Section rintegral_le.
+Variables (d : measure_display) (T : measurableType d) (R : realType).
+Variables (mu : {measure set T -> \bar R}) (D : set T) (mD : measurable D).
+Variables (f : T -> \bar R). 
+Hypotheses (fint : mu.-integrable D f).
+Lemma rintegral_le : `|Rintegral mu D f| <= Rintegral mu D (abse \o f).
+Proof.
+rewrite -fine_abse; [apply: fine_le | exact: integral_fune_fin_num].
+- exact/abse_fin_num/integral_fune_fin_num. 
+- exact/integral_fune_fin_num/integrable_abse.
+by apply: le_abse_integral; case: fint.
+Qed.
+
+End rintegral_le.
 
 Section dominated_convergence_lemma.
 Local Open Scope ereal_scope.


### PR DESCRIPTION
##### Motivation for this change
A super useful lemma is that integrals and derivatives exchange. That is, 
```
d (int (f x y) dx) / dy = int (d (f x y) /dy) dx)
```
This comes up in applications like 
1. Partials derivatives commute
2. Homotopy invariance of path integrals
3. Computing derivatives of certain integral operators, E.G. fourier transform

However, the `derive` infrastructure works on `T -> R` but integration works on `T -> \bar R`. We need to do a lot of work to make them compatible without duplicating the whole theory. To that end, I'm adding a bunch of helper lemmas about `fine` and `integrable` that'll help smooth out the process.

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
  (do not edit former entries, only append new ones, be careful:
   merge and rebase have a tendency to mess up `CHANGELOG_UNRELEASED.md`)
- [ ] ~added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
