### PR TITLE
power function for extended real numbers

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -69,6 +69,13 @@
   + definition `sqrte`
   + lemmas `sqrte0`, `sqrte_ge0`, `lee_sqrt`, `sqrteM`, `sqr_sqrte`,
     `sqrte_sqr`, `sqrte_fin_num`
+- in `exp.v`:
+  + lemma `ln_power_pos`
+  + definition `powere_pos`, notation ``` _ `^ _ ``` in `ereal_scope`
+  + lemmas `powere_pos_EFin`, `powere_posyr`, `powere_pose0`,
+    `powere_pose1`, `powere_posNyr` `powere_pos0r`, `powere_pos1r`,
+    `powere_posNyr`, `fine_powere_pos`, `powere_pos_ge0`,
+    `powere_pos_gt0`, `powere_pos_eq0`, `powere_posM`, `powere12_sqrt`
 
 ### Changed
 
@@ -133,6 +140,8 @@
 - in `lebesgue_measure.v`:
   + lemmas `emeasurable_itv_bnd_pinfty`, `emeasurable_itv_ninfty_bnd`
     (use `emeasurable_itv` instead)
+- in `measure.v`:
+  + lemma `measurable_fun_ext`
 
 ### Removed
 

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -1726,7 +1726,7 @@ apply: measurable_fun_if => //.
 - rewrite setTI; apply: (@measurable_fun_comp _ _ _ _ _ _ setT) => //.
     by apply: continuous_measurable_fun; exact: continuous_expR.
   rewrite (_ : _ @^-1` _ = [set~ 0]); last first.
-    by apply/seteqP; split => [x [/negP/negP/eqP]|x x0]//=; exact/negbTE/eqP.
+    by apply/seteqP; split => [x /negP/negP/eqP|x x0]//=; exact/negbTE/eqP.
   by apply: measurable_funrM; exact: measurable_fun_ln.
 Qed.
 
@@ -1890,7 +1890,7 @@ Lemma emeasurable_fun_cvg D (f_ : (T -> \bar R)^nat) (f : T -> \bar R) :
 Proof.
 move=> mf_ f_f; have fE x : D x -> f x = lim_esup (f_^~ x).
   by move=> Dx; have /cvg_lim  <-// := @cvg_esups _ (f_^~x) (f x) (f_f x Dx).
-apply: (measurable_fun_ext (fun x => lim_esup (f_ ^~ x))) => //.
+apply: (eq_measurable_fun (fun x => lim_esup (f_ ^~ x))) => //.
   by move=> x; rewrite inE => Dx; rewrite fE.
 exact: measurable_fun_lim_esup.
 Qed.

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -1023,10 +1023,8 @@ Proof. exact: measurable_fun_comp. Qed.
 Lemma eq_measurable_fun D (f g : T1 -> T2) :
   {in D, f =1 g} -> measurable_fun D f -> measurable_fun D g.
 Proof.
-move=> Dfg Df mD A mA; rewrite (_ : D `&` _ = D `&` f @^-1` A); first exact: Df.
-apply/seteqP; rewrite /preimage; split => [x /= [Dx Agx]|x /= [Dx Afx]].
-  by split=> //; rewrite Dfg// inE.
-by split=> //; rewrite -Dfg// inE.
+by move=> fg mf mD A mA; rewrite [X in measurable X](_ : _ = D `&` f @^-1` A);
+  [exact: mf|exact/esym/eq_preimage].
 Qed.
 
 Lemma measurable_fun_cst D (r : T2) : measurable_fun D (cst r : T1 -> _).
@@ -1061,13 +1059,6 @@ Qed.
 Lemma measurable_funTS D (f : T1 -> T2) :
   measurable_fun setT f -> measurable_fun D f.
 Proof. exact: measurable_funS. Qed.
-
-Lemma measurable_fun_ext D (f g : T1 -> T2) :
-  {in D, f =1 g} -> measurable_fun D f -> measurable_fun D g.
-Proof.
-by move=> fg mf mD A mA; rewrite [X in measurable X](_ : _ = D `&` f @^-1` A);
-  [exact: mf|exact/esym/eq_preimage].
-Qed.
 
 Lemma measurable_restrict D E (f : T1 -> T2) :
   measurable D -> measurable E -> D `<=` E ->
@@ -1127,7 +1118,9 @@ have [-> _|-> _|-> _ |-> _] := subset_set2 YT.
 Qed.
 
 End measurable_fun.
-Arguments measurable_fun_ext {d1 d2 T1 T2 D} f {g}.
+Arguments eq_measurable_fun {d1 d2 T1 T2 D} f {g}.
+#[deprecated(since="mathcomp-analysis 0.6.2", note="renamed `eq_measurable_fun`")]
+Notation measurable_fun_ext := eq_measurable_fun.
 Arguments measurable_fun_bool {d1 T1 D f} b.
 
 Section measurability.


### PR DESCRIPTION
##### Motivation for this change

generalize `power_pos` to extended real numbers

taken from PR #790

~~waiting for PR #887 to prove powere12_sqrt~~

fixes #883 

@hoheinzollern @t6s @proux01 

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
  (only append to minimize problems when merging/rebasing)
  (you can consider the use of `etc/changes.sh` to generate the changelog)
- [x] added corresponding documentation in the headers

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 2.0

<!-- MathComp-Analysis is compatible with MathComp < 2.0 (branch `master`) and
     MathComp 2.0 ([branch `hierarchy-builder`](https://github.com/math-comp/analysis/pull/698)).

     If this PR targets `master` and if it is merged, the merged commit will also be
     cherry-picked on the branch `hierarchy-builder`.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `hierarchy-builder` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: HB port to record divergences between `master` and `hierarchy-builder` -->

- [x] I added the label `TODO: HB port` to make sure someone ports this PR to
      the `hierarchy-builder` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
