### PR TITLE
gen exp_fun

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -72,8 +72,8 @@
   + generalize `negligible` to `semiRingOfSetsType`
 - in `exp.v`:
   + new lemmas `power_pos_ge0`, `power_pos0`, `power_pos_eq0`,
-    `power_posM`, `power_posAC`, `power12_sqrt`, `power_pos_inv`,
-    `power_pos_intmul`
+    `power_posM`, `power_posAC`, `power12_sqrt`, `power_pos_inv1`,
+    `power_pos_inv`, `power_pos_intmul`
 - in `lebesgue_measure.v`:
   + lemmas `measurable_fun_ln`, `measurable_fun_power_pos`
 
@@ -86,9 +86,9 @@
   + weaken condition of `exp_funr1` and rename to `power_posr1`
   + weaken condition of `exp_fun_inv` and rename to `power_pos_inv`
   + `exp_fun1` -> `power_pos1`
-  + weaken condition of `ler_exp_fun` and rename to `ler_power_pos`
+  + rename `ler_exp_fun` to `ler_power_pos`
   + `exp_funD` -> `power_posD`
-  + `exp_fun_mulrn` -> `power_pos_mulrn`
+  + weaken condition of `exp_fun_mulrn` and rename to `power_pos_mulrn`
   + the notation ``` `^ ``` has now scope `real_scope`
   + weaken condition of `riemannR_gt0` and `dvg_riemannR`
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -71,7 +71,8 @@
 - in `measure.v`:
   + generalize `negligible` to `semiRingOfSetsType`
 - in `exp.v`:
-  + new lemmas `power_pos_ge0`, `power_pos0`, `power12_sqrt`
+  + new lemmas `power_pos_ge0`, `power_pos0`, `power_pos_eq0`,
+    `power_posM`, `power_posAC`, `power12_sqrt`
 - in `lebesgue_measure.v`:
   + lemmas `measurable_fun_ln`, `measurable_fun_power_pos`
 
@@ -80,9 +81,9 @@
 - in `exp.v`:
   + generalize `exp_fun` and rename to `power_pos`
   + `exp_fun_gt0` has now a condition and is renamed to `power_pos_gt0`
+  + remove condition of `exp_funr0` and rename to `power_posr0`
   + weaken condition of `exp_funr1` and rename to `power_posr1`
   + weaken condition of `exp_fun_inv` and rename to `power_pos_inv`
-  + `exp_funr0` -> `power_posr0`
   + `exp_fun1` -> `power_pos1`
   + `ler_exp_fun` -> `ler_power_pos`
   + `exp_funD` -> `power_posD`

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -72,6 +72,8 @@
   + generalize `negligible` to `semiRingOfSetsType`
 - in `exp.v`:
   + new lemmas `power_pos_ge0`, `power_pos0`, `power12_sqrt`
+- in `lebesgue_measure.v`:
+  + lemmas `measurable_fun_ln`, `measurable_fun_power_pos`
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -72,7 +72,8 @@
   + generalize `negligible` to `semiRingOfSetsType`
 - in `exp.v`:
   + new lemmas `power_pos_ge0`, `power_pos0`, `power_pos_eq0`,
-    `power_posM`, `power_posAC`, `power12_sqrt`
+    `power_posM`, `power_posAC`, `power12_sqrt`, `power_pos_inv`,
+    `power_pos_intmul`
 - in `lebesgue_measure.v`:
   + lemmas `measurable_fun_ln`, `measurable_fun_power_pos`
 
@@ -85,7 +86,7 @@
   + weaken condition of `exp_funr1` and rename to `power_posr1`
   + weaken condition of `exp_fun_inv` and rename to `power_pos_inv`
   + `exp_fun1` -> `power_pos1`
-  + `ler_exp_fun` -> `ler_power_pos`
+  + weaken condition of `ler_exp_fun` and rename to `ler_power_pos`
   + `exp_funD` -> `power_posD`
   + `exp_fun_mulrn` -> `power_pos_mulrn`
   + the notation ``` `^ ``` has now scope `real_scope`

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -70,6 +70,23 @@
   + lemmas `eq_bigmax`, `eq_bigmin` changed to respect `P` in the returned type.
 - in `measure.v`:
   + generalize `negligible` to `semiRingOfSetsType`
+- in `exp.v`:
+  + new lemma `power_pos_ge0`
+
+### Changed
+
+- in `exp.v`:
+  + generalize `exp_fun` and rename to `power_pos`
+  + `exp_fun_gt0` has now a condition and is renamed to `power_pos_gt0`
+  + weaken condition of `exp_funr1` and rename to `power_posr1`
+  + weaken condition of `exp_fun_inv` and rename to `power_pos_inv`
+  + `exp_funr0` -> `power_posr0`
+  + `exp_fun1` -> `power_pos1`
+  + `ler_exp_fun` -> `ler_power_pos`
+  + `exp_funD` -> `power_posD`
+  + `exp_fun_mulrn` -> `power_pos_mulrn`
+  + the notation ``` `^ ``` has now scope `real_scope`
+  + weaken condition of `riemannR_gt0` and `dvg_riemannR`
 
 ### Renamed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -71,7 +71,7 @@
 - in `measure.v`:
   + generalize `negligible` to `semiRingOfSetsType`
 - in `exp.v`:
-  + new lemma `power_pos_ge0`
+  + new lemmas `power_pos_ge0`, `power_pos0`, `power12_sqrt`
 
 ### Changed
 

--- a/theories/exp.v
+++ b/theories/exp.v
@@ -592,10 +592,10 @@ rewrite /power_pos => a0; case: ifPn => [/eqP//|h].
 by rewrite mul1r lnK// posrE lt_neqAle eq_sym h.
 Qed.
 
-Lemma power_posr0 a : 0 < a -> a `^ 0 = 1.
+Lemma power_posr0 a : a != 0 -> a `^ 0 = 1.
 Proof.
 move=> a0; rewrite /power_pos mul0r expR0; case: ifPn => //.
-by rewrite eq_le leNgt a0.
+by move: a0 => /eqP ane0 /eqP a0 //.
 Qed.
 
 Lemma power_pos0 : power_pos 0 = fun=> 0.
@@ -604,10 +604,34 @@ Proof. by apply/funext => x; rewrite /power_pos eqxx. Qed.
 Lemma power_pos1 : power_pos 1 = fun=> 1.
 Proof. by apply/funext => x; rewrite /power_pos oner_eq0 ln1 mulr0 expR0. Qed.
 
+Lemma power_pos_eq0 x p : x `^ p = 0 -> x = 0.
+Proof.
+rewrite /power_pos. have [->|_] := eqVneq x 0 => //.
+by move: (expR_gt0 (p * ln x)) => /gt_eqF /eqP.
+Qed.
+
 Lemma ler_power_pos a : 1 < a -> {homo power_pos a : x y / x <= y}.
 Proof.
 move=> a1 x y xy.
 by rewrite /power_pos gt_eqF ?(le_lt_trans _ a1)// ler_expR ler_pmul2r// ln_gt0.
+Qed.
+
+Lemma power_posM x y r : 0 <= x -> 0 <= y -> (x * y) `^ r = x `^ r * y `^ r.
+Proof.
+rewrite 2!le_eqVlt.
+move=> /orP [/eqP <-|x0] /orP [/eqP <-|y0];
+  rewrite ?mul0r ?mulr0 ?power_pos0 ?mul0r ?mulr0 //.
+rewrite /power_pos gt_eqF ?mulr_gt0 // !gt_eqF //.
+by rewrite lnM ?posrE // -expRD mulrDr.
+Qed.
+
+Lemma power_posC x y z :  (x `^ y) `^ z = (x `^ z) `^ y.
+Proof. rewrite /power_pos.
+have [x0|x0] := eqVneq x 0.
+ by rewrite ln0 // ifT // ifT.
+rewrite gt_eqF; last exact: expR_gt0.
+rewrite gt_eqF; last exact: expR_gt0.
+by rewrite !expK 2!mulrA (mulrC z).
 Qed.
 
 Lemma power_posD a : 0 < a -> {morph power_pos a : x y / x + y >-> x * y}.
@@ -618,12 +642,13 @@ Proof.
 rewrite le_eqVlt => /predU1P[<-|a0]; first by rewrite invr0 /power_pos eqxx.
 apply/(@mulrI _ a); first by rewrite unitfE gt_eqF.
 rewrite -[X in X * _ = _](power_posr1 (ltW a0)) -power_posD // subrr.
-by rewrite power_posr0 // divrr // unitfE gt_eqF.
+by rewrite power_posr0; [rewrite divrr // unitfE gt_eqF|apply lt0r_neq0].
 Qed.
 
 Lemma power_pos_mulrn a n : 0 < a -> a `^ n%:R = a ^+ n.
 Proof.
-move=> a0; elim: n => [|n ih]; first by rewrite mulr0n expr0 power_posr0.
+move=> a0; elim: n => [|n ih].
+  by rewrite mulr0n expr0 power_posr0//; apply lt0r_neq0.
 by rewrite -natr1 exprSr power_posD// ih power_posr1// ltW.
 Qed.
 

--- a/theories/exp.v
+++ b/theories/exp.v
@@ -649,7 +649,16 @@ Qed.
 Lemma power_posD a : 0 < a -> {morph power_pos a : x y / x + y >-> x * y}.
 Proof. by move=> a0 x y; rewrite /power_pos gt_eqF// mulrDl expRD. Qed.
 
-Lemma power_pos_inv a : 0 <= a -> a `^ (-1) = a ^-1.
+Lemma power_pos_mulrn a n : 0 <= a -> a `^ n%:R = a ^+ n.
+Proof.
+move=> a0; elim: n => [|n ih].
+  by rewrite mulr0n expr0 power_posr0//; apply: lt0r_neq0.
+move: a0; rewrite le_eqVlt => /predU1P[<-|a0].
+  by rewrite !power_pos0 mulrn_eq0/= oner_eq0/= expr0n.
+by rewrite -natr1 power_posD// ih power_posr1// ?exprS 1?mulrC// ltW.
+Qed.
+
+Lemma power_pos_inv1 a : 0 <= a -> a `^ (-1) = a ^-1.
 Proof.
 rewrite le_eqVlt => /predU1P[<-|a0].
   by rewrite power_pos0 invr0 oppr_eq0 oner_eq0.
@@ -658,13 +667,23 @@ rewrite -[X in X * _ = _](power_posr1 (ltW a0)) -power_posD // subrr.
 by rewrite power_posr0 divff// gt_eqF.
 Qed.
 
-Lemma power_pos_mulrn a n : 0 <= a -> a `^ n%:R = a ^+ n.
+Lemma power_pos_inv a n : 0 <= a -> a `^ (- n%:R) = a ^- n.
 Proof.
 move=> a0; elim: n => [|n ih].
-  by rewrite mulr0n expr0 power_posr0//; apply: lt0r_neq0.
+  by rewrite -mulNrn mulr0n power_posr0 -exprVn expr0.
 move: a0; rewrite le_eqVlt => /predU1P[<-|a0].
-  by rewrite !power_pos0 mulrn_eq0/= oner_eq0/= expr0n.
-by rewrite -natr1 power_posD// ih power_posr1// ?exprS 1?mulrC// ltW.
+  by rewrite power_pos0 oppr_eq0 mulrn_eq0 oner_eq0 orbF exprnN exp0rz oppr_eq0.
+rewrite -natr1 opprD power_posD// (power_pos_inv1 (ltW a0)) ih.
+by rewrite -[in RHS]exprVn exprS [in RHS]mulrC exprVn.
+Qed.
+
+Lemma power_pos_intmul a (z : int) : 0 <= a -> a `^ z%:~R = a ^ z.
+Proof.
+move=> a0; have [z0|z0] := leP 0 z.
+  rewrite -[in RHS](gez0_abs z0) abszE -exprnP -power_pos_mulrn//.
+  by rewrite natr_absz -abszE gez0_abs.
+rewrite -(opprK z) (_ : - z = `|z|%N); last by rewrite ltz0_abs.
+by rewrite -exprnN -power_pos_inv// nmulrn.
 Qed.
 
 Lemma power12_sqrt a : 0 <= a -> a `^ (2^-1) = Num.sqrt a.

--- a/theories/exp.v
+++ b/theories/exp.v
@@ -598,6 +598,9 @@ move=> a0; rewrite /power_pos mul0r expR0; case: ifPn => //.
 by rewrite eq_le leNgt a0.
 Qed.
 
+Lemma power_pos0 : power_pos 0 = fun=> 0.
+Proof. by apply/funext => x; rewrite /power_pos eqxx. Qed.
+
 Lemma power_pos1 : power_pos 1 = fun=> 1.
 Proof. by apply/funext => x; rewrite /power_pos oner_eq0 ln1 mulr0 expR0. Qed.
 
@@ -612,7 +615,7 @@ Proof. by move=> a0 x y; rewrite /power_pos gt_eqF// mulrDl expRD. Qed.
 
 Lemma power_pos_inv a : 0 <= a -> a `^ (-1) = a ^-1.
 Proof.
-rewrite le_eqVlt => /orP[/eqP <-|a0]; first by rewrite invr0 /power_pos eqxx.
+rewrite le_eqVlt => /predU1P[<-|a0]; first by rewrite invr0 /power_pos eqxx.
 apply/(@mulrI _ a); first by rewrite unitfE gt_eqF.
 rewrite -[X in X * _ = _](power_posr1 (ltW a0)) -power_posD // subrr.
 by rewrite power_posr0 // divrr // unitfE gt_eqF.
@@ -622,6 +625,17 @@ Lemma power_pos_mulrn a n : 0 < a -> a `^ n%:R = a ^+ n.
 Proof.
 move=> a0; elim: n => [|n ih]; first by rewrite mulr0n expr0 power_posr0.
 by rewrite -natr1 exprSr power_posD// ih power_posr1// ltW.
+Qed.
+
+Lemma power12_sqrt a : 0 <= a -> a `^ (2^-1) = Num.sqrt a.
+Proof.
+rewrite le_eqVlt => /predU1P[<-|a0]; first by rewrite power_pos0 sqrtr0.
+have /eqP : (a `^ (2^-1)) ^+ 2 = (Num.sqrt a) ^+ 2.
+  rewrite sqr_sqrtr; last exact: ltW.
+  by rewrite /power_pos gt_eqF// -expRMm mulrA divrr ?mul1r ?unitfE// lnK.
+rewrite eqf_sqr => /predU1P[//|/eqP h].
+have : 0 < a `^ 2^-1 by apply: power_pos_gt0.
+by rewrite h oppr_gt0 ltNge sqrtr_ge0.
 Qed.
 
 End PowerPos.
@@ -640,7 +654,7 @@ Proof. by move=> ?; rewrite /riemannR invr_gt0 power_pos_gt0. Qed.
 
 Lemma dvg_riemannR a : 0 <= a <= 1 -> ~ cvg (series (riemannR a)).
 Proof.
-case/andP => a0; rewrite le_eqVlt => /orP[/eqP ->|a1].
+case/andP => a0; rewrite le_eqVlt => /predU1P[->|a1].
   rewrite (_ : riemannR 1 = harmonic); first exact: dvg_harmonic.
   by rewrite funeqE => i /=; rewrite power_posr1.
 have : forall n, harmonic n <= riemannR a n.

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -5,7 +5,7 @@ From mathcomp.classical Require Import boolp classical_sets functions.
 From mathcomp.classical Require Import cardinality fsbigop mathcomp_extra.
 Require Import reals ereal signed topology numfun normedtype.
 From HB Require Import structures.
-Require Import sequences esum measure real_interval realfun.
+Require Import sequences esum measure real_interval realfun exp.
 
 (******************************************************************************)
 (*                            Lebesgue Measure                                *)
@@ -1630,7 +1630,7 @@ rewrite -(addrA (f x * g x *+ 2)) -opprB opprK (addrC (g x ^+ 2)) addrK.
 by rewrite -(mulr_natr (f x * g x)) -(mulrC 2) mulrA mulVr ?mul1r// unitfE.
 Qed.
 
-Lemma measurable_fun_max  D f g :
+Lemma measurable_fun_max D f g :
   measurable_fun D f -> measurable_fun D g -> measurable_fun D (f \max g).
 Proof.
 move=> mf mg mD; apply (measurability (RGenCInfty.measurableE R)) => //.
@@ -1699,6 +1699,36 @@ apply: (@measurable_fun_lim_sup _ h) => // t Dt.
 Qed.
 
 End measurable_fun_realType.
+
+Lemma measurable_fun_ln (R : realType) : measurable_fun [set~ (0:R)] (@ln R).
+Proof.
+rewrite (_ : [set~ 0] = `]-oo, 0[ `|` `]0, +oo[); last first.
+  by rewrite -(setCitv `[0, 0]); apply/seteqP; split => [|]x/=;
+    rewrite in_itv/= -eq_le eq_sym; [move/eqP/negbTE => ->|move/negP/eqP].
+apply/measurable_funU; [exact: measurable_itv|exact: measurable_itv|split].
+- apply/(@measurable_restrict _ _ _ _ _ setT)=> //; first exact: measurable_itv.
+  rewrite (_ : _ \_ _ = cst (0:R)); first exact: measurable_fun_cst.
+  apply/funext => y; rewrite patchE.
+  by case: ifPn => //; rewrite inE/= in_itv/= => y0; rewrite ln0// ltW.
+- have : {in `]0, +oo[%classic, continuous (@ln R)}.
+    by move=> x; rewrite inE/= in_itv/= andbT => x0; exact: continuous_ln.
+  rewrite -continuous_open_subspace; last exact: interval_open.
+  by move/subspace_continuous_measurable_fun; apply; exact: measurable_itv.
+Qed.
+
+Lemma measurable_fun_power_pos (R : realType) p :
+  measurable_fun [set: R] (@power_pos R ^~ p).
+Proof.
+apply: measurable_fun_if => //.
+- apply: (measurable_fun_bool true); rewrite (_ : _ @^-1` _ = [set 0])//.
+  by apply/seteqP; split => [_ /eqP ->//|_ -> /=]; rewrite eqxx.
+- exact: measurable_fun_cst.
+- rewrite setTI; apply: (@measurable_fun_comp _ _ _ _ _ _ setT) => //.
+    by apply: continuous_measurable_fun; exact: continuous_expR.
+  rewrite (_ : _ @^-1` _ = [set~ 0]); last first.
+    by apply/seteqP; split => [x [/negP/negP/eqP]|x x0]//=; exact/negbTE/eqP.
+  by apply: measurable_funrM; exact: measurable_fun_ln.
+Qed.
 
 Section standard_emeasurable_fun.
 Variable R : realType.


### PR DESCRIPTION
- rename to power_pow
- fix doc
- add scope to notation

##### Motivation for this change

We @hoheinzollern @t6s needed a bit more general version of `exp_fun` for PR #790 and PR #516 
(in particular to define a power function with extended reals)

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- [x] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
