### PR TITLE
Having a structure for sigma finite measures

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -11,6 +11,7 @@
   + mixin `isProbability`, structure `Probability`, type `probability`
   + lemma `probability_le1`
   + definition `discrete_measurable_unit`
+  + structures `sigma_finite_additive_measure` and `sigma_finite_measure`
 
 - in `constructive_ereal.v`:
   + lemma `oppe_inj`
@@ -32,6 +33,8 @@
   + lemma `measurable_fun_opp`
 - in `lebesgue_integral.v`
   + lemmas `integral0_eq`, `fubini_tonelli`
+  + product measures now takes `{measure _ -> _}` arguments and their
+    theory quantify over a `{sigma_finite_measure}`.
 
 - in `classical_sets.v`:
   + lemma `trivIset_mkcond`
@@ -86,5 +89,3 @@
 ### Infrastructure
 
 ### Misc
-
-

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -42,6 +42,8 @@
   + lemmas `xsection_indic`, `ysection_indic`
 - in `classical_sets.v`:
   + lemmas `xsectionI`, `ysectionI`
+- in `lebesgue_integral.v`:
+  + notations `\x`, `\x^` for `product_measure1` and `product_measure2`
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -33,13 +33,15 @@
   + lemma `measurable_fun_opp`
 - in `lebesgue_integral.v`
   + lemmas `integral0_eq`, `fubini_tonelli`
-  + product measures now takes `{measure _ -> _}` arguments and their
-    theory quantify over a `{sigma_finite_measure}`.
+  + product measures now take `{measure _ -> _}` arguments and their
+    theory quantifies over a `{sigma_finite_measure _ -> _}`.
 
 - in `classical_sets.v`:
   + lemma `trivIset_mkcond`
 - in `numfun.v`:
   + lemmas `xsection_indic`, `ysection_indic`
+- in `classical_sets.v`:
+  + lemmas `xsectionI`, `ysectionI`
 
 ### Changed
 
@@ -78,6 +80,8 @@
   + lemma `measurable_sfunP`
 - in `measure.v`:
   + lemma `measure_bigcup` generalized,
+- in `classical_sets.v`:
+  + `xsection_preimage_snd`, `ysection_preimage_fst`
 
 ### Deprecated
 

--- a/classical/classical_sets.v
+++ b/classical/classical_sets.v
@@ -3112,24 +3112,22 @@ Proof. by move=> X Y XY y; rewrite /xsection /= 2!inE => /XY. Qed.
 Lemma le_ysection y : {homo ysection ^~ y : X Y / X `<=` Y >-> X `<=` Y}.
 Proof. by move=> X Y XY x; rewrite /ysection /= 2!inE => /XY. Qed.
 
+Lemma xsectionI A B x : xsection (A `&` B) x = xsection A x `&` xsection B x.
+Proof. by rewrite /xsection predeqE => y/=; split; rewrite !inE => -[]. Qed.
+
+Lemma ysectionI A B y : ysection (A `&` B) y = ysection A y `&` ysection B y.
+Proof. by rewrite /ysection predeqE => x/=; split; rewrite !inE => -[]. Qed.
+
 Lemma xsectionD X Y x : xsection (X `\` Y) x = xsection X x `\` xsection Y x.
-Proof.
-rewrite predeqE /xsection /= => y; split; last by rewrite 3!inE.
-by rewrite inE => -[Xxy Yxy]; rewrite 2!inE.
-Qed.
+Proof. by rewrite predeqE /xsection /= => y; split; rewrite !inE. Qed.
 
 Lemma ysectionD X Y y : ysection (X `\` Y) y = ysection X y `\` ysection Y y.
-Proof.
-rewrite predeqE /ysection /= => x; split; last by rewrite 3!inE.
-by rewrite inE => -[Xxy Yxy]; rewrite 2!inE.
-Qed.
+Proof. by rewrite predeqE /ysection /= => x; split; rewrite !inE. Qed.
 
-Lemma xsection_preimage_snd (Z : Type) (f : T2 -> Z) (A : set Z) (x : T1) :
-  xsection ((f \o snd) @^-1` A) x = f @^-1` A.
+Lemma xsection_preimage_snd (B : set T2) x : xsection (snd @^-1` B) x = B.
 Proof. by apply/seteqP; split; move=> y/=; rewrite /xsection/= inE. Qed.
 
-Lemma ysection_preimage_fst (Z : Type) (f : T1 -> Z) (A : set Z) (y : T2) :
-  ysection ((f \o fst) @^-1` A) y = f @^-1` A.
+Lemma ysection_preimage_fst (A : set T1) y : ysection (fst @^-1` A) y = A.
 Proof. by apply/seteqP; split; move=> x/=; rewrite /ysection/= inE. Qed.
 
 End section.

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -88,6 +88,11 @@ From HB Require Import structures.
 (*     isMeasure == factory corresponding to the type of measures             *)
 (*     Measure == structure corresponding to measures                         *)
 (*     finite_measure mu == the measure mu is finite                          *)
+(*  {sigma_finite_additive_measure set T -> \bar R} ==                        *)
+(*                   additive measures that are also sigma finite             *)
+(*  {sigma_finite_measure set T -> \bar R} ==                                 *)
+(*                    measures that are also sigma finite                     *)
+(*     isSigmaFinite == factory corresponding to sigma finiteness             *)
 (*                                                                            *)
 (*  pushforward mf m == pushforward/image measure of m by f, where mf is a    *)
 (*                      proof that f is measurable                            *)
@@ -1579,6 +1584,33 @@ move=> n; split; first by case: ifPn.
 by case: ifPn => // _; rewrite ?measure0//; exact: finite_measure.
 Qed.
 
+HB.mixin Record isSigmaFinite d (R : numFieldType) (T : semiRingOfSetsType d)
+    (mu : set T -> \bar R) := {
+  sigma_finiteT : sigma_finite setT mu
+}.
+
+#[short(type="sigma_finite_additive_measure")]
+HB.structure Definition SigmaFiniteAdditiveMeasure d R T :=
+  {mu of isSigmaFinite d R T mu & @AdditiveMeasure d R T mu}.
+Arguments sigma_finiteT {d R T} s.
+
+Notation "{ 'sigma_finite_additive_measure' 'set' T '->' '\bar' R }" :=
+  (sigma_finite_additive_measure R T)
+  (at level 36, T, R at next level,
+    format "{ 'sigma_finite_additive_measure'  'set'  T  '->'  '\bar'  R }")
+  : ring_scope.
+
+#[global]
+Hint Resolve sigma_finiteT : core.
+
+#[short(type="sigma_finite_measure")]
+HB.structure Definition SigmaFiniteMeasure d R T :=
+  {mu of isSigmaFinite d R T mu & @Measure d R T mu}.
+
+Notation "{ 'sigma_finite_measure' 'set' T '->' '\bar' R }" := (sigma_finite_measure R T)
+  (at level 36, T, R at next level,
+    format "{ 'sigma_finite_measure'  'set'  T  '->'  '\bar'  R }") : ring_scope.
+
 Section pushforward_measure.
 Local Open Scope ereal_scope.
 Context d d' (T1 : measurableType d) (T2 : measurableType d') (f : T1 -> T2).
@@ -1927,6 +1959,8 @@ Proof.
 exists (fun n => `I_n.+1); first by apply/seteqP; split=> //x _; exists x => /=.
 by move=> k; split => //; rewrite /counting/= asboolT// ltry.
 Qed.
+HB.instance Definition _ R :=
+  @isSigmaFinite.Build _ _ _ (counting R) (sigma_finite_counting R).
 
 Lemma big_trivIset (I : choiceType) D T (R : Type) (idx : R)
    (op : Monoid.com_law idx) (A : I -> set T) (F : set T -> R) :


### PR DESCRIPTION
##### Motivation for this change

Making the definition of `product_measure` seamingly symmetric.

TODO: we will need to rename `SigmaFiniteAdditiveMeasure` before merging if we rename additive measures to contents in the code. 

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
  (do not edit former entries, only append new ones, be careful:
   merge and rebase have a tendency to mess up `CHANGELOG_UNRELEASED.md`)
- [x] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.