### PR TITLE
Adapt to coq/coq#16798 (cast in pattern is an error by default)

### DIFF
--- a/theories/constructive_ereal.v
+++ b/theories/constructive_ereal.v
@@ -2427,7 +2427,11 @@ Arguments lee_sum_nneg_natr {R}.
 Arguments lee_sum_npos_natr {R}.
 Arguments lee_sum_nneg_natl {R}.
 Arguments lee_sum_npos_natl {R}.
+
+(* <=%E contains casts but we don't mind that they are ignored when matching for this hint *)
+Set Warnings "-cast-in-pattern".
 #[global] Hint Extern 0 (is_true (0 <= `| _ |)%E) => solve [apply: abse_ge0] : core.
+Set Warnings "+cast-in-pattern".
 
 #[deprecated(since="mathcomp-analysis 0.6", note="Use lte_spaddre instead.")]
 Notation lte_spaddr := lte_spaddre.

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -680,8 +680,11 @@ Proof. by []. Qed.
 
 End simple_fun_raw_integral.
 
-#[global] Hint Extern 0 (is_true (0 <= (_ : {measure set _ -> \bar _}) _)%E) =>
+(* <=%E contains casts but we don't mind that they are ignored when matching for this hint *)
+Set Warnings "-cast-in-pattern".
+#[global] Hint Extern 0 (is_true (0 <= _ _)%E) =>
   solve [apply: measure_ge0] : core.
+Set Warnings "+cast-in-pattern".
 
 Section sintegral_lemmas.
 Variables (d : measure_display) (T : measurableType d).

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -130,7 +130,11 @@ rewrite hlength_itv; case: ifPn => //; case: (i.1 : \bar _) => [r| |].
 - by rewrite ltNge leey.
 - by case: (i.2 : \bar _) => //= [r _]; rewrite leey.
 Qed.
+
+(* <=%E contains casts but we don't mind that they are ignored when matching for this hint *)
+Set Warnings "-cast-in-pattern".
 Local Hint Extern 0 (0%:E <= hlength _) => solve[apply: hlength_ge0] : core.
+Set Warnings "+cast-in-pattern".
 
 Lemma hlength_Rhull (A : set R) : hlength [set` Rhull A] = hlength A.
 Proof. by rewrite /hlength Rhull_involutive. Qed.

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -1375,9 +1375,12 @@ Hint Resolve measure_semi_additive2 : core.
 End additive_measure_on_semiring_of_sets.
 Arguments measure0 {d R T} _.
 
+(* <=%E contains casts but we don't mind that they are ignored when matching for this hint *)
+Set Warnings "-cast-in-pattern".
 #[global] Hint Extern 0
-  (is_true (0 <= (_ : {additive_measure set _ -> \bar _}) _)%E) =>
+  (is_true (0 <= _ _)%E) =>
   solve [apply: measure_ge0] : core.
+Set Warnings "+cast-in-pattern".
 
 #[global]
 Hint Resolve measure0 measure_semi_additive2 measure_semi_additive : core.
@@ -1522,7 +1525,11 @@ Arguments measure_bigcup {d R T} mu A.
 #[global] Hint Extern 0 (_ set0 = 0) => solve [apply: measure0] : core.
 #[global] Hint Extern 0 (sigma_additive _) =>
   solve [apply: measure_sigma_additive] : core.
+
+(* <=%E contains casts but we don't mind that they are ignored when matching for this hint *)
+Set Warnings "-cast-in-pattern".
 #[global] Hint Extern 0 (is_true (0 <= _)) => solve [apply: measure_ge0] : core.
+Set Warnings "+cast-in-pattern".
 
 Section pushforward_measure.
 Local Open Scope ereal_scope.

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -474,6 +474,8 @@ End infty_nbhs_instances.
 #[global] Hint Extern 0 (is_true (?x \is Num.real)) => match goal with
   H : x \is_near _ |- _ => near: x; exact: nbhs_ninfty_real end : core.
 
+(* <=%E and company contain casts but we don't mind that they are ignored when matching for these hints *)
+Set Warnings "-cast-in-pattern".
 #[global] Hint Extern 0 (is_true (_ < ?x)%E) => match goal with
   H : x \is_near _ |- _ => near: x; exact: ereal_nbhs_pinfty_gt end : core.
 #[global] Hint Extern 0 (is_true (_ <= ?x)%E) => match goal with
@@ -482,6 +484,8 @@ End infty_nbhs_instances.
   H : x \is_near _ |- _ => near: x; exact: ereal_nbhs_ninfty_lt end : core.
 #[global] Hint Extern 0 (is_true (_ >= ?x)%E) => match goal with
   H : x \is_near _ |- _ => near: x; exact: ereal_nbhs_ninfty_le end : core.
+Set Warnings "+cast-in-pattern".
+
 #[global] Hint Extern 0 (is_true (fine ?x \is Num.real)) => match goal with
   H : x \is_near _ |- _ => near: x; exact: ereal_nbhs_pinfty_real end : core.
 #[global] Hint Extern 0 (is_true (fine ?x \is Num.real)) => match goal with

--- a/theories/numfun.v
+++ b/theories/numfun.v
@@ -221,10 +221,13 @@ have [|fx0] := leP 0 (f x); last rewrite add0e.
 Qed.
 
 End funposneg_lemmas.
+(* <=%E contains casts but we don't mind that they are ignored when matching for this hint *)
+Set Warnings "-cast-in-pattern".
 #[global]
 Hint Extern 0 (is_true (0 <= _ ^\+ _)%E) => solve [apply: funepos_ge0] : core.
 #[global]
 Hint Extern 0 (is_true (0 <= _ ^\- _)%E) => solve [apply: funeneg_ge0] : core.
+Set Warnings "+cast-in-pattern".
 
 Definition indic {T} {R : ringType} (A : set T) (x : T) : R := (x \in A)%:R.
 Reserved Notation "'\1_' A" (at level 8, A at level 2, format "'\1_' A") .


### PR DESCRIPTION
A pattern `x : y` is equivalent to just `x`.

Some of the casts were bogus and so were removed.

Other casts come from notations (from constructive_ereals around line 260), for these the warning was ignored as it seems ignoring them was not a problem.
