### PR TITLE
Hb uniform pseudometric

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -83,6 +83,15 @@
     `discrete_zero_dimension`, `zero_dimension_totally_disconnected`, 
     `totally_disconnected_cvg`, and `totally_disconnected_prod`.
 
+- in file `topology.v`,
+  + new definitions `split_sym`, `gauge`, `gauge_uniformType_mixin`, 
+    `gauge_topologicalTypeMixin`, `gauge_filtered`, `gauge_topologicalType`, 
+    `gauge_uniformType`, `gauge_psuedoMetric_mixin`, and 
+    `gauge_psuedoMetricType`.
+  + new lemmas `iter_split_ent`, `gauge_ent`, `gauge_filter`, 
+    `gauge_refl`, `gauge_inv`, `gauge_split`, `gauge_countable_uniformity`, and 
+    `uniform_pseudometric_sup`.
+
 ### Changed
 
 - in `mathcomp_extra.v`

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -250,6 +250,9 @@ Require Import reals signed.
 (*                                                                            *)
 (*                      [locally P] := forall a, A a -> G (within A (nbhs x)) *)
 (*                                     if P is convertible to G (globally A)  *)
+(*              quotient_topology Q == the quotient topology corresponding to *)
+(*                                     quotient Q : quotType T where T has    *)
+(*                                     type topologicalType                   *)
 (*                                                                            *)
 (* * Function space topologies :                                              *)
 (*     {uniform` A -> V} == The space U -> V, equipped with the topology of   *)
@@ -296,6 +299,12 @@ Require Import reals signed.
 (*                sup_uniformType == the uniform space for sup topologies     *)
 (*         countable_uniformity T == T's entourage has a countable base. This *)
 (*                                   is equivalent to `T` being metrizable    *)
+(*                        gauge E == For an entourage E, gauge E is a filter  *)
+(*                                   which includes `iter n split_ent E`.     *)
+(*                                   Critically, `gauge E` forms a uniform    *)
+(*                                   space with a countable uniformity        *)
+(*       gauge_psuedoMetricType E == the pseudoMetricType associated with the *)
+(*                                   `gauge E`                                *)
 (*                                                                            *)
 (* * PseudoMetric spaces :                                                    *)
 (*                entourage_ ball == entourages defined using balls           *)
@@ -322,9 +331,6 @@ Require Import reals signed.
 (*                     close x y <-> x and y are arbitrarily close w.r.t. to  *)
 (*                                   balls.                                   *)
 (*          weak_pseudoMetricType == the metric space for weak topologies     *)
-(*            quotient_topology Q == the quotient topology corresponding to   *)
-(*                                   quotient Q : quotType T. where T has     *)
-(*                                   type topologicalType                     *)
 (*                                                                            *)
 (* * Complete uniform spaces :                                                *)
 (*                      cauchy F <-> the set of sets F is a cauchy filter     *)
@@ -6777,6 +6783,105 @@ by move=> A [x _ <-]; exact: compact_set1.
 Qed.
 
 End UniformPointwise.
+
+Section gauges.
+
+Let split_sym {T : uniformType} (W : set (T * T)) :=
+  (split_ent W) `&` (split_ent W)^-1.
+
+Section entourage_gauge.
+Context {T : uniformType} (E : set (T * T)) (entE : entourage E).
+
+Definition gauge :=
+  filter_from [set: nat] (fun n => iter n split_sym (E `&` E^-1)).
+
+Lemma iter_split_ent j : entourage (iter j split_sym (E `&` E^-1)).
+Proof. by elim: j => [|i IH]; exact: filterI. Qed.
+
+Lemma gauge_ent A : gauge A -> entourage A.
+Proof.
+case=> n; elim: n A; first by move=> ? _ /filterS; apply; apply: filterI.
+by move=> n ? A _ /filterS; apply; apply: filterI; have ? := iter_split_ent n.
+Qed.
+
+Lemma gauge_filter : Filter gauge.
+Proof.
+apply: filter_from_filter; first by exists 0%N.
+move=> i j _ _; wlog ilej : i j / (i <= j)%N.
+  by move=> WH; have [|/ltnW] := leqP i j;
+    [|rewrite (setIC (iter _ _ _))]; exact: WH.
+exists j => //; rewrite subsetI; split => //; elim: j i ilej => [i|j IH i].
+  by rewrite leqn0 => /eqP ->.
+rewrite leq_eqVlt => /predU1P[<-//|/ltnSE/IH]; apply: subset_trans.
+by move=> x/= [jx _]; apply: split_ent_subset => //; exact: iter_split_ent.
+Qed.
+
+Lemma gauge_refl A : gauge A -> [set fg | fg.1 = fg.2] `<=` A.
+Proof.
+case=> n _; apply: subset_trans => -[_ a]/= ->.
+by apply: entourage_refl; exact: iter_split_ent.
+Qed.
+
+Lemma gauge_inv A : gauge A -> gauge (A^-1)%classic.
+Proof.
+case=> n _ EA; apply: (@filterS _ _ _ (iter n split_sym (E `&` E^-1))).
+- exact: gauge_filter.
+- by case: n EA; last move=> n; move=> EA [? ?] [/=] ? ?; exact: EA.
+- by exists n .
+Qed.
+
+Lemma gauge_split A : gauge A -> exists2 B, gauge B & B \; B `<=` A.
+Proof.
+case => n _ EA; exists (iter n.+1 split_sym (E `&` E^-1)); first by exists n.+1.
+apply: subset_trans EA; apply: subset_trans; first last.
+  by apply: subset_split_ent; exact: iter_split_ent.
+by case=> a c [b] [] ? ? [] ? ?; exists b.
+Qed.
+
+Definition gauge_uniformType_mixin :=
+ UniformMixin gauge_filter gauge_refl gauge_inv gauge_split erefl.
+
+Definition gauge_topologicalTypeMixin :=
+  topologyOfEntourageMixin gauge_uniformType_mixin.
+
+Definition gauge_filtered := FilteredType T T (nbhs_ gauge).
+Definition gauge_topologicalType :=
+  TopologicalType gauge_filtered gauge_topologicalTypeMixin.
+Definition gauge_uniformType := UniformType
+  gauge_topologicalType gauge_uniformType_mixin.
+
+Lemma gauge_countable_uniformity : countable_uniformity gauge_uniformType.
+Proof.
+exists [set iter n split_sym (E `&` E^-1) | n in [set: nat]].
+split; [exact: card_image_le | by move=> W [n] _ <-; exists n|].
+by move=> D [n _ ?]; exists (iter n split_sym (E `&` E^-1)).
+Qed.
+
+Definition gauge_pseudoMetric_mixin {R : realType} :=
+  @countable_uniform_pseudoMetricType_mixin R _ gauge_countable_uniformity.
+
+Definition gauge_pseudoMetricType {R : realType} :=
+  PseudoMetricType gauge_uniformType (@gauge_pseudoMetric_mixin R).
+
+End entourage_gauge.
+
+Lemma uniform_pseudometric_sup {R : realType} {T : uniformType} :
+    @entourage T = @sup_ent T {E : set (T * T) | @entourage T E}
+  (fun E => Uniform.class (@gauge_pseudoMetricType T (projT1 E) (projT2 E) R)).
+Proof.
+rewrite eqEsubset; split => [E entE|E].
+  exists E => //=.
+  pose pe : {classic {E0 : set (T * T) | _}} * _ := (exist _ E entE, E).
+  have entPE : `[< @entourage (gauge_uniformType entE) E >].
+    by apply/asboolP; exists 0%N => // ? [].
+  exists (fset1 (exist _ pe entPE)) => //=; first by move=> ?; rewrite in_setE.
+  by rewrite set_fset1 bigcap_set1.
+case=> W /= [/= J] _ <- /filterS; apply; apply: filter_bigI => -[] [] [] /= D.
+move=> entD G /[dup] /asboolP [n _ + _ _] => /filterS; apply.
+exact: iter_split_ent.
+Qed.
+
+End gauges.
 
 Section ArzelaAscoli.
 Context {X : topologicalType}.

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -6784,7 +6784,8 @@ Qed.
 
 End UniformPointwise.
 
-Section gauges.
+Module gauge.
+Section gauge.
 
 Let split_sym {T : uniformType} (W : set (T * T)) :=
   (split_ent W) `&` (split_ent W)^-1.
@@ -6838,50 +6839,46 @@ apply: subset_trans EA; apply: subset_trans; first last.
 by case=> a c [b] [] ? ? [] ? ?; exists b.
 Qed.
 
-Definition gauge_uniformType_mixin :=
- UniformMixin gauge_filter gauge_refl gauge_inv gauge_split erefl.
+Let gauged : Type := T.
 
-Definition gauge_topologicalTypeMixin :=
-  topologyOfEntourageMixin gauge_uniformType_mixin.
+HB.instance Definition _ := Pointed.on gauged.
+HB.instance Definition _ :=
+  @isUniform.Build gauged gauge gauge_filter gauge_refl gauge_inv gauge_split.
 
-Definition gauge_filtered := FilteredType T T (nbhs_ gauge).
-Definition gauge_topologicalType :=
-  TopologicalType gauge_filtered gauge_topologicalTypeMixin.
-Definition gauge_uniformType := UniformType
-  gauge_topologicalType gauge_uniformType_mixin.
-
-Lemma gauge_countable_uniformity : countable_uniformity gauge_uniformType.
+Lemma gauge_countable_uniformity : countable_uniformity gauged.
 Proof.
 exists [set iter n split_sym (E `&` E^-1) | n in [set: nat]].
 split; [exact: card_image_le | by move=> W [n] _ <-; exists n|].
 by move=> D [n _ ?]; exists (iter n split_sym (E `&` E^-1)).
 Qed.
 
-Definition gauge_pseudoMetric_mixin {R : realType} :=
-  @countable_uniform_pseudoMetricType_mixin R _ gauge_countable_uniformity.
+Definition type := countable_uniform.type gauge_countable_uniformity.
 
-Definition gauge_pseudoMetricType {R : realType} :=
-  PseudoMetricType gauge_uniformType (@gauge_pseudoMetric_mixin R).
+#[export] HB.instance Definition _ := Uniform.on type.
+#[export] HB.instance Definition _ {R : realType} : PseudoMetric R _ := 
+  PseudoMetric.on type.
 
 End entourage_gauge.
+End gauge.
+Module Exports. HB.reexport. End Exports.
+End gauge.
+Export gauge.Exports.
 
 Lemma uniform_pseudometric_sup {R : realType} {T : uniformType} :
     @entourage T = @sup_ent T {E : set (T * T) | @entourage T E}
-  (fun E => Uniform.class (@gauge_pseudoMetricType T (projT1 E) (projT2 E) R)).
+  (fun E => Uniform.class (@gauge.type T (projT1 E) (projT2 E))).
 Proof.
 rewrite eqEsubset; split => [E entE|E].
   exists E => //=.
   pose pe : {classic {E0 : set (T * T) | _}} * _ := (exist _ E entE, E).
-  have entPE : `[< @entourage (gauge_uniformType entE) E >].
+  have entPE : `[< @entourage (gauge.type entE) E >].
     by apply/asboolP; exists 0%N => // ? [].
   exists (fset1 (exist _ pe entPE)) => //=; first by move=> ?; rewrite in_setE.
   by rewrite set_fset1 bigcap_set1.
 case=> W /= [/= J] _ <- /filterS; apply; apply: filter_bigI => -[] [] [] /= D.
 move=> entD G /[dup] /asboolP [n _ + _ _] => /filterS; apply.
-exact: iter_split_ent.
+exact: gauge.iter_split_ent.
 Qed.
-
-End gauges.
 
 Section ArzelaAscoli.
 Context {X : topologicalType}.
@@ -7117,6 +7114,5 @@ move=> lcpt; split => [[Wid ectsW]|[fWf]pcptW].
   exact: pointwise_precompact_equicontinuous.
 split; last exact: precompact_equicontinuous.
 exact: precompact_pointwise_precompact.
-Qed.
-
+Qed. 
 End ArzelaAscoli.


### PR DESCRIPTION
##### Motivation for this change

Following the module pattern used with `countable_uniformity`, this ports #857 to HB.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 2.0

<!-- MathComp-Analysis is compatible with MathComp < 2.0 (branch `master`) and
     MathComp 2.0 ([branch `hierarchy-builder`](https://github.com/math-comp/analysis/pull/698)).

     If this PR targets `master` and if it is merged, the merged commit will also be
     cherry-picked on the branch `hierarchy-builder`.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `hierarchy-builder` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: HB port to record divergences between `master` and `hierarchy-builder` -->

- [ ] I added the label `TODO: HB port` to make sure someone ports this PR to
      the `hierarchy-builder` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
