### PR TITLE
setIv setvI are duplicated

### DIFF
--- a/theories/classical_sets.v
+++ b/theories/classical_sets.v
@@ -624,9 +624,7 @@ Proof. by rewrite predeqE => t; split => // -[]. Qed.
 Lemma setUv A : A `|` ~` A = setT.
 Proof. by apply/predeqP => x; split=> //= _; apply: lem. Qed.
 
-Lemma setIv A : A `&` ~` A = set0. Proof. by rewrite -setDE setDv. Qed.
 Lemma setvU A : ~` A `|` A = setT. Proof. by rewrite setUC setUv. Qed.
-Lemma setvI A : ~` A `&` A = set0. Proof. by rewrite setIC setIv. Qed.
 
 Lemma setUCK A B : (A `|` B) `|` ~` B = setT.
 Proof. by rewrite -setUA setUv setUT. Qed.
@@ -635,10 +633,10 @@ Lemma setUKC A B : ~` A `|` (A `|` B) = setT.
 Proof. by rewrite setUA setvU setTU. Qed.
 
 Lemma setICK A B : (A `&` B) `&` ~` B = set0.
-Proof. by rewrite -setIA setIv setI0. Qed.
+Proof. by rewrite -setIA setICr setI0. Qed.
 
 Lemma setIKC A B : ~` A `&` (A `&` B) = set0.
-Proof. by rewrite setIA setvI set0I. Qed.
+Proof. by rewrite setIA setICl set0I. Qed.
 
 Lemma setDIK A B : A `&` (B `\` A) = set0.
 Proof. by rewrite setDE setICA -setDE setDv setI0. Qed.
@@ -994,6 +992,10 @@ Qed.
 End basic_lemmas.
 #[global]
 Hint Resolve subsetUl subsetUr subIsetl subIsetr subDsetl subDsetr : core.
+#[deprecated(since="mathcomp-analysis 0.6", note="Use setICl instead.")]
+Notation setvI := setICl.
+#[deprecated(since="mathcomp-analysis 0.6", note="Use setICr instead.")]
+Notation setIv := setICr.
 
 Lemma image2E {TA TB rT : Type} (A : set TA) (B : set TB) (f : TA -> TB -> rT) :
   [set f x y | x in A & y in B] = uncurry f @` (A `*` B).

--- a/theories/fsbigop.v
+++ b/theories/fsbigop.v
@@ -283,7 +283,7 @@ Lemma fsbigU (R : Type) (idx : R) (op : Monoid.com_law idx)
      op (\big[op/idx]_(i \in A) F i) (\big[op/idx]_(i \in B) F i).
 Proof.
 move=> Afin Bfin AB0; rewrite (fsbigID A) ?finite_setU; last by split.
-rewrite setUK -setDE; congr (op _ _); rewrite setDE setIUl setIv set0U.
+rewrite setUK -setDE; congr (op _ _); rewrite setDE setIUl setICr set0U.
 by apply: fsbig_widen => //; rewrite -setDE setDD setIC.
 Qed.
 Arguments fsbigU {R idx op I} [A B F].

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -2658,7 +2658,7 @@ Definition near_covering (K : set X) :=
 Let near_covering_compact : near_covering `<=` compact.
 Proof.
 move=> K locK F PF FK; apply/set0P/eqP=> KclstF0; case: (PF) => + FF; apply.
-rewrite (_ : xpredp0 = set0)// -(setIv K); apply: filterI => //.
+rewrite (_ : xpredp0 = set0)// -(setICr K); apply: filterI => //.
 have /locK : forall x, K x ->
     \forall x' \near x & i \near powerset_filter_from F, (~` i) x'.
   move=> x Kx; have : ~ cluster F x.
@@ -2877,7 +2877,7 @@ Lemma compactU (A B : set X) : compact A -> compact B -> compact (A `|` B).
 Proof.
 rewrite compact_ultra => cptA cptB F UF FAB; rewrite setIUl.
 have [/cptA[x AFx]|] := in_ultra_setVsetC A UF; first by exists x; left.
-move=> /(filterI FAB); rewrite setIUl setIv set0U => FBA.
+move=> /(filterI FAB); rewrite setIUl setICr set0U => FBA.
 have /cptB[x BFx] : F B by apply: filterS FBA; exact: subIsetr.
 by exists x; right.
 Qed.


### PR DESCRIPTION
##### Motivation for this change

I did not touch the changelog but used deprecated pragmas.

##### Things done/to do

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- [ ] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
