### PR TITLE
R is locally compact

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -110,6 +110,9 @@
   + lemma `nnseries_is_cvg`
 - in `constructive_ereal.v`:
   + lemma `fine_lt0E`
+- in file `normedtype.v`
+  + lemma `locally_compactR` 
+
 
 ### Changed
 - in `topology.v`

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -111,7 +111,7 @@
 - in `constructive_ereal.v`:
   + lemma `fine_lt0E`
 - in file `normedtype.v`
-  + lemma `locally_compactR` 
+  + lemmas `closed_ballR_compact` and `locally_compactR` 
 
 
 ### Changed

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -3983,13 +3983,10 @@ Section locally_compact.
 
 Lemma locally_compactR (R : realType) : locally_compact [set: R].
 Proof.
-move=> x  _; rewrite withinET; exists (`[x-1, x+1]%classic); first last.
-split; [|apply: compact_closed] => //; exact: segment_compact.
-apply: (@filterS _ _ _ `]x-1, x+1[%classic).
-  by move=> z /=; rewrite ?in_itv //= => /andP [/ltW -> /ltW ->].
-apply: open_nbhs_nbhs; split; first exact: interval_open.
-rewrite /= in_itv /=; apply/andP. 
-by split; rewrite ?ltr_subl_addl ?[1+_]addrC ltr_addl.
-Qed.
+move=> x _; rewrite withinET; exists (`[x - 1, x + 1]%classic); first last.
+  by split; [|apply: compact_closed] => //; apply: segment_compact.
+near=> y; apply: subset_itv_oo_cc; near: y; apply: near_in_itv.
+by rewrite in_itv -ltr_distl subrr normr0.
+Unshelve. all: by end_near. Qed.
 
 End locally_compact.

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -3717,9 +3717,9 @@ Proof. move=> r0; rewrite /closed_ball; apply: subset_closure. Qed.
 
 Lemma locally_compactR (R : realType) : locally_compact [set: R].
 Proof.
-move=> x _; rewrite withinET; exists (closed_ball x 1); last first.
-  by split; [apply: closed_ballR_compact|apply: closed_ball_closed].
-by apply/nbhs_closedballP; exists 1%:pos.
+move=> x _; rewrite withinET; exists (closed_ball x 1).
+  by apply/nbhs_closedballP; exists 1%:pos.
+by split; [apply: closed_ballR_compact | apply: closed_ball_closed].
 Qed.
 
 (*TBA topology.v once ball_normE is there*)

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -3984,9 +3984,9 @@ Section locally_compact.
 Lemma locally_compactR (R : realType) : locally_compact [set: R].
 Proof.
 move=> x _; rewrite withinET; exists (`[x - 1, x + 1]%classic); first last.
-  by split; [|apply: compact_closed] => //; apply: segment_compact.
-near=> y; apply: subset_itv_oo_cc; near: y; apply: near_in_itv.
-by rewrite in_itv -ltr_distl subrr normr0.
-Unshelve. all: by end_near. Qed.
+  by split; [|apply: compact_closed] => //; exact: segment_compact.
+apply/nbhs_closedballP; exists 1%:pos => y; rewrite closed_ballE//= in_itv.
+by rewrite -ler_distlC.
+Qed.
 
 End locally_compact.

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -3978,3 +3978,18 @@ by rewrite ler_pmul //; near: r; exists 1; split => // x /ltW; apply le_trans.
 Unshelve. all: by end_near. Qed.
 
 End LinearContinuousBounded.
+
+Section locally_compact.
+
+Lemma locally_compactR (R : realType) : locally_compact [set: R].
+Proof.
+move=> x  _; rewrite withinET; exists (`[x-1, x+1]%classic); first last.
+split; [|apply: compact_closed] => //; exact: segment_compact.
+apply: (@filterS _ _ _ `]x-1, x+1[%classic).
+  by move=> z /=; rewrite ?in_itv //= => /andP [/ltW -> /ltW ->].
+apply: open_nbhs_nbhs; split; first exact: interval_open.
+rewrite /= in_itv /=; apply/andP. 
+by split; rewrite ?ltr_subl_addl ?[1+_]addrC ltr_addl.
+Qed.
+
+End locally_compact.

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -3686,6 +3686,13 @@ Lemma closed_ball_closed (R : realFieldType) (V : normedModType R) (x : V)
   (r : R) : 0 < r -> closed (closed_ball x r).
 Proof. by move => r0; rewrite closed_ballE //; exact: closed_closed_ball_. Qed.
 
+Lemma closed_ballR_compact (R : realType) (x e : R) : 0 < e ->
+   compact (closed_ball x e).
+Proof.
+move=> e_gt0; have : compact `[x - e, x + e] by apply: segment_compact.
+by rewrite closed_ballE//; under eq_set do rewrite in_itv -ler_distlC.
+Qed.
+
 Lemma closed_ball_subset (R : realFieldType) (M : normedModType R) (x : M)
   (r0 r1 : R) : 0 < r0 -> r0 < r1 -> closed_ball x r0 `<=` ball x r1.
 Proof.
@@ -3710,10 +3717,9 @@ Proof. move=> r0; rewrite /closed_ball; apply: subset_closure. Qed.
 
 Lemma locally_compactR (R : realType) : locally_compact [set: R].
 Proof.
-move=> x _; rewrite withinET; exists (`[x - 1, x + 1]%classic); first last.
-  by split; [|apply: compact_closed] => //; exact: segment_compact.
-apply/nbhs_closedballP; exists 1%:pos => y; rewrite closed_ballE//= in_itv.
-by rewrite -ler_distlC.
+move=> x _; rewrite withinET; exists (closed_ball x 1); last first.
+  by split; [apply: closed_ballR_compact|apply: closed_ball_closed].
+by apply/nbhs_closedballP; exists 1%:pos.
 Qed.
 
 (*TBA topology.v once ball_normE is there*)

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -3708,6 +3708,14 @@ Lemma subset_closed_ball (R : realFieldType) (V : normedModType R) (x : V)
   (r : R) : 0 < r -> ball x r `<=` closed_ball x r.
 Proof. move=> r0; rewrite /closed_ball; apply: subset_closure. Qed.
 
+Lemma locally_compactR (R : realType) : locally_compact [set: R].
+Proof.
+move=> x _; rewrite withinET; exists (`[x - 1, x + 1]%classic); first last.
+  by split; [|apply: compact_closed] => //; exact: segment_compact.
+apply/nbhs_closedballP; exists 1%:pos => y; rewrite closed_ballE//= in_itv.
+by rewrite -ler_distlC.
+Qed.
+
 (*TBA topology.v once ball_normE is there*)
 
 Lemma nbhs0_lt (K : numFieldType) (V : normedModType K) e :
@@ -3978,15 +3986,3 @@ by rewrite ler_pmul //; near: r; exists 1; split => // x /ltW; apply le_trans.
 Unshelve. all: by end_near. Qed.
 
 End LinearContinuousBounded.
-
-Section locally_compact.
-
-Lemma locally_compactR (R : realType) : locally_compact [set: R].
-Proof.
-move=> x _; rewrite withinET; exists (`[x - 1, x + 1]%classic); first last.
-  by split; [|apply: compact_closed] => //; exact: segment_compact.
-apply/nbhs_closedballP; exists 1%:pos => y; rewrite closed_ballE//= in_itv.
-by rewrite -ler_distlC.
-Qed.
-
-End locally_compact.


### PR DESCRIPTION
##### Motivation for this change
Just proves `R` is locally compact. Primarily, this is useful to bridge the gap from "compact convergence" to "locally uniform" convergence. We'll eventually need lots of other results here: local compactness respects products, subspaces, etc. But this is a fine place to start. 

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
  (do not edit former entries, only append new ones, be careful:
   merge and rebase have a tendency to mess up `CHANGELOG_UNRELEASED.md`)
~ - [ ] added corresponding documentation in the headers~
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
