### PR TITLE
Cluster1

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -95,6 +95,9 @@
     `clopen_comp`, `connected_closure`, `clopen_separatedP`, and 
     `clopen_connectedP`.
 
+- in file `topology.v`,
+  + new lemmas `powerset_filter_fromP`, `compact_near_coveringE`, and `compact_cluster_set1`.
+
 ### Changed
 
 - in `fsbigop.v`:

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -96,7 +96,7 @@
     `clopen_connectedP`.
 
 - in file `topology.v`,
-  + new lemmas `powerset_filter_fromP`, `compact_near_coveringE`, and `compact_cluster_set1`.
+  + new lemmas `powerset_filter_fromP` and `compact_cluster_set1`.
 
 ### Changed
 
@@ -116,6 +116,8 @@
   + lemma `max_fimfun_subproof`
   + mixin `IsNonNegFun`, structure `NonNegFun`, notation `{nnfun _ >-> _}`
 
+- in file `topology.v`,
+  + lemma `compact_near_coveringP`
 ### Renamed
 
 - in `measurable.v`:

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -3036,10 +3036,10 @@ move=> ? cptV nxV PF FV clFx1 U nbhsU; rewrite nbhs_simpl.
 wlog oU : U nbhsU / open U.
   rewrite /= nbhsE in nbhsU; case: nbhsU => O oO OsubU /(_ O) WH.
   by apply: (filterS OsubU); apply: WH; [exact: open_nbhs_nbhs | by case: oO].
-have /compact_near_coveringP cptVU : compact (V `\` U). 
+have /compact_near_coveringP : compact (V `\` U).
   apply: (subclosed_compact _ cptV) => //.
   by apply: closedI; [exact: compact_closed | exact: open_closedC].
-have [] := cptVU _ (powerset_filter_from F) (fun W x => ~ W x).
+move=> /(_ _ (powerset_filter_from F) (fun W x => ~ W x))[].
   move=> z [Vz ?]; have zE : x <> z by move/nbhs_singleton: nbhsU => /[swap] ->.
   have : ~ cluster F z by move: zE; apply: contra_not; rewrite clFx1 => ->.
   case/existsNP=> C /existsPNP [D] FC /existsNP [Dz] /set0P/negP/negPn/eqP.

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -1584,7 +1584,7 @@ Lemma powerset_filter_fromP C :
   F C -> powerset_filter_from [set W | F W /\ W `<=` C].
 Proof.
 move=> FC; exists [set W | F W /\ W `<=` C] => //; split; first by move=> ? [].
-  by move=> ? ? [? ?] ? E2E1; split => //; apply: (subset_trans E2E1).
+  by move=> A B [_ AC] FB /subset_trans/(_ AC).
 by exists C; split.
 Qed.
 

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -3055,8 +3055,7 @@ have [] := cptVU _ (powerset_filter_from F) (fun W x => ~ W x).
   by case => t W [Dt] [FW] /subsetCP; apply; apply: CD0.
 move=> M [MF ME2 [W] MW /(_ _ MW) VUW].
 apply: (@filterS _ _ _ (V `&` W)); last by apply: filterI => //; exact: MF.
-apply: subsetC2 => t ?; rewrite setCI /=; case: (pselect (V t)); last by left.
-by move=> Vt; right; apply: VUW; split.
+by move=> t [Vt Wt]; apply: contrapT => Ut; exact: (VUW t).
 Qed.
 
 Section Precompact.

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -2854,14 +2854,8 @@ move=> /(_ _ _ GP U1x) => [[x'[]]][] Kx' /[swap] U1x'.
 by case; split => // i [? ?]; exact: (subP (x', i)).
 Unshelve. end_near. Qed.
 
-Lemma compact_near_coveringP : compact `<=>` near_covering.
+Lemma compact_near_coveringP A : compact A <-> near_covering A.
 Proof.
-by split; [exact: compact_near_covering| exact: near_covering_compact].
-Qed.
-
-Lemma compact_near_coveringE : compact = near_covering.
-Proof.
-apply/ predeqP => ?.
 by split; [exact: compact_near_covering| exact: near_covering_compact].
 Qed.
 
@@ -3042,10 +3036,9 @@ move=> ? cptV nxV PF FV clFx1 U nbhsU; rewrite nbhs_simpl.
 wlog oU : U nbhsU / open U.
   rewrite /= nbhsE in nbhsU; case: nbhsU => O oO OsubU /(_ O) WH.
   by apply: (filterS OsubU); apply: WH; [exact: open_nbhs_nbhs | by case: oO].
-have cptVU : compact (V `\` U). 
+have /compact_near_coveringP cptVU : compact (V `\` U). 
   apply: (subclosed_compact _ cptV) => //.
   by apply: closedI; [exact: compact_closed | exact: open_closedC].
-rewrite compact_near_coveringE in cptVU.
 have [] := cptVU _ (powerset_filter_from F) (fun W x => ~ W x).
   move=> z [Vz ?]; have zE : x <> z by move/nbhs_singleton: nbhsU => /[swap] ->.
   have : ~ cluster F z by move: zE; apply: contra_not; rewrite clFx1 => ->.
@@ -7400,7 +7393,7 @@ suff : \forall g \near within W (nbhs f), forall y, K y -> E (f y, g y).
 near (powerset_filter_from (@entourage Y)) => E'.
 have entE' : entourage E' by exact: (near (near_small_set _)).
 pose Q := fun (h : X -> Y) x => E' (f x, h x).
-apply: compact_near_coveringP.1 => // x Kx.
+apply: (iffLR (compact_near_coveringP K)) => // x Kx.
 near=> y g => /=.
 apply: (entourage_split (f x) eE).
   apply entourage_sym; apply: (near (small_ent_sub _) E') => //.
@@ -7455,7 +7448,7 @@ have [//|U UWx [cptU clU]] := @lcptX x; rewrite withinET in UWx.
 near (powerset_filter_from (@entourage Y)) => E'.
 have entE' : entourage E' by exact: (near (near_small_set _)).
 pose Q := fun (y : X) (f : {family compact, X -> Y}) => E' (f x, f y).
-apply: (compact_near_coveringP.1 _ cptW) => f Wf; near=> g y => /=.
+apply: (iffLR (compact_near_coveringP W)) => // f Wf; near=> g y => /=.
 apply: (entourage_split (f x) entE).
   apply/entourage_sym; apply: (near (small_ent_sub _) E') => //.
   exact: (near (fam_nbhs _ entE' (@compact_set1 _ x)) g).

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -1580,6 +1580,14 @@ split=> [E [] //| |]; last by exists U; split.
 by move=> E1 E2 [F1 E1U F2 E2subE1]; split => //; exact: subset_trans E1U.
 Qed.
 
+Lemma powerset_filter_fromP C :
+  F C -> powerset_filter_from [set W | F W /\ W `<=` C].
+Proof.
+move=> FC; exists [set W | F W /\ W `<=` C] => //; split; first by move=> ? [].
+  by move=> ? ? [? ?] ? E2E1; split => //; apply: (subset_trans E2E1).
+by exists C; split.
+Qed.
+
 End NearSet.
 
 Section PrincipalFilters.
@@ -2851,6 +2859,12 @@ Proof.
 by split; [exact: compact_near_covering| exact: near_covering_compact].
 Qed.
 
+Lemma compact_near_coveringE : compact = near_covering.
+Proof.
+apply/ predeqP => ?.
+by split; [exact: compact_near_covering| exact: near_covering_compact].
+Qed.
+
 End near_covering.
 
 Section Tychonoff.
@@ -3019,6 +3033,31 @@ by apply/cvg_sup => i; apply/cvg_image=> //; have /getPex [] := cvpFA i.
 Qed.
 
 End Tychonoff.
+
+Lemma compact_cluster_set1 {T : topologicalType} (x : T) F V :
+  hausdorff_space T -> compact V -> nbhs x V ->
+  ProperFilter F -> F V -> cluster F = [set x] -> F --> x.
+Proof.
+move=> ? cptV nxV PF FV clFx1 U nbhsU; rewrite nbhs_simpl.
+wlog oU : U nbhsU / open U.
+  rewrite /= nbhsE in nbhsU; case: nbhsU => O oO OsubU /(_ O) WH.
+  by apply: (filterS OsubU); apply: WH; [exact: open_nbhs_nbhs | by case: oO].
+have cptVU : compact (V `\` U). 
+  apply: (subclosed_compact _ cptV) => //.
+  by apply: closedI; [exact: compact_closed | exact: open_closedC].
+rewrite compact_near_coveringE in cptVU.
+have [] := cptVU _ (powerset_filter_from F) (fun W x => ~ W x).
+  move=> z [Vz ?]; have zE : x <> z by move/nbhs_singleton: nbhsU => /[swap] ->.
+  have : ~ cluster F z by move: zE; apply: contra_not; rewrite clFx1 => ->.
+  case/existsNP=> C /existsPNP [D] FC /existsNP [Dz] /set0P/negP/negPn/eqP.
+  rewrite setIC => /disjoints_subset CD0; exists (D, [set W | F W /\ W `<=` C]).
+    by split; rewrite //= nbhs_simpl; exact: powerset_filter_fromP.
+  by case => t W [Dt] [FW] /subsetCP; apply; apply: CD0.
+move=> M [MF ME2 [W] MW /(_ _ MW) VUW].
+apply: (@filterS _ _ _ (V `&` W)); last by apply: filterI => //; exact: MF.
+apply: subsetC2 => t ?; rewrite setCI /=; case: (pselect (V t)); last by left.
+by move=> Vt; right; apply: VUW; split.
+Qed.
 
 Section Precompact.
 


### PR DESCRIPTION
##### Motivation for this change

This should be an easy review. We prove a classic topology result that in compact spaces, a filter `F` with one cluster point `x` converges to `x`. This is another nice application of the `near_covering` definition. I claim this formalization is a good approximation of the classical proof:

> Pick an open neighborhood `U` of x. For each point `y` in `~U`, the filter does _not_ cluster at `y`. So we have a neighborhood `V` of y with `F (~V)`. This forms a cover of `~U` which is closed therefore compact. Taking finite intersections, `F (~V_1 \cap ... \cap ~V_n)` and ` ~U <= V_1 \cup ... \cup V_n  ->  ~V_1 \cap ... \cap ~V_n \subset U`. So F converges to x.

In coq, the `powerset_filter_from F` encodes "finite intersections" and the property `(fun x W => ~ W x)` encodes the complements. Plugging these into the statement that `V \ U` is near_covering compact, we get a new goal to build the cover. Then given a `y` with `~U y` we know `y <> x`. So `~ cluster F y`, and we get our neighborhood. The rest is just bookkeeping (pushing negations through quantifiers and handling the a vacuous `~V t` case).
  
<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
  (do not edit former entries, only append new ones, be careful:
   merge and rebase have a tendency to mess up `CHANGELOG_UNRELEASED.md`)
- [x] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
