### PR TITLE
rename and doc finSubCover

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -63,6 +63,8 @@
 - in `constructive_ereal.v`:
   + lemmas `adde_def_doppeD`, `adde_def_doppeB`
   + lemma `fin_num_sume_distrr`
+- in `classical_sets.v`:
+  + lemma `coverE`
 
 ### Changed
 
@@ -106,6 +108,8 @@
   + `oppeB` -> `fin_num_oppeB`
   + `doppeD` -> `fin_num_doppeD`
   + `doppeB` -> `fin_num_doppeB`
+- in `topology.v`:
+  + `finSubCover` -> `finite_subset_cover`
 
 ### Generalized
 

--- a/classical/classical_sets.v
+++ b/classical/classical_sets.v
@@ -2464,6 +2464,9 @@ Proof. by move=> y z _ _ [x [[_ <-] [_ <-]]]. Qed.
 
 Definition cover T I D (F : I -> set T) := \bigcup_(i in D) F i.
 
+Lemma coverE T I D (F : I -> set T) : cover D F = \bigcup_(i in D) F i.
+Proof. by []. Qed.
+
 Lemma cover_restr T I D' D (F : I -> set T) :
   D `<=` D' -> (forall i, D' i -> ~ D i -> F i = set0) ->
   cover D F = cover D' F.

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -748,7 +748,7 @@ Qed.
 HB.instance Definition T_isRingOfSets := @isRingOfSets.Build d T ptclass
   measurable measurable0 measurableU mD.
 
-Lemma measurableT : measurable (@setT T).
+Lemma measurableT : measurable [set: T].
 Proof. by rewrite -setC0; apply: measurableC; exact: measurable0. Qed.
 
 HB.instance Definition T_isAlgebraOfSets : AlgebraOfSets_from_RingOfSets d T :=

--- a/theories/reals.v
+++ b/theories/reals.v
@@ -74,7 +74,7 @@ Lemma has_ubound0 : has_ubound (@set0 R). Proof. by exists 0. Qed.
 Lemma ubound0 : ubound (@set0 R) = setT.
 Proof. by rewrite predeqE => r; split => // _. Qed.
 
-Lemma lboundT : lbound (@setT R) = set0.
+Lemma lboundT : lbound [set: R] = set0.
 Proof.
 rewrite predeqE => r; split => // /(_ (r - 1) Logic.I).
 rewrite ler_subr_addl addrC -ler_subr_addl subrr.

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -218,6 +218,8 @@ Require Import reals signed.
 (*                                     (and closed) neighborhood              *)
 (*               hausdorff_space T <-> T is a Hausdorff space (T_2).          *)
 (*                discrete_space T <-> every nbhs is a principal filter       *)
+(*        finite_subset_cover D F A == the family of sets F is a cover of A   *)
+(*                                     for a finite number of indices in D    *)
 (*                    cover_compact == set of compact sets w.r.t. the open    *)
 (*                                     cover-based definition of compactness. *)
 (*                    near_covering == a reformulation of covering compact    *)
@@ -237,7 +239,7 @@ Require Import reals signed.
 (*     {uniform` A -> V} == The space U -> V, equipped with the topology of   *)
 (*                          uniform convergence from a set A to V, where      *)
 (*                          V is a uniformType.                               *)
-(*      {uniform U -> V} := {uniform` @setT U -> V}                           *)
+(*      {uniform U -> V} := {uniform` [set: U] -> V}                          *)
 (*  {uniform A, F --> f} == F converges to f in {uniform A -> V}.             *)
 (*    {uniform, F --> f} := {uniform setT, F --> f}                           *)
 (*         {ptws U -> V} == The space U -> V, equipped with the topology of   *)
@@ -772,7 +774,7 @@ Arguments filter_not_empty {T} F {_}.
 
 Notation ProperFilter := ProperFilter'.
 
-Lemma filter_setT (T' : Type) : Filter (@setT (set T')).
+Lemma filter_setT (T' : Type) : Filter [set: set T'].
 Proof. by constructor. Qed.
 
 Lemma filterP_strong T (F : set (set T)) {FF : Filter F} (P : set T) :
@@ -2957,7 +2959,7 @@ have subst_coordT i pi f : subst_coord i pi f i = pi.
 have subst_coordN i pi f j : i != j -> subst_coord i pi f j = f j.
   move=> inej; rewrite /subst_coord; case: eqP => // e.
   by move: inej; rewrite {1}e => /negP.
-have pr_surj i : @^~ i @` (@setT (forall i, T i)) = setT.
+have pr_surj i : @^~ i @` [set: forall i, T i] = setT.
   rewrite predeqE => pi; split=> // _.
   by exists (subst_coord i pi (fun _ => point))=> //; rewrite subst_coordT.
 set pF := fun i => [set @^~ i @` B | B in F].
@@ -3114,10 +3116,9 @@ move=> FF sDFf D' sD; apply: (@filter_ex _ F); apply: filter_bigI.
 by move=> A /sD; rewrite inE => /sDFf.
 Qed.
 
-Definition finSubCover (I : choiceType) (D : set I)
+Definition finite_subset_cover (I : choiceType) (D : set I)
     U (F : I -> set U) (A : set U) :=
-  exists2 D' : {fset I}, {subset D' <= D} &
-    A `<=` \bigcup_(i in [set i | i \in D']) F i.
+  exists2 D' : {fset I}, {subset D' <= D} & A `<=` cover [set` D'] F.
 
 Section Covers.
 
@@ -3125,18 +3126,17 @@ Variable T : topologicalType.
 
 Definition cover_compact (A : set T) :=
   forall (I : choiceType) (D : set I) (f : I -> set T),
-  (forall i, D i -> open (f i)) -> A `<=` \bigcup_(i in D) f i ->
-  finSubCover D f A.
+  (forall i, D i -> open (f i)) -> A `<=` cover D f ->
+  finite_subset_cover D f A.
 
 Definition open_fam_of (A : set T) I (D : set I) (f : I -> set T) :=
   exists2 g : I -> set T, (forall i, D i -> open (g i)) &
     forall i, D i -> f i = A `&` g i.
 
-Lemma cover_compactE :
-  cover_compact =
+Lemma cover_compactE : cover_compact =
   [set A | forall (I : choiceType) (D : set I) (f : I -> set T),
-    open_fam_of A D f -> A `<=` \bigcup_(i in D) f i -> finSubCover D f A].
-
+    open_fam_of A D f ->
+      A `<=` cover D f -> finite_subset_cover D f A].
 Proof.
 rewrite predeqE => A; split=> [Aco I D f [g gop feAg] fcov|Aco I D f fop fcov].
   have gcov : A `<=` \bigcup_(i in D) g i.
@@ -3192,8 +3192,7 @@ split=> [Aco I D f [g gop feAg] fcov|Aco I D f [g gcl feAg]].
       by move=> gip; apply: nfip; rewrite feAg.
     by rewrite feAg // => - [].
   move=> D' sD.
-  have /asboolP : ~ A `<=` \bigcup_(i in [set i | i \in D']) f i.
-    by move=> sAIf; apply: (sfncov D').
+  have /asboolP : ~ A `<=` cover [set` D'] f by move=> sAIf; exact: (sfncov D').
   rewrite asbool_neg => /existsp_asboolPn [p /asboolP].
   rewrite asbool_neg => /imply_asboolPn [Ap nUfp].
   by exists p => i D'i; split=> // fip; apply: nUfp; exists i.
@@ -3629,8 +3628,8 @@ move=> NOx; split; [exact: closedT |]; rewrite eqEsubset; split => x // _.
 move=> U; rewrite nbhsE; case=> V [][] oV Vx VU.
 have Vnx: V != [set x] by apply/eqP => M; apply: (NOx x); rewrite -M.
 have /existsNP [y /existsNP [Vy Ynx]] : ~ forall y, V y -> y = x.
-  move/negP: Vnx; apply: contra_not => Vxy; apply/eqP; rewrite eqEsubset. 
-  by split => // ? ->. 
+  move/negP: Vnx; apply: contra_not => Vxy; apply/eqP; rewrite eqEsubset.
+  by split => // ? ->.
 by exists y; split => //; [exact/eqP | exact: VU].
 Qed.
 
@@ -3811,7 +3810,7 @@ apply Build_ProperFilter; last exact: Uniform.ax1.
 by move=> A entA; exists (point, point); apply: entourage_refl.
 Qed.
 
-Lemma entourageT : entourage (@setT (M * M)).
+Lemma entourageT : entourage [set: M * M].
 Proof. exact: filterT. Qed.
 
 Lemma entourage_inv (A : set (M * M)) : entourage A -> entourage (A^-1)%classic.
@@ -5587,7 +5586,7 @@ End RestrictedUniformTopology.
 
 Notation "{ 'uniform`' A -> V }" := (@fct_RestrictedUniform _ A V) :
   classical_set_scope.
-Notation "{ 'uniform' U -> V }" := ({uniform` (@setT U) -> V}) :
+Notation "{ 'uniform' U -> V }" := ({uniform` [set: U] -> V}) :
   classical_set_scope.
 
 Notation "{ 'uniform' A , F --> f }" :=
@@ -5803,19 +5802,20 @@ Lemma family_cvg_finite_covers (famA famB : set U -> Prop)
   (F : set (set (U -> V))) (f : U -> V) : Filter F ->
   (forall P, famA P ->
     exists (I : choiceType) f,
-      (forall i, famB (f i)) /\ finSubCover (@setT I) f P) ->
+      (forall i, famB (f i)) /\ finite_subset_cover [set: I] f P) ->
   {family famB, F --> f} -> {family famA, F --> f}.
 Proof.
 move=> FF ex_finCover /fam_cvgP rFf; apply/fam_cvgP => A famAA.
 move: ex_finCover => /(_ _ famAA) [R [g [g_famB [D _]]]].
 move/uniform_subset_cvg; apply.
 elim/finSet_rect: D => X IHX.
-have [/eqP ->|/set0P[x xX]] := boolP ([set i | i \in X] == set0).
-  by rewrite bigcup_set0; apply: cvg_uniform_set0.
-rewrite (bigcup_fsetD1 x)//; apply: cvg_uniformU.
+have [->|/set0P[x xX]] := eqVneq [set` X] set0.
+  by rewrite coverE bigcup_set0; apply: cvg_uniform_set0.
+rewrite coverE (bigcup_fsetD1 x)//; apply: cvg_uniformU.
   exact/rFf/g_famB.
 exact/IHX/fproperD1.
 Qed.
+
 End UniformCvgLemmas.
 
 Notation "{ 'family' fam , U -> V }" :=  (@fct_UniformFamily U V fam).
@@ -6519,7 +6519,7 @@ Qed.
 
 Lemma nbhs_subspaceT (x : T) : nbhs (x : subspace setT) = nbhs x.
 Proof.
-rewrite {1}/nbhs //=; have [_|] := nbhs_subspaceP (@setT T); last by cbn.
+rewrite {1}/nbhs //=; have [_|] := nbhs_subspaceP [set: T]; last by cbn.
 rewrite eqEsubset withinE; split => [W [V nbhsV]|W ?]; last by exists W.
 by rewrite 2!setIT => ->.
 Qed.
@@ -6836,7 +6836,7 @@ Unshelve. end_near. Qed.
 Section UniformPointwise.
 Context {U : topologicalType} {V : uniformType}.
 
-Definition singletons {T : Type} := [set [set x] | x in @setT T].
+Definition singletons {T : Type} := [set [set x] | x in [set: T]].
 
 Lemma pointwise_cvg_family_singleton F (f: U -> V):
   Filter F -> {ptws, F --> f} = {family @singletons U, F --> f}.
@@ -7042,7 +7042,7 @@ exists (closure (W : set {ptws X -> Y })) => //; exact: equicontinuous_closure.
 Qed.
 
 Section precompact_equicontinuous.
-Hypothesis lcptX : locally_compact (@setT X).
+Hypothesis lcptX : locally_compact [set: X].
 
 Let compact_equicontinuous (W : set {family compact, X -> Y}) :
   (forall f, W f -> continuous f) ->


### PR DESCRIPTION
##### Motivation for this change

fixes #658 

I added a documentation entry.
Since the naming was questioned, I propose a new one that essentially gets rid of camlCase
which is more commonly used for mixins and structures in MathComp.
I haven't changed the definition as suggested by the issue.

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- [x] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
