### PR TITLE
Projections

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -202,10 +202,9 @@
 - in `measure.v`:
   + lemma `measurable_fun_bool`
 
+  + new lemma `dfwith_projK`
 - in file `topology.v`,
-  + new definition `product_embed`.
-  + new lemmas `product_embedE`, `product_embedNE`, `product_embed_id`, 
-    `embed_projectK`, `product_embed_continuous`, and `projection_open`.
+  + new lemmas `dfwith_continuous`, and `proj_open`.
 
 
 ### Changed
@@ -352,9 +351,7 @@
   + `cvgi_map_lim` -> `cvgi_lim`
   + `app_cvg_locally` -> `cvg_ball`
 - in file `topology.v`,
-  + `prod_topo_apply` -> `projection`
-  + `prod_topo_applyE` -> `projectionE` 
-  + `prod_topo_apply_continuous` -> `projection_continuous`
+  + `prod_topo_apply_continuous` -> `proj_continuous`
 
 ### Generalized
 
@@ -410,6 +407,8 @@
   + `ereal_lim_sum` -> `cvg_nnesum`
 - moved from `sequences.v` to `topology.v`:
   + `nat_cvgPpinfty` -> `cvgnyPge`
+- in file `topology.v`
+  + `prod_topo_apply` -> `proj`
 
 ### Deprecated
 
@@ -479,6 +478,8 @@
     `range_factor`, `mem_factor_itv`,
     `set_itv_ge`, `trivIset_set_itv_nth`, `disjoint_itvxx`, `lt_disjoint`,
     `disjoint_neitv`, `neitv_bnd1`, `neitv_bnd2` (moved to `classical/set_interval.v`)
+- in file `topology.v`
+  + lemmas `prod_topo_applyE`
 
 ### Infrastructure
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -202,6 +202,12 @@
 - in `measure.v`:
   + lemma `measurable_fun_bool`
 
+- in file `topology.v`,
+  + new definition `product_embed`.
+  + new lemmas `product_embedE`, `product_embedNE`, `product_embed_id`, 
+    `embed_projectK`, `product_embed_continuous`, and `projection_open`.
+
+
 ### Changed
 - in `topology.v`
   + definition `fct_restrictedUniformType` changed to use `weak_uniformType`
@@ -345,6 +351,10 @@
   + `cvg_map_lim` -> `cvg_lim`
   + `cvgi_map_lim` -> `cvgi_lim`
   + `app_cvg_locally` -> `cvg_ball`
+- in file `topology.v`,
+  + `prod_topo_apply` -> `projection`
+  + `prod_topo_applyE` -> `projectionE` 
+  + `prod_topo_apply_continuous` -> `projection_continuous`
 
 ### Generalized
 

--- a/classical/mathcomp_extra.v
+++ b/classical/mathcomp_extra.v
@@ -1096,5 +1096,8 @@ by case: (eqVneq i j) => [<-|nij];
    [rewrite dfwithin|rewrite dfwithout//]; constructor.
 Qed.
 
+Lemma dfwith_projK (i : I) (x : T i) : cancel (@dfwith i) (proj i).
+Proof. by move=> z; rewrite /proj dfwithin. Qed.
+
 End DFunWith.
 Arguments dfwith {I T} f [i] x.

--- a/classical/mathcomp_extra.v
+++ b/classical/mathcomp_extra.v
@@ -1096,8 +1096,8 @@ by case: (eqVneq i j) => [<-|nij];
    [rewrite dfwithin|rewrite dfwithout//]; constructor.
 Qed.
 
-Lemma dfwith_projK (i : I) (x : T i) : cancel (@dfwith i) (proj i).
+Lemma projK i (x : T i) : cancel (@dfwith i) (proj i).
 Proof. by move=> z; rewrite /proj dfwithin. Qed.
 
 End DFunWith.
-Arguments dfwith {I T} f [i] x.
+Arguments dfwith {I T} f i x.

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -3041,25 +3041,24 @@ Let PK := product_topologicalType K.
 Lemma proj_continuous i : continuous (proj i : PK -> K i).
 Proof.
 move=> f; have /cvg_sup/(_ i)/cvg_image : f --> f by apply: cvg_id.
-move=> h; apply: (cvg_trans _ (h _)) => {h}.
+move=> h; apply: cvg_trans (h _) => {h}.
   by move=> Q /= [W nbdW <-]; apply: filterS nbdW; exact: preimage_image.
-rewrite eqEsubset; split => y //; exists (@dfwith I _ (fun=> point) i y) => //.
+rewrite eqEsubset; split => y //; exists (dfwith (fun=> point) i y) => //.
 by rewrite dfwithin.
 Qed.
 
-Lemma dfwith_continuous g (i : I) : continuous ((@dfwith I _ g i) : K i -> PK).
+Lemma dfwith_continuous g (i : I) : continuous (dfwith g _ : K i -> PK).
 Proof.
 move=> z U [] P [] [] Q QfinP <- [] [] V JV Vpz.
-move /(@preimage_subset _ _ (@dfwith I _ g i))/filterS; apply.
-apply: (@filterS _ _ _ ((@dfwith I _ g _) @^-1` V)); first by exists V.
+move/(@preimage_subset _ _ (dfwith g i))/filterS; apply.
+apply: (@filterS _ _ _ ((dfwith g i) @^-1` V)); first by exists V.
 have [L Lsub /[dup] VL <-] := QfinP _ JV; rewrite preimage_bigcap.
-apply: filter_bigI => /= M /[dup] LM /Lsub /set_mem [] w _ [N] oN /[dup] NM <-.
-case: (eqVneq w i) => [wx|].
-  move: N NM oN; rewrite wx => N NM oN; apply (@filterS _ _ _ N).
-    by move=> ? ?; rewrite /= dfwithin.
+apply: filter_bigI => /= M /[dup] LM /Lsub /set_mem [] w _ [+] + /[dup] + <-.
+have [->|wnx] := eqVneq w i => N oN NM.
+  apply (@filterS _ _ _ N); first by move=> ? ?; rewrite /= dfwithin.
   apply: open_nbhs_nbhs; split => //; move: Vpz.
   by rewrite -VL => /(_ _ LM); rewrite -NM /= dfwithin.
-move=> wnx; (apply: filterS; last exact: filterT) => y _ /=; move: Vpz.
+apply: nearW => y /=; move: Vpz.
 by rewrite -VL => /(_ _ LM); rewrite -NM /= ? dfwithout // eq_sym.
 Qed.
 
@@ -3067,8 +3066,8 @@ Lemma proj_open i (A : set PK) : open A -> open (proj i @` A).
 Proof.
 move=> oA; rewrite openE => z [f Af <-]; rewrite openE in oA.
 have {oA} := oA _ Af; rewrite /interior => nAf.
-apply: (@filterS _ _ _ ((@dfwith I _ f _) @^-1` A)).
-  by move=> w Apw; exists (@dfwith I _ f _ w) => //; rewrite dfwith_projK.
+apply: (@filterS _ _ _ ((dfwith f i) @^-1` A)).
+  by move=> w Apw; exists (dfwith f i w) => //; rewrite projK.
 apply: dfwith_continuous => /=; move: nAf; congr (nbhs _ A).
 by apply: functional_extensionality_dep => ?; case: dfwithP.
 Qed.
@@ -5672,7 +5671,7 @@ move=> FF; rewrite cvg_sigL; split.
   apply/uniform_nbhs; exists E; split=> //= h /=.
   rewrite /sigL => R u _; rewrite oinv_set_val.
   by case: insubP=> /= *; [apply: R|apply: entourage_refl].
-- move /(@cvg_app _ _ _ _ (sigL A)).
+- move/(@cvg_app _ _ _ _ (sigL A)).
   rewrite -fmap_comp sigL_restrict => D.
   apply: cvg_trans; first exact: D.
   move=> P /uniform_nbhs [E [/=entE EsubP]]; apply: (filterS EsubP).


### PR DESCRIPTION
##### Motivation for this change
Should be an easy review. When I first wrote `prod_topo_apply` I got confused by the dependent types. This is just a projection, I don't know why I thought things were more complex. This PR cleans up the names, and adds it's right inverse `product_embed`. We also prove that projections are an open map, which is a generally useful fact. 

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
  (do not edit former entries, only append new ones, be careful:
   merge and rebase have a tendency to mess up `CHANGELOG_UNRELEASED.md`)
- [x] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
