### PR TITLE
add a type for finite measures

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -104,16 +104,19 @@
   + definition `sfinite_measure_def`
   + mixin `Measure_isSFinite_subdef`, structure `SFiniteMeasure`,
     notation `{sfinite_measure set _ -> \bar _}`
-  + mixin `SigmaFinite_isFinite`, structure `FiniteMeasure`,
+  + mixin `SigmaFinite_isFinite` with field `fin_num_measure`, structure `FiniteMeasure`,
     notation `{finite_measure set _ -> \bar _}`
-  + lemma `sfinite_measure_sigma_finite`, `sigma_finite_mzero`,
-  + instances `isSigmaFinite`, `SigmaFinite_isFinite` for `mzero`
+  + lemmas `sfinite_measure_sigma_finite`, `sfinite_mzero`, `sigma_finite_mzero`, `finite_mzero`
   + factory `Measure_isFinite`, `Measure_isSFinite`
   + lemma `sfinite_measure`
   + mixin `FiniteMeasure_isSubProbability`, structure `SubProbability`,
     notation `subprobability`
   + factory `Measure_isSubProbability`
   + factory `FiniteMeasure_isSubProbability`
+  + factory `Measure_isSigmaFinite`
+  + lemmas `fin_num_fun_finite_measure`, `finite_measure_fin_num_fun`
+  + definition `fin_num_fun`
+  + structure `FinNumFun`
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -113,7 +113,7 @@
   + factory `Measure_isSubProbability`
   + factory `FiniteMeasure_isSubProbability`
   + factory `Measure_isSigmaFinite`
-  + lemmas `fin_num_fun_lty`, `finite_measure_fin_num_fun`
+  + lemmas `fin_num_fun_lty`, `lty_fin_num_fun`
   + definition `fin_num_fun`
   + structure `FinNumFun`
 
@@ -140,7 +140,6 @@
 - in `functions.v`:
   + notation `mem_fun_`
 - in `measure.v`:
-  + `finite_measure` is now a lemma that applies to a finite measure
   + order of arguments of `isContent`, `Content`, `measure0`, `isMeasure0`,
     `Measure`, `isSigmaFinite`, `SigmaFiniteContent`, `SigmaFiniteMeasure`
   + `sigma_finite` now specialized to the full set
@@ -197,7 +196,7 @@
   + lemma `integrable_abse`
 
   + `sigma_finite` generalized from `numFieldType` to `numDomainType`
-  + `finite_measure_sigma_finite` generalized from `measurableType` to `algebraOfSetsType`
+  + `fin_num_fun_sigma_finite` generalized from `measurableType` to `algebraOfSetsType`
 
 ### Deprecated
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -144,6 +144,7 @@
   + `finite_measure` is now a lemma that applies to a finite measure
   + order of arguments of `isContent`, `Content`, `measure0`, `isMeasure0`,
     `Measure`, `isSigmaFinite`, `SigmaFiniteContent`, `SigmaFiniteMeasure`
+  + `sigma_finite` now specialized to the full set
 
 ### Renamed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -142,7 +142,6 @@
 - in `measure.v`:
   + order of arguments of `isContent`, `Content`, `measure0`, `isMeasure0`,
     `Measure`, `isSigmaFinite`, `SigmaFiniteContent`, `SigmaFiniteMeasure`
-  + `sigma_finite` now specialized to the full set
 
 ### Renamed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -7,7 +7,6 @@
 - in `classical_sets.v`:
   + canonical `unit_pointedType`
 - in `measure.v`:
-  + definition `finite_measure`
   + mixin `isProbability`, structure `Probability`, type `probability`
   + lemma `probability_le1`
   + definition `discrete_measurable_unit`
@@ -36,7 +35,7 @@
   + lemmas `measurable_curry`, `measurable_fun_fst`, `measurable_fun_snd`,
     `measurable_fun_swap`, `measurable_fun_pair`, `measurable_fun_if_pair`
   + lemmas `dirac0`, `diracT`
-  + lemma `finite_measure_sigma_finite`
+  + lemma `fin_num_fun_sigma_finite`
 - in `lebesgue_measure.v`:
   + lemma `measurable_fun_opp`
 - in `lebesgue_integral.v`
@@ -106,7 +105,7 @@
     notation `{sfinite_measure set _ -> \bar _}`
   + mixin `SigmaFinite_isFinite` with field `fin_num_measure`, structure `FiniteMeasure`,
     notation `{finite_measure set _ -> \bar _}`
-  + lemmas `sfinite_measure_sigma_finite`, `sfinite_mzero`, `sigma_finite_mzero`, `finite_mzero`
+  + lemmas `sfinite_measure_sigma_finite`, `sfinite_mzero`, `sigma_finite_mzero`
   + factory `Measure_isFinite`, `Measure_isSFinite`
   + lemma `sfinite_measure`
   + mixin `FiniteMeasure_isSubProbability`, structure `SubProbability`,
@@ -114,7 +113,7 @@
   + factory `Measure_isSubProbability`
   + factory `FiniteMeasure_isSubProbability`
   + factory `Measure_isSigmaFinite`
-  + lemmas `fin_num_fun_finite_measure`, `finite_measure_fin_num_fun`
+  + lemmas `fin_num_fun_lty`, `finite_measure_fin_num_fun`
   + definition `fin_num_fun`
   + structure `FinNumFun`
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -102,6 +102,17 @@
 - in file `topology.v`,
   + new lemmas `powerset_filter_fromP` and `compact_cluster_set1`.
 
+- in `measure.v`:
+  + definition `sfinite_measure_def`
+  + mixin `Measure_isSFinite_subdef`, structure `SFiniteMeasure`,
+    notation `{sfinite_measure set _ -> \bar _}`
+  + mixin `SigmaFinite_isFinite`, structure `FiniteMeasure`,
+    notation `{finite_measure set _ -> \bar _}`
+  + lemma `sfinite_measure_sigma_finite`, `sigma_finite_mzero`,
+  + instances `isSigmaFinite`, `SigmaFinite_isFinite` for `mzero`
+  + factory `Measure_isFinite`, `Measure_isSFinite`
+  + lemma `sfinite_measure`
+
 ### Changed
 
 - in `fsbigop.v`:
@@ -126,6 +137,8 @@
   + notation `mem_fun_`
 - in `measure.v`:
   + `finite_measure` is now a lemma that applies to a finite measure
+  + order of arguments of `isContent`, `Content`, `measure0`, `isMeasure0`,
+    `Measure`, `isSigmaFinite`, `SigmaFiniteContent`, `SigmaFiniteMeasure`
 
 ### Renamed
 
@@ -178,6 +191,8 @@
 - in `lebesgue_integral.v`:
   + lemma `integrable_abse`
 
+  + `sigma_finite` generalized from `numFieldType` to `numDomainType`
+  + `finite_measure_sigma_finite` generalized from `measurableType` to `algebraOfSetsType`
 
 ### Deprecated
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -107,7 +107,7 @@
     notation `{finite_measure set _ -> \bar _}`
   + lemmas `sfinite_measure_sigma_finite`, `sfinite_mzero`, `sigma_finite_mzero`
   + factory `Measure_isFinite`, `Measure_isSFinite`
-  + lemma `sfinite_measure`
+  + defintion `sfinite_measure_seq`, lemma `sfinite_measure_seqP`
   + mixin `FiniteMeasure_isSubProbability`, structure `SubProbability`,
     notation `subprobability`
   + factory `Measure_isSubProbability`

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -89,8 +89,6 @@
     `join_product_continuous`, `join_product_open`, `join_product_inj`, and 
     `join_product_weak`. 
 - in `measure.v`:
-  + mixin `isFiniteMeasureFunction` with field `finite_measure_function`
-  + structure `FiniteMeasureFunction`
   + structure `FiniteMeasure`, notation `{finite_measure set _ -> \bar _}`
 
 - in file `topology.v`,

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -112,6 +112,10 @@
   + instances `isSigmaFinite`, `SigmaFinite_isFinite` for `mzero`
   + factory `Measure_isFinite`, `Measure_isSFinite`
   + lemma `sfinite_measure`
+  + mixin `FiniteMeasure_isSubProbability`, structure `SubProbability`,
+    notation `subprobability`
+  + factory `Measure_isSubProbability`
+  + factory `FiniteMeasure_isSubProbability`
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -88,6 +88,10 @@
   + new lemmas `weak_sep_cvg`, `weak_sep_nbhsE`, `weak_sep_openE`, 
     `join_product_continuous`, `join_product_open`, `join_product_inj`, and 
     `join_product_weak`. 
+- in `measure.v`:
+  + mixin `isFiniteMeasureFunction` with field `finite_measure_function`
+  + structure `FiniteMeasureFunction`
+  + structure `FiniteMeasure`, notation `{finite_measure set _ -> \bar _}`
 
 - in file `topology.v`,
   + new definition `clopen`.
@@ -120,6 +124,9 @@
   + lemma `compact_near_coveringP`
 - in `functions.v`:
   + notation `mem_fun_`
+- in `measure.v`:
+  + `finite_measure` is now a lemma that applies to a finite measure
+
 ### Renamed
 
 - in `measurable.v`:

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -4381,7 +4381,7 @@ have mF1F2 n : measurable (F1 n `*` F2 n) /\ m (F1 n `*` F2 n) < +oo.
   have [? ?] := F1_oo n; have [? ?] := F2_oo n.
   split; first exact: measurableM.
   by rewrite /m product_measure1E // lte_mul_pinfty// ge0_fin_numE.
-have sm : sigma_finite m by exists (fun n => F1 n `*` F2 n).
+have sm : sigma_finite setT m by exists (fun n => F1 n `*` F2 n).
 pose C : set (set (T1 * T2)) := [set C |
   exists A1, measurable A1 /\ exists A2, measurable A2 /\ C = A1 `*` A2].
 have CI : setI_closed C.

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -3732,9 +3732,10 @@ End integrable_fune.
 
 Section integral_counting.
 Local Open Scope ereal_scope.
-Variables (R : realType).
+Variable R : realType.
 
-Lemma counting_dirac (A : set nat) : counting R A = \sum_(n <oo) \d_ n A.
+Lemma counting_dirac (A : set nat) :
+  counting A = \sum_(n <oo) \d_ n A :> \bar R.
 Proof.
 have -> : \sum_(n <oo) \d_ n A = \esum_(i in A) \d_ i A :> \bar R.
   rewrite nneseries_esum// (_ : [set _ | _] = setT); last exact/seteqP.
@@ -3753,13 +3754,13 @@ apply: (@le_lt_trans _ _ (\sum_(i <oo) `|fine (a i)|%:E)).
   apply: lee_nneseries => // n _; rewrite integral_dirac//.
   move: (@summable_pinfty _ _ _ _ sa n Logic.I).
   by case: (a n) => //= r _; rewrite indicE/= mem_set// mul1r.
-move: (sa); rewrite /summable (_ : [set: nat] = (fun=> true))//; last exact/seteqP.
+move: (sa); rewrite /summable (_ : [set: nat] = xpredT)//; last exact/seteqP.
 rewrite -nneseries_esum//; apply: le_lt_trans.
 by apply: lee_nneseries => // n _ /=; case: (a n) => //; rewrite leey.
 Qed.
 
 Lemma integral_count (a : nat -> \bar R) : summable setT a ->
-  \int[counting R]_t (a t) = \sum_(k <oo) (a k).
+  \int[counting]_t (a t) = \sum_(k <oo) (a k).
 Proof.
 move=> sa.
 transitivity (\int[mseries (fun n => [the measure _ _ of \d_ n]) O]_t a t).
@@ -4380,7 +4381,7 @@ have mF1F2 n : measurable (F1 n `*` F2 n) /\ m (F1 n `*` F2 n) < +oo.
   have [? ?] := F1_oo n; have [? ?] := F2_oo n.
   split; first exact: measurableM.
   by rewrite /m product_measure1E // lte_mul_pinfty// ge0_fin_numE.
-have sm : sigma_finite setT m by exists (fun n => F1 n `*` F2 n).
+have sm : sigma_finite m by exists (fun n => F1 n `*` F2 n).
 pose C : set (set (T1 * T2)) := [set C |
   exists A1, measurable A1 /\ exists A2, measurable A2 /\ C = A1 `*` A2].
 have CI : setI_closed C.

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -3754,9 +3754,8 @@ apply: (@le_lt_trans _ _ (\sum_(i <oo) `|fine (a i)|%:E)).
   apply: lee_nneseries => // n _; rewrite integral_dirac//.
   move: (@summable_pinfty _ _ _ _ sa n Logic.I).
   by case: (a n) => //= r _; rewrite indicE/= mem_set// mul1r.
-move: (sa); rewrite /summable (_ : [set: nat] = xpredT)//; last exact/seteqP.
-rewrite -nneseries_esum//; apply: le_lt_trans.
-by apply: lee_nneseries => // n _ /=; case: (a n) => //; rewrite leey.
+move: (sa); rewrite /summable -fun_true -nneseries_esum//; apply: le_lt_trans.
+by apply lee_nneseries => // n _ /=; case: (a n) => //; rewrite leey.
 Qed.
 
 Lemma integral_count (a : nat -> \bar R) : summable setT a ->

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -331,7 +331,7 @@ apply/andP; split=> //; apply: contraTneq xbj => ->.
 by rewrite in_itv/= le_gtF// (itvP xabi).
 Qed.
 
-HB.instance Definition _ := isContent.Build _ R _
+HB.instance Definition _ := isContent.Build _ _ R
   (hlength : set ocitv_type -> _) (@hlength_ge0') hlength_semi_additive.
 
 Hint Extern 0 ((_ .-ocitv).-measurable _) => solve [apply: is_ocitv] : core.

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -378,7 +378,7 @@ do !case: ifPn => //= ?; do ?by rewrite ?adde_ge0 ?lee_fin// ?subr_ge0// ?ltW.
 by rewrite addrAC lee_fin ler_add// subr_le0 leNgt.
 Qed.
 
-Lemma hlength_sigma_finite : sigma_finite [set: ocitv_type] hlength.
+Lemma hlength_sigma_finite : sigma_finite (hlength : set ocitv_type -> _).
 Proof.
 exists (fun k : nat => `] (- k%:R)%R, k%:R]%classic).
   apply/esym; rewrite -subTset => x _ /=; exists `|(floor `|x| + 1)%R|%N => //=.

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -378,7 +378,7 @@ do !case: ifPn => //= ?; do ?by rewrite ?adde_ge0 ?lee_fin// ?subr_ge0// ?ltW.
 by rewrite addrAC lee_fin ler_add// subr_le0 leNgt.
 Qed.
 
-Lemma hlength_sigma_finite : sigma_finite (hlength : set ocitv_type -> _).
+Lemma hlength_sigma_finite : sigma_finite setT (hlength : set ocitv_type -> _).
 Proof.
 exists (fun k : nat => `] (- k%:R)%R, k%:R]%classic).
   apply/esym; rewrite -subTset => x _ /=; exists `|(floor `|x| + 1)%R|%N => //=.

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -2543,7 +2543,7 @@ Definition fin_num_fun d (T : semiRingOfSetsType d) (R : numDomainType)
   (mu : set T -> \bar R) := forall U, measurable U -> mu U \is a fin_num.
 
 Lemma fin_num_fun_lty d (T : algebraOfSetsType d) (R : realFieldType)
-    (mu : set T -> \bar R) : fin_num_fun mu -> mu setT < +oo.
+  (mu : set T -> \bar R) : fin_num_fun mu -> mu setT < +oo.
 Proof. by move=> h; rewrite ltey_eq h. Qed.
 
 Lemma lty_fin_num_fun d (T : algebraOfSetsType d)

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -111,8 +111,8 @@ From HB Require Import structures.
 (*     {sfinite_measure set T -> \bar R} == type of s-finite measures         *)
 (*     Measure_isSFinite == factory for s-finite measures                     *)
 (*                                                                            *)
-(*     sigma_finite f == the measure function f is sigma-finite on the full   *)
-(*                       set [set: T]  with T : semiRingOfSetsType            *)
+(*     sigma_finite A f == the measure function f is sigma-finite on the set  *)
+(*                         A : set T  with T : semiRingOfSetsType             *)
 (*     isSigmaFinite == mixin corresponding to sigma finiteness               *)
 (*     {sigma_finite_content set T -> \bar R} == contents that are also sigma *)
 (*                                               finite                       *)
@@ -2559,13 +2559,13 @@ Definition sfinite_measure_def d (T : measurableType d) (R : realType)
     forall U, measurable U -> mu U = mseries s 0 U.
 
 Definition sigma_finite d (T : semiRingOfSetsType d) (R : numDomainType)
-    (mu : set T -> \bar R) :=
-  exists2 F : (set T)^nat, setT = \bigcup_(i : nat) F i &
+    (A : set T) (mu : set T -> \bar R) :=
+  exists2 F : (set T)^nat, A = \bigcup_(i : nat) F i &
       forall i, measurable (F i) /\ mu (F i) < +oo.
 
 Lemma fin_num_fun_sigma_finite d (T : algebraOfSetsType d)
     (R : realFieldType) (mu : set T -> \bar R) : mu set0 < +oo ->
-  fin_num_fun mu -> sigma_finite mu.
+  fin_num_fun mu -> sigma_finite setT mu.
 Proof.
 move=> muoo; exists (fun i => if i \in [set 0%N] then setT else set0).
   by rewrite -bigcup_mkcondr setTI bigcup_const//; exists 0%N.
@@ -2574,7 +2574,7 @@ Qed.
 
 Lemma sfinite_measure_sigma_finite d (T : measurableType d)
     (R : realType) (mu : {measure set T -> \bar R}) :
-  sigma_finite mu -> sfinite_measure_def mu.
+  sigma_finite setT mu -> sfinite_measure_def mu.
 Proof.
 move=> [F UF mF]; rewrite /sfinite_measure_def.
 have mDF k : measurable (seqDU F k).
@@ -2609,7 +2609,7 @@ Notation "{ 'sfinite_measure' 'set' T '->' '\bar' R }" :=
     format "{ 'sfinite_measure'  'set'  T  '->'  '\bar'  R }") : ring_scope.
 
 HB.mixin Record isSigmaFinite d (T : semiRingOfSetsType d) (R : numFieldType)
-  (mu : set T -> \bar R) := { sigma_finiteT : sigma_finite mu }.
+  (mu : set T -> \bar R) := { sigma_finiteT : sigma_finite setT mu }.
 
 #[short(type="sigma_finite_content")]
 HB.structure Definition SigmaFiniteContent d T R :=
@@ -2634,7 +2634,7 @@ Notation "{ 'sigma_finite_measure' 'set' T '->' '\bar' R }" :=
 
 HB.factory Record Measure_isSigmaFinite d (T : measurableType d) (R : realType)
     (mu : set T -> \bar R) of isMeasure _ _ _ mu :=
-  { sigma_finiteT : sigma_finite mu }.
+  { sigma_finiteT : sigma_finite setT mu }.
 
 HB.builders Context d (T : measurableType d) (R : realType)
   mu of @Measure_isSigmaFinite d T R mu.
@@ -2649,7 +2649,7 @@ HB.instance Definition _ := @isSigmaFinite.Build _ _ _ mu sigma_finiteT.
 HB.end.
 
 Lemma sigma_finite_mzero d (T : measurableType d) (R : realType) :
-  sigma_finite (@mzero d T R).
+  sigma_finite setT (@mzero d T R).
 Proof. by apply: fin_num_fun_sigma_finite => //; rewrite measure0. Qed.
 
 HB.instance Definition _ d (T : measurableType d) (R : realType) :=
@@ -2692,7 +2692,7 @@ Qed.
 
 HB.instance Definition _ := @Measure_isSFinite_subdef.Build d T R k sfinite.
 
-Let sigma_finite : sigma_finite k.
+Let sigma_finite : sigma_finite setT k.
 Proof.
 by apply: fin_num_fun_sigma_finite; [rewrite measure0|exact: fin_num_measure].
 Qed.
@@ -2832,7 +2832,7 @@ HB.instance Definition _ x :=
 End pdirac.
 
 Lemma sigma_finite_counting (R : realType) :
-  sigma_finite (@counting [choiceType of nat] R).
+  sigma_finite [set: nat] (@counting _ R).
 Proof.
 exists (fun n => `I_n.+1); first by apply/seteqP; split=> //x _; exists x => /=.
 by move=> k; split => //; rewrite /counting/= asboolT// ltry.
@@ -2964,11 +2964,11 @@ End boole_inequality.
 Notation le_mu_bigsetU := Boole_inequality.
 
 Section sigma_finite_lemma.
-Context d (R : realFieldType) (T : ringOfSetsType d)
+Context d (R : realFieldType) (T : ringOfSetsType d) (A : set T)
         (mu : {content set T -> \bar R}).
 
-Lemma sigma_finiteP : sigma_finite mu ->
-  exists2 F, setT = \bigcup_i F i &
+Lemma sigma_finiteP : sigma_finite A mu ->
+  exists2 F, A = \bigcup_i F i &
     nondecreasing_seq F /\ forall i, measurable (F i) /\ mu (F i) < +oo.
 Proof.
 move=> [S AS moo]; exists (fun n => \big[setU/set0]_(i < n.+1) S i).
@@ -3804,8 +3804,8 @@ Qed.
 HB.instance Definition _ := isMeasure.Build _ _ _ Hahn_ext
   Hahn_ext0 Hahn_ext_ge0 Hahn_ext_sigma_additive.
 
-Lemma Hahn_ext_sigma_finite : @sigma_finite _ T _ mu ->
-  @sigma_finite _ _ _ Hahn_ext.
+Lemma Hahn_ext_sigma_finite : @sigma_finite _ T _ setT mu ->
+  @sigma_finite _ _ _ setT Hahn_ext.
 Proof.
 move=> -[S setTS mS]; exists S => //; move=> i; split.
   by have := (mS i).1; exact: sub_sigma_algebra.
@@ -3813,7 +3813,7 @@ by rewrite /Hahn_ext /= measurable_mu_extE //;
   [exact: (mS i).2 | exact: (mS i).1].
 Qed.
 
-Lemma Hahn_ext_unique : sigma_finite mu ->
+Lemma Hahn_ext_unique : sigma_finite [set: T] mu ->
   (forall mu' : {measure set I -> \bar R},
     (forall X, d.-measurable X -> mu X = mu' X) ->
     (forall X, (d.-measurable).-sigma.-measurable X -> Hahn_ext X = mu' X)).

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -2798,6 +2798,14 @@ HB.instance Definition _ := @isProbability.Build _ _ _ P probability_setT.
 
 HB.end.
 
+Section pdirac.
+Context d (T : measurableType d) (R : realType).
+
+HB.instance Definition _ x :=
+  Measure_isProbability.Build _ _ _ (@dirac _ T x R) (diracT R x).
+
+End pdirac.
+
 Lemma sigma_finite_counting (R : realType) :
   sigma_finite [set: nat] (counting R).
 Proof.


### PR DESCRIPTION
##### Motivation for this change

This PR improves the hierarchy of measures as follows:

![charge_tred](https://user-images.githubusercontent.com/33154536/218924942-a027b74c-6e8a-453e-907f-313a0be0cc67.png)

Rounded boxes were already there.
Finite measures were already there but through the predicate `finite_measure` only.
Square boxes are new.
Dashed boxes and `FinNumFun` come with this PR.
`AdditiveCharge` and `Charge` come with PR #777 (rebased on this PR)

This PR is necessary to rebase the branch `kernels` PR #749 because
the latter proves Fubini for s-finite measures which relies
on Fubini for sigma-finite measures which are given
a type using HB which calls for automatic inference
of the type of s-finite measures from the type
of sigma-finite measures.
In the branch `kernels` we also need to equip the return type of
s-finite kernels with the type of s-finite measures to apply Fubini
for s-finite measures in the proof of commutativity of let-in.

This PR also adde subprobability measures (just to match the hierarchy of kernels)

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- [x] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
