### PR TITLE
Uniform spaces are sups of pseudometrics

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -3,6 +3,14 @@
 ## [Unreleased]
 
 ### Added
+- in file `topology.v`,
+  + new definitions `split_sym`, `gauge`, `gauge_uniformType_mixin`, 
+    `gauge_topologicalTypeMixin`, `gauge_filtered`, `gauge_topologicalType`, 
+    `gauge_uniformType`, `gauge_psuedoMetric_mixin`, and 
+    `gauge_psuedoMetricType`.
+  + new lemmas `iter_split_ent`, `gauge_ent`, `gauge_filter`, 
+    `gauge_refl`, `gauge_inv`, `gauge_split`, `gauge_countable_uniformity`, and 
+    `uniform_pseudometric_sup`.
 
 - in `contructive_ereal.v`:
   + lemmas `ereal_blatticeMixin`, `ereal_tblatticeMixin`

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -3,14 +3,6 @@
 ## [Unreleased]
 
 ### Added
-- in file `topology.v`,
-  + new definitions `split_sym`, `gauge`, `gauge_uniformType_mixin`, 
-    `gauge_topologicalTypeMixin`, `gauge_filtered`, `gauge_topologicalType`, 
-    `gauge_uniformType`, `gauge_psuedoMetric_mixin`, and 
-    `gauge_psuedoMetricType`.
-  + new lemmas `iter_split_ent`, `gauge_ent`, `gauge_filter`, 
-    `gauge_refl`, `gauge_inv`, `gauge_split`, `gauge_countable_uniformity`, and 
-    `uniform_pseudometric_sup`.
 
 - in `contructive_ereal.v`:
   + lemmas `ereal_blatticeMixin`, `ereal_tblatticeMixin`
@@ -71,6 +63,15 @@
   + lemmas `inum_eq`, `inum_le`, `inum_lt`
 - in `measure.v`:
   + lemmas `ae_imply`, `ae_imply2`
+
+- in file `topology.v`,
+  + new definitions `split_sym`, `gauge`, `gauge_uniformType_mixin`, 
+    `gauge_topologicalTypeMixin`, `gauge_filtered`, `gauge_topologicalType`, 
+    `gauge_uniformType`, `gauge_psuedoMetric_mixin`, and 
+    `gauge_psuedoMetricType`.
+  + new lemmas `iter_split_ent`, `gauge_ent`, `gauge_filter`, 
+    `gauge_refl`, `gauge_inv`, `gauge_split`, `gauge_countable_uniformity`, and 
+    `uniform_pseudometric_sup`.
 
 ### Changed
 

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -7266,7 +7266,7 @@ End UniformPointwise.
 
 Section gauges.
 
-Definition split_sym {T : uniformType} (W : set (T * T)) :=
+Let split_sym {T : uniformType} (W : set (T * T)) :=
   (split_ent W) `&` (split_ent W)^-1.
 
 Section entourage_gauge.

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -245,7 +245,7 @@ Require Import reals signed.
 (*                      [locally P] := forall a, A a -> G (within A (nbhs x)) *)
 (*                                     if P is convertible to G (globally A)  *)
 (*              quotient_topology Q == the quotient topology corresponding to *)
-(*                                     quotient Q : quotType T. where T has   *)
+(*                                     quotient Q : quotType T where T has    *)
 (*                                     type topologicalType                   *)
 (*                                                                            *)
 (* * Function space topologies :                                              *)


### PR DESCRIPTION
##### Motivation for this change
A "deep" result that's now surprisingly easy. Every uniform space `T` is the supremum topology of pseudometrics. Given an entourage `E`, the "gauge filter" generated by `E, split_ent E, split_ent (split_ent E),...` is a weaker uniformity on `T` (some bookkeeping details about symmetry with ` E & E^-1` left out). This uniformity is countable, so it's actually a pseudometric using the `countable_uniform_pseudoMetricType_mixin` sledgehammer. Taking the the sup of `gauge E` for all entourages regenerates the original uniformity.

Interestingly, this supremum is _much_ larger than required. With some extra work, this approach can prove stronger results. E.G. if `T`'s entourage has a basis indexed by `I`, then we can choose the supremum to have `I` elements. But, I think it's worth contributing what's already here. 

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
  (do not edit former entries, only append new ones, be careful:
   merge and rebase have a tendency to mess up `CHANGELOG_UNRELEASED.md`)
- [x] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
