### PR TITLE
Convex exp

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -141,10 +141,13 @@
   + lemma `derivable_within_continuous`
 - in `realfun.v`:
   + definition `derivable_oo_continuous_bnd`, lemma `derivable_oo_continuous_bnd_within`
+- in `exp.v`:
+  + lemmas `derive_expR`, `convex_expR`
 - new file `convex.v`:
   + mixin `isConvexSpace`, structure `ConvexSpace`, notations `convType`,
     `_ <| _ |> _`
-  + lemmas `conv1`, `second_derivative_convexf_pt`
+  + lemmas `conv1`, `second_derivative_convex`
+
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -133,8 +133,18 @@
 - in `set_interval.v`:
   + lemma `onem_factor`
 - in `set_interval.v`:
-  + lemma `subset_itvW`
-- new file `convex.v`
+  + lemmas `in1_subset_itv`, `subset_itvW`
+- in `normedtype.v`:
+  + lemmas `cvg_at_right_filter`, `cvg_at_left_filter`,
+    `cvg_at_right_within`, `cvg_at_left_within`
+- in `derive.v`:
+  + lemma `derivable_within_continuous`
+- in `realfun.v`:
+  + definition `derivable_oo_continuous_bnd`, lemma `derivable_oo_continuous_bnd_within`
+- new file `convex.v`:
+  + mixin `isConvexSpace`, structure `ConvexSpace`, notations `convType`,
+    `_ <| _ |> _`
+  + lemmas `conv1`, `second_derivative_convexf_pt`
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -130,6 +130,12 @@
     `discrete_pseudoMetricType`, and `pseudoMetric_bool`.
   + new lemmas `finite_compact`, `discrete_ball_center`, `compact_cauchy_cvg`
 
+- in `set_interval.v`:
+  + lemma `onem_factor`
+- in `set_interval.v`:
+  + lemma `subset_itvW`
+- new file `convex.v`
+
 ### Changed
 
 - in `mathcomp_extra.v`

--- a/_CoqProject
+++ b/_CoqProject
@@ -40,6 +40,7 @@ theories/probability.v
 theories/summability.v
 theories/signed.v
 theories/itv.v
+theories/convex.v
 theories/altreals/xfinmap.v
 theories/altreals/discrete.v
 theories/altreals/realseq.v

--- a/classical/set_interval.v
+++ b/classical/set_interval.v
@@ -50,6 +50,10 @@ Qed.
 Lemma subset_itvP i j : {subset i <= j} <-> [set` i] `<=` [set` j].
 Proof. by []. Qed.
 
+Lemma in1_subset_itv (P : T -> Prop) i j :
+  [set` j] `<=` [set` i] -> {in i, forall x, P x} -> {in j, forall x, P x}.
+Proof. by move=> /subset_itvP ji iP z zB; apply: iP; exact: ji. Qed.
+
 Lemma subset_itvW x y z u b0 b1 :
     (x <= y)%O -> (z <= u)%O ->
   `]y, z[ `<=` [set` Interval (BSide b0 x) (BSide b1 u)].
@@ -58,7 +62,7 @@ move=> xy zu; apply: (@subset_trans _ `]x, u[%classic).
   move=> x0/=; rewrite 2!in_itv/= => /andP[].
   by move=> /(le_lt_trans xy) ->/= /lt_le_trans; exact.
 by move: b0 b1 => [] [] /=; [exact: subset_itv_oo_co|exact: subset_itv_oo_cc|
-                        exact: subset_refl|exact: subset_itv_oo_oc].
+  exact: subset_refl|exact: subset_itv_oo_oc].
 Qed.
 
 Lemma set_itvoo x y : `]x, y[%classic = [set z | (x < z < y)%O].

--- a/classical/set_interval.v
+++ b/classical/set_interval.v
@@ -50,6 +50,17 @@ Qed.
 Lemma subset_itvP i j : {subset i <= j} <-> [set` i] `<=` [set` j].
 Proof. by []. Qed.
 
+Lemma subset_itvW x y z u b0 b1 :
+    (x <= y)%O -> (z <= u)%O ->
+  `]y, z[ `<=` [set` Interval (BSide b0 x) (BSide b1 u)].
+Proof.
+move=> xy zu; apply: (@subset_trans _ `]x, u[%classic).
+  move=> x0/=; rewrite 2!in_itv/= => /andP[].
+  by move=> /(le_lt_trans xy) ->/= /lt_le_trans; exact.
+by move: b0 b1 => [] [] /=; [exact: subset_itv_oo_co|exact: subset_itv_oo_cc|
+                        exact: subset_refl|exact: subset_itv_oo_oc].
+Qed.
+
 Lemma set_itvoo x y : `]x, y[%classic = [set z | (x < z < y)%O].
 Proof. by []. Qed.
 
@@ -487,6 +498,12 @@ Lemma range_factor ba bb a b : a < b ->
    factor a b @` [set` Interval (BSide ba a) (BSide bb b)] =
                  [set` Interval (BSide ba 0) (BSide bb 1)].
 Proof. by move=> /(factor_itv_bij ba bb)/Pbij[f ->]; rewrite image_eq. Qed.
+
+Lemma onem_factor a b x : a != b -> `1-(factor a b x) = factor b a x.
+Proof.
+rewrite eq_sym -subr_eq0 => ab; rewrite /onem /factor -(divff ab) -mulrBl.
+by rewrite opprB addrA subrK -mulrNN opprB -invrN opprB.
+Qed.
 
 End line_path_factor_numFieldType.
 

--- a/theories/Make
+++ b/theories/Make
@@ -30,6 +30,8 @@ numfun.v
 lebesgue_integral.v
 summability.v
 signed.v
+itv.v
+convex.v
 altreals/xfinmap.v
 altreals/discrete.v
 altreals/realseq.v

--- a/theories/convex.v
+++ b/theories/convex.v
@@ -62,26 +62,22 @@ apply/differentiable_continuous; rewrite -derivable1_diffP.
 by apply: di; rewrite inE.
 Qed.
 
-Lemma cvg_at_right_within (R : numFieldType)
-  (K : numDomainType) (V : pseudoMetricNormedZmodType K) (F : R -> V) (x : R) :
+Lemma cvg_at_right_within (R : numFieldType) (V : topologicalType)
+  (F : R -> V) (x : R) :
   F x @[x --> x^'+] --> F x ->
   F x @[x --> within (fun u => x <= u) (nbhs x)] --> F x.
 Proof.
-move=> Fxr; apply/cvgrPdist_lt => e e0.
-rewrite /at_right in Fxr; move/cvgrPdist_lt : Fxr => /(_ _ e0).
-rewrite !near_withinE; apply: filterS => y h.
-by rewrite le_eqVlt => /predU1P[->|//]; rewrite subrr normr0.
+move=> Fxr U Ux; rewrite ?near_simpl ?near_withinE; near=> z; rewrite le_eqVlt.
+by move/predU1P => [<-|]; [exact: nbhs_singleton | near: z; exact: Fxr].
 Unshelve. all: by end_near. Qed.
 
-Lemma cvg_at_left_within (R : numFieldType)
-  (K : numDomainType) (V : pseudoMetricNormedZmodType K) (F : R -> V) (y : R) :
+Lemma cvg_at_left_within (R : numFieldType) (V : topologicalType)
+  (F : R -> V) (y : R) :
   F x @[x --> y^'-] --> F y ->
   F x @[x --> within (fun u => u <= y) (nbhs y)] --> F y.
 Proof.
-move=> Fyl; apply/cvgrPdist_lt => e e0.
-rewrite /at_left in Fyl; move/cvgrPdist_lt : Fyl => /(_ _ e0).
-rewrite !near_withinE; apply: filterS => x h.
-by rewrite le_eqVlt => /predU1P[->|//]; rewrite subrr normr0.
+move=> Fxr U Ux; rewrite ?near_simpl ?near_withinE; near=> z; rewrite le_eqVlt.
+by move/predU1P => [->|]; [exact: nbhs_singleton | near: z; exact: Fxr].
 Unshelve. all: by end_near. Qed.
 
 Lemma derivable_oo_within_cc_continuous {R : numFieldType} {V : normedModType R}

--- a/theories/convex.v
+++ b/theories/convex.v
@@ -40,8 +40,7 @@ Lemma cvg_at_right_filter (R : numFieldType) (V : topologicalType)
   f z @[z --> x] --> f x -> f z @[z --> x^'+] --> f x.
 Proof. exact: (@cvg_within_filter _ _ _ (nbhs x)). Qed.
 
-Lemma cvg_at_left_filter (R : numFieldType)
-  (K : numDomainType) (V : pseudoMetricNormedZmodType K)
+Lemma cvg_at_left_filter (R : numFieldType) (V : topologicalType)
   (f : R -> V) (x : R) :
   f z @[z --> x] --> f x -> f z @[z --> x^'-] --> f x.
 Proof. exact: (@cvg_within_filter _ _ _ (nbhs x)). Qed.

--- a/theories/convex.v
+++ b/theories/convex.v
@@ -35,8 +35,7 @@ Local Open Scope ring_scope.
 
 Import numFieldNormedType.Exports.
 
-Lemma cvg_at_right_filter (R : numFieldType)
-  (K : numDomainType) (V : pseudoMetricNormedZmodType K)
+Lemma cvg_at_right_filter (R : numFieldType) (V : topologicalType)
   (f : R -> V) (x : R) :
   f z @[z --> x] --> f x -> f z @[z --> x^'+] --> f x.
 Proof. exact: (@cvg_within_filter _ _ _ (nbhs x)). Qed.

--- a/theories/convex.v
+++ b/theories/convex.v
@@ -8,9 +8,14 @@ Require Import normedtype derive set_interval itv.
 From HB Require Import structures.
 
 (******************************************************************************)
-(* isConvexSpace R T == interface for convex spaces                           *)
-(*     ConvexSpace R == structure of convex space                             *)
-(*       a <| t |> b == convexity operator                                    *)
+(*                                Convexity                                   *)
+(*                                                                            *)
+(* This file provides a small account of convexity using convex spaces, to be *)
+(* completed with material from infotheo.                                     *)
+(*                                                                            *)
+(*   isConvexSpace R T == interface for convex spaces                         *)
+(*       ConvexSpace R == structure of convex space                           *)
+(*         a <| t |> b == convexity operator                                  *)
 (* E : lmodType R with R : realDomainType and R : realDomainType are shown to *)
 (* be convex spaces                                                           *)
 (*                                                                            *)
@@ -30,41 +35,67 @@ Local Open Scope ring_scope.
 
 Import numFieldNormedType.Exports.
 
-(* TODO: move *)
-Lemma factorNN {R : numDomainType} (a b x : R) :
-  factor a b x = (a - x) / (a - b).
-Proof.
-by rewrite /factor -(opprB x a) -(opprB b a) invrN mulrNN.
-Qed.
-
-Lemma factor1 {R : numFieldType} (a b x : R) : a != b ->
-  factor a b x + factor b a x = 1.
-Proof.
-move=> ab.
-by rewrite factorNN /factor -mulrDl addrA subrK divrr// unitfE subr_eq0.
-Qed.
-
-(* TODO: move *)
-Lemma subset_itvW d {T : porderType d} (a b c e : T) u v :
-    (a <= b)%O -> (c <= e)%O ->
-  `]b, c[ `<=` [set` Interval (BSide u a) (BSide v e)].
-Proof.
-move=> ab ce; apply: (@subset_trans _ `]a, e[%classic).
-  move=> x/=; rewrite 2!in_itv/= => /andP[].
-  by move=> /(le_lt_trans ab) ->/= /lt_le_trans; exact.
-move: u v => [] [] /=; [exact: subset_itv_oo_co|exact: subset_itv_oo_cc|
-                        exact: subset_refl|exact: subset_itv_oo_oc].
-Qed.
-
-(* TODO: move *)
 Lemma cvg_at_right_filter (R : numFieldType) (f : R -> R) (x : R) :
   f z @[z --> x] --> f x -> f z @[z --> x^'+] --> f x.
 Proof. exact: (@cvg_within_filter _ _ _ (nbhs x)). Qed.
 
-(* TODO: move *)
 Lemma cvg_at_left_filter (R : numFieldType) (f : R -> R) (x : R) :
   f z @[z --> x] --> f x -> f z @[z --> x^'-] --> f x.
 Proof. exact: (@cvg_within_filter _ _ _ (nbhs x)). Qed.
+
+Lemma derivable_oo_itvW {R : numFieldType} (f : R -> R) (a b a' b' : R) :
+    a <= a' -> b' <= b ->
+  {in `]a, b[, forall x, derivable f x 1} ->
+  {in `]a', b'[, forall x, derivable f x 1}.
+Proof. by move=> aa' bb' + x xab; apply; exact: subset_itvW xab. Qed.
+
+Lemma derivable_within_continuous {R : numFieldType} (F : R -> R)
+    (i : interval R) :
+  {in i, forall x, derivable F x 1} ->
+  {within [set` i], continuous F}.
+Proof.
+move=> di; apply/continuous_in_subspaceT => z /[1!inE] zA.
+apply/differentiable_continuous; rewrite -derivable1_diffP.
+by apply: di; rewrite inE.
+Qed.
+
+Lemma cvg_at_right_within (R : numFieldType) (F : R -> R) (x : R) :
+  F x @[x --> x^'+] --> F x ->
+  F x @[x --> within (fun u => x <= u) (nbhs x)] --> F x.
+Proof.
+move=> Fxr; apply/cvgrPdist_lt => e e0.
+rewrite /at_right in Fxr; move/cvgrPdist_lt : Fxr => /(_ _ e0).
+rewrite !near_withinE; apply: filterS => y h.
+by rewrite le_eqVlt => /predU1P[->|//]; rewrite subrr normr0.
+Unshelve. all: by end_near. Qed.
+
+Lemma cvg_at_left_within (R : numFieldType) (F : R -> R) (y : R) :
+  F x @[x --> y^'-] --> F y ->
+  F x @[x --> within (fun u => u <= y) (nbhs y)] --> F y.
+Proof.
+move=> Fyl; apply/cvgrPdist_lt => e e0.
+rewrite /at_left in Fyl; move/cvgrPdist_lt : Fyl => /(_ _ e0).
+rewrite !near_withinE; apply: filterS => x h.
+by rewrite le_eqVlt => /predU1P[->|//]; rewrite subrr normr0.
+Unshelve. all: by end_near. Qed.
+
+Lemma derivable_oo_within_cc_continuous {R : numFieldType} (F : R -> R)
+  (x y : R):
+    {in `]x, y[, forall x, derivable F x 1} ->
+  F @ x^'+ --> F x -> F @ y^'- --> F y -> {within `[x, y], continuous F}.
+Proof.
+move=> Fxy Fxr Fyl; apply/subspace_continuousP => z /=.
+rewrite in_itv/= => /andP[]; rewrite le_eqVlt => /predU1P[<-{z} xy|].
+  have := cvg_at_right_within Fxr; apply: cvg_trans; apply: cvg_app.
+  by apply: within_subset => z/=; rewrite in_itv/= => /andP[].
+move=> /[swap].
+rewrite le_eqVlt => /predU1P[->{z} xy|zy xz].
+  have := cvg_at_left_within Fyl; apply: cvg_trans; apply: cvg_app.
+  by apply: within_subset => z/=; rewrite in_itv/= => /andP[].
+apply: cvg_within_filter.
+apply/differentiable_continuous; rewrite -derivable1_diffP.
+by apply: Fxy; rewrite in_itv/= xz zy.
+Unshelve. all: by end_near. Qed.
 
 Declare Scope convex_scope.
 
@@ -82,7 +113,8 @@ HB.mixin Record isConvexSpace (R : realDomainType) (T : Type) := {
 }.
 
 #[short(type=convType)]
-HB.structure Definition ConvexSpace (R : realDomainType) := {T of isConvexSpace R T }.
+HB.structure Definition ConvexSpace (R : realDomainType) :=
+  {T of isConvexSpace R T }.
 
 Canonical conv_eqType (R : realDomainType) (T : convType R) :=
   Eval hnf in EqType (ConvexSpace.sort T) convexspacechoiceclass.
@@ -163,56 +195,6 @@ HB.instance Definition _ := @isConvexSpace.Build R R^o
 
 End realDomainType_convex_space.
 
-Lemma derivable_oo_itvW {R : numFieldType} (f : R -> R) (a b a' b' : R) :
-    a <= a' -> b' <= b -> {in `]a, b[, forall x, derivable f x 1} ->
-  {in `]a', b'[, forall x, derivable f x 1}.
-Proof. by move=> aa' bb' + x xab; apply; exact: subset_itvW xab. Qed.
-
-Lemma derivable_within_continuous {R : numFieldType} (F : R -> R) (A : interval R) :
-  {in A, forall x, derivable F x 1} -> {within [set` A], continuous F}.
-Proof.
-move=> di; apply/continuous_in_subspaceT => z /[1!inE] zA.
-apply/differentiable_continuous; rewrite -derivable1_diffP.
-by apply: di; rewrite inE.
-Qed.
-
-Lemma cvg_at_right_within (R : numFieldType) (F : R -> R) (x : R) :
-  F x @[x --> x^'+] --> F x ->
-  F x @[x --> within (fun u => x <= u) (nbhs x)] --> F x.
-Proof.
-move=> Fxr; apply/cvgrPdist_lt => e e0.
-rewrite /at_right in Fxr; move/cvgrPdist_lt : Fxr => /(_ _ e0).
-rewrite !near_withinE; apply: filterS => y h.
-by rewrite le_eqVlt => /predU1P[->|//]; rewrite subrr normr0.
-Unshelve. all: by end_near. Qed.
-
-Lemma cvg_at_left_within (R : numFieldType) (F : R -> R) (y : R) :
-  F x @[x --> y^'-] --> F y ->
-  F x @[x --> within (fun u => u <= y) (nbhs y)] --> F y.
-Proof.
-move=> Fyl; apply/cvgrPdist_lt => e e0.
-rewrite /at_left in Fyl; move/cvgrPdist_lt : Fyl => /(_ _ e0).
-rewrite !near_withinE; apply: filterS => x h.
-by rewrite le_eqVlt => /predU1P[->|//]; rewrite subrr normr0.
-Unshelve. all: by end_near. Qed.
-
-Lemma derivable_oo_within_cc_continuous {R : numFieldType} (F : R -> R) (x y : R):
-  {in `]x, y[, forall x, derivable F x 1} ->
-  F @ x^'+ --> F x -> F @ y^'- --> F y -> {within `[x, y], continuous F}.
-Proof.
-move=> Fxy Fxr Fyl; apply/subspace_continuousP => z /=.
-rewrite in_itv/= => /andP[]; rewrite le_eqVlt => /predU1P[<-{z} xy|].
-  have := cvg_at_right_within Fxr; apply: cvg_trans; apply: cvg_app.
-  by apply: within_subset => z/=; rewrite in_itv/= => /andP[].
-move=> /[swap].
-rewrite le_eqVlt => /predU1P[->{z} xy|zy xz].
-  have := cvg_at_left_within Fyl; apply: cvg_trans; apply: cvg_app.
-  by apply: within_subset => z/=; rewrite in_itv/= => /andP[].
-apply: cvg_within_filter.
-apply/differentiable_continuous; rewrite -derivable1_diffP.
-by apply: Fxy; rewrite in_itv/= xz zy.
-Unshelve. all: by end_near. Qed.
-
 (* ref: http://www.math.wisc.edu/~nagel/convexity.pdf *)
 Section twice_derivable_convex.
 Context {R : realType}.
@@ -230,17 +212,17 @@ Let L x := f a + factor a b x * (f b - f a).
 
 Let LE x : L x = factor b a x * f a + factor a b x * f b.
 Proof.
-rewrite /L mulrBr [in LHS]addrA addrAC; congr +%R.
-by apply/eqP; rewrite subr_eq -mulrDl factor1 ?mul1r// gt_eqF.
+rewrite /L -(@onem_factor _ a) ?lt_eqF// /onem mulrBl mul1r.
+by rewrite -addrA -mulrN -mulrDr (addrC (f b)).
 Qed.
 
 Let convexf_ptP : (forall x, a <= x <= b -> 0 <= L x - f x) ->
   forall t, f (a <| t |> b) <= f a <| t |> f b.
 Proof.
 move=> h t; set x := a <| t |> b; have /h : a <= x <= b.
-  by rewrite -(conv1 a b) -{1}(conv0 a b) /x !le_conv//= itv_ge0/=.
+  by rewrite -(conv1 a b) -{1}(conv0 a b) /x !le_line_path//= itv_ge0/=.
 rewrite subr_ge0 => /le_trans; apply.
-by rewrite LE /x convK ?lt_eqF// convC convK ?gt_eqF.
+by rewrite LE /x line_pathK ?lt_eqF// convC line_pathK ?gt_eqF.
 Qed.
 
 Hypothesis HDf : {in `]a, b[, forall x, derivable f x 1}.
@@ -252,69 +234,71 @@ Proof. by apply: derivable_within_continuous => z zab; exact: HDDf. Qed.
 Lemma second_derivative_convexf_pt (t : {i01 R}) :
   f (a <| t |> b) <= f a <| t |> f b.
 Proof.
-apply/convexf_ptP => x /andP[]; rewrite /L.
-rewrite le_eqVlt => /predU1P[-> _|ax].
-  by rewrite factorl mul0r addr0 subrr lexx.
+apply/convexf_ptP => x /andP[].
+rewrite le_eqVlt => /predU1P[<-|ax].
+  by rewrite /L factorl mul0r addr0 subrr.
 rewrite le_eqVlt => /predU1P[->|xb].
-  by rewrite factorr ?lt_eqF// mul1r addrCA subrr addr0 subrr.
-have LfE : L x - f x =
-    (x - a) * (b - x) / (b - a) * ((f b - f x) / (b - x)) -
-    (b - x) * (x - a) / (b - a) * ((f x - f a) / (x - a)).
-  rewrite !mulrA -(mulrC (b - x)) -(mulrC (b - x)^-1) !mulrA.
-  rewrite mulVr ?mul1r ?unitfE ?subr_eq0 ?gt_eqF//.
-  rewrite -(mulrC (x - a)) -(mulrC (x - a)^-1) !mulrA.
-  rewrite mulVr ?mul1r ?unitfE ?subr_eq0 ?gt_eqF//.
-  rewrite -factorNN -/(factor _ _ _).
-  rewrite !mulrBr opprB -!mulrN addrACA -mulrDl factor1 ?mul1r ?lt_eqF//.
-  by rewrite LE (addrC (_ * f b)).
+  by rewrite /L factorr ?lt_eqF// mul1r addrAC addrA subrK subrr.
 have [c2 Ic2 Hc2] : exists2 c2, x < c2 < b & (f b - f x) / (b - x) = 'D_1 f c2.
-  have h : {in `]x, b[, forall z, derivable f z 1}.
-    by apply: derivable_oo_itvW HDf => //; exact/ltW.
+  have xbf : {in `]x, b[, forall z, derivable f z 1} :=
+    derivable_oo_itvW (ltW ax) (lexx _) HDf.
   have derivef z : z \in `]x, b[ -> is_derive z 1 f ('D_1 f z).
-    by move=> zxb; apply/derivableP/h; exact: zxb.
+    by move=> zxb; apply/derivableP/xbf; exact: zxb.
   have [|z zxb fbfx] := MVT xb derivef.
-    apply/(derivable_oo_within_cc_continuous h _ cvg_left)/cvg_at_right_filter.
+    apply/(derivable_oo_within_cc_continuous xbf _ cvg_left)/cvg_at_right_filter.
     have := derivable_within_continuous HDf.
     rewrite continuous_open_subspace//; last exact: interval_open.
     by apply; rewrite inE/= in_itv/= ax.
   by exists z => //; rewrite fbfx -mulrA divff ?mulr1// subr_eq0 gt_eqF.
 have [c1 Ic1 Hc1] : exists2 c1, a < c1 < x & (f x - f a) / (x - a) = 'D_1 f c1.
-  have h : {in `]a, x[, forall z, derivable f z 1} :=
-    derivable_oo_itvW (@lexx _ _ _) (ltW xb) HDf.
+  have axf : {in `]a, x[, forall z, derivable f z 1} :=
+    derivable_oo_itvW (lexx _ ) (ltW xb) HDf.
   have derivef z : z \in `]a, x[ -> is_derive z 1 f ('D_1 f z).
-    by move=> zax; apply /derivableP/h.
+    by move=> zax; apply /derivableP/axf.
   have [|z zax fxfa] := MVT ax derivef.
-    apply/(derivable_oo_within_cc_continuous h cvg_right)/cvg_at_left_filter.
+    apply/(derivable_oo_within_cc_continuous axf cvg_right)/cvg_at_left_filter.
     have := derivable_within_continuous HDf.
     rewrite continuous_open_subspace//; last exact: interval_open.
     by apply; rewrite inE/= in_itv/= ax.
   by exists z => //; rewrite fxfa -mulrA divff ?mulr1// subr_eq0 gt_eqF.
 have c1c2 : c1 < c2.
   by move: Ic2 Ic1 => /andP[+ _] => /[swap] /andP[_] /lt_trans; apply.
-have {LfE Hc1 Hc2}lfE : L x - f x = (b - x) * (x - a) * (c2 - c1) / (b - a) *
-                                    (('D_1 f c2 - 'D_1 f c1) / (c2 - c1)).
-  rewrite LfE Hc2 Hc1 (mulrC (x - a)%R) -mulrBr -!mulrA.
-  congr (_ * (_ * _)); rewrite mulrCA; congr *%R.
-  by rewrite mulrCA mulrV ?mulr1// unitfE subr_eq0 gt_eqF.
 have [d Id h] :
     exists2 d, c1 < d < c2 & ('D_1 f c2 - 'D_1 f c1) / (c2 - c1) = DDf d.
   have h : {in `]c1, c2[, forall z, derivable Df z 1}.
-    exact/(derivable_oo_itvW (ltW (andP Ic1).1) (@lexx _ _ _))
-         /(derivable_oo_itvW (@lexx _ _ _) (ltW (andP Ic2).2)).
+    exact/(derivable_oo_itvW (ltW (andP Ic1).1) (lexx _))
+         /(derivable_oo_itvW (lexx _) (ltW (andP Ic2).2)).
   have derivef z : z \in `]c1, c2[ -> is_derive z 1 Df ('D_1 Df z).
     by move=> zc1c2; apply/derivableP/h.
   have [|z zc1c2 {}h] := MVT c1c2 derivef.
     apply: (derivable_oo_within_cc_continuous h).
     + apply: cvg_at_right_filter.
       move: cDf; rewrite continuous_open_subspace//; last exact: interval_open.
-      move=> /(_ c1); apply.
-      by rewrite inE/= in_itv/= (andP Ic1).1/= (lt_trans _ (andP Ic2).2).
+      by apply; rewrite inE/= in_itv/= (andP Ic1).1 (lt_trans _ (andP Ic2).2).
     + apply: cvg_at_left_filter.
       move: cDf; rewrite continuous_open_subspace//; last exact: interval_open.
-      move=> /(_ c2); apply.
-      by rewrite inE/= in_itv/= (andP Ic2).2 andbT (lt_trans (andP Ic1).1).
+      by apply; rewrite inE/= in_itv/= (andP Ic2).2 (lt_trans (andP Ic1).1).
   by exists z => //; rewrite h -mulrA divff ?mulr1// subr_eq0 gt_eqF.
-rewrite {}lfE {}h mulr_ge0//; last first.
+have LfE : L x - f x =
+    ((x - a) * (b - x)) / (b - a) * ((f b - f x) / (b - x)) -
+    ((b - x) * factor a b x) * ((f x - f a) / (x - a)).
+  rewrite !mulrA -(mulrC (b - x)) -(mulrC (b - x)^-1) !mulrA.
+  rewrite mulVf ?mul1r ?subr_eq0 ?gt_eqF//.
+  rewrite -(mulrC (x - a)) -(mulrC (x - a)^-1) !mulrA.
+  rewrite mulVf ?mul1r ?subr_eq0 ?gt_eqF//.
+  rewrite -/(factor a b x).
+  rewrite -(opprB a b) -(opprB x b) invrN mulrNN -/(factor b a x).
+  rewrite -(@onem_factor _ a) ?lt_eqF//.
+  rewrite /onem mulrBl mul1r opprB addrA -mulrDr addrA subrK.
+  by rewrite /L -addrA addrC opprB -addrA (addrC (f a)).
+have {Hc1 Hc2} -> : L x - f x = (b - x) * (x - a) * (c2 - c1) / (b - a) *
+                                (('D_1 f c2 - 'D_1 f c1) / (c2 - c1)).
+  rewrite LfE Hc2 Hc1.
+  rewrite -(mulrC (b - x)) mulrA -mulrBr.
+  rewrite (mulrC ('D_1 f c2 - _)) ![in RHS]mulrA; congr *%R.
+  rewrite -2!mulrA; congr *%R.
+  by rewrite mulrCA divff ?mulr1// subr_eq0 gt_eqF.
+rewrite {}h mulr_ge0//; last first.
   rewrite DDf_ge0//; apply/andP; split.
     by rewrite (lt_trans (andP Ic1).1)//; case/andP : Id.
   by rewrite (lt_trans (andP Id).2)//; case/andP : Ic2.

--- a/theories/convex.v
+++ b/theories/convex.v
@@ -1,10 +1,10 @@
 (* mathcomp analysis (c) 2022 Inria and AIST. License: CeCILL-C.              *)
 From mathcomp Require Import all_ssreflect ssralg ssrint ssrnum finmap.
 From mathcomp Require Import matrix interval zmodp vector fieldext falgebra.
-From mathcomp.classical Require Import boolp classical_sets.
+From mathcomp.classical Require Import boolp classical_sets set_interval.
 From mathcomp.classical Require Import functions cardinality mathcomp_extra.
 Require Import ereal reals signed topology prodnormedzmodule.
-Require Import normedtype derive realfun set_interval itv.
+Require Import normedtype derive realfun itv.
 From HB Require Import structures.
 
 (******************************************************************************)

--- a/theories/convex.v
+++ b/theories/convex.v
@@ -4,13 +4,18 @@ From mathcomp Require Import matrix interval zmodp vector fieldext falgebra.
 From mathcomp.classical Require Import boolp classical_sets.
 From mathcomp.classical Require Import functions cardinality mathcomp_extra.
 Require Import ereal reals signed topology prodnormedzmodule.
-Require Import normedtype derive set_interval.
+Require Import normedtype derive set_interval itv.
 From HB Require Import structures.
 
 (******************************************************************************)
-(* This file provides properties of standard real-valued functions over real  *)
-(* numbers (e.g., the continuity of the inverse of a continuous function).    *)
+(* isConvexSpace R T == interface for convex spaces *)
+(* ConvexSpace R == structure of convex space*)
+(* a <| t |> b == convexity operator*)
+(* E : lmodType R with R : realDomainType and R : realDomainType are shown to be convex spaces *)
 (******************************************************************************)
+
+Reserved Notation "x <| p |> y" (format "x  <| p |>  y", at level 49).
+
 
 Set Implicit Arguments.
 Unset Strict Implicit.
@@ -24,231 +29,247 @@ Local Open Scope ring_scope.
 
 Import numFieldNormedType.Exports.
 
-(* vvv probability vvv *)
-Reserved Notation "x %:pr" (at level 0, format "x %:pr").
-Reserved Notation "p '.~'" (format "p .~", at level 5).
+(* NB: recent addition to MathComp *)
+Lemma divrNN (R : unitRingType) (x y: R) : (- x) / (- y) = x / y.
+Proof. exact: divrNN. Qed.
 
-Module Prob.
-Section prob.
-Variable (R : numDomainType).
-Record t := mk { p :> R ; Op1 : 0 <= p <= 1 }.
-Definition O1 (p : t) := Op1 p.
-Arguments O1 : simpl never.
-End prob.
-Module Exports.
-Section exports.
-Variables (R : numDomainType).
-Canonical prob_subType := Eval hnf in [subType for @p R].
-Local Notation prob := (t R).
-Definition prob_eqMixin := [eqMixin of prob by <:].
-Canonical prob_eqType := Eval hnf in EqType _ prob_eqMixin.
-Definition prob_choiceMixin := [choiceMixin of prob by <:].
-Canonical prob_choiceType := ChoiceType prob prob_choiceMixin.
-Definition prob_porderMixin := [porderMixin of prob by <:].
-Canonical prob_porderType := POrderType ring_display prob prob_porderMixin.
-Lemma prob_ge0 (p : prob) : 0 <= Prob.p p.
-Proof. by case: p => p /= /andP[]. Qed.
-Lemma prob_le1 (p : prob) : Prob.p p <= 1.
-Proof. by case: p => p /= /andP[]. Qed.
-End exports.
-Global Hint Resolve prob_ge0 : core.
-Global Hint Resolve prob_le1 : core.
-End Exports.
-End Prob.
-Export Prob.Exports.
-Notation prob := Prob.t.
-Notation "q %:pr" := (@Prob.mk _ q (@Prob.O1 _ _)).
-Coercion Prob.p : prob >-> Num.NumDomain.sort.
-(*  ^^^ probability ^^^ *)
+(* TODO: move *)
+Lemma factorE {R : numDomainType} (a b x : R) : factor a b x = (a - x) / (a - b).
+Proof.
+by rewrite /factor -(opprB x a) -(opprB b a) invrN mulrNN.
+Qed.
 
-Definition derivable_interval {R : numFieldType}(f : R -> R) (a b: R) :=
+(* TODO: move *)
+Lemma factor1 {R : numFieldType} (a b x : R) : a != b ->
+  factor a b x + factor b a x = 1.
+Proof.
+move=> ab.
+by rewrite factorE /factor -mulrDl addrA subrK divrr// unitfE subr_eq0.
+Qed.
+
+(* TODO: move *)
+Lemma in_IntervalW d {T : porderType d} (a b c e : T):
+  (a <= b)%O -> (c <= e)%O -> forall x, x \in `[b, c] -> x \in `[a, e].
+Proof.
+move=> ab ce x; rewrite 2!in_itv /= => /andP[bx xc].
+by rewrite (le_trans ab)//= (le_trans _ ce).
+Qed.
+
+Declare Scope convex_scope.
+
+Local Open Scope convex_scope.
+
+HB.mixin Record isConvexSpace (R : realDomainType) (T : Type) := {
+  convexspacechoiceclass : Choice.class_of T ;
+  conv : {i01 R} -> T -> T -> T ;
+  conv0 : forall a b, conv 0%:i01 a b = a ;
+  convmm : forall (p : {i01 R}) a, conv p a a = a ;
+  convC : forall (p : {i01 R}) a b, conv p a b = conv (1 - p%:inum)%:i01 b a;
+  convA : forall (p q r : {i01 R}) (a b c : T),
+    p%:inum * (`1-(q%:inum)) = (`1-(p%:inum * q%:inum)) * r%:inum ->
+    conv p a (conv q b c) = conv (p%:inum * q%:inum)%:i01 (conv r a b) c
+}.
+
+#[short(type=convType)]
+HB.structure Definition ConvexSpace (R : realDomainType) := {T of isConvexSpace R T }.
+
+Canonical conv_eqType (R : realDomainType) (T : convType R) :=
+  Eval hnf in EqType (ConvexSpace.sort T) convexspacechoiceclass.
+Canonical conv_choiceType (R : realDomainType) (T : convType R) :=
+  Eval hnf in ChoiceType (ConvexSpace.sort T) convexspacechoiceclass.
+Coercion conv_choiceType : convType >-> choiceType.
+
+Notation "a <| p |> b" := (conv p a b) : convex_scope.
+
+Section convex_space_lemmas.
+Context R (A : convType R).
+Implicit Types a b : A.
+
+Lemma conv1 a b : a <| 1%:i01 |> b = b.
+Proof.
+rewrite convC/= [X in _ <| X |> _](_ : _ = 0%:i01) ?conv0//.
+by apply/val_inj => /=; rewrite subrr.
+Qed.
+
+End convex_space_lemmas.
+
+Local Open Scope convex_scope.
+
+Section lmodType_convex_space.
+Context {R : realDomainType} {E : lmodType R}.
+Implicit Type p q r : {i01 R}.
+
+Let avg p (a b : E) := `1-(p%:inum) *: a + p%:inum *: b.
+
+Let avg0 a b : avg 0%:i01 a b = a.
+Proof. by rewrite /avg/= onem0 scale0r scale1r addr0. Qed.
+
+Let avgI p x : avg p x x = x.
+Proof. by rewrite /avg -scalerDl/= addrC add_onemK scale1r. Qed.
+
+Let avgC p x y : avg p x y = avg (`1-(p%:inum))%:i01 y x.
+Proof. by rewrite /avg onemK addrC. Qed.
+
+Let avgA p q r (a b c : E) :
+  p%:inum * (`1-(q%:inum)) = (`1-(p%:inum * q%:inum)) * r%:inum ->
+  avg p a (avg q b c) = avg (p%:inum * q%:inum)%:i01 (avg r a b) c.
+Proof.
+move=> pq; rewrite /avg.
+rewrite [in LHS]scalerDr [in LHS]addrA [in RHS]scalerDr; congr (_ + _ + _).
+- rewrite scalerA; congr (_ *: _) => /=.
+  by rewrite mulrDr mulr1 mulrN -pq mulrBr mulr1 opprB addrA subrK.
+- by rewrite 2!scalerA; congr (_ *: _).
+- by rewrite scalerA.
+Qed.
+
+HB.instance Definition _ :=
+  @isConvexSpace.Build R E (Choice.class _) avg avg0 avgI avgC avgA.
+
+End lmodType_convex_space.
+
+Section realDomainType_convex_space.
+Context {R : realDomainType}.
+Implicit Types p q : {i01 R}.
+
+Let avg p (a b : [the lmodType R of R^o]) := a <| p |> b.
+
+Let avg0 a b : avg 0%:i01 a b = a.
+Proof. by rewrite /avg conv0. Qed.
+
+Let avgI p x : avg p x x = x.
+Proof. by rewrite /avg convmm. Qed.
+
+Let avgC p x y : avg p x y = avg `1-(p%:inum)%:i01 y x.
+Proof. by rewrite /avg convC. Qed.
+
+Let avgA p q r (a b c : R) :
+  p%:inum * (`1-(q%:inum)) = (`1-(p%:inum * q%:inum)) * r%:inum ->
+  avg p a (avg q b c) = avg (p%:inum * q%:inum)%:i01 (avg r a b) c.
+Proof. by move=> h; rewrite /avg (convA _ _ r). Qed.
+
+HB.instance Definition _ := @isConvexSpace.Build R R^o
+  (Choice.class _) _ avg0 avgI avgC avgA.
+
+End realDomainType_convex_space.
+
+Definition derivable_interval {R : numFieldType} (f : R -> R) (a b : R) :=
   forall x, x \in `[a, b] -> derivable f x 1.
 
-Lemma in_IntervalW [disp: unit] [T: porderType disp] (a b c d: T):
-  (a <= b)%O -> (c <= d)%O -> forall x, x \in `[b, c] -> x \in `[a, d].
+Lemma derivable_continuous {R : realType} (F : R -> R) (x y : R):
+  derivable_interval F x y -> {within `[x, y], continuous F}.
 Proof.
-move=> ab cd x. rewrite 2!in_itv /= => /andP [bx xc].
-apply/andP. split.
-  exact: (le_trans ab).
-exact: (le_trans _ cd).
+move=> di.
+have h z : z \in `[x, y] -> {for z, continuous F}.
+  move=> zxy; apply/differentiable_continuous.
+  by rewrite -derivable1_diffP; exact: di.
+by apply/continuous_in_subspaceT => z /[1!inE] zin; exact: h.
 Qed.
 
-Lemma derivable_interval_le {R : numFieldType} (f:R -> R) (a b a' : R):
-    a <= a' -> derivable_interval f a b -> derivable_interval f a' b.
+Lemma derivable_interval_le {R : numFieldType} (f : R -> R) (a b a' : R) :
+  a <= a' -> derivable_interval f a b -> derivable_interval f a' b.
 Proof.
-rewrite /derivable_interval => aa' deriv x xin. apply/deriv.
-by move: xin; apply/in_IntervalW.
+rewrite /derivable_interval => aa' deriv x xab; apply/deriv.
+exact: in_IntervalW xab.
 Qed.
 
-Lemma derivable_interval_ge {R: numFieldType} (f:R -> R) (a b b': R):
+Lemma derivable_interval_ge {R : numFieldType} (f : R -> R) (a b b' : R) :
   b >= b' -> derivable_interval f a b -> derivable_interval f a b'.
 Proof.
-rewrite/derivable_interval => b'b deriv x xin. apply/deriv.
-by move: xin; apply in_IntervalW.
+rewrite/derivable_interval => b'b deriv x xab'; apply/deriv.
+exact: in_IntervalW xab'.
 Qed.
 
 (* ref: http://www.math.wisc.edu/~nagel/convexity.pdf *)
 Section twice_derivable_convex.
+Context {R : realType}.
+Variables (f : R -> R^o) (a b : R^o).
+Hypothesis ab : a < b.
 
-Variable R : realType.
-Variables (f : R -> R) (a b : R).
-Hypothesis ab : (a < b)%R.
+Let Df := 'D_1 f.
+Let DDf := 'D_1 Df.
 
-Definition Df x: R := 'D_1 f x.
-Definition DDf x := 'D_1 Df x.
+Hypothesis DDf_ge0 : forall x, a <= x <= b -> 0 <= DDf x.
 
-Hypothesis DDf_ge0 : forall x, a <= x <= b -> (0 <= DDf x)%R.
+Let L x := f a + factor a b x * (f b - f a).
 
-Let prob := Prob.t R.
-
-
-Definition conv' (a b: R) (p:prob) : R := conv a b (Prob.p p).
-
-Definition L (x : R) := (f a + (x - a) / (b - a) * (f b - f a))%R.
-
-Lemma LE x : L x = ((b - x) / (b - a) * f a + (x - a) / (b - a) * f b)%R.
+Let LE x : L x = factor b a x * f a + factor a b x * f b.
 Proof.
-rewrite /L mulrBr [in LHS]addrA addrAC; congr (_ + _)%R.
-rewrite -{1}(mul1r (f a)) -mulrBl; congr (_ * _)%R.
+rewrite /L mulrBr [in LHS]addrA addrAC; congr +%R.
+rewrite -{1}(mul1r (f a)) -mulrBl; congr *%R.
 rewrite -(@mulrV _ (b-a)); last first.
   by move: ab; rewrite unitfE subr_eq0 lt_def => /andP [ba _].
-by rewrite -mulrBl opprB addrA subrK.
+rewrite -factorE.
+rewrite factorr ?gt_eqF// -(@factor1 _ a b x) ?lt_eqF//.
+by rewrite addrAC subrr add0r.
 Qed.
 
-Lemma divrNN (x y: R): (- x) / (- y) = x / y.
-Proof. by rewrite -[RHS]mulrNN -invrN. Qed.
-
-Lemma sub_divC (x y c d: R):
-    (x - y) / (c - d) = (y - x) / (d - c).
-Proof. by rewrite -divrNN !opprB. Qed.
-
-Lemma convexf_ptP : (forall x, a <= x <= b -> 0 <= L x - f x)%R ->
-  forall t, f (conv' a b t) <= conv' (f a) (f b) t.
+Let convexf_ptP : (forall x, a <= x <= b -> 0 <= L x - f x) ->
+  forall t, f (a <| t |> b) <= f a <| t |> f b.
 Proof.
-move=> H t.
-set p := (Prob.p t). set x := conv' a b t.
-have : (a <= x <= b)%R.
-  rewrite -(conv1 a b) -{1}(conv0 a b) /x le_conv // le_conv //.
-  by apply/andP.
-move/H; rewrite subr_ge0 => /le_trans. apply.
-rewrite LE.
-have -> : ((b - x) / (b - a) = 1 - p).
-  rewrite /x sub_divC -/(factor b a _) /conv' conv_sym.
-  by rewrite convK // gt_eqF.
-have -> : ((x - a) / (b - a) = p).
-  rewrite /x -/(factor a b _) /conv'.
-  by rewrite convK // lt_eqF.
-done.
+move=> H t; set x := a <| t |> b.
+have /H : a <= x <= b.
+  rewrite -(conv1 (a : R^o) b) -{1}(conv0 (a : R^o) b) /x.
+  by rewrite !le_conv//= ge0/=.
+rewrite subr_ge0 => /le_trans; apply.
+by rewrite LE /x convK ?lt_eqF// convC convK ?gt_eqF.
 Qed.
 
 Hypothesis HDf : derivable_interval f a b.
 Hypothesis HDDf : derivable_interval Df a b.
 
-Lemma unitfB: forall (x y:R), x < y -> y - x \is a GRing.unit.
+Lemma second_derivative_convexf_pt (t : {i01 R}) :
+  f (a <| t |> b) <= f a <| t |> f b.
 Proof.
-  by move=> x y xy; rewrite unitfE subr_eq0 (gt_eqF xy).
-Qed.
-
-Lemma derivable_continuous (F: R -> R) (x y: R):
-  derivable_interval F x y -> {within `[x, y], continuous F}.
-Proof.
-rewrite /derivable_interval.
-move=> di.
-have h: (forall x0, x0 \in `[x, y] -> {for x0, continuous F}); last first .
-  apply/continuous_in_subspaceT.
-  move=> z zin. apply h.
-  by rewrite inE in zin.
-move=> x0 x0xy.
-apply/differentiable_continuous.
-rewrite -derivable1_diffP.
-by apply di.
-Qed.
-
-Lemma second_derivative_convexf_pt : forall t : prob,
-    f (conv a b t) <= conv (f a) (f b) t.
-Proof.
-have note1 : forall x, 1 = (x - a) / (b - a) + (b - x) / (b - a).
-  move=> x; rewrite -mulrDl addrC addrA subrK mulrV //.
-  exact: unitfB.
-have step1 : forall x, f x = (x - a) / (b - a) * f x + (b - x) / (b - a) * f x.
-  by move=> x; rewrite -mulrDl -note1 mul1r.
-apply /convexf_ptP => // x axb.
-rewrite /L.
-move: axb => /andP [].
-rewrite le_eqVlt => /orP [/eqP -> _|].
-  rewrite /L subrr 2!mul0r addr0 subrr. exact/lexx.
-move=> ax.
-rewrite le_eqVlt => /orP -[/eqP ->|].
-  rewrite /L  mulrV ?mul1r; last exact/unitfB.
-  rewrite (addrC (f a)) subrK subrr; exact/lexx.
-move=> xb.
-have {step1}step2 : L x - f x =
-  (x - a) * (b - x) / (b - a) * ((f b - f x) / (b - x)) -
-  (b - x) * (x - a) / (b - a) * ((f x - f a) / (x - a)).
-  rewrite {1}step1 {step1}.
-  rewrite opprD addrA addrC addrA LE //.
-  rewrite -(mulrN _ (f x)).
-  rewrite addrA. rewrite -mulrDr (addrC _ (f a)).
-  rewrite -(mulrN _ (f x)) -addrA -mulrDr addrC.
-  rewrite -(opprK (f a - f x)) mulrN  opprB.
-  congr (_ + _).
-  - rewrite -!mulrA; congr (_ * _); rewrite mulrCA; congr (_ * _).
-    by rewrite mulrCA mulrV ?mulr1 // unitfB //.
-  - rewrite -!mulNr -!mulrA; congr (_ * _); rewrite mulrCA; congr (_ * _).
-    by rewrite mulrCA mulrV ?mulr1 // unitfB //.
-have [c2 [Ic2 Hc2]] : exists c2, (x < c2 < b /\ (f b - f x) / (b - x) = 'D_1 f c2).
-  have H : derivable_interval f x b.
-    apply: (derivable_interval_le); last exact HDf.
-    by apply /ltW.
-  have derivef: forall x0:R, x0 \in `]x, b[ -> is_derive x0 1 f ('D_1 f x0).
-    move=> x0 x0in; apply/derivableP /H. move: x0in.
-    exact: subset_itv_oo_cc.
-  case: (MVT xb derivef ) => [ | b0 b0in fbfx]; first by apply/derivable_continuous.
-  exists b0. split => //.
-  rewrite fbfx -mulrA divff; last by rewrite -unitfE unitfB.
-  by rewrite mulr1.
-have [c1 [Ic1 Hc1]] : exists c1, (a < c1 < x /\ (f x - f a) / (x - a) = 'D_1 f c1).
-  have H : derivable_interval f a x.
-    apply: (derivable_interval_ge); last exact HDf.
-    by apply /ltW.
-  have derivef: forall x0:R, x0 \in `]a, x[ -> is_derive x0 1 f ('D_1 f x0).
-    move=> x0 x0in; apply /derivableP /H.
-    exact: subset_itv_oo_cc.
-  case: (MVT ax derivef); first by apply /derivable_continuous.
-  move=> a0 a0in fxfa.
-  exists a0. split => //.
-  rewrite fxfa -mulrA divff; last by rewrite -unitfE unitfB.
-  by rewrite mulr1.
-have c1c2 : c1 < c2 by apply (@lt_trans _ _ x); [case: (andP Ic1) | case: (andP Ic2)].
-have {step2 Hc1 Hc2}step3 : (L x - f x =
-  (b - x) * (x - a) * (c2 - c1) / (b - a) * (('D_1 f c2 - 'D_1 f c1) / (c2 - c1)))%R.
-  rewrite {}step2 Hc2 Hc1 (mulrC (x - a)%R) -mulrBr -!mulrA.
+apply/convexf_ptP => x /andP[]; rewrite /L.
+rewrite le_eqVlt => /predU1P[-> _|ax].
+  by rewrite factorl mul0r addr0 subrr lexx.
+rewrite le_eqVlt => /predU1P[->|xb].
+  by rewrite factorr ?lt_eqF// mul1r addrCA subrr addr0 subrr.
+have LfE : L x - f x =
+    (x - a) * (b - x) / (b - a) * ((f b - f x) / (b - x)) -
+    (b - x) * (x - a) / (b - a) * ((f x - f a) / (x - a)).
+  rewrite !mulrA -(mulrC (b - x)) -(mulrC (b - x)^-1) !mulrA.
+  rewrite mulVr ?mul1r ?unitfE ?subr_eq0 ?gt_eqF//.
+  rewrite -(mulrC (x - a)) -(mulrC (x - a)^-1) !mulrA.
+  rewrite mulVr ?mul1r ?unitfE ?subr_eq0 ?gt_eqF//.
+  rewrite -factorE -/(factor _ _ _).
+  rewrite !mulrBr opprB -!mulrN addrACA -mulrDl factor1 ?mul1r ?lt_eqF//.
+  by rewrite LE (addrC (_ * f b)).
+have [c2 Ic2 Hc2] : exists2 c2, x < c2 < b & (f b - f x) / (b - x) = 'D_1 f c2.
+  have h : derivable_interval f x b := derivable_interval_le (ltW ax) HDf.
+  have derivef z : z \in `]x, b[ -> is_derive z 1 f ('D_1 f z).
+    by move=> zxb; apply/derivableP/h; exact: subset_itv_oo_cc zxb.
+  have [ |z zxb fbfx] := MVT xb derivef; first by apply/derivable_continuous.
+  by exists z => //; rewrite fbfx -mulrA divff ?mulr1// subr_eq0 gt_eqF.
+have [c1 Ic1 Hc1] : exists2 c1, a < c1 < x & (f x - f a) / (x - a) = 'D_1 f c1.
+  have h : derivable_interval f a x := derivable_interval_ge (ltW xb) HDf.
+  have derivef z : z \in `]a, x[ -> is_derive z 1 f ('D_1 f z).
+    by move=> zax; apply /derivableP/h/subset_itv_oo_cc.
+  have [|z zax fxfa] := MVT ax derivef; first exact/derivable_continuous.
+  by exists z => //; rewrite fxfa -mulrA divff ?mulr1// subr_eq0 gt_eqF.
+have c1c2 : c1 < c2.
+  by move: Ic2 Ic1 => /andP[+ _] => /[swap] /andP[_] /lt_trans; apply.
+have {LfE Hc1 Hc2}lfE : L x - f x = (b - x) * (x - a) * (c2 - c1) / (b - a) *
+                                    (('D_1 f c2 - 'D_1 f c1) / (c2 - c1)).
+  rewrite LfE Hc2 Hc1 (mulrC (x - a)%R) -mulrBr -!mulrA.
   congr (_ * (_ * _)); rewrite mulrCA; congr (_ * _).
-  rewrite mulrCA mulrV ?mulr1 //. exact/unitfB.
-have [d [Id H]] : exists d, c1 < d < c2 /\ ('D_1 f c2 - 'D_1 f c1) / (c2 - c1) = DDf d.
-  have H : derivable_interval Df c1 c2.
-    by apply /(derivable_interval_le (ltW (proj1 (andP Ic1))))
-             /(derivable_interval_ge (ltW (proj2 (andP Ic2)))).
-  have derivef: forall x0:R, x0 \in `]c1, c2[ -> is_derive x0 1 Df ('D_1 Df x0).
-    move=> x0 x0in; apply /derivableP /H.
-    exact: subset_itv_oo_cc.
-  case: (MVT c1c2 derivef); first by apply /derivable_continuous.
-  move=> x0 x0in Dfc2Dfc1. exists x0. split => //.
-  rewrite Dfc2Dfc1 -mulrA divff; last by rewrite -unitfE unitfB.
-  by rewrite mulr1.
-rewrite {}step3 {}H.
-apply/mulr_ge0; last first.
-  apply /DDf_ge0 /andP; split.
-    apply (@le_trans _ _ c1).
-      apply/ltW; by case: (andP Ic1).
-     by case: (andP Id) => /ltW.
-  apply (@le_trans _ _ c2).
-    by case: (andP Id) => _ /ltW.
-  apply/ltW; by case: (andP Ic2).
-apply/mulr_ge0; last by rewrite invr_ge0 subr_ge0 ltW.
-apply/mulr_ge0; last first.
-  by rewrite subr_ge0; case: (andP Id) => Id1 Id2; apply (@le_trans _ _ d); exact/ltW.
-by apply/mulr_ge0; rewrite subr_ge0; exact/ltW.
+  by rewrite mulrCA mulrV ?mulr1// unitfE subr_eq0 gt_eqF.
+have [d Id h] :
+    exists2 d, c1 < d < c2 & ('D_1 f c2 - 'D_1 f c1) / (c2 - c1) = DDf d.
+  have h : derivable_interval Df c1 c2.
+    exact/(derivable_interval_le (ltW (andP Ic1).1))
+         /(derivable_interval_ge (ltW (andP Ic2).2)).
+  have derivef z : z \in `]c1, c2[ -> is_derive z 1 Df ('D_1 Df z).
+    by move=> zc1c2; apply/derivableP/h/subset_itv_oo_cc.
+  have [|z zc1c2 {}h] := MVT c1c2 derivef; first by apply /derivable_continuous.
+  by exists z => //; rewrite h -mulrA divff ?mulr1// subr_eq0 gt_eqF.
+rewrite {}lfE {}h mulr_ge0//; last first.
+  rewrite DDf_ge0//; apply/andP; split.
+    by rewrite (le_trans (ltW (andP Ic1).1))// (le_trans (ltW (andP Id).1)).
+  by rewrite (le_trans (ltW (andP Id).2))// (le_trans (ltW (andP Ic2).2)).
+rewrite mulr_ge0// ?invr_ge0 ?subr_ge0 ?(ltW ab)//.
+rewrite mulr_ge0// ?subr_ge0 ?(ltW c1c2)//.
+by rewrite mulr_ge0// subr_ge0 ltW.
 Qed.
 
 End twice_derivable_convex.

--- a/theories/convex.v
+++ b/theories/convex.v
@@ -61,6 +61,36 @@ Notation "q %:pr" := (@Prob.mk _ q (@Prob.O1 _ _)).
 Coercion Prob.p : prob >-> Num.NumDomain.sort.
 (*  ^^^ probability ^^^ *)
 
+Definition derivable_interval {R : numFieldType}(f : R -> R) (a b: R) :=
+  forall x, x \in `]a, b[ -> derivable f x 1.
+
+Lemma BRightLeft_le {R:numFieldType} (x y: R) :
+  x <= y <-> (BRight x <= BLeft y)%O.
+Admitted.
+
+Lemma Interval_le_l {R: numFieldType} (a b a': R):
+  a <= a' -> forall x,  x \in `]a', b[ -> x \in `]a, b[.
+Proof.
+  move=> aa' x.
+  move /andP => [l r]. apply /andP. split => //.
+  rewrite -BRightLeft_le in l.
+  apply /BRightLeft_le.
+  by apply: (le_trans aa').
+Qed.
+
+Lemma derivable_interval_le {R : numFieldType} (f:R -> R) (a b a' : R):
+    a <= a' -> derivable_interval f a b -> derivable_interval f a' b.
+Proof.
+  rewrite /derivable_interval.
+  move=> aa' dab x xin.
+  by apply /dab /(Interval_le_l aa').
+Qed.
+
+
+
+Lemma derivable_interval_ge {R: numFieldType} (f:R -> R) (a b b': R):
+    b >= b' -> derivable_interval f a b -> derivable_interval f a b'.
+Admitted.
 (* ref: http://www.math.wisc.edu/~nagel/convexity.pdf *)
 Section twice_derivable_convex.
 
@@ -115,21 +145,8 @@ have -> : ((x - a) / (b - a) = p).
 done.
 Qed.
 
-Variable pderivable : (R -> R) -> (R -> Prop) -> Prop.
-Definition derive_pt (f: R -> R) (x: R) : R := f^`() x.
-Let I := fun x0 => (a <= x0 <= b).
-
-Definition derivable_interval (f : R -> R) (a b: R) :=
-  forall x, x \in `]a, b[ -> derivable f x 1.
 Hypothesis HDf : derivable_interval f a b.
 Hypothesis HDDf : derivable_interval Df a b.
-
-Lemma derivable_interval_le : forall f a b a',
-    a <= a' -> derivable_interval f a b -> derivable_interval f a' b.
-Admitted.
-Lemma derivable_interval_ge : forall f a b b',
-    b >= b' -> derivable_interval f a b -> derivable_interval f a b'.
-Admitted.
 
 Lemma unitfB: forall (x y:R), x < y -> y - x \is a GRing.unit.
 Proof.

--- a/theories/convex.v
+++ b/theories/convex.v
@@ -136,7 +136,6 @@ End realDomainType_convex_space.
 Section twice_derivable_convex.
 Context {R : realType}.
 Variables (f : R -> R^o) (a b : R^o).
-Hypothesis ab : a < b.
 
 Let Df := 'D_1 f.
 Let DDf := 'D_1 Df.
@@ -147,19 +146,19 @@ Hypothesis cvg_right : (f @ a^'+) --> f a.
 
 Let L x := f a + factor a b x * (f b - f a).
 
-Let LE x : L x = factor b a x * f a + factor a b x * f b.
+Let LE x : a < b -> L x = factor b a x * f a + factor a b x * f b.
 Proof.
-rewrite /L -(@onem_factor _ a) ?lt_eqF// /onem mulrBl mul1r.
+move=> ab; rewrite /L -(@onem_factor _ a) ?lt_eqF// /onem mulrBl mul1r.
 by rewrite -addrA -mulrN -mulrDr (addrC (f b)).
 Qed.
 
-Let convexf_ptP : (forall x, a <= x <= b -> 0 <= L x - f x) ->
+Let convexf_ptP : a < b -> (forall x, a <= x <= b -> 0 <= L x - f x) ->
   forall t, f (a <| t |> b) <= f a <| t |> f b.
 Proof.
-move=> h t; set x := a <| t |> b; have /h : a <= x <= b.
+move=> ab h t; set x := a <| t |> b; have /h : a <= x <= b.
   by rewrite -(conv1 a b) -{1}(conv0 a b) /x !le_line_path//= itv_ge0/=.
 rewrite subr_ge0 => /le_trans; apply.
-by rewrite LE /x line_pathK ?lt_eqF// convC line_pathK ?gt_eqF.
+by rewrite LE// /x line_pathK ?lt_eqF// convC line_pathK ?gt_eqF.
 Qed.
 
 Hypothesis HDf : {in `]a, b[, forall x, derivable f x 1}.
@@ -168,10 +167,11 @@ Hypothesis HDDf : {in `]a, b[, forall x, derivable Df x 1}.
 Let cDf : {within `]a, b[, continuous Df}.
 Proof. by apply: derivable_within_continuous => z zab; exact: HDDf. Qed.
 
-Lemma second_derivative_convexf_pt (t : {i01 R}) :
+Lemma second_derivative_convex (t : {i01 R}) : a <= b ->
   f (a <| t |> b) <= f a <| t |> f b.
 Proof.
-apply/convexf_ptP => x /andP[].
+rewrite le_eqVlt => /predU1P[<-|/[dup] ab]; first by rewrite !convmm.
+move/convexf_ptP; apply => x /andP[].
 rewrite le_eqVlt => /predU1P[<-|ax].
   by rewrite /L factorl mul0r addr0 subrr.
 rewrite le_eqVlt => /predU1P[->|xb].

--- a/theories/convex.v
+++ b/theories/convex.v
@@ -8,14 +8,14 @@ Require Import normedtype derive set_interval itv.
 From HB Require Import structures.
 
 (******************************************************************************)
-(* isConvexSpace R T == interface for convex spaces *)
-(* ConvexSpace R == structure of convex space*)
-(* a <| t |> b == convexity operator*)
-(* E : lmodType R with R : realDomainType and R : realDomainType are shown to be convex spaces *)
+(* isConvexSpace R T == interface for convex spaces                           *)
+(* ConvexSpace R == structure of convex space                                 *)
+(* a <| t |> b == convexity operator                                          *)
+(* E : lmodType R with R : realDomainType and R : realDomainType are shown to *)
+(* be convex spaces                                                           *)
 (******************************************************************************)
 
 Reserved Notation "x <| p |> y" (format "x  <| p |>  y", at level 49).
-
 
 Set Implicit Arguments.
 Unset Strict Implicit.
@@ -107,7 +107,7 @@ Proof. by rewrite /avg/= onem0 scale0r scale1r addr0. Qed.
 Let avgI p x : avg p x x = x.
 Proof. by rewrite /avg -scalerDl/= addrC add_onemK scale1r. Qed.
 
-Let avgC p x y : avg p x y = avg (`1-(p%:inum))%:i01 y x.
+Let avgC p x y : avg p x y = avg (1 - (p%:inum))%:i01 y x.
 Proof. by rewrite /avg onemK addrC. Qed.
 
 Let avgA p q r (a b c : E) :
@@ -139,7 +139,7 @@ Proof. by rewrite /avg conv0. Qed.
 Let avgI p x : avg p x x = x.
 Proof. by rewrite /avg convmm. Qed.
 
-Let avgC p x y : avg p x y = avg `1-(p%:inum)%:i01 y x.
+Let avgC p x y : avg p x y = avg (1 - (p%:inum))%:i01 y x.
 Proof. by rewrite /avg convC. Qed.
 
 Let avgA p q r (a b c : R) :
@@ -209,7 +209,7 @@ Proof.
 move=> H t; set x := a <| t |> b.
 have /H : a <= x <= b.
   rewrite -(conv1 (a : R^o) b) -{1}(conv0 (a : R^o) b) /x.
-  by rewrite !le_conv//= ge0/=.
+  by rewrite !le_conv//= itv_ge0/=.
 rewrite subr_ge0 => /le_trans; apply.
 by rewrite LE /x convK ?lt_eqF// convC convK ?gt_eqF.
 Qed.

--- a/theories/convex.v
+++ b/theories/convex.v
@@ -35,22 +35,27 @@ Local Open Scope ring_scope.
 
 Import numFieldNormedType.Exports.
 
-Lemma cvg_at_right_filter (R : numFieldType) (f : R -> R) (x : R) :
+Lemma cvg_at_right_filter (R : numFieldType)
+  (K : numDomainType) (V : pseudoMetricNormedZmodType K)
+  (f : R -> V) (x : R) :
   f z @[z --> x] --> f x -> f z @[z --> x^'+] --> f x.
 Proof. exact: (@cvg_within_filter _ _ _ (nbhs x)). Qed.
 
-Lemma cvg_at_left_filter (R : numFieldType) (f : R -> R) (x : R) :
+Lemma cvg_at_left_filter (R : numFieldType)
+  (K : numDomainType) (V : pseudoMetricNormedZmodType K)
+  (f : R -> V) (x : R) :
   f z @[z --> x] --> f x -> f z @[z --> x^'-] --> f x.
 Proof. exact: (@cvg_within_filter _ _ _ (nbhs x)). Qed.
 
-Lemma derivable_oo_itvW {R : numFieldType} (f : R -> R) (a b a' b' : R) :
+Lemma derivable_oo_itvW {R : numFieldType} (V : normedModType R)
+    (f : R -> V) (a b a' b' : R) :
     a <= a' -> b' <= b ->
   {in `]a, b[, forall x, derivable f x 1} ->
   {in `]a', b'[, forall x, derivable f x 1}.
 Proof. by move=> aa' bb' + x xab; apply; exact: subset_itvW xab. Qed.
 
-Lemma derivable_within_continuous {R : numFieldType} (F : R -> R)
-    (i : interval R) :
+Lemma derivable_within_continuous {R : numFieldType} (V : normedModType R)
+    (F : R -> V) (i : interval R) :
   {in i, forall x, derivable F x 1} ->
   {within [set` i], continuous F}.
 Proof.
@@ -59,7 +64,8 @@ apply/differentiable_continuous; rewrite -derivable1_diffP.
 by apply: di; rewrite inE.
 Qed.
 
-Lemma cvg_at_right_within (R : numFieldType) (F : R -> R) (x : R) :
+Lemma cvg_at_right_within (R : numFieldType)
+  (K : numDomainType) (V : pseudoMetricNormedZmodType K) (F : R -> V) (x : R) :
   F x @[x --> x^'+] --> F x ->
   F x @[x --> within (fun u => x <= u) (nbhs x)] --> F x.
 Proof.
@@ -69,7 +75,8 @@ rewrite !near_withinE; apply: filterS => y h.
 by rewrite le_eqVlt => /predU1P[->|//]; rewrite subrr normr0.
 Unshelve. all: by end_near. Qed.
 
-Lemma cvg_at_left_within (R : numFieldType) (F : R -> R) (y : R) :
+Lemma cvg_at_left_within (R : numFieldType)
+  (K : numDomainType) (V : pseudoMetricNormedZmodType K) (F : R -> V) (y : R) :
   F x @[x --> y^'-] --> F y ->
   F x @[x --> within (fun u => u <= y) (nbhs y)] --> F y.
 Proof.
@@ -79,8 +86,8 @@ rewrite !near_withinE; apply: filterS => x h.
 by rewrite le_eqVlt => /predU1P[->|//]; rewrite subrr normr0.
 Unshelve. all: by end_near. Qed.
 
-Lemma derivable_oo_within_cc_continuous {R : numFieldType} (F : R -> R)
-  (x y : R):
+Lemma derivable_oo_within_cc_continuous {R : numFieldType} {V : normedModType R}
+  (F : R -> V) (x y : R):
     {in `]x, y[, forall x, derivable F x 1} ->
   F @ x^'+ --> F x -> F @ y^'- --> F y -> {within `[x, y], continuous F}.
 Proof.

--- a/theories/convex.v
+++ b/theories/convex.v
@@ -1,0 +1,123 @@
+(* mathcomp analysis (c) 2022               *)
+From mathcomp Require Import all_ssreflect ssralg ssrint ssrnum finmap.
+From mathcomp Require Import matrix interval zmodp vector fieldext falgebra.
+From mathcomp.classical Require Import boolp classical_sets.
+From mathcomp.classical Require Import functions cardinality mathcomp_extra.
+Require Import ereal reals signed topology prodnormedzmodule.
+Require Import normedtype derive set_interval.
+From HB Require Import structures.
+
+(******************************************************************************)
+(* This file provides properties of standard real-valued functions over real  *)
+(* numbers (e.g., the continuity of the inverse of a continuous function).    *)
+(******************************************************************************)
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+
+Import Order.TTheory GRing.Theory Num.Def Num.Theory.
+Import numFieldTopology.Exports.
+
+Local Open Scope classical_set_scope.
+Local Open Scope ring_scope.
+
+Import numFieldNormedType.Exports.
+
+(* vvv probability vvv *)
+Reserved Notation "x %:pr" (at level 0, format "x %:pr").
+Reserved Notation "p '.~'" (format "p .~", at level 5).
+
+Module Prob.
+Section prob.
+Variable (R : numDomainType).
+Record t := mk { p :> R ; Op1 : 0 <= p <= 1 }.
+Definition O1 (p : t) := Op1 p.
+Arguments O1 : simpl never.
+End prob.
+Module Exports.
+Section exports.
+Variables (R : numDomainType).
+Canonical prob_subType := Eval hnf in [subType for @p R].
+Local Notation prob := (t R).
+Definition prob_eqMixin := [eqMixin of prob by <:].
+Canonical prob_eqType := Eval hnf in EqType _ prob_eqMixin.
+Definition prob_choiceMixin := [choiceMixin of prob by <:].
+Canonical prob_choiceType := ChoiceType prob prob_choiceMixin.
+Definition prob_porderMixin := [porderMixin of prob by <:].
+Canonical prob_porderType := POrderType ring_display prob prob_porderMixin.
+Lemma prob_ge0 (p : prob) : 0 <= Prob.p p.
+Proof. by case: p => p /= /andP[]. Qed.
+Lemma prob_le1 (p : prob) : Prob.p p <= 1.
+Proof. by case: p => p /= /andP[]. Qed.
+End exports.
+Global Hint Resolve prob_ge0 : core.
+Global Hint Resolve prob_le1 : core.
+End Exports.
+End Prob.
+Export Prob.Exports.
+Notation prob := Prob.t.
+Notation "q %:pr" := (@Prob.mk _ q (@Prob.O1 _ _)).
+Coercion Prob.p : prob >-> Num.NumDomain.sort.
+(*  ^^^ probability ^^^ *)
+
+(* ref: http://www.math.wisc.edu/~nagel/convexity.pdf *)
+Section twice_derivable_convex.
+
+Variable R : realType.
+Variables (f : R -> R) (a b : R).
+Hypothesis ab : (a < b)%R.
+
+Definition Df x: R := f^`() x.
+Definition DDf x := f^`(2) x.
+
+Hypothesis DDf_ge0 : forall x, a <= x <= b -> (0 <= DDf x)%R.
+
+Let prob := Prob.t R.
+
+
+Definition conv' (a b: R) (p:prob) : R := conv a b (Prob.p p).
+
+Definition L (x : R) := (f a + (x - a) / (b - a) * (f b - f a))%R.
+
+Lemma LE x : L x = ((b - x) / (b - a) * f a + (x - a) / (b - a) * f b)%R.
+Proof.
+rewrite /L mulrBr [in LHS]addrA addrAC; congr (_ + _)%R.
+rewrite -{1}(mul1r (f a)) -mulrBl; congr (_ * _)%R.
+rewrite -(@mulrV _ (b-a)); last first.
+  by move: ab; rewrite unitfE subr_eq0 lt_def => /andP [ba _].
+by rewrite -mulrBl opprB addrA subrK.
+Qed.
+
+Lemma divrNN (x y: R): (- x) / (- y) = x / y.
+Proof. by rewrite -[RHS]mulrNN -invrN. Qed.
+
+Lemma sub_divC (x y c d: R): 
+    (x - y) / (c - d) = (y - x) / (d - c).
+Proof. by rewrite -divrNN !opprB. Qed.
+
+Lemma convexf_ptP : (forall x, a <= x <= b -> 0 <= L x - f x)%R ->
+  forall t, f (conv' a b t) <= conv' (f a) (f b) t.
+Proof.
+move=> H t.
+set p := (Prob.p t). set x := conv' a b t.
+have : (a <= x <= b)%R.
+  rewrite -(conv1 a b) -{1}(conv0 a b) /x le_conv // le_conv //.
+  by apply/andP.
+move/H; rewrite subr_ge0 => /le_trans. apply.
+rewrite LE.
+have -> : ((b - x) / (b - a) = 1 - p).
+  rewrite /x sub_divC -/(factor b a _) /conv' conv_sym.
+  by rewrite convK // gt_eqF.
+have -> : ((x - a) / (b - a) = p).
+  rewrite /x -/(factor a b _) /conv'.
+  by rewrite convK // lt_eqF.
+done.
+Qed.
+
+Lemma second_derivative_convexf_pt : forall t : prob,
+    f (conv a b t) <= conv (f a) (f b) t.
+Proof.
+Admitted.
+
+End twice_derivable_convex.

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -1042,6 +1042,14 @@ have -> : (fun h => (f \o shift x) h%:A) = f \o shift x.
 by have /diff_locally := dfx; rewrite diff1E // derive1E =>->.
 Qed.
 
+Lemma derivable_within_continuous f (i : interval R) :
+  {in i, forall x, derivable f x 1} -> {within [set` i], continuous f}.
+Proof.
+move=> di; apply/continuous_in_subspaceT => z /[1!inE] zA.
+apply/differentiable_continuous; rewrite -derivable1_diffP.
+by apply: di; rewrite inE.
+Qed.
+
 End DeriveRU.
 
 Section DeriveVW.

--- a/theories/exp.v
+++ b/theories/exp.v
@@ -5,6 +5,7 @@ From mathcomp.classical Require Import boolp classical_sets functions.
 From mathcomp.classical Require Import mathcomp_extra.
 Require Import reals ereal nsatz_realtype.
 Require Import signed topology normedtype landau sequences derive realfun.
+Require Import itv convex.
 
 (******************************************************************************)
 (*               Theory of exponential/logarithm functions                    *)
@@ -349,6 +350,9 @@ Qed.
 Lemma derivable_expR x : derivable expR x 1.
 Proof. by apply: ex_derive; apply: is_derive_exp. Qed.
 
+Lemma derive_expR : 'D_1 expR = expR :> (R -> R).
+Proof. by apply/funext => r /=; rewrite derive_val. Qed.
+
 Lemma continuous_expR : continuous (@expR R).
 Proof.
 by move=> x; exact/differentiable_continuous/derivable1_diffP/derivable_expR.
@@ -463,6 +467,18 @@ case: (lerP 1 x) => [/expR_total_gt1[y [_ _ Hy]]|x_lt1 x_gt0].
 have /expR_total_gt1[y [H1y H2y H3y]] : 1 <= x^-1 by rewrite ltW // !invf_cp1.
 by exists (-y); rewrite expRN H3y invrK.
 Qed.
+
+Local Open Scope convex_scope.
+Lemma convex_expR (t : {i01 R}) (a b : R^o) : a <= b ->
+  expR (a <| t |> b) <= (expR a : R^o) <| t |> (expR b : R^o).
+Proof.
+move=> ab; apply: second_derivative_convex => //.
+- by move=> x axb; rewrite derive_expR derive_val expR_ge0.
+- exact/cvg_at_left_filter/continuous_expR.
+- exact/cvg_at_right_filter/continuous_expR.
+- by move=> z zab; rewrite derive_expR; exact: derivable_expR.
+Qed.
+Local Close Scope convex_scope.
 
 End expR.
 

--- a/theories/itv.v
+++ b/theories/itv.v
@@ -457,11 +457,11 @@ Variant interval_sign_spec (l u : itv_bound int) : option KnownSign.real -> Set 
   | ISignNone : (u <= l)%O -> interval_sign_spec l u None
   | ISignEqZero : l = BLeft 0 -> u = BRight 0 ->
                   interval_sign_spec l u (Some (KnownSign.Sign =0))
-  | ISignNeg : (l < BLeft 0%Z)%O -> (u <= BRight 0%Z)%O ->
+  | ISignNeg : (l < BLeft 0%:Z)%O -> (u <= BRight 0%:Z)%O ->
                interval_sign_spec l u (Some (KnownSign.Sign <=0))
-  | ISignPos : (BLeft 0%Z <= l)%O -> (BRight 0%Z < u)%O ->
+  | ISignPos : (BLeft 0%:Z <= l)%O -> (BRight 0%:Z < u)%O ->
                interval_sign_spec l u (Some (KnownSign.Sign >=0))
-  | ISignBoth : (l < BLeft 0%Z)%O -> (BRight 0%Z < u)%O ->
+  | ISignBoth : (l < BLeft 0%:Z)%O -> (BRight 0%:Z < u)%O ->
                 interval_sign_spec l u (Some >=<0%snum_sign).
 
 Lemma interval_signP l u :
@@ -503,7 +503,7 @@ Definition mul_itv_boundr_subdef (b1 b2 : itv_bound int) : itv_bound int :=
 Arguments mul_itv_boundr_subdef /.
 
 Lemma mul_itv_boundl_subproof b1 b2 (x1 x2 : R) :
-  (BLeft 0%Z <= b1 -> BLeft 0%Z <= b2 ->
+  (BLeft 0%:Z <= b1 -> BLeft 0%:Z <= b2 ->
    Itv.map_itv_bound intr b1 <= BLeft x1 ->
    Itv.map_itv_bound intr b2 <= BLeft x2 ->
    Itv.map_itv_bound intr (mul_itv_boundl_subdef b1 b2) <= BLeft (x1 * x2))%O.
@@ -579,7 +579,7 @@ case: b1 => [[|p1]|p1].
 Qed.
 
 Lemma mul_itv_boundr'_subproof b1 b2 (x1 x2 : R) :
-  (BLeft 0%R <= BLeft x1 -> BRight 0%Z <= b2 ->
+  (BLeft 0%:R <= BLeft x1 -> BRight 0%:Z <= b2 ->
    BRight x1 <= Itv.map_itv_bound intr b1 ->
    BRight x2 <= Itv.map_itv_bound intr b2 ->
    BRight (x1 * x2) <= Itv.map_itv_bound intr (mul_itv_boundr_subdef b1 b2))%O.

--- a/theories/itv.v
+++ b/theories/itv.v
@@ -2,7 +2,7 @@
 From Coq Require Import ssreflect ssrfun ssrbool.
 From mathcomp Require Import ssrnat eqtype choice order ssralg ssrnum ssrint.
 From mathcomp Require Import interval mathcomp_extra.
-From mathcomp.classical Import boolp.
+From mathcomp.classical Require Import boolp.
 Require Import signed.
 
 (******************************************************************************)

--- a/theories/itv.v
+++ b/theories/itv.v
@@ -2,7 +2,8 @@
 From Coq Require Import ssreflect ssrfun ssrbool.
 From mathcomp Require Import ssrnat eqtype choice order ssralg ssrnum ssrint.
 From mathcomp Require Import interval mathcomp_extra.
-Require Import boolp signed.
+From mathcomp.classical Import boolp.
+Require Import signed.
 
 (******************************************************************************)
 (* This file develops tools to make the manipulation of numbers within        *)

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -1852,8 +1852,8 @@ End open_closed_sets.
 #[global] Hint Extern 0 (closed _) => now apply: closed_le : core.
 #[global] Hint Extern 0 (closed _) => now apply: closed_eq : core.
 
-Section at_left_right_pmNormedZmod.
-Variable (R : numFieldType) (V : pseudoMetricNormedZmodType R).
+Section at_left_right.
+Variable R : numFieldType.
 
 Definition at_left (x : R) := within (fun u => u < x) (nbhs x).
 Definition at_right (x : R) := within (fun u => x < u) (nbhs x).
@@ -1930,8 +1930,42 @@ Lemma nbhs_left_ge x z : z < x -> \forall y \near x^'-, z <= y.
 Proof. by move=> xz; near do apply/ltW; apply: nbhs_left_gt.
 Unshelve. all: by end_near. Qed.
 
+End at_left_right.
+#[global] Typeclasses Opaque at_left at_right.
+Notation "x ^'-" := (at_left x) : classical_set_scope.
+Notation "x ^'+" := (at_right x) : classical_set_scope.
+
+Section at_left_right_topologicalType.
+Variables (R : numFieldType) (V : topologicalType) (f : R -> V) (x : R).
+
+Lemma cvg_at_right_filter : f z @[z --> x] --> f x -> f z @[z --> x^'+] --> f x.
+Proof. exact: (@cvg_within_filter _ _ _ (nbhs x)). Qed.
+
+Lemma cvg_at_left_filter : f z @[z --> x] --> f x -> f z @[z --> x^'-] --> f x.
+Proof. exact: (@cvg_within_filter _ _ _ (nbhs x)). Qed.
+
+Lemma cvg_at_right_within : f x @[x --> x^'+] --> f x ->
+  f x @[x --> within (fun u => x <= u) (nbhs x)] --> f x.
+Proof.
+move=> fxr U Ux; rewrite ?near_simpl ?near_withinE; near=> z; rewrite le_eqVlt.
+by move/predU1P => [<-|]; [exact: nbhs_singleton | near: z; exact: fxr].
+Unshelve. all: by end_near. Qed.
+
+Lemma cvg_at_left_within : f x @[x --> x^'-] --> f x ->
+  f x @[x --> within (fun u => u <= x) (nbhs x)] --> f x.
+Proof.
+move=> fxr U Ux; rewrite ?near_simpl ?near_withinE; near=> z; rewrite le_eqVlt.
+by move/predU1P => [->|]; [exact: nbhs_singleton | near: z; exact: fxr].
+Unshelve. all: by end_near. Qed.
+
+End at_left_right_topologicalType.
+
+Section at_left_right_pmNormedZmod.
+Variables (R : numFieldType) (V : pseudoMetricNormedZmodType R).
+
 Lemma nbhsr0P (P : set V) x :
-  (\forall y \near x, P y) <-> (\forall e \near 0^'+, forall y, `|x - y| <= e -> P y).
+  (\forall y \near x, P y) <->
+  (\forall e \near 0^'+, forall y, `|x - y| <= e -> P y).
 Proof.
 rewrite nbhs0P/= near_withinE/= !near_simpl.
 split=> /nbhs_norm0P[/= _/posnumP[e] /(_ _) Px]; apply/nbhs_norm0P.
@@ -1950,10 +1984,10 @@ Let cvgrP {F : set (set V)} {FF : Filter F} (y : V) : [<->
 Proof.
 tfae; first by move=> *; apply: cvgr_dist_le.
 - by move=> Fy; near do apply: Fy; apply: nbhs_right_gt.
-- move=> Fy; near=> e; near 0^'+ => d; near=> x.
+- move=> Fy; near=> e; near (0:R)^'+ => d; near=> x.
   rewrite (@le_lt_trans _ _ d)//; first by near: x; near: d.
   by near: d; apply: nbhs_right_lt; near: e; apply: nbhs_right_gt.
-- move=> Fy; apply/cvgrPdist_lt => e e_gt0; near 0^'+ => d.
+- move=> Fy; apply/cvgrPdist_lt => e e_gt0; near (0:R)^'+ => d.
   near=> x; rewrite (@lt_le_trans _ _ d)//; first by near: x; near: d.
   by near: d; apply: nbhs_right_le.
 Unshelve. all: by end_near. Qed.
@@ -2011,7 +2045,7 @@ Qed.
 Lemma cvgr_norm_lt {T} {F : set (set T)} {FF : Filter F} (f : T -> V) (y : V) :
   f @ F --> y -> forall u, `|y| < u -> \forall t \near F, `|f t| < u.
 Proof.
-move=> Fy z zy; near 0^'+ => k; near=> x; have : `|f x - y| < k.
+move=> Fy z zy; near (0:R)^'+ => k; near=> x; have : `|f x - y| < k.
   by near: x; apply: cvgr_distC_lt => //; near: k; apply: nbhs_right_gt.
 move=> /(le_lt_trans (ler_dist_dist _ _)) /real_ltr_normlW.
 rewrite realB// ltr_subl_addl => /(_ _)/lt_le_trans; apply => //.
@@ -2027,7 +2061,7 @@ Unshelve. all: by end_near. Qed.
 Lemma cvgr_norm_gt {T} {F : set (set T)} {FF : Filter F} (f : T -> V) (y : V) :
   f @ F --> y -> forall u, `|y| > u -> \forall t \near F, `|f t| > u.
 Proof.
-move=> Fy z zy; near 0^'+ => k; near=> x; have: `|f x - y| < k.
+move=> Fy z zy; near (0:R)^'+ => k; near=> x; have: `|f x - y| < k.
   by near: x; apply: cvgr_distC_lt => //; near: k; apply: nbhs_right_gt.
 move=> /(le_lt_trans (ler_dist_dist _ _)); rewrite distrC => /real_ltr_normlW.
 rewrite realB// ltr_subl_addl  -ltr_subl_addr => /(_ isT); apply: le_lt_trans.
@@ -2089,9 +2123,6 @@ Arguments cvgr_neq0 {R V T F FF f}.
 #[global] Hint Extern 0 (is_true (?x <= _)) => match goal with
   H : x \is_near _ |- _ => near: x; exact: nbhs_left_le end : core.
 
-#[global] Typeclasses Opaque at_left at_right.
-Notation "x ^'-" := (at_left x) : classical_set_scope.
-Notation "x ^'+" := (at_right x) : classical_set_scope.
 
 Section at_left_rightR.
 Variable (R : numFieldType).

--- a/theories/realfun.v
+++ b/theories/realfun.v
@@ -10,6 +10,10 @@ From HB Require Import structures.
 (******************************************************************************)
 (* This file provides properties of standard real-valued functions over real  *)
 (* numbers (e.g., the continuity of the inverse of a continuous function).    *)
+(*                                                                            *)
+(*   derivable_oo_continuous_bnd f x y == f is derivable on `]x, y[ and       *)
+(*                                        continuous up to the boundary       *)
+(*                                                                            *)
 (******************************************************************************)
 
 Set Implicit Arguments.
@@ -23,6 +27,31 @@ Local Open Scope classical_set_scope.
 Local Open Scope ring_scope.
 
 Import numFieldNormedType.Exports.
+
+Section derivable_oo_continuous_bnd.
+Context {R : numFieldType} {V : normedModType R}.
+
+Definition derivable_oo_continuous_bnd (f : R -> V) (x y : R) :=
+  [/\ {in `]x, y[, forall x, derivable f x 1},
+      f @ x^'+ --> f x & f @ y^'- --> f y].
+
+Lemma derivable_oo_continuous_bnd_within (f : R -> V) (x y : R) :
+  derivable_oo_continuous_bnd f x y -> {within `[x, y], continuous f}.
+Proof.
+move=> [fxy fxr fyl]; apply/subspace_continuousP => z /=.
+rewrite in_itv/= => /andP[]; rewrite le_eqVlt => /predU1P[<-{z} xy|].
+  have := cvg_at_right_within fxr; apply: cvg_trans; apply: cvg_app.
+  by apply: within_subset => z/=; rewrite in_itv/= => /andP[].
+move=> /[swap].
+rewrite le_eqVlt => /predU1P[->{z} xy|zy xz].
+  have := cvg_at_left_within fyl; apply: cvg_trans; apply: cvg_app.
+  by apply: within_subset => z/=; rewrite in_itv/= => /andP[].
+apply: cvg_within_filter.
+apply/differentiable_continuous; rewrite -derivable1_diffP.
+by apply: fxy; rewrite in_itv/= xz zy.
+Qed.
+
+End derivable_oo_continuous_bnd.
 
 Section real_inverse_functions.
 Variable R : realType.


### PR DESCRIPTION
##### Motivation for this change

This is a continuation of PR #794 (I have duplicated the PR because it looks like I cannot push commits to it).
On top of PR #794, it introduces convex spaces and use the type `{i01 R}` from the PR #869.

This PR introduce convexs spaces, show that `lmodType` form instances, and use them to show that a function with a non-negative second derivative is convex (like the exponential function @hoheinzollern).

closes #794 

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
  (do not edit former entries, only append new ones, be careful:
   merge and rebase have a tendency to mess up `CHANGELOG_UNRELEASED.md`)
- [x] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
