### PR TITLE
conv -> line_path

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -24,6 +24,22 @@
   + `ErealGenCInfty.measurable_set1_ninfty` -> `ErealGenCInfty.measurable_set1Ny`
   + `ErealGenCInfty.measurable_set1_pinfty` -> `ErealGenCInfty.measurable_set1y`
 
+- in `set_interval.v`:
+  + `conv` -> `line_path`
+  + `conv_id` -> `line_path_id`
+  + `ndconv` -> `ndline_path`
+  + `convEl` -> `line_pathEl`
+  + `convEr` -> `line_pathEr`
+  + `conv10` -> `line_path10`
+  + `conv0` -> `line_path0`
+  + `conv1` -> `line_path1`
+  + `conv_sym` -> `line_path_sym`
+  + `conv_flat` -> `line_path_flat`
+  + `leW_conv` -> `leW_line_path`
+  + `convK` -> `line_pathK`
+  + `conv_inj` -> `line_path_inj`
+  + `conv_bij` -> `line_path_bij`
+
 ### Generalized
 
 ### Deprecated

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -36,9 +36,16 @@
   + `conv_sym` -> `line_path_sym`
   + `conv_flat` -> `line_path_flat`
   + `leW_conv` -> `leW_line_path`
+  + `ndconvE` -> `ndline_pathE`
   + `convK` -> `line_pathK`
   + `conv_inj` -> `line_path_inj`
   + `conv_bij` -> `line_path_bij`
+  + `le_conv` -> `le_line_path`
+  + `lt_conv` -> `lt_line_path`
+  + `conv_itv_bij` -> `line_path_itv_bij`
+  + `mem_conv_itv` -> `mem_line_path_itv`
+  + `mem_conv_itvcc` -> `mem_line_path_itvcc`
+  + `range_conv` -> `range_line_path`
 
 ### Generalized
 


### PR DESCRIPTION
##### Motivation for this change

This addresses the first part of issue #860 and can already be merged since is is moreover used in PR #873 
(that is just a renaming that anticipates in particular the fact that the operator of convex spaces in PR #873 is naturally called `conv`)

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- [x] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
