### PR TITLE
rename theories/set_interval to avoid dup

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -62,15 +62,23 @@
     `dfsume_gt0`, `dfsume_lt0`, `pdfsume_eq0`, `le0_mule_dfsumr`, `le0_mule_dfsuml`
 - file `classical/set_interval.v`
 - in file `classical/set_interval.v`:
-  + definitions `neitv`, `set_itv_infty_set0`, `set_itvE`, `disjoint_itv`
-    (from `set_interval.v`)
+  + definitions `neitv`, `set_itv_infty_set0`, `set_itvE`,
+    `disjoint_itv`, `conv`, `factor`, `ndconv` (from `set_interval.v`)
   + lemmas `neitv_lt_bnd`, `set_itvP`, `subset_itvP`, `set_itvoo`, `set_itv_cc`,
     `set_itvco`, `set_itvoc`, `set_itv1`, `set_itvoo0`, `set_itvoc0`, `set_itvco0`,
     `set_itv_infty_infty`, `set_itv_o_infty`, `set_itv_c_infty`, `set_itv_infty_o`,
     `set_itv_infty_c`, `set_itv_pinfty_bnd`, `set_itv_bnd_ninfty`, `setUitv1`,
     `setU1itv`, `set_itvI`, `neitvE`, `neitvP`, `setitv0`, `has_lbound_itv`,
-    `has_ubound_itv`, `hasNlbound`, `hasNubound`, `opp_itv_bnd_infty`, `opp_itvoo`,
+    `has_ubound_itv`, `hasNlbound`, `hasNubound`, `opp_itv_bnd_infty`,
+    `opp_itv_infty_bnd`, `opp_itv_bnd_bnd`, `opp_itvoo`,
     `setCitvl`, `setCitvr`, `set_itv_splitI`, `setCitv`, `set_itv_splitD`,
+    `mem_1B_itvcc`, `conv_id`, `convEl`, `convEr`, `conv10`, `conv0`,
+    `conv1`, `conv_sym`, `conv_flat`, `leW_conv`, `leW_factor`,
+    `factor_flat`, `factorl`, `ndconvE`, `factorr`, `factorK`,
+    `convK`, `conv_inj`, `factor_inj`, `conv_bij`, `factor_bij`,
+    `le_conv`, `le_factor`, `lt_conv`, `lt_factor`, `conv_itv_bij`,
+    `factor_itv_bij`, `mem_conv_itv`, `mem_conv_itvcc`, `range_conv`,
+    `range_factor`, `mem_factor_itv`,
     `set_itv_ge`, `trivIset_set_itv_nth`, `disjoint_itvxx`, `lt_disjoint`,
     `disjoint_neitv`, `neitv_bnd1`, `neitv_bnd2` (from `set_interval.v`)
   + lemmas `setNK`, `lb_ubN`, `ub_lbN`, `mem_NE`, `nonemptyN`, `opp_set_eq0`,
@@ -187,15 +195,23 @@
   + lemmas `setNK`, `lb_ubN`, `ub_lbN`, `mem_NE`, `nonemptyN`, `opp_set_eq0`,
     `has_lb_ubN`, `has_ubPn`, `has_lbPn` (moved to `classical/set_interval.v`)
 - in file `set_interval.v`:
-  + definitions `neitv`, `set_itv_infty_set0`, `set_itvE`, `disjoint_itv`
-    (moved to `classical/set_interval.v`)
+  + definitions `neitv`, `set_itv_infty_set0`, `set_itvE`,
+    `disjoint_itv`, `conv`, `factor`, `ndconv` (moved to `classical/set_interval.v`)
   + lemmas `neitv_lt_bnd`, `set_itvP`, `subset_itvP`, `set_itvoo`, `set_itv_cc`,
     `set_itvco`, `set_itvoc`, `set_itv1`, `set_itvoo0`, `set_itvoc0`, `set_itvco0`,
     `set_itv_infty_infty`, `set_itv_o_infty`, `set_itv_c_infty`, `set_itv_infty_o`,
     `set_itv_infty_c`, `set_itv_pinfty_bnd`, `set_itv_bnd_ninfty`, `setUitv1`,
     `setU1itv`, `set_itvI`, `neitvE`, `neitvP`, `setitv0`, `has_lbound_itv`,
-    `has_ubound_itv`, `hasNlbound`, `hasNubound`, `opp_itv_bnd_infty`, `opp_itvoo`,
+    `has_ubound_itv`, `hasNlbound`, `hasNubound`, `opp_itv_bnd_infty`,
+    `opp_itv_infty_bnd`, `opp_itv_bnd_bnd`, `opp_itvoo`,
     `setCitvl`, `setCitvr`, `set_itv_splitI`, `setCitv`, `set_itv_splitD`,
+    `mem_1B_itvcc`, `conv_id`, `convEl`, `convEr`, `conv10`, `conv0`,
+    `conv1`, `conv_sym`, `conv_flat`, `leW_conv`, `leW_factor`,
+    `factor_flat`, `factorl`, `ndconvE`, `factorr`, `factorK`,
+    `convK`, `conv_inj`, `factor_inj`, `conv_bij`, `factor_bij`,
+    `le_conv`, `le_factor`, `lt_conv`, `lt_factor`, `conv_itv_bij`,
+    `factor_itv_bij`, `mem_conv_itv`, `mem_conv_itvcc`, `range_conv`,
+    `range_factor`, `mem_factor_itv`,
     `set_itv_ge`, `trivIset_set_itv_nth`, `disjoint_itvxx`, `lt_disjoint`,
     `disjoint_neitv`, `neitv_bnd1`, `neitv_bnd2` (moved to `classical/set_interval.v`)
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -165,6 +165,7 @@
 - in `sequences.v`:
   + `seqDUE` -> `seqDU_seqD`
 - file `theories/mathcomp_extra.v` moved to `classical/mathcomp_extra.v`
+- `theories/set_interval.v` -> `theories/real_interval.v`
 
 ### Deprecated
 

--- a/_CoqProject
+++ b/_CoqProject
@@ -29,7 +29,7 @@ theories/exp.v
 theories/trigo.v
 theories/nsatz_realtype.v
 theories/esum.v
-theories/set_interval.v
+theories/real_interval.v
 theories/lebesgue_measure.v
 theories/forms.v
 theories/derive.v

--- a/classical/set_interval.v
+++ b/classical/set_interval.v
@@ -10,6 +10,8 @@ From HB Require Import structures.
 (*                         when the support type is a numFieldType, this      *)
 (*                         is equivalent to (i.1 < i.2)%O (lemma neitvE)      *)
 (*   set_itv_infty_set0 == multirule to simplify empty intervals              *)
+(*         conv, ndconv == convexity operator                                 *)
+(*         factor a b x := (x - a) / (b - a)                                  *)
 (*             set_itvE == multirule to turn intervals into inequalities      *)
 (*     disjoint_itv i j == intervals i and j are disjoint                     *)
 (*                                                                            *)

--- a/theories/Make
+++ b/theories/Make
@@ -21,7 +21,7 @@ exp.v
 trigo.v
 nsatz_realtype.v
 esum.v
-set_interval.v
+real_interval.v
 lebesgue_measure.v
 forms.v
 derive.v

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -5,7 +5,7 @@ From mathcomp.classical Require Import boolp classical_sets functions.
 From mathcomp.classical Require Import cardinality fsbigop mathcomp_extra.
 Require Import reals ereal signed topology numfun normedtype.
 From HB Require Import structures.
-Require Import sequences esum measure set_interval realfun.
+Require Import sequences esum measure real_interval realfun.
 
 (******************************************************************************)
 (*                            Lebesgue Measure                                *)

--- a/theories/real_interval.v
+++ b/theories/real_interval.v
@@ -2,7 +2,8 @@
 From mathcomp Require Import all_ssreflect ssralg ssrnum ssrint interval.
 From mathcomp Require Import finmap fingroup perm rat.
 From mathcomp.classical Require Import boolp classical_sets functions.
-From mathcomp.classical Require Export set_interval mathcomp_extra.
+From mathcomp.classical Require Import mathcomp_extra.
+From mathcomp.classical Require Export set_interval.
 From HB Require Import structures.
 Require Import reals ereal signed topology normedtype sequences.
 

--- a/theories/real_interval.v
+++ b/theories/real_interval.v
@@ -9,9 +9,6 @@ Require Import reals ereal signed topology normedtype sequences.
 (******************************************************************************)
 (* This files contains lemmas about sets and intervals on reals.              *)
 (*                                                                            *)
-(*         conv, ndconv == convexity operator                                 *)
-(*         factor a b x := (x - a) / (b - a)                                  *)
-(*                                                                            *)
 (******************************************************************************)
 
 Set Implicit Arguments.

--- a/theories/realfun.v
+++ b/theories/realfun.v
@@ -4,7 +4,7 @@ From mathcomp Require Import matrix interval zmodp vector fieldext falgebra.
 From mathcomp.classical Require Import boolp classical_sets.
 From mathcomp.classical Require Import functions cardinality mathcomp_extra.
 Require Import ereal reals signed topology prodnormedzmodule.
-Require Import normedtype derive set_interval.
+Require Import normedtype derive real_interval.
 From HB Require Import structures.
 
 (******************************************************************************)


### PR DESCRIPTION
##### Motivation for this change

It appears that `set_interval.v` was also duplicated in two directories.
(Also fixes a documentation problem: the header from `set_interval.v`
needed to move to `classical`.)

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- [x] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
