### PR TITLE
pseudoMetric for weak topologies

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -19,6 +19,8 @@
   + definition `sup_ent`, `sup_uniform_mixin`, `sup_uniformType`
   + definition `product_uniformType`
   + lemma `uniform_entourage`
+  + definition `weak_ball`, `weak_pseudoMetricType`
+  + lemma `weak_ballE`
 
 - in `constructive_ereal.v`:
   + lemmas `gte_addl`, `gte_addr`


### PR DESCRIPTION
##### Motivation for this change
Continuing to towards "countable products inherit a metric", we prove here that the weak topology induces a metric. The only non-trivial proof is proving the compatibility between `weak_ent` and `weak_ball`.  Also, I'm once again punting on making things canonical until the "porting to HB" work is done. I'm hoping this approach will mitigate some interference.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
  (do not edit former entries, only append new ones, be careful:
   merge and rebase have a tendency to mess up `CHANGELOG_UNRELEASED.md`)
- [x] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
