### PR TITLE
fix and strengthen eq_bigmax and eq_bigmin

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -12,6 +12,9 @@
 
 ### Changed
 
+- in `mathcomp_extra.v`
+  + lemmas `eq_bigmax`, `eq_bigmin` changed to respect `P` in the returned type.
+
 ### Renamed
 
 - in `lebesgue_measure.v`:

--- a/classical/mathcomp_extra.v
+++ b/classical/mathcomp_extra.v
@@ -830,8 +830,10 @@ by apply/bigmax_leP; split => //; exact: PxF.
 Qed.
 
 Lemma eq_bigmax j P F : P j -> (forall i, P i -> x <= F i) ->
-  {i0 | i0 \in I & \big[max/x]_(i | P i) F i = F i0}.
-Proof. by move=> Pi0 Hx; rewrite (bigmax_eq_arg Pi0) //; eexists. Qed.
+  {i0 | i0 \in P & \big[max/x]_(i | P i) F i = F i0}.
+Proof.
+by move=> Pi0 Hx; rewrite (bigmax_eq_arg Pi0) //; eexists => //; case:arg_maxP.
+Qed.
 
 Lemma le_bigmax2 P F1 F2 : (forall i, P i -> F1 i <= F2 i) ->
   \big[max/x]_(i | P i) F1 i <= \big[max/x]_(i | P i) F2 i.
@@ -980,8 +982,10 @@ by apply/bigmin_geP; split => //; exact: PFx.
 Qed.
 
 Lemma eq_bigmin j P F : P j -> (forall i, P i -> F i <= x) ->
-  {i0 | i0 \in I & \big[min/x]_(i | P i) F i = F i0}.
-Proof. by move=> Pi0 Hx; rewrite (bigmin_eq_arg Pi0) //; eexists. Qed.
+  {i0 | i0 \in P & \big[min/x]_(i | P i) F i = F i0}.
+Proof.
+by move=> Pi0 Hx; rewrite (bigmin_eq_arg Pi0) //; eexists => //; case:arg_minP.
+Qed.
 
 End bigmin_finType.
 


### PR DESCRIPTION
##### Motivation for this change
Lemmas `eq_bigmax` and `eq_bigmin` in `mathcomp_extra.v` is wrongly stated in weaker forms
that does not respect their argument P in the returned type.

##### Things done/to do
This PR fixes the problem by strengthening the statements and amending the proofs.

<!-- please fill in the following checklist -->
- [YES] added corresponding entries in `CHANGELOG_UNRELEASED.md`
  (do not edit former entries, only append new ones, be careful:
   merge and rebase have a tendency to mess up `CHANGELOG_UNRELEASED.md`)
- [NO] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
