### PR TITLE
Draft: HB for kinds of topologies

### DIFF
--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -1026,6 +1026,29 @@ End open_closed_sets.
 #[global] Hint Extern 0 (closed _) => now apply: closed_le : core.
 #[global] Hint Extern 0 (closed _) => now apply: closed_eq : core.
 
+Section field_order_topology.
+
+Context {R : realFieldType}.
+
+Lemma rft_nbhs_order (x : R) : nbhs x = order_nbhs x.
+Proof.
+rewrite eqEsubset; split => A.
+  case => eps Peps /filterS; apply; first exact: order_nbhs_filter.
+  exists (Some (x-eps), Some (x + eps)).
+    by rewrite /= ?in_itv /= (ltr_distlC, =^~ltr_distlC) subrr normrE.
+  by move=> t /=; rewrite in_itv real_ltr_distlC // num_real.
+case; case=> l r lritv /filterS; apply; case: r lritv; case: l => /=.
+- by move=> a b ?; apply: open_nbhs_nbhs; split => //; apply: interval_open.
+- move=> ? ?; apply: open_nbhs_nbhs; split => //.
+- move=> a ?; apply: open_nbhs_nbhs; split => //. 
+  have := @open_gt _ a; congr (open _); rewrite eqEsubset. 
+  by split => ? /=; rewrite in_itv /= andbT.
+- move=> ?; exact: filterT.
+Qed.
+
+HB.instance Definition _ := Nbhs_isOrderTopology.Build _ R rft_nbhs_order.
+End field_order_topology.
+
 Section at_left_right_pmNormedZmod.
 Variable (R : numFieldType) (V : pseudoMetricNormedZmodType R).
 

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -2257,8 +2257,23 @@ by move=> p q /(_ _ _ (discrete_set1 p) (discrete_set1 q))[x [] -> ->].
 Qed.
 *)
 
+Section bool_topology.
 HB.instance Definition _ := DiscreteTopological.copy bool 
   (discrete_topology bool).
+
+Lemma bool_order_nbhs : forall (b : bool), nbhs b = order_nbhs b.
+Proof.
+case; rewrite principal_nbhsE /=; rewrite eqEsubset; split => A.
+- move/principal_filterP => At; exists (Some false, None); rewrite ?in_itv //=.
+  by case.
+- by case => /= ? ? iA; apply/principal_filterP; apply: iA.
+- move/principal_filterP => At; exists (None, Some true); rewrite ?in_itv //=.
+  by case.
+- by case => /= ? ? iA; apply/principal_filterP; apply: iA.
+Qed.
+
+HB.instance Definition _ := Nbhs_isOrderTopology.Build _ bool bool_order_nbhs.
+End bool_topology.
 
 (* TODO MOVE 
 Lemma bool_compact : compact [set: bool].

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -2189,7 +2189,6 @@ HB.instance Definition _ := Nbhs_isNbhsTopological.Build
   M order_nbhs_filter order_nbhs_singleton order_nbhs_nbhs.
 HB.instance Definition _ := Nbhs_isOrderTopology.Build 
   d M (fun x => erefl).
-HB.instance Definition _ := OrderTopological.on M.
 End order_topology.
 
 Module EndowOrderTopology.
@@ -2199,87 +2198,73 @@ End EndowOrderTopology.
 
 
 (* Discrete Topology*)
-(*
 HB.mixin Record Nbhs_isDiscreteTopology M of Nbhs M := {
   principal_nbhsE : forall (x : M), nbhs x = principal_filter x}.
 
 #[short(type="discreteTopologicalType")]
 HB.structure Definition DiscreteTopological := 
   {M of Topological M & Nbhs_isDiscreteTopology M }.
-*)
+
 Lemma principal_nbhs_nbhs {M : Type} (m : M) A :
   principal_filter m A -> principal_filter m (principal_filter^~ A).
 Proof. by move=> ?; apply/principal_filterP. Qed.
 
 Lemma principal_sing {M : Type} (p : M) A : principal_filter p A -> A p.
 Proof. by move=> /principal_filterP. Qed.
-(*
-HB.instance Definition asdf := @Nbhs.Class 
-  discrete_topology P1 P2 P3 P5 P6.
-HB.instance Definition _ := Nbhs.on discrete_topology.
 
+Definition discrete_topology (M : pointedType) : Type := M.
+
+Section discrete_topology.
+Context {M' : pointedType}.
+
+Local Notation M := (discrete_topology M').
+
+HB.instance Definition _ := Pointed.on M.
+HB.instance Definition _ := hasNbhs.Build M principal_filter.
 HB.instance Definition _ := Nbhs_isNbhsTopological.Build 
-  discrete_topology principal_filter_proper principal_sing principal_nbhs_nbhs.
-
+  M principal_filter_proper principal_sing principal_nbhs_nbhs.
 HB.instance Definition _ := Nbhs_isDiscreteTopology.Build 
   M (fun x => erefl).
+End discrete_topology.
 
-HB.instance Definition _ := DiscreteTopological.on M. 
-HB.end.
-End DiscreteTopology.
-
-Section endow_bool.
-Local Import DiscreteTopology.
-HB.instance Definition _ := (DiscreteTopology.Endow.Build bool).
-End endow_bool.
-
-*)
-(*
-Lemma discrete_nbhs (p : X) (A : set X) :
-  principal_filter p A -> principal_filter p (principal_filter^~ A).
-Proof. by move=> ?; exact/principal_filterP. Qed.
-
-End DiscreteMixin.
-
-Definition discrete_space (X : topologicalType) :=
-  @nbhs X _ = @principal_filter X.
-
-Context {X : topologicalType} {dsc: discrete_space X}.
+Section discrete_topologies.
+Context {X : discreteTopologicalType}.
 
 Lemma discrete_open (A : set X) : open A.
 Proof.
-by rewrite openE => ? ?; rewrite /interior dsc; exact/principal_filterP.
+rewrite openE => ? ?; rewrite /interior principal_nbhsE. 
+exact/principal_filterP.
 Qed.
 
 Lemma discrete_set1 (x : X) : nbhs x [set x].
-Proof. by apply open_nbhs_nbhs; split => //; exact: discrete_open. Qed.
+Proof. by apply: open_nbhs_nbhs; split => //; exact: discrete_open. Qed.
 
+(* TODO MOVE 
 Lemma discrete_closed (A : set X) : closed A.
 Proof. by rewrite -[A]setCK closedC; exact: discrete_open. Qed.
-
+*)
 Lemma discrete_cvg (F : set_system X) (x : X) :
   Filter F -> F --> x <-> F [set x].
 Proof.
-rewrite dsc nbhs_simpl; split; first by exact.
+rewrite principal_nbhsE nbhs_simpl; split; first by exact.
 by move=> Fx U /principal_filterP ?; apply: filterS Fx => ? ->.
 Qed.
 
+(* TODO MOVE
 Lemma discrete_hausdorff : hausdorff_space X.
 Proof.
 by move=> p q /(_ _ _ (discrete_set1 p) (discrete_set1 q))[x [] -> ->].
 Qed.
+*)
 
-HB.instance Definition _ := Nbhs_isNbhsTopological.Build bool
-  principal_filter_proper discrete_sing discrete_nbhs.
+HB.instance Definition _ := DiscreteTopological.copy bool 
+  (discrete_topology bool).
 
-Lemma discrete_bool : discrete_space [the topologicalType of bool : Type].
-Proof. by []. Qed.
-
+(* TODO MOVE 
 Lemma bool_compact : compact [set: bool].
 Proof. by rewrite setT_bool; apply/compactU; exact: compact_set1. Qed.
-
-End DiscreteTopology.
 *)
+
 (* Topology on nat *)
 
 Section nat_topologicalType.


### PR DESCRIPTION
##### Motivation for this change
Experimenting with hierarchy build to add more specific kinds of topologies directly into the hierarchy. We now have the ability to prove state and prove things like "for bool, the discrete and order topology agree" and similarly in `R` with the norm and order.

This will unlock a ton of refactoring. For example, all the variations of `cvgnyP` will collapse to a single "refines the right-ray topology" type. Lots of stuff about separation axioms (discrete implies hausdorff implies T0, etc) all get inferred.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`
  (do not edit former entries, only append new ones, be careful:
   merge and rebase have a tendency to mess up `CHANGELOG_UNRELEASED.md`)
- [ ] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and put a milestone if possible.
