### PR TITLE
Countable finite subsets

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -22,6 +22,11 @@
   + definition `weak_ball`, `weak_pseudoMetricType`
   + lemma `weak_ballE`
 
+  + lemma `finI_from_countable`
+- in `cardinality.v`
+  + lemmas `card_eq1`, `card_eq_set1`, `IIDn`, `finite_cardS`,
+      `countable_n_subset`, `countable_finite_subset`, `eq_card_fset_subset`,
+      `fset_subset_countable`
 - in `constructive_ereal.v`:
   + lemmas `gte_addl`, `gte_addr`
   + lemmas `gte_daddl`, `gte_daddr`

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -21,12 +21,12 @@
   + lemma `uniform_entourage`
   + definition `weak_ball`, `weak_pseudoMetricType`
   + lemma `weak_ballE`
-
   + lemma `finI_from_countable`
 - in `cardinality.v`
-  + lemmas `card_eq1`, `card_eq_set1`, `IIDn`, `finite_cardS`,
-      `countable_n_subset`, `countable_finite_subset`, `eq_card_fset_subset`,
-      `fset_subset_countable`
+  + lemmas `eq_card1`, `card_set1`, `card_eqSP`, `countable_n_subset`,
+     `countable_finite_subset`, `eq_card_fset_subset`, `fset_subset_countable`
+- in `classical_sets.v`
+  + lemmas `IIDn`, `IISl`
 - in `constructive_ereal.v`:
   + lemmas `gte_addl`, `gte_addr`
   + lemmas `gte_daddl`, `gte_daddr`

--- a/theories/classical_sets.v
+++ b/theories/classical_sets.v
@@ -2118,6 +2118,7 @@ Canonical prod_pointedType (T T' : pointedType) :=
 Canonical matrix_pointedType m n (T : pointedType) :=
   PointedType 'M[T]_(m, n) (\matrix_(_, _) point)%R.
 Canonical option_pointedType (T : choiceType) := PointedType (option T) None.
+Canonical pointed_fset {T : choiceType} := PointedType {fset T} fset0.
 
 Notation get := (xget point).
 Notation "[ 'get' x | E ]" := (get [set x | E])

--- a/theories/classical_sets.v
+++ b/theories/classical_sets.v
@@ -1034,6 +1034,12 @@ by rewrite ltnS leq_eqVlt => /orP[/eqP ->|]; by [left|right].
 by move/ltn_trans; apply.
 Qed.
 
+Lemma IISl n : `I_n.+1 = n |` `I_n.
+Proof. by rewrite setUC IIS. Qed.
+
+Lemma IIDn n : `I_n.+1 `\ n = `I_n.
+Proof. by rewrite IIS setUDK// => x [->/=]; rewrite ltnn. Qed.
+
 Lemma setI_II m n : `I_m `&` `I_n = `I_(minn m n).
 Proof.
 by case: leqP => mn; [rewrite setIidl// | rewrite setIidr//]

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -2036,6 +2036,13 @@ rewrite predeqE => t; split=> [|fit]; first by apply; rewrite /= inE.
 by move=> ?; rewrite /= inE => /eqP->.
 Qed.
 
+Lemma finI_from_countable (I : pointedType) T (D : set I) (f : I -> set T) :
+  countable D -> countable (finI_from D f).
+Proof.
+move=> ?; apply: (card_le_trans (card_image_le _ _)). 
+exact: fset_subset_countable.
+Qed.
+
 Section TopologyOfSubbase.
 
 Variable (I : pointedType) (T : Type) (D : set I) (b : I -> set T).

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -2039,7 +2039,7 @@ Qed.
 Lemma finI_from_countable (I : pointedType) T (D : set I) (f : I -> set T) :
   countable D -> countable (finI_from D f).
 Proof.
-move=> ?; apply: (card_le_trans (card_image_le _ _)). 
+move=> ?; apply: (card_le_trans (card_image_le _ _)).
 exact: fset_subset_countable.
 Qed.
 


### PR DESCRIPTION
##### Motivation for this change
A classic result: If `D` is countable, then the set of it's finite subsets is also countable. The only annoying detail is dealing with a `A #= I_n.+1` we get during an induction. So we take a minor detour and prove `finite_cardS` that lets us break a size `n.+1` set into a point and a `size n` set. Thankfully `super_bij` does the heavy lifting here.
<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
  (do not edit former entries, only append new ones, be careful:
   merge and rebase have a tendency to mess up `CHANGELOG_UNRELEASED.md`)
- ~[ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
