### PR TITLE
Curry is continuous

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -22,7 +22,6 @@
   + definition `near_covering_within`
   + lemma `near_covering_withinP`
   + lemma `compact_setM`
-  + definition `regular`
   + lemma `compact_regular`
   + lemma `fam_compact_nbhs`
   + definition `compact_open`, notation `{compact-open, U -> V}`

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -13,10 +13,45 @@
 - in `lebesgue_integral.v`:
   + `sigma_finite_measure` instance on product measure `\x`
 
+- in `topology.v`:
+  + lemma `filter_bigI_within`
+  + lemma `near_powerset_map`
+  + lemma `near_powerset_map_monoE`
+  + lemma `fst_open`
+  + lemma `snd_open`
+  + definition `near_covering_within`
+  + lemma `near_covering_withinP`
+  + lemma `compact_setM`
+  + definition `regular`
+  + lemma `compact_regular`
+  + lemma `fam_compact_nbhs`
+  + definition `compact_open`, notation `{compact-open, U -> V}`
+  + notation `{compact-open, F --> f}`
+  + definition `compact_openK`
+  + definition `compact_openK_nbhs`
+  + instance `compact_openK_nbhs_filter`
+  + definition `compact_openK_topological_mixin`
+  + canonicals `compact_openK_filter`, `compact_openK_topological`,
+	`compact_open_pointedType`
+  + definition `compact_open_topologicalType`
+  + canonicals `compact_open_filtered`, `compact_open_topological`
+  + lemma `compact_open_cvgP`
+  + lemma `compact_open_open`
+  + lemma `compact_closedI`
+  + lemma `compact_open_fam_compactP`
+  + lemma `compact_equicontinuous`
+  + lemma `uniform_regular`
+  + lemma `continuous_curry`
+  + lemma `continuous_uncurry_regular`
+  + lemma `continuous_uncurry`
+  + lemma `curry_continuous`
+  + lemma `uncurry_continuous`
+
 ### Changed
 
 - in `topology.v`:
   + lemmas `nbhsx_ballx` and `near_ball` take a parameter of type `R` instead of `{posnum R}`
+  + lemma `pointwise_compact_cvg`
 
 ### Renamed
 

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -6725,14 +6725,14 @@ Unshelve. all: by end_near. Qed.
 
 (* It turns out {family compact, U -> V} can be generalized to only assume    *)
 (* `topologicalType` on V. This topology is called the compact-open topology. *)
-(* This topology is special becaise its the _only_  topology that will allow  *)
+(* This topology is special becaise it _only_ topology that will allow        *)
 (* curry/uncurry to be continuous.                                            *)
 
 Section compact_open.
 
 Context {T U : topologicalType}.
 
-Definition compact_open := (T->U)^o.
+Definition compact_open : Type := T->U.
 
 Section compact_open_setwise.
 Context {K : set T}.
@@ -6801,7 +6801,7 @@ Qed.
 Lemma compact_open_open (K : set T) (O : set U) :
   compact K -> open O -> open ([set g | g @` K `<=` O] : set compact_open).
 Proof.
-pose C := [set g | g @` K `<=` O]; move=> cptK oO.
+pose C := [set g | g @` K `<=` O]; move=> cptK oO. 
 exists [set C]; last by rewrite bigcup_set1.
 move=> ? ->; exists (fset1 C) => //; last by rewrite set_fset1 bigcap_set1.
 by move=> ?; rewrite ?inE => ->; exists (existT _ _ cptK) => // z Cz; exists O.
@@ -6831,43 +6831,41 @@ Lemma compact_open_fam_compactP (f : U -> V) (F : set (set (U -> V))) :
   continuous f -> (Filter F) ->
   {compact-open, F --> f} <-> {family compact, F --> f}.
 Proof.
-move=> ctsf FF; split.
-  move/compact_open_cvgP=> cptOF; apply/cvg_sup; case=> K cptK R.
-  case=> D /= [[E oE <- /=] Ekf] /filterS; apply.
-  move: oE; rewrite openE => /(_ _ Ekf); case => ? [J entJ /=] EKR KfE.
-  near=> z; apply/KfE/EKR; case => u /= Kp.
-  rewrite /= /set_val /= /eqincl /incl/set_val /= /comp.
-  (have Ku : K u by rewrite inE in Kp); move: u Ku {D Kp}; near: z.
-  move/compact_near_coveringP/near_covering_withinP:(cptK); apply.
-  move=> u Ku; near (powerset_filter_from (@entourage V)) => E'.
-  have entE' : entourage E' by exact: (near (near_small_set _)).
-  pose C := f@^-1`(to_set E' (f u))%classic.
-  pose B := \bigcup_(z in K `&` closure C) interior (to_set E' (f z)).
-  have oB : open B by apply: bigcup_open => ? ?; exact: open_interior.
-  have fKB : f @` (K `&` closure C) `<=` B.
-    move=> ? [z ? <-]; exists z => //; rewrite /interior.
-    by rewrite -nbhs_entourageE; exists E'.
-  have cptKC : compact (K `&` closure C).
-    apply: compact_closedI => //; exact: closed_closure.
-  have := cptOF (K `&` closure C) B cptKC oB fKB.
-  exists (C, [set g | [set g x | x in K `&` closure C] `<=` B]).
-  split.
-  - by apply: (ctsf) => //; rewrite /filter_of -nbhs_entourageE; exists E'.
-  - exact: cptOF.
-  - case=> z h /= [Cz KB Kz].
-    case: (KB (h z)); first by (exists z; split => //; apply: subset_closure).
-    move=> w [Kw Cw /interior_subset Jfwhz]; apply:subset_split_ent => //.
-    exists (f w); last apply:(near (small_ent_sub _) E') => //.
-    apply: subset_split_ent => //; exists (f u).
-      apply entourage_sym; apply:(near (small_ent_sub _) E') => //.
-    have [] := Cw (f@^-1` (to_set E' (f w))).
-      by apply: ctsf; rewrite /= -nbhs_entourageE; exists E'.
-    move=> r [Cr /= Ewr]; apply: subset_split_ent => //; exists (f r).
-      by apply:(near (small_ent_sub _) E') => //.
-    by apply entourage_sym; apply:(near (small_ent_sub _) E') => //.
-move=> cptF; apply/compact_open_cvgP => K O cptK oO fKO.
-apply: cptF; have := fam_compact_nbhs oO fKO cptK ctsf; apply: filter_app.
-by near=> g => /=  gKO ? [z Kx <-]; apply: gKO.
+move=> ctsf FF; split; first last.
+  move=> cptF; apply/compact_open_cvgP => K O cptK oO fKO.
+  apply: cptF; have := fam_compact_nbhs oO fKO cptK ctsf; apply: filter_app.
+  by near=> g => /=  gKO ? [z Kx <-]; apply: gKO.
+move/compact_open_cvgP=> cptOF; apply/cvg_sup; case=> K cptK R.
+case=> D [[E oE <-] Ekf] /filterS; apply.
+move: oE; rewrite openE => /(_ _ Ekf); case => ? [J entJ] EKR KfE.
+near=> z; apply/KfE/EKR; case => u Kp; rewrite /= /set_val /= /eqincl /incl.
+(have Ku : K u by rewrite inE in Kp); move: u Ku {D Kp}; near: z.
+move/compact_near_coveringP/near_covering_withinP:(cptK); apply.
+move=> u Ku; near (powerset_filter_from (@entourage V)) => E'.
+have entE' : entourage E' by exact: (near (near_small_set _)).
+pose C := f@^-1`(to_set E' (f u)).
+pose B := \bigcup_(z in K `&` closure C) interior (to_set E' (f z)).
+have oB : open B by apply: bigcup_open => ? ?; exact: open_interior.
+have fKB : f @` (K `&` closure C) `<=` B.
+  move=> ? [z ? <-]; exists z => //; rewrite /interior.
+  by rewrite -nbhs_entourageE; exists E'.
+have cptKC : compact (K `&` closure C).
+  by apply: compact_closedI => //; exact: closed_closure.
+have := cptOF (K `&` closure C) B cptKC oB fKB.
+exists (C, [set g | [set g x | x in K `&` closure C] `<=` B]). 
+  split; last exact: cptOF.
+  by apply: (ctsf) => //; rewrite /filter_of -nbhs_entourageE; exists E'.
+case=> z h /= [Cz KB Kz].
+case: (KB (h z)); first by (exists z; split => //; apply: subset_closure).
+move=> w [Kw Cw /interior_subset Jfwhz]; apply:subset_split_ent => //.
+exists (f w); last apply:(near (small_ent_sub _) E') => //.
+apply: subset_split_ent => //; exists (f u).
+  apply entourage_sym; apply:(near (small_ent_sub _) E') => //.
+have [] := Cw (f@^-1` (to_set E' (f w))).
+  by apply: ctsf; rewrite /= -nbhs_entourageE; exists E'.
+move=> r [Cr /= Ewr]; apply: subset_split_ent => //; exists (f r).
+  by apply:(near (small_ent_sub _) E') => //.
+by apply entourage_sym; apply:(near (small_ent_sub _) E') => //.
 Unshelve. all: by end_near. Qed.
 
 End compact_open_uniform.
@@ -8527,10 +8525,10 @@ Local Notation "U '~>' V" :=
 Context {U V W : topologicalType}.
 
 Lemma continuous_curry (f : U * V ~> W) :
-  continuous f -> continuous ((curry : ((U * V) ~> W) -> (U ~> V ~> W)) f).
+  continuous f -> continuous (curry f : (U ~> V ~> W)).
 Proof.
 move=> ctsf x; apply/compact_open_cvgP => K O /= cptK oO fKO.
-near=> z => /= w /= [+ + <-]; near: z.
+near=> z => w /= [+ + <-]; near: z.
 move/compact_near_coveringP/near_covering_withinP: cptK; apply.
 move=> v Kv; have [[P Q] [Px Qv] PQfO]: nbhs (x,v) (f@^-1` O).
   by apply: ctsf; move: oO; rewrite openE; apply; apply: fKO; exists v.
@@ -8538,32 +8536,25 @@ by exists (Q,P); [split => // |]; case=> b a /= [Qb Pa] Kb; apply: PQfO.
 Unshelve. all: by end_near. Qed.
 
 Lemma continuous_uncurry_regular (f : U ~> V ~> W):
-  locally_compact [set: V] ->
-  @regular V ->
-  continuous f ->
-  (forall u, continuous (f u)) ->
-  continuous ((uncurry : (U ~> V ~> W) -> ((U * V) ~> W)) f).
+  locally_compact [set: V] -> @regular V -> continuous f ->
+  (forall u, continuous (f u)) -> continuous (uncurry f : ((U * V) ~> W)).
 Proof.
-move=> lcV reg ctsf ctsfp /= [u v] D; rewrite /= nbhsE; case=> O [oO Ofuv].
-move/filterS; apply.
-have [B] := @lcV v I; rewrite withinET; move=> Bv [cptB clB].
+move=> lcV reg cf cfp /= [u v] D; rewrite /= nbhsE; case=> O [oO Ofuv] /filterS.
+apply; have [B] := @lcV v I; rewrite withinET; move=> Bv [cptB clB].
 have [R Rv RO] : exists2 R, nbhs v R &  (forall z, closure R z -> O (f u z)).
-  have [] := reg v ((f u)@^-1` O); first by apply: ctsfp; exact: open_nbhs_nbhs.
-  by move=> R nR cRO; exists R.
+  have [] := reg v ((f u)@^-1` O); first by apply: cfp; exact: open_nbhs_nbhs.
+  by move=> R ? ?; exists R.
 exists (f @^-1` ([set g | g @` (B `&` closure R) `<=` O]), (B `&` closure R)).
-  split; [apply/ctsf/open_nbhs_nbhs; split | apply: filterI].
+  split; [apply/cf/open_nbhs_nbhs; split | apply: filterI] => //.
   - apply: compact_open_open => //; apply: compact_closedI => //.
     exact: closed_closure.
   - by move=> ? [x [? + <-]]; apply: RO.
-  - done.
   - by apply: filterS; [exact: subset_closure|].
 by case=> a r /= [fBMO [Br] cmR]; apply: fBMO; exists r.
 Qed.
 
 Lemma continuous_uncurry (f : U ~> V ~> W):
-  locally_compact [set: V] ->
-  hausdorff_space V ->
-  continuous f ->
+  locally_compact [set: V] -> hausdorff_space V -> continuous f ->
   (forall u, continuous (f u)) ->
   continuous ((uncurry : (U ~> V ~> W) -> ((U * V) ~> W)) f).
 Proof.
@@ -8572,9 +8563,7 @@ move=> v; have [B] := @lcV v I; rewrite withinET; move=> Bv [cptB clB].
 by move=> z; apply: (@compact_regular V hsdf v B).
 Qed.
 
-Lemma curry_continuous (f : U * V ~> W) :
-  continuous f ->
-  @regular U ->
+Lemma curry_continuous (f : U * V ~> W) : continuous f -> @regular U ->
   {for f, continuous ((curry : ((U * V) ~> W) -> (U ~> V ~> W)))}.
 Proof.
 move=> ctsf regU; apply/compact_open_cvgP.
@@ -8587,12 +8576,10 @@ suff : \forall x' \near u & i \near nbhs f, K x' ->
     (\bigcap_(i in [set` N]) i) (curry i x').
   apply: filter_app; near=> a b => + Ka => /(_ Ka) => ?.
   by exists (\bigcap_(i in [set` N]) i).
-apply: filter_bigI_within=> R RN.
-have /set_mem [[M cptM _]] := Asub _ RN.
+apply: filter_bigI_within=> R RN; have /set_mem [[M cptM _]] := Asub _ RN.
 have Rfu : R (curry f u) by exact: INf.
-case/(_ _ Rfu) => O [fMO oO] MOR.
-near=> p => /= Ki; apply: MOR => + [+ + <-] => _.
-move=> v Mv; move: v Mv Ki; near: p.
+case/(_ _ Rfu) => O [fMO oO] MOR; near=> p => /= Ki; apply: MOR => + [+ + <-].
+move=> _ v Mv; move: v Mv Ki; near: p.
 have umb : \forall y \near u, (forall b, M b -> nbhs (y, b) (f@^-1` O) ).
   move/compact_near_coveringP/near_covering_withinP : (cptM); apply => v Mv.
   have [[P Q] [Pu Qv] PQO] : nbhs (u,v) (f@^-1` O).
@@ -8603,26 +8590,23 @@ move/compact_near_coveringP/near_covering_withinP : (cptM); apply => v Mv.
 have [P' P'u cPO] := regU u _ umb.
 pose L := [set h | h @`((K `&` (closure P'))`*`M) `<=` O].
 exists (setT, (P' `*` L)).
-  split => //; first exact: filterT.
-  exists (P', L) => //; split => //.
+  split => //; [exact: filterT|]; exists (P', L) => //; split => //.
   apply: open_nbhs_nbhs; split; first apply: compact_open_open => //.
-    apply: compact_setM => //; apply: compact_closedI => //; exact: closed_closure.
+    apply: compact_setM => //; apply: compact_closedI => //.
+    exact: closed_closure.
   by move=> ? [[a b] [[Ka /cPO +] Mb <-]] => /(_ _ Mb)/nbhs_singleton.
 case => b [a h] [? [Pa] +] Ma Ka; apply.
 exists (a,b); split => //; split => //; apply/subset_closure => //.
 Unshelve. all: by end_near. Qed.
 
 Lemma uncurry_continuous (f : U ~> V ~> W) :
-  locally_compact [set: V] ->
-  @regular V ->
-  @regular U ->
-  continuous f ->
-  (forall u, continuous (f u)) ->
+  locally_compact [set: V] -> @regular V -> @regular U ->
+  continuous f -> (forall u, continuous (f u)) ->
   {for f, continuous ((uncurry : (U ~> V ~> W) -> (U * V ~> W)))}.
 Proof.
 move=> lcV regV regU ctsf ctsfp; apply/compact_open_cvgP.
   by apply: fmap_filter; exact:nbhs_filter.
-move=> /= K O cptK oO fKO; near=> h => /= ? [+ + <-]; near: h.
+move=> /= K O cptK oO fKO; near=> h => ? [+ + <-]; near: h.
 move/compact_near_coveringP/near_covering_withinP : (cptK); apply.
 case=> u v Kuv.
 have : exists P Q, [/\ closed P, compact Q, nbhs u P, nbhs v Q & P `*` Q `<=` uncurry f @^-1` O].
@@ -8631,18 +8615,15 @@ have : exists P Q, [/\ closed P, compact Q, nbhs u P, nbhs v Q & P `*` Q `<=` un
     by apply: fKO; exists (u,v).
   case=> /= P' Q' [P'u Q'v] PQO.
   have [B] := @lcV v I; rewrite withinET; move=> Bv [cptB clB].
-  have [P Pu cPP'] := regU u P' P'u.
-  have [Q Qv cQQ'] := regV v Q' Q'v.
+  have [P Pu cPP'] := regU u P' P'u; have [Q Qv cQQ'] := regV v Q' Q'v.
   exists (closure P), (B `&` closure Q); split.
   - exact: closed_closure.
   - by apply: compact_closedI => //; exact: closed_closure.
   - by apply: filterS; first exact: subset_closure.
   - by apply: filterI=> //; apply: filterS; first exact: subset_closure.
   - by case => a b [/cPP' ?] [_ /cQQ' ?]; exact: PQO.
-case=> P [Q [clP cptQ Pu Qv PQfO]].
-pose R := [set g : V ~> W | g @` Q `<=` O].
-have oR : open R by exact: compact_open_open.
-pose P' := f@^-1` R.
+case=> P [Q [clP cptQ Pu Qv PQfO]]; pose R := [set g : V ~> W | g @` Q `<=` O].
+(have oR : open R by exact: compact_open_open); pose P' := f@^-1` R.
 pose L := [set h : U ~> V ~> W | h @` (fst @` K `&` P) `<=` R].
 exists (((P`&` P') `*` Q), L).
   split => /=.
@@ -8655,9 +8636,8 @@ exists (((P`&` P') `*` Q), L).
     exact: cvg_fst.
   move=> /= ? [a [Pa ?] <-] ? [b Qb <-]. 
   by apply: (PQfO (a,b)); split => //; apply: nbhs_singleton. 
-case; case => a b h [/= [[Pa P'a] Bb Lh] Kab].
-move/(_ (h a)): Lh ; rewrite /L/=/R/=.
-apply; first by exists a => //; split => //; exists (a,b).
+case; case => a b h [/= [[? ?] ? Lh] ?].
+apply: (Lh (h a)); first by exists a => //; split => //; exists (a,b).
 by exists b.
 Unshelve. all: by end_near. Qed.
 End currying.

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -8329,14 +8329,12 @@ exact.
 Qed.
 
 Section currying.
+Context {U V W : uniformType}.
 
 Local Notation "U '~>' V" := 
   ({family compact, [topologicalType of U] -> [uniformType of V]}) 
   (at level 99,  right associativity).
 
-Section currying_pt1.
-Context {U V W : uniformType}.
- 
 Lemma continuous_snd (f : U ~> V ~> W) v :
   continuous f -> 
   (forall u, continuous (f u)) ->
@@ -8413,19 +8411,16 @@ Lemma curry_continuous (f : U * V ~> W) :
 Proof.
 move=> ctsf; apply/cvg_sup.
   by apply: fmap_filter; apply:nbhs_filter.
-case=> K cptK /=.
-move=> T /= [C1 [[C2 oR <- /= Rxcf RT]]]. 
+case=> K cptK T [C1 [[C2 oR <- Rxcf RT]]]. 
 move: oR; rewrite openE => /(_ _ Rxcf); case => C3 [E entE] EE' EKR.
-rewrite nbhs_simpl /=.
-move: entE => [O [/=]].
-move=> D dcpt <- IDE.
+move: entE => [O []] => D dcpt <- IDE; rewrite nbhs_simpl /=.
 near=> z; apply/RT/EKR/EE'; case=> w Kiw; have Kw : K w by rewrite inE in Kiw.
 apply: IDE; rewrite /= /set_val /= /eqincl /incl. 
-move: w Kw {Kiw C1 C2 Rxcf RT EKR C3 EE' O T}. near: z.
+move: w Kw {Kiw C1 C2 Rxcf RT EKR C3 EE' O T}; near: z.
 near_simpl; move/compact_near_coveringP/near_covering_withinP : (cptK).
-move=> /(_ _ (nbhs f)); apply => /= u Ku.
-apply: filter_bigI_within; case; case; case => /= J cptJ L /= /[dup] /asboolP entL ? _.
-case: entL => C1 [R /= entR] RC1 C1L.
+move=> /(_ _ (nbhs f)); apply => u Ku.
+apply: filter_bigI_within; (do 3 case) => J cptJ L /[dup] /asboolP entL ? _.
+case: entL => C1 [R entR] RC1 C1L.
 exists (setT, [set g | forall pq, (K `*` J) pq -> R (f pq, g pq)]).
   split; last apply: fam_nbhs => //; last exact: compact_setM.
   apply: filterT.

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -8654,3 +8654,4 @@ apply: (Lh (h a)); first by exists a => //; split => //; exists (a,b).
 by exists b.
 Unshelve. all: by end_near. Qed.
 End cartesian_closed.
+End currying.

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -8333,153 +8333,28 @@ apply/entourage_sym; apply: (near (small_ent_sub _) E') => //.
 apply: PQfE; split => //; exact: nbhs_singleton.
 Unshelve. all: by end_near. Qed.
 
-exists (setT , curry f x @^-1` [set g | forall (z:V), K z -> E (curry f x z, g z)]).
-have /filterS := @fam_nbhs _ W _ K _ (curry f x) entE cptK; apply.
-near: z.
-apply: (filterS RT); near=> z => /=.
-move=> z /= zke; apply/RT/EKR/EE'; case=> w Kw; have ? : K w by rewrite inE in Kw. 
-exact: zke.
-set F := fmap _ _.
-have [] := @pointwise_compact_cvg V W F (curry f x) _. 
-  rewrite /F; apply: near_map_powerset; first exact: equicontinuous_subset_id.
-  admit.
-have Pfc : {ptws, F --> curry f x}.
-  apply/cvg_sup => y D [/= ? [[E oE] <- /=] ecfxy /filterS]; apply.
-  have [[P Q] [Px Qy] PQfE] : nbhs (x, y) (f@^-1` E). 
-    by apply: ctsf; apply: open_nbhs_nbhs.
-  rewrite nbhs_simpl /= /F /=.
-  near=> z; rewrite /curry /=;  apply: PQfE => /=. 
-  by split; last exact: nbhs_singleton; apply (near Px z).
-move=> /(_ Pfc) + _ => /cvg_trans; apply.
-move=> T /= [? [[R oR <- /= Rxcf RT]]]. 
-move: oR; rewrite openE => /(_ _ Rxcf); case => E' [E entE] EE' EKR.
-have /filterS := @fam_nbhs _ W _ K _ (curry f x) entE cptK; apply.
-move=> z /= zke; apply/RT/EKR/EE'; case=> w Kw; have ? : K w by rewrite inE in Kw. 
-exact: zke.
-Qed.
-
-move oR; rewrite -nbhs_entourageE.
-rewrite /filter_of /= nbhs_simpl .
-congr (cvg_to _); rewrite /filter_of.
-move=> R /= [] /= E [[/= J oJ]] <- /= jsgl /filterS; apply.
-rewrite nbhs_simpl /=; near=> z => /=; near: z; near_simpl.
-  
-
-=> NR.
-near=> z => /=.
-near=> R.
-rewrite 
-apply/cvg_sup.
-  admit.
-move=> /(_ Pfc) + _.
-rewrite /cvg_to /= /GRing.regular.
-rewrite /filter_of /= ?nbhs_simpl /nbhs /fct_UniformFamilyFilteredType /=.
-rewrite /filter_of /=.
-rewrite /nbhs /=.
-congr(_ _).
-rewrite eqEsubset; split => Z /=.
-suff : @nbhs {family compact, V -> W}  (curry f x) = nbhs (curry f x : {ptws V -> W}) .
- 
-rewrite eqEsubset; split => R /=; rewrite /nbhs /=.
-
-simpl.
-apply P1.
-apply/Q.
-  apply/cvg_sup => y D [/= ? [[E oE] <- /=] ecfxy /filterS]; apply.
-  have [[P Q] [Px Qy] PQfE] : nbhs (x, y) (f@^-1` E). 
-    by apply: ctsf; apply: open_nbhs_nbhs.
-  rewrite nbhs_simpl /=; near=> z; rewrite /curry /=. 
-  by apply: PQfE => /=; split; last exact: nbhs_singleton; apply (near Px z).
-apply: near_map_powerset; first exact: equicontinuous_subset_id.
-have [A] := @lcU x I; rewrite withinET => nAx [cptA clA].
-exists [set W | nbhs x W /\ W `<=` A] => /=; first split.
-- by move=> ? [].
-- by move=> E1 E2 [nE1 E1A E2x ?]; split => //; apply: (subset_trans _ E1A).
-- by exists A; split.
-move=> B /= [Bx BA] y /= E entE; near=> z => + [ + + <-] => _; near: z.
-suff : \forall x0 \near y, forall x1 : U, closure B x1 -> 
-  E (f (x1, y), f (x1, x0)).
-  by apply: filter_app; apply: nearW=> ? + ? ?; apply; apply/subset_closure.
-have /compact_near_coveringP : compact (closure B).
-  apply: (subclosed_compact _ cptA); first exact: closed_closure.
-  by rewrite closure_id in clA; rewrite clA; apply: closure_subset.
-apply => x' clBx'; near (powerset_filter_from (@entourage W)) => E'.
-have entE' : entourage E' by exact: (near (near_small_set _)).
-have : nbhs (x' , y) (f@^-1` (to_set E' (f (x',y)))).
-  by apply: ctsf; rewrite /= -nbhs_entourageE; exists E'.
-case; case=> P Q /= [Px Qy] PQfE; exists (P, Q); first by split => //.
-case=> a b /= [Pa Qb]; apply: subset_split_ent => //.
-exists (f (x', y)); last by apply: (near (small_ent_sub _) E')=>//; exact: PQfE.
-apply/entourage_sym; apply: (near (small_ent_sub _) E') => //.
-by apply: PQfE; split => //; apply: nbhs_singleton.
-Unshelve. all: by end_near. Qed.
-
-Lemma continuous_snd (f : U ~> V ~> W) v :
-  continuous f -> 
-  (forall u, continuous (f u)) ->
-  continuous (fun q => f q v).
-Proof.
-move=> ctsf ctsfp x ?. 
-rewrite /= -nbhs_entourageE; case=> E entE /filterS; apply.
-rewrite ?nbhs_simpl /=; near=> z => /=; near: z.
-near (powerset_filter_from (@entourage W)) => E'.
-have entE' : entourage E' by exact: (near (near_small_set _)).
-have nvE' : nbhs v (f x @^-1` (to_set E' (f x v))). 
-  by apply: ctsfp; rewrite /= -nbhs_entourageE; exists E'.
-suff [O Ofx OE] : exists2 O, nbhs (f x) O & (forall g, O g -> E (f x v, g v)).
-  move/ctsf: Ofx; rewrite /= nbhs_simpl /=; apply: filter_app.
-  by near_simpl; near=> z => foz; apply: OE.
-exists [set g | forall z, [set v] z -> E (f x z, g z)].
-  by apply: fam_nbhs => //; exact: compact_set1.
-by move=> g; apply.
-Unshelve. all: by end_near. Qed.
-
 Lemma continuous_uncurry (f : U ~> V ~> W):
+  locally_compact [set: V] ->
   continuous f ->
   (forall u, continuous (f u)) ->
   continuous ((uncurry : (U ~> V ~> W) -> ((U * V) ~> W)) f).
 Proof.
-move=> ctsf ctsfp /= [u v] D /=. 
-rewrite -nbhs_entourageE; case => E entE /filterS; apply.
-have [A] := @lcU u I; rewrite withinET; move=> Au [cptA clA]. 
-have cptfA : compact (f @` A).
-  by apply: continuous_compact => //; apply: continuous_subspaceT.
-(*
-have ects : equicontinuous (f @` A) id.
-  by apply: compact_equicontinuous => //= g [? ? <-]; apply: ctsfp.
-*)
+move=> lcV ctsf ctsfp /= [u v] D /=; rewrite -nbhs_entourageE.
+case => E entE /filterS; apply.
+have [B] := @lcV v I; rewrite withinET; move=> Bv [cptB clB].
 near (powerset_filter_from (@entourage W)) => E'.
 have entE' : entourage E' by exact: (near (near_small_set _)).
-simpl.
-move=> Mv; exists ((fun q => f q v) @^-1` (to_set E' (f u v)) `&` A, M).
-split => //; apply: filterI => //; apply: continuous_snd => //=.
-case=> a b [/=] [fuav] Aa Mb.
-apply: subset_split_ent => //; exists (f a v) => /=; first last.
+have /ctsf /= cfN := @fam_nbhs _ _ _ B _ (f u : V ~> W) entE' cptB.
+exists (
+    f@^-1`[set g | forall y, B y -> E' (f u y, g y)],
+    f u @^-1` (to_set E' (f u v)) `&` B).
+  split => //; apply: filterI => //; apply: ctsfp. 
+  by rewrite /= -nbhs_entourageE /=; exists E'.
+case=> a b /= [Eua [Evb Bb]].
+apply: subset_split_ent => //; exists (f u b) => /=.
   apply: (near (small_ent_sub _) E') => //; apply: Mb; exists a => //.
-apply: (near (small_ent_sub _) E') => //.
+by apply: (near (small_ent_sub _) E') => //; apply: Eua.
 Unshelve. all: by end_near. Qed.
-
-End currying_pt1.
-Section currying_pt2.
-Context {U V : uniformType}.
-
-Local Notation "U '~>' V" := 
-  ({family compact, [topologicalType of U] -> [uniformType of V]}) 
-  (at level 99,  right associativity). 
-
-Hypothesis lcU : locally_compact [set: U].
-Hypothesis hsdfU : hausdorff_space U.
-
-Definition eval : ((U ~> V) * U) ~> V := fun fx => fx.1 fx.2.
-
-Lemma eval_continuous (f : U ~> V) (x : U) :
-  continuous f -> {for (f,x), continuous eval}.
-Proof.
-move=> ctsf.
-have : eval = curry 
-apply: curry_continuous.
-apply: uncurry
-
 
 Lemma curry_continuous (f : ((U * V) ~> W)) :
   continuous f -> 

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -1625,24 +1625,18 @@ Qed.
 
 #[global] Typeclasses Opaque within.
 
+Canonical within_filter_on T D (F : filter_on T) :=
+  FilterType (within D F) (within_filter _ _).
+
 Lemma filter_bigI_within T (I : choiceType) (D : {fset I}) (f : I -> set T)
   (F : set (set T)) (P : set T) :
   Filter F -> (forall i, i \in D -> F ([set j | P j -> f i j])) ->
   F ([set j | P j -> (\bigcap_(i in [set i | i \in D]) f i) j]).
 Proof. move=> FF FfD; exact: (@filter_bigI T I D f _ (within_filter P FF)). Qed.
-
-Canonical within_filter_on T D (F : filter_on T) :=
-  FilterType (within D F) (within_filter _ _).
 
 Definition subset_filter {T} (F : set (set T)) (D : set T) :=
   [set P : set {x | D x} | F [set x | forall Dx : D x, P (exist _ x Dx)]].
 Arguments subset_filter {T} F D _.
-
-Lemma filter_bigI_within T (I : choiceType) (D : {fset I}) (f : I -> set T)
-  (F : set (set T)) (P : set T) :
-  Filter F -> (forall i, i \in D -> F ([set j | P j -> f i j])) ->
-  F ([set j | P j -> (\bigcap_(i in [set i | i \in D]) f i) j]).
-Proof. move=> FF FfD; exact: (@filter_bigI T I D f _ (within_filter P FF)). Qed.
 
 Global Instance subset_filter_filter T F (D : set T) :
   Filter F -> Filter (subset_filter F D).
@@ -1726,12 +1720,12 @@ Qed.
 End NearSet.
 
 Lemma near_powerset_map {T U : Type} (f : T -> U) (F : set (set T))
-  (P : (set U) -> Prop) : 
+  (P : (set U) -> Prop) :
   ProperFilter F ->
-  (\forall y \near powerset_filter_from (f x @[x --> F]), P y) -> 
+  (\forall y \near powerset_filter_from (f x @[x --> F]), P y) ->
   (\forall y \near powerset_filter_from F, P (f @` y)).
 Proof.
-move=> FF [] G /= [Gf Gs [D GD GP]]. 
+move=> FF [] G /= [Gf Gs [D GD GP]].
 have PpF : ProperFilter (powerset_filter_from F).
   by apply: powerset_filter_from_filter.
 have /= := Gf _ GD; rewrite nbhs_simpl => FfD.
@@ -1743,13 +1737,13 @@ by move/image_subset/subset_trans; apply; apply: image_preimage_subset.
 Unshelve. all: by end_near. Qed.
 
 Lemma near_map_powerset {T U : Type} (f : T -> U) (F : set (set T))
-  (P : (set U) -> Prop) : 
+  (P : (set U) -> Prop) :
   (forall X Y, X `<=` Y -> P Y -> P X) ->
   ProperFilter F ->
   (\forall y \near powerset_filter_from F, P (f @` y)) ->
   (\forall y \near powerset_filter_from (f x @[x --> F]), P y).
 Proof.
-move=> Psub FF [] G /= [Gf Gs [D GD GP]]. 
+move=> Psub FF [] G /= [Gf Gs [D GD GP]].
 have PpF : ProperFilter (powerset_filter_from (f x @[x-->F])).
   by apply: powerset_filter_from_filter.
 have /= := Gf _ GD; rewrite nbhs_simpl => FfD.
@@ -3156,10 +3150,10 @@ Definition near_covering_within (K : set X) :=
   (forall x, K x -> \forall x' \near x & i \near F, K x' -> P i x') ->
   \near F, K `<=` P F.
 
-Lemma near_covering_withinP (K : set X): 
+Lemma near_covering_withinP (K : set X):
   near_covering_within K <-> near_covering K.
 Proof.
-split. 
+split.
   move=> cvrW I F P FF cvr.
   near=> i; suff : K `<=` (fun q : X => K q -> P i q).
     by move=> KKP k Kk; apply: KKP.
@@ -3169,7 +3163,7 @@ move=> cvrW I F P FF cvr.
 near=> i; suff : K `<=` (fun q : X => K q -> P i q).
   by move=> KKP k Kk; apply: KKP.
 near: i.
-have := (cvrW I F (fun i q => K q -> P i q) FF). 
+have := (cvrW I F (fun i q => K q -> P i q) FF).
 apply => x Kx; have := cvr x Kx; apply: filter_app.
 by near=> j => + ?; apply.
 Unshelve. all: by end_near. Qed.
@@ -3836,9 +3830,9 @@ move=> cptv Vx; apply: (@compact_cluster_set1 T x _ V) => //.
 rewrite eqEsubset; split; first last.
   move=> ? -> A B [C Cx CA /nbhs_singleton Bx]; exists x; split => //.
   by apply/CA/subset_closure; exact: nbhs_singleton.
-move=> y /=; apply: contraPeq; move: sep; rewrite open_hausdorff => /[apply]. 
+move=> y /=; apply: contraPeq; move: sep; rewrite open_hausdorff => /[apply].
 case; case=> B A /=; rewrite ?inE; case=> By Ax [oB oA BA0].
-apply/existsNP; exists (closure A); apply/existsNP; exists B; apply/not_implyP. 
+apply/existsNP; exists (closure A); apply/existsNP; exists B; apply/not_implyP.
 split; first by exists A => //; apply: open_nbhs_nbhs.
 apply/not_implyP; split; first by exact: open_nbhs_nbhs.
 apply/set0P/negP; rewrite negbK; apply/eqP/disjoints_subset.
@@ -6716,12 +6710,12 @@ Lemma fam_compact_nbhs {U : topologicalType} {V : uniformType}
   open O -> (f @` A `<=` O) -> compact A -> continuous f ->
   nbhs (f : {family compact, U -> V}) [set g | forall y, A y -> O (g y)].
 Proof.
-move=> oO fAO /[dup] ? /compact_near_coveringP/near_covering_withinP cfA ctsf. 
+move=> oO fAO /[dup] ? /compact_near_coveringP/near_covering_withinP cfA ctsf.
 near=> z => /=; (suff : A `<=` [set y | O (z y)] by exact); near: z.
-apply: cfA => x Ax; have : O (f x) by apply: fAO. 
-move: (oO); rewrite openE /= => /[apply] /[dup] /ctsf Ofx /=. 
+apply: cfA => x Ax; have : O (f x) by apply: fAO.
+move: (oO); rewrite openE /= => /[apply] /[dup] /ctsf Ofx /=.
 rewrite /interior -nbhs_entourageE; case => E entE EfO.
-exists (f @^-1` (to_set (split_ent E) (f x)), 
+exists (f @^-1` (to_set (split_ent E) (f x)),
     [set g | forall w, A w -> split_ent E (f w, g w)]).
   split => //=; last exact: fam_nbhs.
   by apply: ctsf; rewrite /= -nbhs_entourageE; exists (split_ent E).
@@ -6745,12 +6739,12 @@ Context {K : set T}.
 
 Definition compact_openK := let _ := K in compact_open.
 
-Definition compact_openK_nbhs (f : compact_openK) := 
-  filter_from 
-    [set O | f @` K `<=` O /\ open O] 
+Definition compact_openK_nbhs (f : compact_openK) :=
+  filter_from
+    [set O | f @` K `<=` O /\ open O]
     (fun O =>  [set g | g @` K `<=` O]).
 
-Global Instance compact_openK_nbhs_filter (f : compact_openK) : 
+Global Instance compact_openK_nbhs_filter (f : compact_openK) :
   ProperFilter (compact_openK_nbhs f).
 Proof.
 split; first by case=> g [gKO oO] /(_ f); apply.
@@ -6761,9 +6755,9 @@ move=> P Q [fKP oP] [fKQ oQ]; exists (P `&` Q); first split.
 by move=> g /= gPQ; split; apply: (subset_trans gPQ) => ? [].
 Qed.
 
-Program Definition compact_openK_topological_mixin : 
+Program Definition compact_openK_topological_mixin :
   Topological.mixin_of compact_openK_nbhs :=
-    @Topological.Mixin compact_openK compact_openK_nbhs 
+    @Topological.Mixin compact_openK compact_openK_nbhs
     (@open_of_nbhs _ compact_openK_nbhs) _ _ _.
 Next Obligation.
 move=> f; rewrite eqEsubset; split => A /=.
@@ -6773,26 +6767,26 @@ by case=> B [oB Bf /filterS]; apply; apply: oB.
 Qed.
 Next Obligation. done. Qed.
 
-Canonical compact_openK_filter := FilteredType 
+Canonical compact_openK_filter := FilteredType
   compact_openK compact_openK compact_openK_nbhs.
-Canonical compact_openK_topological := TopologicalType 
+Canonical compact_openK_topological := TopologicalType
   compact_openK compact_openK_topological_mixin.
 End compact_open_setwise.
 
-Canonical compact_open_pointedType : pointedType := 
+Canonical compact_open_pointedType : pointedType :=
   PointedType compact_open point.
 
-Definition compact_open_topologicalType : topologicalType := 
+Definition compact_open_topologicalType : topologicalType :=
   @sup_topologicalType _ (sigT (@compact T))
     (fun K => Topological.class (@compact_openK_topological (projT1 K))).
 
-Canonical compact_open_filtered := 
+Canonical compact_open_filtered :=
   [filteredType compact_open of compact_open for compact_open_topologicalType].
 
-Canonical compact_open_topological := 
+Canonical compact_open_topological :=
   [topologicalType of compact_open for compact_open_topologicalType].
 
-Lemma compact_open_cvgP (F : set (set (compact_open_topological))) 
+Lemma compact_open_cvgP (F : set (set (compact_open_topological)))
     (f : compact_open_topological) :
   Filter F ->
   (F --> f) <-> (forall K O, @compact T K -> @open U O -> f @` K `<=` O ->
@@ -6800,14 +6794,14 @@ Lemma compact_open_cvgP (F : set (set (compact_open_topological)))
 Proof.
 move=> FF; split.
   by move/cvg_sup => + K O cptK ? ? => /(_ (existT _ _ cptK)); apply; exists O.
-move=> fko; apply/cvg_sup; case=> A cptK O /= [C /= [fAC oC]]. 
+move=> fko; apply/cvg_sup; case=> A cptK O /= [C /= [fAC oC]].
 by move/filterS; apply; apply: fko.
 Qed.
 
 Lemma compact_open_open (K : set T) (O : set U) :
   compact K -> open O -> open ([set g | g @` K `<=` O] : set compact_open).
 Proof.
-pose C := [set g | g @` K `<=` O]; move=> cptK oO. 
+pose C := [set g | g @` K `<=` O]; move=> cptK oO.
 exists [set C]; last by rewrite bigcup_set1.
 move=> ? ->; exists (fset1 C) => //; last by rewrite set_fset1 bigcap_set1.
 by move=> ?; rewrite ?inE => ->; exists (existT _ _ cptK) => // z Cz; exists O.
@@ -6815,17 +6809,17 @@ Qed.
 
 End compact_open.
 
-Lemma compact_closedI {T : topologicalType} (A B : set T) : 
+Lemma compact_closedI {T : topologicalType} (A B : set T) :
   compact A -> closed B -> compact (A `&` B).
 Proof.
 move=> cptA clB F PF FAB; have FA : F A by move: FAB; apply: filterS.
-(have FB : F B by move: FAB; apply: filterS); have [x [Ax]] := cptA F PF FA. 
-move=> /[dup] clx; rewrite {1}clusterE => /(_ (closure B)); move: clB. 
+(have FB : F B by move: FAB; apply: filterS); have [x [Ax]] := cptA F PF FA.
+move=> /[dup] clx; rewrite {1}clusterE => /(_ (closure B)); move: clB.
 by rewrite closure_id => /[dup] + <- => <- /(_ FB) Bx; exists x; split.
 Qed.
 
 Notation "{ 'compact-open' , U -> V }" := (@compact_open U V).
-Notation "{ 'compact-open' , F --> f }" := 
+Notation "{ 'compact-open' , F --> f }" :=
   (F --> (f : @compact_open_topological _ _)).
 
 Section compact_open_uniform.
@@ -6834,10 +6828,10 @@ Context {U : topologicalType} {V : uniformType}.
 Let small_ent_sub := @small_set_sub _ (@entourage V).
 
 Lemma compact_open_fam_compactP (f : U -> V) (F : set (set (U -> V))) :
-  continuous f -> (Filter F) -> 
+  continuous f -> (Filter F) ->
   {compact-open, F --> f} <-> {family compact, F --> f}.
 Proof.
-move=> ctsf FF; split. 
+move=> ctsf FF; split.
   move/compact_open_cvgP=> cptOF; apply/cvg_sup; case=> K cptK R.
   case=> D /= [[E oE <- /=] Ekf] /filterS; apply.
   move: oE; rewrite openE => /(_ _ Ekf); case => ? [J entJ /=] EKR KfE.
@@ -6847,26 +6841,26 @@ move=> ctsf FF; split.
   move/compact_near_coveringP/near_covering_withinP:(cptK); apply.
   move=> u Ku; near (powerset_filter_from (@entourage V)) => E'.
   have entE' : entourage E' by exact: (near (near_small_set _)).
-  pose C := f@^-1`(to_set E' (f u))%classic. 
+  pose C := f@^-1`(to_set E' (f u))%classic.
   pose B := \bigcup_(z in K `&` closure C) interior (to_set E' (f z)).
   have oB : open B by apply: bigcup_open => ? ?; exact: open_interior.
   have fKB : f @` (K `&` closure C) `<=` B.
-    move=> ? [z ? <-]; exists z => //; rewrite /interior. 
+    move=> ? [z ? <-]; exists z => //; rewrite /interior.
     by rewrite -nbhs_entourageE; exists E'.
   have cptKC : compact (K `&` closure C).
     apply: compact_closedI => //; exact: closed_closure.
   have := cptOF (K `&` closure C) B cptKC oB fKB.
   exists (C, [set g | [set g x | x in K `&` closure C] `<=` B]).
-  split. 
+  split.
   - by apply: (ctsf) => //; rewrite /filter_of -nbhs_entourageE; exists E'.
-  - exact: cptOF. 
-  - case=> z h /= [Cz KB Kz]. 
+  - exact: cptOF.
+  - case=> z h /= [Cz KB Kz].
     case: (KB (h z)); first by (exists z; split => //; apply: subset_closure).
     move=> w [Kw Cw /interior_subset Jfwhz]; apply:subset_split_ent => //.
     exists (f w); last apply:(near (small_ent_sub _) E') => //.
     apply: subset_split_ent => //; exists (f u).
       apply entourage_sym; apply:(near (small_ent_sub _) E') => //.
-    have [] := Cw (f@^-1` (to_set E' (f w))). 
+    have [] := Cw (f@^-1` (to_set E' (f w))).
       by apply: ctsf; rewrite /= -nbhs_entourageE; exists E'.
     move=> r [Cr /= Ewr]; apply: subset_split_ent => //; exists (f r).
       by apply:(near (small_ent_sub _) E') => //.
@@ -8401,7 +8395,7 @@ move=> W; wlog Wf : f W / W f.
   by apply: (filterS _ FW) => z Wz; apply: subset_closure.
 move=> FW ectsW; split=> [ptwsF|]; last exact: pointwise_cvg_compact_family.
 apply/fam_cvgP => K ? U /=; rewrite uniform_nbhs => [[E [eE EsubU]]].
-suff : \forall g \near within W (nbhs (f : {ptws X -> Y})), 
+suff : \forall g \near within W (nbhs (f : {ptws X -> Y})),
     forall y, K y -> E (f y, g y).
   rewrite near_withinE; near_simpl => N; apply: (filter_app _ _ FW).
   by apply: ptwsF; near=> g => ?; apply: EsubU; apply: (near N g).
@@ -8509,37 +8503,34 @@ Qed.
 
 End ArzelaAscoli.
 
+Lemma uniform_regular {T : uniformType} : @regular T.
+Proof.
+move=> x R; rewrite /= -{1}nbhs_entourageE; case=> E entE ER.
+pose E' := (split_ent E); have ? : entourage E' by exact: entourage_split_ent.
+exists (to_set (E' `&` E'^-1%classic) x).
+  rewrite -nbhs_entourageE; exists (E' `&` E'^-1%classic) => //.
+  exact: filterI.
+move=> z /= clEz; apply: ER; apply: subset_split_ent => //.
+have [] := clEz (to_set (E' `&` E'^-1%classic) z).
+  rewrite -nbhs_entourageE; exists (E' `&` E'^-1%classic) => //.
+  exact: filterI.
+move=> y /= [[? ?]] [? ?]; exists y => //.
+Qed.
+
+#[global] Hint Resolve uniform_regular : core.
+
 Section currying.
-Local Notation "U '~>' V" := 
-  ({compact-open, [topologicalType of U] -> [topologicalType of V]}) 
+Local Notation "U '~>' V" :=
+  ({compact-open, [topologicalType of U] -> [topologicalType of V]})
   (at level 99, right associativity).
 
 Context {U V W : topologicalType}.
 
-(*
-Lemma continuous_snd (f : U ~> V ~> W) (v : V) :
-  continuous f ->
-  (forall u, continuous (f u)) ->
-  continuous (fun (q : U) => f q v).
-Proof.
-move=> ctsf ctsfp x R /= fxvR; rewrite nbhs_simpl /=.
-near=> z => /=; near: z.
-have nvE' : nbhs v (f x @^-1` (to_set E' (f x v))). 
-  by apply: ctsfp; rewrite /= -nbhs_entourageE; exists E'.
-suff [O Ofx OE] : exists2 O, nbhs (f x) O & (forall g, O g -> E (f x v, g v)).
-  move/ctsf: Ofx; rewrite /= nbhs_simpl /=; apply: filter_app.
-  by near_simpl; near=> z => foz; apply: OE.
-exists [set g | forall z, [set v] z -> E (f x z, g z)].
-  by apply: fam_nbhs => //; exact: compact_set1.
-by move=> g; apply.
-Unshelve. all: by end_near. Qed.
-*)
-
-Lemma continuous_curry (f : U * V ~> W) : 
+Lemma continuous_curry (f : U * V ~> W) :
   continuous f -> continuous ((curry : ((U * V) ~> W) -> (U ~> V ~> W)) f).
 Proof.
 move=> ctsf x; apply/compact_open_cvgP => K O /= cptK oO fKO.
-near=> z => /= w /= [+ + <-]; near: z. 
+near=> z => /= w /= [+ + <-]; near: z.
 move/compact_near_coveringP/near_covering_withinP: cptK; apply.
 move=> v Kv; have [[P Q] [Px Qv] PQfO]: nbhs (x,v) (f@^-1` O).
   by apply: ctsf; move: oO; rewrite openE; apply; apply: fKO; exists v.
@@ -8560,12 +8551,12 @@ have [R Rv RO] : exists2 R, nbhs v R &  (forall z, closure R z -> O (f u z)).
   have [] := reg v ((f u)@^-1` O); first by apply: ctsfp; exact: open_nbhs_nbhs.
   by move=> R nR cRO; exists R.
 exists (f @^-1` ([set g | g @` (B `&` closure R) `<=` O]), (B `&` closure R)).
-  split; [apply/ctsf/open_nbhs_nbhs; split | apply: filterI]. 
-  - apply: compact_open_open => //; apply: compact_closedI => //. 
+  split; [apply/ctsf/open_nbhs_nbhs; split | apply: filterI].
+  - apply: compact_open_open => //; apply: compact_closedI => //.
     exact: closed_closure.
   - by move=> ? [x [? + <-]]; apply: RO.
   - done.
-  - by apply: filterS; [exact: subset_closure|]. 
+  - by apply: filterS; [exact: subset_closure|].
 by case=> a r /= [fBMO [Br] cmR]; apply: fBMO; exists r.
 Qed.
 
@@ -8583,111 +8574,90 @@ Qed.
 
 Lemma curry_continuous (f : U * V ~> W) :
   continuous f ->
+  @regular U ->
   {for f, continuous ((curry : ((U * V) ~> W) -> (U ~> V ~> W)))}.
 Proof.
-move=> ctsf; apply/cvg_sup.
-  by apply: fmap_filter; apply:nbhs_filter.
-case=> K cptK T [C1 [[C2 oR <- Rxcf RT]]]. 
-move: oR; rewrite openE => /(_ _ Rxcf); case => C3 [E entE] EE' EKR.
-move: entE => [O []] => D dcpt <- IDE; rewrite nbhs_simpl /=.
-near=> z; apply/RT/EKR/EE'; case=> w Kiw; have Kw : K w by rewrite inE in Kiw.
-apply: IDE; rewrite /= /set_val /= /eqincl /incl. 
-move: w Kw {Kiw C1 C2 Rxcf RT EKR C3 EE' O T}; near: z.
-near_simpl; move/compact_near_coveringP/near_covering_withinP : (cptK).
-move=> /(_ _ (nbhs f)); apply => u Ku.
-apply: filter_bigI_within; (do 3 case) => J cptJ L /[dup] /asboolP entL ? _.
-case: entL => C1 [R entR] RC1 C1L.
-exists (setT, [set g | forall pq, (K `*` J) pq -> R (f pq, g pq)]).
-  split; last apply: fam_nbhs => //; last exact: compact_setM.
-  apply: filterT.
-case=> a g /= [? pJR] Ka.
-apply: C1L; apply: RC1; rewrite /map_pair; case=> v /= Jiv. 
-rewrite /= /set_val /= /eqincl /incl. 
-by apply: pJR; split => //; rewrite inE in Jiv.
+move=> ctsf regU; apply/compact_open_cvgP.
+  by apply: fmap_filter; exact:nbhs_filter.
+move=> K ? cptK [D OfinIo <-] fKD /=; near=> z => w [+ + <-]; near: z.
+move/compact_near_coveringP/near_covering_withinP : (cptK); apply => u Ku.
+have [] := fKD (curry f u); first by exists u.
+move=> E /[dup]/[swap]/OfinIo [N Asub <- DIN INf].
+suff : \forall x' \near u & i \near nbhs f, K x' ->
+    (\bigcap_(i in [set` N]) i) (curry i x').
+  apply: filter_app; near=> a b => + Ka => /(_ Ka) => ?.
+  by exists (\bigcap_(i in [set` N]) i).
+apply: filter_bigI_within=> R RN.
+have /set_mem [[M cptM _]] := Asub _ RN.
+have Rfu : R (curry f u) by exact: INf.
+case/(_ _ Rfu) => O [fMO oO] MOR.
+near=> p => /= Ki; apply: MOR => + [+ + <-] => _.
+move=> v Mv; move: v Mv Ki; near: p.
+have umb : \forall y \near u, (forall b, M b -> nbhs (y, b) (f@^-1` O) ).
+  move/compact_near_coveringP/near_covering_withinP : (cptM); apply => v Mv.
+  have [[P Q] [Pu Qv] PQO] : nbhs (u,v) (f@^-1` O).
+    by apply: ctsf; apply: open_nbhs_nbhs; split => //; apply: fMO; exists v.
+  exists (Q, P); [by split| case => b a [Qb Pa Mb]].
+  by apply: ctsf; apply: open_nbhs_nbhs; split => //; apply: PQO.
+move/compact_near_coveringP/near_covering_withinP : (cptM); apply => v Mv.
+have [P' P'u cPO] := regU u _ umb.
+pose L := [set h | h @`((K `&` (closure P'))`*`M) `<=` O].
+exists (setT, (P' `*` L)).
+  split => //; first exact: filterT.
+  exists (P', L) => //; split => //.
+  apply: open_nbhs_nbhs; split; first apply: compact_open_open => //.
+    apply: compact_setM => //; apply: compact_closedI => //; exact: closed_closure.
+  by move=> ? [[a b] [[Ka /cPO +] Mb <-]] => /(_ _ Mb)/nbhs_singleton.
+case => b [a h] [? [Pa] +] Ma Ka; apply.
+exists (a,b); split => //; split => //; apply/subset_closure => //.
 Unshelve. all: by end_near. Qed.
 
-Lemma uncurry_continuous (f : U ~> V ~> W) : 
+Lemma uncurry_continuous (f : U ~> V ~> W) :
   locally_compact [set: V] ->
+  @regular V ->
+  @regular U ->
   continuous f ->
   (forall u, continuous (f u)) ->
   {for f, continuous ((uncurry : (U ~> V ~> W) -> (U * V ~> W)))}.
 Proof.
-move=> lcV ctsf ctsfp; apply/cvg_sup.
-  by apply: fmap_filter; apply:nbhs_filter.
-case=> K cptK T [C1 [[C2 oR <- Rxcf RT]]]. 
-move: oR; rewrite openE => /(_ _ Rxcf); case => C3 [E entE] EE' EKR.
-rewrite nbhs_simpl /=.
-near=> z; apply/RT/EKR/EE'; case=> w Kiw; have Kw : K w by rewrite inE in Kiw.
-rewrite /= /set_val /= /eqincl /incl. 
-move: w Kw {Kiw C1 C2 Rxcf RT EKR C3 EE' T}; near: z.
-near_simpl; move/compact_near_coveringP/near_covering_withinP : (cptK).
-near (powerset_filter_from (@entourage W)) => E'.
-have entE' : entourage E' by exact: (near (near_small_set _)).
-move=> /(_ _ (nbhs f)); apply; case => u v Kxy.
-have ectsf : equicontinuous (f @` (fst @` K)) id.
-  apply: compact_equicontinuous => //.
-    by move=> ? [? [? ? <- <-]]; apply: ctsfp.
-  apply: continuous_compact; first exact: continuous_subspaceT.
-  apply: continuous_compact => //; apply: continuous_subspaceT => ?; exact: cvg_fst.
-have Efv : forall b, \forall y \near b, forall a, (fst @` K) a -> E' (f a b, f a y).
-  move=> b; move: (ectsf b E' entE'). 
-  apply: filter_app; near=> z => + a [[? r /[swap] /= ->] Kab].
-  by apply; exists a => //; exists (a,r).
-have cptK2 : compact (snd @` K).
-  apply: continuous_compact => //; apply: continuous_subspaceT => ?; exact: cvg_snd.
-have : \forall y \near v, forall b, (snd @` K) b -> (forall a, (fst @` K) a -> E' (f a b, f a y)).
-  move/compact_near_coveringP/near_covering_withinP: cptK2.
-  apply=> // z K2z; have := Efv z E' entE'.
-  
-exists ( 
-    (((f^~ v) @^-1` to_set E' (f u v)) `*` 
-    [set y | forall b, (fst @` K) b -> E' (f b v, f b y)]), 
-    [set g | forall ab, K ab -> E' (f u v, g ab.1 ab.2)]); first last.
-  case; case => /= a b g [[fvE' P1b] fgE'] Kab.
-  apply: subset_split_ent => //; exists (f a v) => /=.
-    apply/entourage_sym; apply: (near (small_ent_sub _) E') => //; apply: P1b.
-    by exists (a,b).
-  apply: subset_split_ent => //; exists (f u v) => /=.
-    apply/entourage_sym; apply: (near (small_ent_sub _) E') => //; apply: fvE'.
-  by apply: (near (small_ent_sub _) E') => //; apply: (fgE' (a,b)).
-split; first exists 
-  (((f^~ v) @^-1` to_set E' (f u v)), 
-  [set y | forall b, (fst @` K) b -> E' (f b v, f b y)]) => //=. 
-  split => //; apply: continuous_snd => //; rewrite /= -nbhs_entourageE.
-  by exists E'.
-rewrite nbhs_simpl /=.
-
-  exists (((f^~ v) @^-1` to_set E' (f u v)), P1) => //; split => //.
-  by apply: continuous_snd => //=.
-rewrite nbhs_simpl /=.
-suff : [set g | forall a, (fst @` K) a -> N (f a, g a) ]`<=` 
-       [set g | forall a b, K (a , b) -> E'(f u v, g a b) ].
-  move/filterS; apply; apply: fam_nbhs => //; apply: continuous_compact => //.
-  by apply: continuous_subspaceT => ?; exact: cvg_fst.
-move=> g /= fa a b Kab. 
-apply: fa.
-have : nbhs f [set g | forall a b, (fst @` K) -> ]
-
-  
-
-
-have := P1b (g a).
-case.
-move: P1b; rewrite /P1 (g a).
-have := Evcts.
-  
-have [B] := @lcV v I; rewrite withinET; move=> Bv [cptB clB].
-have fzE : forall z, nbhs (f z) [set g | forall w, B w -> E (f z w, g w)].
-  move=> z; apply: fam_nbhs => //.
-move: (fzE u); rewrite -nbhs_entourageE; case=> R entR RBE.
-have fE : nbhs f [set g | forall w, (fst @` K) w -> R (f w, g w)].
-  apply: fam_nbhs=>//; 
-  by apply: continuous_subspaceT => ?; apply: cvg_fst.
-exists ((setT `*` B), [set g | forall w, (fst @` K) w -> R (f w, g w)]).
-  split => //; exists (setT, B) => //; split => //; exact: filterT.
-case;case=> a b /= g [[_ Bb] wKR] KAB.
-have /= := (RBE (f a)).
-have : nbhs f [set g | forall z, fst @` K z -> ]
-
-
+move=> lcV regV regU ctsf ctsfp; apply/compact_open_cvgP.
+  by apply: fmap_filter; exact:nbhs_filter.
+move=> /= K O cptK oO fKO; near=> h => /= ? [+ + <-]; near: h.
+move/compact_near_coveringP/near_covering_withinP : (cptK); apply.
+case=> u v Kuv.
+have : exists P Q, [/\ closed P, compact Q, nbhs u P, nbhs v Q & P `*` Q `<=` uncurry f @^-1` O].
+  have : continuous (uncurry f) by apply: continuous_uncurry_regular.
+  move/continuousP/(_ _ oO); rewrite openE => /(_ (u,v)) [].
+    by apply: fKO; exists (u,v).
+  case=> /= P' Q' [P'u Q'v] PQO.
+  have [B] := @lcV v I; rewrite withinET; move=> Bv [cptB clB].
+  have [P Pu cPP'] := regU u P' P'u.
+  have [Q Qv cQQ'] := regV v Q' Q'v.
+  exists (closure P), (B `&` closure Q); split.
+  - exact: closed_closure.
+  - by apply: compact_closedI => //; exact: closed_closure.
+  - by apply: filterS; first exact: subset_closure.
+  - by apply: filterI=> //; apply: filterS; first exact: subset_closure.
+  - by case => a b [/cPP' ?] [_ /cQQ' ?]; exact: PQO.
+case=> P [Q [clP cptQ Pu Qv PQfO]].
+pose R := [set g : V ~> W | g @` Q `<=` O].
+have oR : open R by exact: compact_open_open.
+pose P' := f@^-1` R.
+pose L := [set h : U ~> V ~> W | h @` (fst @` K `&` P) `<=` R].
+exists (((P`&` P') `*` Q), L).
+  split => /=.
+    exists (P `&` P', Q) => //; split => //=; apply: filterI => //.
+    apply: ctsf; apply: open_nbhs_nbhs; split => // ? [b ? <-]. 
+    by apply: (PQfO (u,b)); split => //; exact: nbhs_singleton.
+  rewrite nbhs_simpl /=; apply: open_nbhs_nbhs; split.
+    apply: compact_open_open => //; apply: compact_closedI => //.
+    apply: continuous_compact => //; apply: continuous_subspaceT => ?.
+    exact: cvg_fst.
+  move=> /= ? [a [Pa ?] <-] ? [b Qb <-]. 
+  by apply: (PQfO (a,b)); split => //; apply: nbhs_singleton. 
+case; case => a b h [/= [[Pa P'a] Bb Lh] Kab].
+move/(_ (h a)): Lh ; rewrite /L/=/R/=.
+apply; first by exists a => //; split => //; exists (a,b).
+by exists b.
+Unshelve. all: by end_near. Qed.
 End currying.

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -299,8 +299,10 @@ Require Import reals signed.
 (*                                     for a finite number of indices in D    *)
 (*                    cover_compact == set of compact sets w.r.t. the open    *)
 (*                                     cover-based definition of compactness  *)
+(*                          regular == regular space                          *)
 (*                    near_covering == a reformulation of covering compact    *)
 (*                                     better suited for use with `near`      *)
+(*             near_covering_within == equivalent definition of near_covering *)
 (*              kolmogorov_space T <-> T is a Kolmogorov space (T0)           *)
 (*              accessible_space T <-> T is an accessible space (T1)          *)
 (*                       close x y <-> x and y are arbitrarily close w.r.t.   *)
@@ -449,26 +451,29 @@ Require Import reals signed.
 (*                                                                            *)
 (* ### Function space topologies                                              *)
 (* ```                                                                        *)
-(*     {uniform` A -> V} == the space U -> V, equipped with the topology of   *)
-(*                          uniform convergence from a set A to V, where      *)
-(*                          V is a uniformType                                *)
-(*      {uniform U -> V} := {uniform` [set: U] -> V}                          *)
-(*  {uniform A, F --> f} == F converges to f in {uniform A -> V}              *)
-(*    {uniform, F --> f} := {uniform setT, F --> f}                           *)
-(*         {ptws U -> V} == the space U -> V, equipped with the topology of   *)
-(*                          pointwise convergence from U to V, where V is a   *)
-(*                          topologicalType                                   *)
-(*                          This is a notation for @fct_Pointwise U V.        *)
-(*       {ptws, F --> f} == F converges to f in {ptws U -> V}                 *)
-(*  {family fam, U -> V} == The space U -> V, equipped with the supremum      *)
-(*                          topology of {uniform A -> f} for each A in 'fam'  *)
-(*                          In particular {family compact, U -> V} is the     *)
-(*                          topology of compact convergence.                  *)
-(* {family fam, F --> f} == F converges to f in {family fam, U -> V}          *)
+(*       {uniform` A -> V} == the space U -> V, equipped with the topology    *)
+(*                            of uniform convergence from a set A to V, where *)
+(*                            V is a uniformType                              *)
+(*        {uniform U -> V} := {uniform` [set: U] -> V}                        *)
+(*    {uniform A, F --> f} == F converges to f in {uniform A -> V}            *)
+(*      {uniform, F --> f} := {uniform setT, F --> f}                         *)
+(*           {ptws U -> V} == the space U -> V, equipped with the topology of *)
+(*                            pointwise convergence from U to V, where V is   *)
+(*                            a topologicalType                               *)
+(*                            This is a notation for @fct_Pointwise U V.      *)
+(*         {ptws, F --> f} == F converges to f in {ptws U -> V}               *)
+(*    {family fam, U -> V} == the space U -> V, equipped with the supremum    *)
+(*                            topology of {uniform A -> f} for each A in      *)
+(*                            'fam'                                           *)
+(*                            In particular {family compact, U -> V} is the   *)
+(*                            topology of compact convergence.                *)
+(*   {family fam, F --> f} == F converges to f in {family fam, U -> V}        *)
+(*  {compact_open, U -> V} == compact-open topology                           *)
+(* {compact_open, F --> f} == F converges to f in {compact_open, U -> V}      *)
 (*                                                                            *)
-(*               dense S == the set (S : set T) is dense in T, with T of      *)
-(*                          type topologicalType                              *)
-(*  weak_pseudoMetricType == the metric space for weak topologies             *)
+(*                 dense S == the set (S : set T) is dense in T, with T of    *)
+(*                            type topologicalType                            *)
+(*   weak_pseudoMetricType == the metric space for weak topologies            *)
 (* ```                                                                        *)
 (*                                                                            *)
 (* ### Subspaces of topological spaces                                        *)
@@ -6617,7 +6622,7 @@ Qed.
 
 Definition fct_UniformFamily (fam : (set U) -> Prop) := U -> V.
 
-Definition family_cvg_uniformType (fam: set U -> Prop) :=
+Definition family_cvg_uniformType (fam : set U -> Prop) :=
   @sup_uniformType  _
     (sigT fam)
     (fun k => Uniform.class (@fct_restrictedUniformType U (projT1 k) V)).
@@ -6712,15 +6717,15 @@ case=> y g [/= Efxy] AEg Ay; apply: EfO; apply: subset_split_ent => //.
 by exists (f y) => //=; exact: AEg.
 Unshelve. all: by end_near. Qed.
 
-(* It turns out {family compact, U -> V} can be generalized to only assume    *)
-(* `topologicalType` on V. This topology is called the compact-open topology. *)
-(* This topology is special because it is the _only_ topology that will allow *)
-(* curry/uncurry to be continuous.                                            *)
+(**md It turns out `{family compact, U -> V}` can be generalized to only assume
+  `topologicalType` on `V`. This topology is called the compact-open topology.
+   This topology is special because it is the _only_ topology that will allow
+   `curry`/`uncurry` to be continuous. *)
 
 Section compact_open.
 Context {T U : topologicalType}.
 
-Definition compact_open : Type := T->U.
+Definition compact_open : Type := T -> U.
 
 Section compact_open_setwise.
 Context {K : set T}.


### PR DESCRIPTION
##### Motivation for this change

Machinery for more function space topologies, and proofs that `curry` and `uncurry` are continuous (E.G. curry is a homeomorphism from `U x V -> W` to `U -> V -> W` in the right spaces.

For more bit more on the _why_, this is a piece of prep work for homotopy theory. One can define fundamental group of a (path-connected) space `V` as `the connected components of {compact-open, S1 ->  V}`. When we're proving things are homotopies, it's far easier to work in `U x [0,1] -> V`. But for certain bits of theory, it's much nicer to work in `[0,1] -> (U -> V)` instead. E.G. "is homotopic" inherits "is an equivalence relation" from path components. This PR will let us easily move between them with curry/uncurry as we please.

When `V` is a uniform space, the compact-open topology and the "family compact" topology agree. But we very rarely need the uniform assumption on `V`, so we do the more general work here. We also will need both `S1` and `[0,1]`, so we proof these results for any locally-compact, uniform space. The only meaningful issue is that `locally compact` is slightly too strong. Long story short, the category `Top` is not cartesian closed, and locally-compact fixes this, but excludes some exotic CW-complexes. A more general form of this works for what's called "compactly generated". That generalization is out of scope for now. My long-term goal is to prove stuff about winding numbers in low-dimensional spaces. Everything will be locally compact for a long time. 

The HB port should probably do two things 
1. Define an alias for the compact-open topology, and build the topology on that.
2. Create a module which canonically assigns the compact-open topology to all the arrow types.

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 2.0

<!-- MathComp-Analysis is compatible with MathComp < 2.0 (branch `master`) and
     MathComp 2.0 ([branch `hierarchy-builder`](https://github.com/math-comp/analysis/pull/698)).

     If this PR targets `master` and if it is merged, the merged commit will also be
     cherry-picked on the branch `hierarchy-builder`.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `hierarchy-builder` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: HB port to record divergences between `master` and `hierarchy-builder` -->

- [x] I added the label `TODO: HB port` to make sure someone ports this PR to
      the `hierarchy-builder` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
