### PR TITLE
Fix #839

### DIFF
--- a/theories/topology.v
+++ b/theories/topology.v
@@ -4913,8 +4913,9 @@ Context {T : topologicalType} {Q0 : quotType T}.
 
 Let Q := quotient_topology Q0.
 
-Canonical quotient_eq := EqType Q gen_eqMixin.
-Canonical quotient_choice := ChoiceType Q gen_choiceMixin.
+Canonical quotient_subtype := [subType Q of T by %/].
+Canonical quotient_eq := EqType Q [eqMixin of Q by <:].
+Canonical quotient_choice := ChoiceType Q  [choiceMixin of Q by <:].
 Canonical quotient_pointed := PointedType Q (\pi_Q point).
 
 Definition quotient_open U := open (\pi_Q @^-1` U).


### PR DESCRIPTION
##### Motivation for this change
The introducing new mixins will break the inheritance. 

@CohenCyril does this solve the problem? I didn't realize before I also needed the subtype canonical before the rest would infer correctly. 

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`
  (do not edit former entries, only append new ones, be careful:
   merge and rebase have a tendency to mess up `CHANGELOG_UNRELEASED.md`)
- [ ] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
