### PR TITLE
measurable_fun lemmas renaming

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -13,7 +13,7 @@
 - in `sequences.v`:
   + lemma `eq_eseriesl`
 - in `lebesgue_measure.v`:
-  + lemma `measurable_fun_expR`
+  + lemma `measurable_expR`
 
 - in file `topology.v`,
   + new definitions `basis`, and `second_countable`.
@@ -44,6 +44,9 @@
     `measurable_fun_integral_kernel`, and `integral_kcomp`.
   + lemma `measurable_fun_mnormalize`
 
+- in `measure.v`:
+  + lemmas `measurable_pair1`, `measurable_pair2`
+
 ### Changed
 
 - in `lebesgue_measure.v`
@@ -62,14 +65,42 @@
   + `Rmult_rev_linear` -> `mulr_rev_linear`
   + `Rmult_bilinear` -> `mulr_bilinear`
   + `is_diff_Rmult` -> `is_diff_mulr`
+- in `lebesgue_measure.v`
+  + `measurable_funN` -> `measurable_oppr`
+  + `emeasurable_fun_minus` -> `measurable_oppe`
+  + `measurable_fun_abse` -> `measurable_abse`
+  + `measurable_EFin` -> `measurable_image_EFin`
+  + `measurable_fun_EFin` -> `measurable_EFin`
+  + `measurable_fine` -> `measurable_image_fine`
+  + `measurable_fun_fine` -> `measurable_fine`
+  + `measurable_fun_normr` -> `measurable_normr`
+  + `measurable_fun_exprn` -> `measurable_exprn`
+  + `emeasurable_fun_max` -> `measurable_maxe`
+  + `emeasurable_fun_min` -> `measurable_mine`
+  + `measurable_fun_max` -> `measurable_maxr`
+  + `measurable_fun_er_map` -> `measurable_er_map`
+  + `emeasurable_fun_funepos` -> `measurable_funepos`
+  + `emeasurable_fun_funeneg` -> `measurable_funeneg`
+  + `measurable_funrM` -> `measurable_mulrl`
+- in `measure.v`:
+  + `measurable_fun_id` -> `measurable_id`
+  + `measurable_fun_cst` -> `measurable_cst`
+  + `measurable_fun_comp` -> `measurable_comp`
+  + `measurable_funT_comp` -> `measurableT_comp`
+  + `measurable_fun_fst` -> `measurable_fst`
+  + `measurable_fun_snd` -> `measurable_snd`
+  + `measurable_fun_swap` -> `measurable_swap`
+  + `measurable_fun_pair` -> `measurable_fun_prod`
+- in `lebesgue_integral.v`:
+  + `measurable_fun_indic` -> `measurable_indic`
 
 ### Generalized
 
 ### Deprecated
 
 - in `lebesgue_measure.v`:
-  + lemma `measurable_fun_sqr` (use `measurable_fun_exprn` instead)
-  + lemma `measurable_fun_opp` (use `measurable_funN` instead)
+  + lemma `measurable_fun_sqr` (use `measurable_exprn` instead)
+  + lemma `measurable_fun_opp` (use `measurable_oppr` instead)
 
 ### Removed
 
@@ -79,9 +110,11 @@
   + instances `ae_filter_algebraOfSetsType`, `ae_filter_measurableType`,
   `ae_properfilter_measurableType`
 - in `lebesgue_measure.v`:
-  + lemma `emeasurable_funN` (use `measurable_funT_comp`) instead
+  + lemma `emeasurable_funN` (use `measurableT_comp`) instead
+  + lemma `measurable_fun_prod1` (use `measurableT_comp` instead)
+  + lemma `measurable_fun_prod2` (use `measurableT_comp` instead)
 - in `lebesgue_integral.v`
-  + lemma `emeasurable_funN` (already in `lebesgue_measure.v`)
+  + lemma `emeasurable_funN` (was already in `lebesgue_measure.v`, use `measurableT_comp` instead)
 
 ### Infrastructure
 

--- a/theories/kernel.v
+++ b/theories/kernel.v
@@ -207,7 +207,7 @@ Definition kzero : X -> {measure set Y -> \bar R} :=
 
 Let measurable_fun_kzero U : measurable U ->
   measurable_fun [set: X] (kzero ^~ U).
-Proof. by move=> ?/=; exact: measurable_fun_cst. Qed.
+Proof. by move=> ?/=; exact: measurable_cst. Qed.
 
 HB.instance Definition _ :=
   @isKernel.Build _ _ X Y R kzero measurable_fun_kzero.
@@ -482,13 +482,13 @@ rewrite (_ : (fun x => _) =
     apply: ereal_nondecreasing_is_cvg => m n mn.
     apply: ge0_le_integral => //.
     - by move=> y _; rewrite lee_fin.
-    - exact/EFin_measurable_fun/measurable_fun_prod1.
+    - exact/EFin_measurable_fun/measurableT_comp.
     - by move=> y _; rewrite lee_fin.
-    - exact/EFin_measurable_fun/measurable_fun_prod1.
+    - exact/EFin_measurable_fun/measurableT_comp.
     - by move=> y _; rewrite lee_fin; exact/lefP/ndk_.
   rewrite -monotone_convergence//.
   - by apply: eq_integral => y _; apply/esym/cvg_lim => //; exact: k_k.
-  - by move=> n; exact/EFin_measurable_fun/measurable_fun_prod1.
+  - by move=> n; exact/EFin_measurable_fun/measurableT_comp.
   - by move=> n y _; rewrite lee_fin.
   - by move=> y _ m n mn; rewrite lee_fin; exact/lefP/ndk_.
 apply: measurable_fun_lim_esup => n.
@@ -501,10 +501,8 @@ rewrite [X in measurable_fun _ X](_ : _ = (fun x => \sum_(r \in range (k_ n))
   apply/funext => x; rewrite -ge0_integral_fsum//.
   - by apply: eq_integral => y _; rewrite -fsumEFin.
   - move=> r.
-    apply/EFin_measurable_fun/measurable_funT_comp => [//|].
-    apply/measurable_fun_prod1 => /=.
-    rewrite (_ : \1_ _ = mindic R (measurable_sfunP (k_ n) (measurable_set1 r)))//.
-    exact/measurable_funP.
+    apply/EFin_measurable_fun/measurableT_comp => [//|].
+    exact/measurableT_comp.
   - by move=> m y _; rewrite nnfun_muleindic_ge0.
 apply: emeasurable_fun_fsum => // r.
 rewrite [X in measurable_fun _ X](_ : _ = (fun x => r%:E *
@@ -512,9 +510,7 @@ rewrite [X in measurable_fun _ X](_ : _ = (fun x => r%:E *
   apply/funext => x; under eq_integral do rewrite EFinM.
   have [r0|r0] := leP 0%R r.
     rewrite ge0_integralM//; last by move=> y _; rewrite lee_fin.
-    apply/EFin_measurable_fun/measurable_fun_prod1 => /=.
-    rewrite (_ : \1_ _ = mindic R (measurable_sfunP (k_ n) (measurable_set1 r)))//.
-    exact/measurable_funP.
+    exact/EFin_measurable_fun/measurableT_comp.
   rewrite integral0_eq; last first.
     by move=> y _; rewrite preimage_nnfun0// indic0 mule0.
   by rewrite integral0_eq ?mule0// => y _; rewrite preimage_nnfun0// indic0.
@@ -572,7 +568,7 @@ Let measurable_fun_kdirac U : measurable U ->
   measurable_fun [set: X] (kdirac mf ^~ U).
 Proof.
 move=> mU; apply/EFin_measurable_fun.
-by rewrite (_ : (fun x => _) = mindic R mU \o f)//; exact/measurable_funT_comp.
+by rewrite (_ : (fun x => _) = mindic R mU \o f)//; exact/measurableT_comp.
 Qed.
 
 HB.instance Definition _ := isKernel.Build _ _ _ _ _ (kdirac mf)
@@ -782,13 +778,12 @@ apply: measurable_fun_if => //.
   by apply: measurableU; exact: kernel_measurable_eq_cst.
 - apply/emeasurable_funM; first exact/measurable_funTS/measurable_kernel.
   apply/EFin_measurable_fun; rewrite setTI.
-  apply: (@measurable_fun_comp _ _ _ _ _ _ [set r : R | r != 0%R]).
+  apply: (@measurable_comp _ _ _ _ _ _ [set r : R | r != 0%R]).
   + exact: open_measurable.
   + by move=> /= _ [x /norP[s0 soo]] <-; rewrite -eqe fineK ?ge0_fin_numE ?ltey.
   + apply: open_continuous_measurable_fun => //; apply/in_setP => x /= x0.
     exact: inv_continuous.
-  + apply: measurable_funT_comp; last exact/measurable_funS/measurable_kernel.
-    exact: measurable_fun_fine.
+  + by apply: measurableT_comp => //; exact/measurable_funS/measurable_kernel.
 Qed.
 
 Section knormalize.
@@ -819,14 +814,14 @@ apply: measurable_fun_if => //.
 - apply: emeasurable_funM.
     by have := measurable_kernel f U mU; exact: measurable_funS.
   apply/EFin_measurable_fun.
-  apply: (@measurable_fun_comp _ _ _ _ _ _ [set r : R | r != 0%R]) => //.
+  apply: (@measurable_comp _ _ _ _ _ _ [set r : R | r != 0%R]) => //.
   + exact: open_measurable.
   + move=> /= r [t] [] [_ ft0] ftoo ftr; apply/eqP => r0.
     move: (ftr); rewrite r0 => /eqP; rewrite fine_eq0 ?ft0//.
     by rewrite ge0_fin_numE// lt_neqAle leey ftoo.
   + apply: open_continuous_measurable_fun => //; apply/in_setP => x /= x0.
     exact: inv_continuous.
-  + apply: measurable_funT_comp => /=; first exact: measurable_fun_fine.
+  + apply: measurableT_comp => //=.
     by have := measurable_kernel f _ measurableT; exact: measurable_funS.
 Qed.
 
@@ -882,7 +877,7 @@ move=> U mU tU mUU; rewrite [X in _ --> X](_ : _ =
 apply/cvg_closeP; split.
   by apply: is_cvg_nneseries => n _; exact: integral_ge0.
 rewrite closeE// integral_nneseries// => n.
-by have /measurable_fun_prod1 := measurable_kernel k _ (mU n).
+exact: measurableT_comp (measurable_kernel k _ (mU n)) _.
 Qed.
 
 HB.instance Definition _ x := isMeasure.Build _ R _
@@ -927,8 +922,7 @@ have /measure_fam_uubP[s hs] := measure_uub l.
 apply/measure_fam_uubP; exists (PosNum [gt0 of (r%:num * s%:num)%R]) => x /=.
 apply: (@le_lt_trans _ _ (\int[l x]__ r%:num%:E)).
   apply: ge0_le_integral => //.
-  - have /measurable_fun_prod1 := measurable_kernel k _ measurableT.
-    exact.
+  - exact: measurableT_comp (measurable_kernel k _ measurableT) _.
   - by move=> y _; exact/ltW/hr.
 by rewrite integral_cst//= EFinM lte_pmul2l.
 Qed.
@@ -964,11 +958,10 @@ transitivity (([the _.-ker _ ~> _ of kseries l_] \;
     by move=> *; rewrite hl_.
   by apply: eq_integral => y _; rewrite hk_.
 rewrite /= /kcomp/= integral_nneseries//=; last first.
-  move=> n; have /measurable_fun_prod1 := measurable_kernel (k_ n) _ mU.
-   exact.
+  by move=> n; exact: measurableT_comp (measurable_kernel (k_ n) _ mU) _.
 transitivity (\sum_(i <oo) \sum_(j <oo) (l_ j \; k_ i) x U).
   apply: eq_eseriesr => i _; rewrite integral_kseries//.
-  by have /measurable_fun_prod1 := measurable_kernel (k_ i) _ mU; exact.
+  by exact: measurableT_comp (measurable_kernel (k_ i) _ mU) _.
 rewrite /mseries -hkl/=.
 rewrite (_ : setT = setT `*`` (fun=> setT)); last by apply/seteqP; split.
 rewrite -(@esum_esum _ _ _ _ _ (fun i j => (l_ j \; k_ i) x U))//.
@@ -1017,7 +1010,7 @@ Let k_2_ge0 n x : (0 <= k_2 n x)%R. Proof. by []. Qed.
 HB.instance Definition _ n := @isNonNegFun.Build _ _ _ (k_2_ge0 n).
 
 Let mk_2 n : measurable_fun [set: X * Y] (k_2 n).
-Proof. by apply: measurable_funT_comp => //; exact: measurable_fun_snd. Qed.
+Proof. by apply: measurableT_comp => //; exact: measurable_snd. Qed.
 
 HB.instance Definition _ n := @isMeasurableFun.Build _ _ _ _ (mk_2 n).
 
@@ -1078,7 +1071,7 @@ Let integral_kcomp_nnsfun x (f : {nnsfun Z >-> R}) :
 Proof.
 under [in LHS]eq_integral do rewrite fimfunE -fsumEFin//.
 rewrite ge0_integral_fsum//; last 2 first.
-  - move=> r; apply/EFin_measurable_fun/measurable_funT_comp => [//|].
+  - move=> r; apply/EFin_measurable_fun/measurableT_comp => [//|].
     have fr : measurable (f @^-1` [set r]) by exact/measurable_sfunP.
     by rewrite (_ : \1__ = mindic R fr).
   - by move=> r z _; rewrite EFinM nnfun_muleindic_ge0.
@@ -1087,7 +1080,7 @@ under [in RHS]eq_integral.
   under eq_integral.
     by move=> z _; rewrite fimfunE -fsumEFin//; over.
   rewrite /= ge0_integral_fsum//; last 2 first.
-    - move=> r; apply/EFin_measurable_fun/measurable_funT_comp => [//|].
+    - move=> r; apply/EFin_measurable_fun/measurableT_comp => [//|].
       have fr : measurable (f @^-1` [set r]) by exact/measurable_sfunP.
       by rewrite (_ : \1__ = mindic R fr).
     - by move=> r z _; rewrite EFinM nnfun_muleindic_ge0.
@@ -1100,9 +1093,7 @@ under [in RHS]eq_integral.
   over.
 rewrite /= ge0_integral_fsum//; last 2 first.
   - move=> r; apply: measurable_funeM.
-    have := measurable_kernel k (f @^-1` [set r])
-            (measurable_sfunP f (measurable_set1 r)).
-    by move=> /measurable_fun_prod1; exact.
+    exact: measurableT_comp (measurable_kernel k (f @^-1` [set r]) _) _.
   - move=> n y _.
     have := mulemu_ge0 (fun n => f @^-1` [set n]).
     by apply; exact: preimage_nnfun0.
@@ -1112,9 +1103,7 @@ rewrite (integralM_indic _ (fun r => f @^-1` [set r]))//; last first.
 rewrite /= integral_kcomp_indic; last exact/measurable_sfunP.
 have [r0|r0] := leP 0%R r.
   rewrite ge0_integralM//; last first.
-    have := measurable_kernel k (f @^-1` [set r])
-            (measurable_sfunP f (measurable_set1 r)).
-    by move/measurable_fun_prod1; exact.
+    exact: measurableT_comp (measurable_kernel k (f @^-1` [set r]) _) _.
   by congr (_ * _); apply: eq_integral => y _; rewrite integral_indic// setIT.
 rewrite integral0_eq ?mule0; last first.
    move=> y _; rewrite integral0_eq// => z _.
@@ -1139,8 +1128,7 @@ rewrite (_ : (fun _ => _) =
 transitivity (\int[l x]_y lim (fun n => \int[k (x, y)]_z (f_ n z)%:E)).
   rewrite -monotone_convergence//; last 3 first.
   - move=> n; apply: measurable_fun_integral_kernel => //.
-    + move=> U mU; have := measurable_kernel k _ mU.
-      by move=> /measurable_fun_prod1; exact.
+    + by move=> U mU; exact: measurableT_comp (measurable_kernel k _ mU) _.
     + by move=> z; rewrite lee_fin.
     + exact/EFin_measurable_fun.
   - by move=> n y _; apply: integral_ge0 => // z _; rewrite lee_fin.

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -153,7 +153,7 @@ Definition cst_mfun x := [the {mfun aT >-> rT} of cst x].
 Lemma mfun_cst x : @cst_mfun x =1 cst x. Proof. by []. Qed.
 
 HB.instance Definition _ := @isMeasurableFun.Build _ _ rT
-  (@normr rT rT) (@measurable_fun_normr rT setT).
+  (@normr rT rT) (@measurable_normr rT setT).
 
 End mfun.
 
@@ -163,7 +163,7 @@ Context d (aT : measurableType d) (rT : realType).
 Lemma mfun_subring_closed : subring_closed (@mfun _ aT rT).
 Proof.
 split=> [|f g|f g]; rewrite !inE/=.
-- exact: measurable_fun_cst.
+- exact: measurable_cst.
 - exact: measurable_funB.
 - exact: measurable_funM.
 Qed.
@@ -225,22 +225,23 @@ HB.instance Definition _ k f := MeasurableFun.copy (k \o* f) (f * cst_mfun k).
 Definition scale_mfun k f := [the {mfun aT >-> rT} of k \o* f].
 
 Lemma max_mfun_subproof f g : @isMeasurableFun d aT rT (f \max g).
-Proof. by split; apply: measurable_fun_max. Qed.
+Proof. by split; apply: measurable_maxr. Qed.
 HB.instance Definition _ f g := max_mfun_subproof f g.
 Definition max_mfun f g := [the {mfun aT >-> _} of f \max g].
 
 End ring.
 Arguments indic_mfun {d aT rT} _.
 
-Lemma measurable_fun_indic d (T : measurableType d) (R : realType)
+Lemma measurable_indic d (T : measurableType d) (R : realType)
     (D A : set T) : measurable A ->
   measurable_fun D (\1_A : T -> R).
 Proof.
 by move=> mA; apply/measurable_funTS; rewrite (_ : \1__ = mindic R mA).
 Qed.
-
 #[global] Hint Extern 0  (measurable_fun _ (\1__ : _ -> _)) =>
-  (exact: measurable_fun_indic ) : core.
+  (exact: measurable_indic ) : core.
+#[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_indic` instead")]
+Notation measurable_fun_indic := measurable_indic.
 
 Section sfun_pred.
 Context {d} {aT : measurableType d} {rT : realType}.
@@ -1184,7 +1185,7 @@ Definition approx : (T -> R)^nat := fun n x =>
 Let mA n k : measurable (A n k).
 Proof.
 rewrite /A; case: ifPn => [kn|_]//; rewrite -preimage_comp.
-by apply: mf => //; apply/measurable_EFin; exact: measurable_itv.
+by apply: mf => //; apply/measurable_image_EFin; exact: measurable_itv.
 Qed.
 
 Let trivIsetA n : trivIset setT (A n).
@@ -1601,13 +1602,10 @@ Variables (D : set T) (mD : measurable D) (mf : measurable_fun D f).
 Lemma approximation_sfun :
   exists g : {sfun T >-> R}^nat, (forall x, D x -> EFin \o g^~x --> f x).
 Proof.
-have fp0 : (forall x, 0 <= f^\+ x)%E by [].
-have mfp : measurable_fun D f^\+%E by exact: emeasurable_fun_max.
-have fn0 : (forall x, 0 <= f^\- x)%E by [].
-have mfn : measurable_fun D f^\-%E.
-  by apply: emeasurable_fun_max => //; exact: measurable_funT_comp.
-have [fp_ [fp_nd fp_cvg]] := approximation mD mfp (fun x _ => fp0 x).
-have [fn_ [fn_nd fn_cvg]] := approximation mD mfn (fun x _ => fn0 x).
+have [fp_ [fp_nd fp_cvg]] :=
+  approximation mD (measurable_funepos mf) (fun=> ltac:(by [])).
+have [fn_ [fn_nd fn_cvg]] :=
+  approximation mD (measurable_funeneg mf) (fun=> ltac:(by [])).
 exists (fun n => [the {sfun T >-> R} of fp_ n \+ cst (-1) \* fn_ n]) => x /=.
 rewrite [X in X --> _](_ : _ =
     EFin \o fp_^~ x \+ (-%E \o EFin \o fn_^~ x))%E; last first.
@@ -1673,7 +1671,7 @@ Lemma emeasurable_fun_sum D I s (h : I -> (T -> \bar R)) :
   measurable_fun D (fun x => \sum_(i <- s) h i x).
 Proof.
 elim: s => [|s t ih] mf.
-  by under eq_fun do rewrite big_nil; exact: measurable_fun_cst.
+  by under eq_fun do rewrite big_nil; exact: measurable_cst.
 under eq_fun do rewrite big_cons //=; apply: emeasurable_funD => //.
 exact: ih.
 Qed.
@@ -1701,7 +1699,7 @@ Qed.
 Lemma emeasurable_funB D f g :
   measurable_fun D f -> measurable_fun D g -> measurable_fun D (f \- g).
 Proof.
-by move=> mf mg mD; apply: emeasurable_funD => //; exact: measurable_funT_comp.
+by move=> mf mg mD; apply: emeasurable_funD => //; exact: measurableT_comp.
 Qed.
 
 Lemma emeasurable_funM D f g :
@@ -2112,9 +2110,8 @@ move=> fk0 mfk; have [k0|k0] := ltP k 0%R.
   rewrite integral0_eq//; last by move=> x _; rewrite fk0// indic0 mulr0.
   by rewrite integral0_eq ?mule0// => x _; rewrite fk0// indic0.
 under eq_integral do rewrite EFinM.
-rewrite ge0_integralM//.
-- exact/EFin_measurable_fun/measurable_fun_indic.
-- by move=> y _; rewrite lee_fin.
+rewrite ge0_integralM//; first exact/EFin_measurable_fun.
+by move=> y _; rewrite lee_fin.
 Qed.
 
 Lemma integralM_indic_nnsfun (f : {nnsfun T >-> R}) (k : R) :
@@ -2144,8 +2141,7 @@ Let integral_mscale_nnsfun (h : {nnsfun T >-> R}) :
 Proof.
 under [LHS]eq_integral do rewrite fimfunE -fsumEFin//.
 rewrite [LHS]ge0_integral_fsum//; last 2 first.
-  - move=> r.
-  apply/EFin_measurable_fun/measurable_funT_comp => //=. 
+  - by move=> r; exact/EFin_measurable_fun/measurableT_comp.
   - by move=> n x _; rewrite EFinM nnfun_muleindic_ge0.
 rewrite -[RHS]ge0_integralM//; last 2 first.
   - exact/EFin_measurable_fun/measurable_funTS.
@@ -2155,12 +2151,11 @@ under [RHS]eq_integral.
     by move=> r; rewrite EFinM nnfun_muleindic_ge0.
   over.
 rewrite [RHS]ge0_integral_fsum//; last 2 first.
-  - move=> r; apply/EFin_measurable_fun/measurable_funT_comp => //=. 
-   apply: measurable_funT_comp => //= . 
+  - by move=> r; apply/EFin_measurable_fun; do 2 apply/measurableT_comp => //.
   - by move=> n x _; rewrite EFinM mule_ge0// nnfun_muleindic_ge0.
 apply: eq_fsbigr => r _; rewrite ge0_integralM//.
 - by rewrite !integralM_indic_nnsfun//= integral_mscale_indic// muleCA.
-- apply/EFin_measurable_fun/measurable_funT_comp => //= . 
+- exact/EFin_measurable_fun/measurableT_comp.
 - by move=> t _; rewrite nnfun_muleindic_ge0.
 Qed.
 
@@ -2189,7 +2184,7 @@ apply/ereal_nondecreasing_is_cvg => a b ab; apply: ge0_le_integral => //.
 - exact/EFin_measurable_fun/measurable_funTS.
 - by move=> x _; rewrite lee_fin.
 - exact/EFin_measurable_fun/measurable_funTS.
-  by move=> x _; rewrite lee_fin; move/ndf_ : ab => /lefP.
+- by move=> x _; rewrite lee_fin; move/ndf_ : ab => /lefP.
 Qed.
 
 End integral_mscale.
@@ -2311,7 +2306,7 @@ rewrite monotone_convergence //.
   rewrite -lee_pdivr_mulr; last by rewrite fine_gt0// lt0e muD0 measure_ge0.
   rewrite lee_fin; apply: le_trans MDm.
   by rewrite natr_absz (le_trans (ceil_ge _))// ler_int ler_norm.
-- by move=> n; exact: measurable_fun_cst.
+- by move=> n; exact: measurable_cst.
 - by move=> n x Dx; rewrite lee_fin.
 - by move=> t Dt n m nm; rewrite /g lee_fin ler_nat.
 Qed.
@@ -2343,8 +2338,7 @@ transitivity (lim (fun n => \int[pushforward mu mphi]_x (f_ n x)%:E)).
   - by move=> y _ m n mn; rewrite lee_fin; apply/lefP/ndf_.
 rewrite (_ : (fun _ => _) = (fun n => \int[mu]_x (EFin \o f_ n \o phi) x)).
   rewrite -monotone_convergence//; last 3 first.
-    - move=> n /=; apply: measurable_funT_comp; first exact: measurable_fun_EFin.
-      by apply: measurable_funT_comp => //; exact: measurable_sfun.
+    - by move=> n /=; apply: measurableT_comp => //; exact: measurableT_comp.
     - by move=> n x _ /=; rewrite lee_fin.
     - by move=> x _ m n mn; rewrite lee_fin; exact/lefP/ndf_.
   by apply: eq_integral => x _ /=; apply/cvg_lim => //; exact: f_f.
@@ -2398,7 +2392,7 @@ rewrite ge0_integral_fsum//.
   rewrite fsbig1 ?adde0// => r /= [_ rfna].
   rewrite integral_indic//= diracE memNset ?mule0//=.
   by apply/not_andP; left; exact/nesym.
--  move=> r; apply/EFin_measurable_fun/measurable_funT_comp => //=.
+- by move=> r; exact/EFin_measurable_fun/measurableT_comp.
 - by move=> r x _; rewrite nnfun_muleindic_ge0.
 Qed.
 
@@ -2406,8 +2400,8 @@ Lemma integral_dirac (f : T -> \bar R) (mf : measurable_fun D f) :
   \int[\d_ a]_(x in D) f x = (\1_D a)%:E * f a.
 Proof.
 have [/[!inE] aD|aD] := boolP (a \in D).
-  rewrite integralE ge0_integral_dirac//; last exact/emeasurable_fun_funepos.
-  rewrite ge0_integral_dirac//; last exact/emeasurable_fun_funeneg.
+  rewrite integralE ge0_integral_dirac//; last exact/measurable_funepos.
+  rewrite ge0_integral_dirac//; last exact/measurable_funeneg.
   by rewrite [in RHS](funeposneg f) indicE mem_set// mul1e.
 rewrite indicE (negbTE aD) mul0e -(integral_measure_zero D f)//.
 apply: eq_measure_integral => //= S mS DS; rewrite /dirac indicE memNset// => /DS.
@@ -2435,8 +2429,7 @@ Let integralT_measure_sum (f : {nnsfun T >-> R}) :
 Proof.
 under eq_integral do rewrite fimfunE -fsumEFin//.
 rewrite ge0_integral_fsum//; last 2 first.
-  - move=> r /=; apply: measurable_funT_comp => //.
-  apply: measurable_funT_comp => //. 
+  - by move=> r /=; apply: measurableT_comp => //; exact: measurableT_comp.
   - by move=> r t _; rewrite EFinM nnfun_muleindic_ge0.
 transitivity (\sum_(i \in range f)
     (\sum_(n < N) i%:E * \int[m_ n]_x (\1_(f @^-1` [set i]) x)%:E)).
@@ -2545,8 +2538,7 @@ Lemma integral_measure_series_nnsfun (D : set T) (mD : measurable D)
 Proof.
 under eq_integral do rewrite fimfunE -fsumEFin//.
 rewrite ge0_integral_fsum//; last 2 first.
-  - move=> r /=; apply: measurable_funT_comp => //.
-  apply: measurable_funT_comp => //.
+  - by move=> r /=; apply: measurableT_comp => //; exact: measurableT_comp.
   - by move=> r t _; rewrite EFinM nnfun_muleindic_ge0.
 transitivity (\sum_(i \in range f)
     (\sum_(n <oo) i%:E * \int[m_ n]_x (\1_(f @^-1` [set i]) x)%:E)).
@@ -2682,13 +2674,13 @@ Lemma le_integral_abse (D : set T) (mD : measurable D) (g : T -> \bar R) a :
   a%:E * mu (D `&` [set x | `|g x| >= a%:E]) <= \int[mu]_(x in D) `|g x|.
 Proof.
 move=> mg a0; have ? : measurable (D `&` [set x | a%:E <= `|g x|]).
-  by apply: emeasurable_fun_c_infty => //; exact: measurable_funT_comp.
+  by apply: emeasurable_fun_c_infty => //; exact: measurableT_comp.
 apply: (@le_trans _ _ (\int[mu]_(x in D `&` [set x | `|g x| >= a%:E]) `|g x|)).
   rewrite -integral_cstr//; apply: ge0_le_integral => //.
   - by move=> x _ /=; exact/ltW.
-  - by apply: measurable_funT_comp => //; exact: measurable_funS mg.
+  - by apply: measurableT_comp => //; exact: measurable_funS mg.
   - by move=> x /= [].
-by apply: subset_integral => //; exact: measurable_funT_comp.
+by apply: subset_integral => //; exact: measurableT_comp.
 Qed.
 
 End subset_integral.
@@ -2729,8 +2721,8 @@ Lemma eq_integrable f g : {in D, f =1 g} -> mu_int f -> mu_int g.
 Proof.
 move=> fg [mf fi]; split; first exact: eq_measurable_fun mf.
 rewrite (le_lt_trans _ fi)//; apply: ge0_le_integral=> //.
-  by apply: measurable_funT_comp => //; exact: eq_measurable_fun mf.
-  by apply: measurable_funT_comp => //; exact: eq_measurable_fun mf.
+  by apply: measurableT_comp => //; exact: eq_measurable_fun mf.
+  by apply: measurableT_comp => //; exact: eq_measurable_fun mf.
 by move=> x Dx; rewrite fg// inE.
 Qed.
 
@@ -2738,20 +2730,20 @@ Lemma le_integrable f g : measurable_fun D f ->
   (forall x, D x -> `|f x| <= `|g x|) -> mu_int g -> mu_int f.
 Proof.
 move=> mf fg [mfg goo]; split => //; rewrite (le_lt_trans _ goo) //.
-by apply: ge0_le_integral => //; exact: measurable_funT_comp.
+by apply: ge0_le_integral => //; exact: measurableT_comp.
 Qed.
 
 Lemma integrableN f : mu_int f -> mu_int (-%E \o f).
 Proof.
 move=> [mf foo]; split; last by rewrite /comp; under eq_fun do rewrite abseN.
-by rewrite /comp; apply: measurable_funT_comp =>//; exact: emeasurable_fun_minus.
+by rewrite /comp; apply: measurableT_comp =>//; exact: measurable_oppe.
 Qed.
 
 Lemma integrablerM (k : R) f : mu_int f -> mu_int (fun x => k%:E * f x).
 Proof.
 move=> [mf foo]; split; first exact: measurable_funeM.
 under eq_fun do rewrite abseM.
-by rewrite ge0_integralM// ?lte_mul_pinfty//; exact: measurable_funT_comp.
+by rewrite ge0_integralM// ?lte_mul_pinfty//; exact: measurableT_comp.
 Qed.
 
 Lemma integrableMr (k : R) f : mu_int f -> mu_int (f \* cst k%:E).
@@ -2764,11 +2756,11 @@ Proof.
 move=> [mf foo] [mg goo]; split; first exact: emeasurable_funD.
 apply: (@le_lt_trans _ _ (\int[mu]_(x in D) (`|f x| + `|g x|))).
   apply: ge0_le_integral => //.
-  - by apply: measurable_funT_comp => //; exact: emeasurable_funD.
-  - by apply: emeasurable_funD; apply: measurable_funT_comp.
+  - by apply: measurableT_comp => //; exact: emeasurable_funD.
+  - by apply: emeasurable_funD; apply: measurableT_comp.
   - by move=> *; exact: lee_abs_add.
 by rewrite ge0_integralD //; [exact: lte_add_pinfty|
-  exact: measurable_funT_comp|exact: measurable_funT_comp].
+  exact: measurableT_comp|exact: measurableT_comp].
 Qed.
 
 Lemma integrableB f g : mu_int f -> mu_int g -> mu_int (f \- g).
@@ -2779,8 +2771,8 @@ Lemma integrable_add_def f : mu_int f ->
 Proof.
 move=>  [mf]; rewrite -[fun x => _]/(abse \o f) fune_abse => foo.
 rewrite ge0_integralD // in foo; last 2 first.
-  - exact: emeasurable_fun_funepos.
-  - exact: emeasurable_fun_funeneg.
+  - exact: measurable_funepos.
+  - exact: measurable_funeneg.
 apply: ltpinfty_adde_def.
 - by apply: le_lt_trans foo; rewrite lee_addl// integral_ge0.
 - by rewrite inE (@le_lt_trans _ _ 0)// lee_oppl oppe0 integral_ge0.
@@ -2788,19 +2780,19 @@ Qed.
 
 Lemma integrable_funepos f : mu_int f -> mu_int f^\+.
 Proof.
-move=> [Df foo]; split; first exact: emeasurable_fun_funepos.
+move=> [Df foo]; split; first exact: measurable_funepos.
 apply: le_lt_trans foo; apply: ge0_le_integral => //.
-- by apply/measurable_funT_comp => //; exact: emeasurable_fun_funepos.
-- exact/measurable_funT_comp.
+- by apply/measurableT_comp => //; exact: measurable_funepos.
+- exact/measurableT_comp.
 - by move=> t Dt; rewrite -/((abse \o f) t) fune_abse gee0_abs// lee_addl.
 Qed.
 
 Lemma integrable_funeneg f : mu_int f -> mu_int f^\-.
 Proof.
-move=> [Df foo]; split; first exact: emeasurable_fun_funeneg.
+move=> [Df foo]; split; first exact: measurable_funeneg.
 apply: le_lt_trans foo; apply: ge0_le_integral => //.
-- by apply/measurable_funT_comp => //; exact: emeasurable_fun_funeneg.
-- exact/measurable_funT_comp.
+- by apply/measurableT_comp => //; exact: measurable_funeneg.
+- exact/measurableT_comp.
 - by move=> t Dt; rewrite -/((abse \o f) t) fune_abse gee0_abs// lee_addr.
 Qed.
 
@@ -2808,8 +2800,8 @@ Lemma integral_funeneg_lt_pinfty f : mu_int f ->
   \int[mu]_(x in D) f^\- x < +oo.
 Proof.
 move=> [mf]; apply: le_lt_trans; apply: ge0_le_integral => //.
-- by apply: emeasurable_fun_funeneg => //; exact: emeasurable_funN.
-- exact: measurable_funT_comp.
+- exact: measurable_funeneg.
+- exact: measurableT_comp.
 - move=> x Dx; have [fx0|/ltW fx0] := leP (f x) 0.
     rewrite lee0_abs// /funeneg.
     by move: fx0; rewrite -{1}oppe0 -lee_oppr => /max_idPl ->.
@@ -2821,8 +2813,8 @@ Lemma integral_funepos_lt_pinfty f : mu_int f ->
   \int[mu]_(x in D) f^\+ x < +oo.
 Proof.
 move=> [mf]; apply: le_lt_trans; apply: ge0_le_integral => //.
-- by apply: emeasurable_fun_funepos => //; exact: emeasurable_funN.
-- exact: measurable_funT_comp.
+- exact: measurable_funepos.
+- exact: measurableT_comp.
 - move=> x Dx; have [fx0|/ltW fx0] := leP (f x) 0.
     rewrite lee0_abs// /funepos.
     by move: (fx0) => /max_idPr ->; rewrite -lee_oppr oppe0.
@@ -2836,8 +2828,8 @@ move=> fi.
 rewrite fin_numElt; apply/andP; split.
   by rewrite (@lt_le_trans _ _ 0) ?lte_ninfty//; exact: integral_ge0.
 case: fi => mf; apply: le_lt_trans; apply: ge0_le_integral => //.
-- exact/emeasurable_fun_funeneg.
-- exact/measurable_funT_comp.
+- exact/measurable_funeneg.
+- exact/measurableT_comp.
 - by move=> x Dx; rewrite -/((abse \o f) x) (fune_abse f) lee_addr.
 Qed.
 
@@ -2848,8 +2840,8 @@ move=> fi.
 rewrite fin_numElt; apply/andP; split.
   by rewrite (@lt_le_trans _ _ 0) ?lte_ninfty//; exact: integral_ge0.
 case: fi => mf; apply: le_lt_trans; apply: ge0_le_integral => //.
-- exact/emeasurable_fun_funepos.
-- exact/measurable_funT_comp.
+- exact/measurable_funepos.
+- exact/measurableT_comp.
 - by move=> x Dx; rewrite -/((abse \o f) x) (fune_abse f) lee_addl.
 Qed.
 
@@ -2871,8 +2863,8 @@ Lemma integral_measure_series (D : set T) (mD : measurable D) (f : T -> \bar R) 
   \int[m]_(x in D) f x = \sum_(n <oo) \int[m_ n]_(x in D) f x.
 Proof.
 move=> fi mf fmoo fpoo; rewrite integralE.
-rewrite ge0_integral_measure_series//; last exact/emeasurable_fun_funepos.
-rewrite ge0_integral_measure_series//; last exact/emeasurable_fun_funeneg.
+rewrite ge0_integral_measure_series//; last exact/measurable_funepos.
+rewrite ge0_integral_measure_series//; last exact/measurable_funeneg.
 transitivity (\sum_(n <oo) (fine (\int[m_ n]_(x in D) f^\+ x))%:E -
               \sum_(n <oo) (fine (\int[m_ n]_(x in D) f^\- x))%:E).
   by congr (_ - _); apply: eq_eseriesr => n _; rewrite fineK//;
@@ -2970,7 +2962,7 @@ Lemma integrableS (E D : set T) (f : T -> \bar R) :
 Proof.
 move=> mE mD DE [mf ifoo]; split; first exact: measurable_funS mf.
 apply: le_lt_trans ifoo; apply: subset_integral => //.
-exact: measurable_funT_comp.
+exact: measurableT_comp.
 Qed.
 
 Lemma integrable_mkcond D f : measurable D ->
@@ -3032,14 +3024,14 @@ have [M M0 muM] : exists2 M, (0 <= M)%R &
     forall n, n%:R%:E * mu (E `&` D) <= M%:E.
   exists (fine (\int[mu]_(x in D) `|f x|)); first exact/fine_ge0/integral_ge0.
   move=> n; rewrite -integral_indic// -ge0_integralM//; last 2 first.
-    - by apply: measurable_funT_comp=> //; exact/measurable_fun_indic.
+    - exact: measurableT_comp.
     - by move=> *; rewrite lee_fin.
   rewrite fineK//; last first.
     by case: fint => _ foo; rewrite ge0_fin_numE//; exact: integral_ge0.
   apply: ge0_le_integral => //.
   - by move=> *; rewrite lee_fin /indic.
-  - apply/EFin_measurable_fun/measurable_funT_comp => //=.  
-  - by apply: measurable_funT_comp => //; case: fint.
+  - exact/EFin_measurable_fun/measurableT_comp.
+  - by apply: measurableT_comp => //; case: fint.
   - move=> x Dx; rewrite /= indicE.
     have [|xE] := boolP (x \in E); last by rewrite mule0.
     by rewrite /E inE /= => -[->]; rewrite leey.
@@ -3077,17 +3069,17 @@ have [r0|r0|->] := ltgtP r 0%R; last first.
   by under eq_fun do rewrite mul0e; rewrite mul0e integral0.
 - rewrite [in LHS]integralE// gt0_funeposM// gt0_funenegM//.
   rewrite (ge0_integralM_EFin _ _ _ _ (ltW r0)) //; last first.
-    by apply: emeasurable_fun_funepos => //; case: intf.
+    by apply: measurable_funepos => //; case: intf.
   rewrite (ge0_integralM_EFin _ _ _ _ (ltW r0)) //; last first.
-    by apply: emeasurable_fun_funeneg => //; case: intf.
+    by apply: measurable_funeneg => //; case: intf.
   rewrite -muleBr 1?[in RHS]integralE//.
   by apply: integrable_add_def; case: intf.
 - rewrite [in LHS]integralE// lt0_funeposM// lt0_funenegM//.
   rewrite ge0_integralM_EFin //; last 2 first.
-    + by apply: emeasurable_fun_funeneg => //; case: intf.
+    + by apply: measurable_funeneg => //; case: intf.
     + by rewrite -ler_oppr oppr0 ltW.
   rewrite ge0_integralM_EFin //; last 2 first.
-    + by apply: emeasurable_fun_funepos => //; case: intf.
+    + by apply: measurable_funepos => //; case: intf.
     + by rewrite -ler_oppr oppr0 ltW.
   rewrite -mulNe -EFinN opprK addeC EFinN mulNe -muleBr //; last first.
     by apply: integrable_add_def; case: intf.
@@ -3159,26 +3151,26 @@ move/(congr1 (fun y => \int[mu]_(x in D) (y x) )).
 rewrite (ge0_integralD mu mD); last 4 first.
   - by move=> x _; rewrite adde_ge0.
   - apply: emeasurable_funD.
-      by apply/emeasurable_fun_funepos/emeasurable_funD; [case: if1|case: if2].
-    by apply: emeasurable_fun_funeneg; case: if1.
+      by apply/measurable_funepos/emeasurable_funD; [case: if1|case: if2].
+    by apply: measurable_funeneg; case: if1.
   - by [].
-  - by apply: emeasurable_fun_funeneg; case: if2.
+  - by apply: measurable_funeneg; case: if2.
 rewrite (ge0_integralD mu mD); last 4 first.
   - by [].
-  - by apply/emeasurable_fun_funepos/emeasurable_funD; [case: if1|case: if2].
+  - by apply/measurable_funepos/emeasurable_funD; [case: if1|case: if2].
   - by [].
-  - by apply/emeasurable_fun_funepos/measurable_funT_comp => //; case: if1.
+  - by apply/measurable_funepos/measurableT_comp => //; case: if1.
 move=> ->.
 rewrite (ge0_integralD mu mD); last 4 first.
   - by move=> x _; exact: adde_ge0.
   - apply: emeasurable_funD.
-      by apply/emeasurable_fun_funeneg/emeasurable_funD; [case: if1|case: if2].
-    by apply: emeasurable_fun_funepos; case: if1.
+      by apply/measurable_funeneg/emeasurable_funD; [case: if1|case: if2].
+    by apply: measurable_funepos; case: if1.
   - by [].
-  - by apply: emeasurable_fun_funepos; case: if2.
+  - by apply: measurable_funepos; case: if2.
 rewrite (ge0_integralD mu mD) //.
-- by apply/emeasurable_fun_funeneg/emeasurable_funD => //; [case: if1|case: if2].
-- by apply: emeasurable_fun_funepos; case: if1.
+- by apply/measurable_funeneg/emeasurable_funD => //; [case: if1|case: if2].
+- by apply: measurable_funepos; case: if1.
 Qed.
 
 End linearity.
@@ -3205,7 +3197,7 @@ rewrite integralE (le_trans (lee_abs_sub _ _))// gee0_abs; last first.
   exact: integral_ge0.
 rewrite gee0_abs; last exact: integral_ge0.
 by rewrite -ge0_integralD // -?fune_abse//;
-  [exact: emeasurable_fun_funepos | exact: emeasurable_fun_funeneg].
+  [exact: measurable_funepos | exact: measurable_funeneg].
 Qed.
 
 Section integral_indic.
@@ -3297,13 +3289,12 @@ have le_f_M t : D t -> `|f t| <= M%:E * (f' t)%:E.
 have : 0 <= \int[mu]_(x in D) `|f x|  <= `|M|%:E * mu Df_neq0.
   rewrite integral_ge0//= /Df_neq0 -{2}(setIid D) setIAC -integral_indic//.
   rewrite -/Df_neq0 -ge0_integralM//; last 2 first.
-    - by apply: measurable_funT_comp=> //; exact: measurable_fun_indic.
+    - exact: measurableT_comp.
     - by move=> x ?; rewrite lee_fin.
   apply: ge0_le_integral => //.
-  - exact: measurable_funT_comp.
+  - exact: measurableT_comp.
   - by move=> x Dx; rewrite mule_ge0// lee_fin.
-  - apply: emeasurable_funM => //.
-    by apply: measurable_funT_comp => //; exact: measurable_fun_indic.
+  - by apply: emeasurable_funM => //; exact: measurableT_comp.
   - move=> x Dx.
     rewrite (le_trans (le_f_M _ Dx))// lee_fin /f' indicE.
     by case: (_ \in _) => //; rewrite ?mulr1 ?mulr0// ler_norm.
@@ -3342,9 +3333,9 @@ move=> mf; split=> [iDf0|Df0].
   transitivity (lim (fun n => mu (D `&` [set x | `|f x| >= n.+1%:R^-1%:E]))).
     apply/esym/cvg_lim => //; apply: nondecreasing_cvg_mu.
     - move=> i; apply: emeasurable_fun_c_infty => //.
-      exact: measurable_funT_comp.
+      exact: measurableT_comp.
     - apply: bigcupT_measurable => i.
-      by apply: emeasurable_fun_c_infty => //; exact: measurable_funT_comp.
+      by apply: emeasurable_fun_c_infty => //; exact: measurableT_comp.
     - move=> m n mn; apply/subsetPset; apply: setIS => t /=.
       by apply: le_trans; rewrite lee_fin lef_pinv // ?ler_nat // posrE.
   by rewrite (_ : (fun _ => _) = cst 0) ?lim_cst//= funeqE => n /=; rewrite muDf.
@@ -3363,7 +3354,7 @@ have -> : (fun x => `|f x|) = (fun x => lim (f_^~ x)).
   by rewrite min_l// subrr normr0.
 transitivity (lim (fun n => \int[mu]_(x in D) (f_ n x) )).
   apply/esym/cvg_lim => //; apply: cvg_monotone_convergence => //.
-  - by move=> n; apply: emeasurable_fun_min => //; exact: measurable_funT_comp.
+  - by move=> n; apply: measurable_mine => //; exact: measurableT_comp.
   - by move=> n t Dt; rewrite /f_ lexI abse_ge0 //= lee_fin.
   - move=> t Dt m n mn; rewrite /f_ lexI.
     have [ftm|ftm] := leP `|f t|%E m%:R%:E.
@@ -3381,7 +3372,7 @@ have f_bounded n x : D x -> `|f_ n x| <= n%:R%:E.
   by rewrite gee0_abs// lee_fin.
 have if_0 n : \int[mu]_(x in D) `|f_ n x|  = 0.
   apply: (@ae_eq_integral_abs_bounded _ _ _ n%:R) => //.
-    by apply: emeasurable_fun_min => //; exact: measurable_funT_comp.
+    by apply: measurable_mine => //; exact: measurableT_comp.
   exact: f_bounded.
 rewrite (_ : (fun _ => _) = cst 0) // ?lim_cst// funeqE => n.
 by rewrite -(if_0 n); apply: eq_integral => x _; rewrite gee0_abs// /f_.
@@ -3396,7 +3387,7 @@ rewrite (eq_integral (fun x => `|f x * (\1_N x)%:E|)); last first.
   by move=> t _; rewrite abseM (@gee0_abs _ (\1_N t)%:E)// lee_fin.
 apply/ae_eq_integral_abs => //.
   apply: emeasurable_funM => //; first exact: (measurable_funS mD).
-  exact/EFin_measurable_fun/measurable_fun_indic.
+  exact/EFin_measurable_fun.
 exists N; split => // t /= /not_implyP[_]; rewrite indicE.
 by have [|] := boolP (t \in N); rewrite ?inE ?mule0.
 Qed.
@@ -3438,7 +3429,7 @@ have h1 : mu.-integrable D f <-> mu.-integrable D (fun x => f x * (oneCN x)%:E).
     rewrite (eq_integral (fun x => `|f x| * (\1_(~` N) x)%:E)); last first.
       by move=> t _; rewrite abseM (@gee0_abs _ (\1_(~` N) t)%:E) // lee_fin.
     rewrite -integral_setI_indic//; case: intf => _; apply: le_lt_trans.
-    by apply: subset_integral => //; [exact:measurableI|exact:measurable_funT_comp].
+    by apply: subset_integral => //; [exact:measurableI|exact:measurableT_comp].
   split => //; rewrite (funID mN f) -/oneCN -/oneN.
   have ? : measurable_fun D (fun x : T => f x * (oneCN x)%:E).
     by apply: emeasurable_funM=> //; exact/EFin_measurable_fun/measurable_funTS.
@@ -3448,11 +3439,10 @@ have h1 : mu.-integrable D f <-> mu.-integrable D (fun x => f x * (oneCN x)%:E).
   apply: (@le_lt_trans _ _
     (\int[mu]_(x in D) (`|f x * (oneCN x)%:E| + `|f x * (oneN x)%:E|))).
     apply: ge0_le_integral => //.
-    - by apply: measurable_funT_comp => //; exact: emeasurable_funD.
-    - by apply: emeasurable_funD; exact: measurable_funT_comp.
+    - by apply: measurableT_comp => //; exact: emeasurable_funD.
+    - by apply: emeasurable_funD; exact: measurableT_comp.
     - by move=> *; rewrite lee_abs_add.
-  rewrite ge0_integralD//;
-    [|exact: measurable_funT_comp|exact: measurable_funT_comp].
+  rewrite ge0_integralD//; [|exact: measurableT_comp|exact: measurableT_comp].
   by apply: lte_add_pinfty; [case: intCf|case: intone].
 have h2 : mu.-integrable (D `\` N) f <->
     mu.-integrable D (fun x => f x * (oneCN x)%:E).
@@ -3464,7 +3454,7 @@ have h2 : mu.-integrable (D `\` N) f <->
       by move=> t _; rewrite abseM (@gee0_abs _ (\1_(~` N) t)%:E)// lee_fin.
     rewrite -integral_setI_indic //; case: intCf => _; apply: le_lt_trans.
     apply: subset_integral=> //; [exact: measurableI|exact: measurableD|].
-    by apply: measurable_funT_comp => //; apply: measurable_funS mf => // ? [].
+    by apply: measurableT_comp => //; apply: measurable_funS mf => // ? [].
   split.
     move=> mDN A mA; rewrite setDE (setIC D) -setIA; apply: measurableI => //.
     exact: mf.
@@ -3504,12 +3494,10 @@ Proof.
 move=> mD mf mg f0 g0 [N [mN N0 subN]].
 rewrite integralEindic// [RHS]integralEindic//.
 rewrite (negligible_integral mN)//; last 2 first.
-  - apply: emeasurable_funM => //.
-    exact/EFin_measurable_fun/measurable_fun_indic.
+  - by apply: emeasurable_funM => //; exact/EFin_measurable_fun.
   - by move=> x Dx; apply: mule_ge0 => //; [exact: f0|rewrite lee_fin].
 rewrite [RHS](negligible_integral mN)//; last 2 first.
-  - apply: emeasurable_funM => //.
-    exact/EFin_measurable_fun/measurable_fun_indic.
+  - by apply: emeasurable_funM => //; exact/EFin_measurable_fun.
   - by move=> x Dx; apply: mule_ge0 => //; [exact: g0|rewrite lee_fin].
 - apply: eq_integral => x;rewrite in_setD => /andP[_ xN].
   apply: contrapT; rewrite indicE; have [|?] := boolP (x \in D).
@@ -3525,10 +3513,10 @@ Lemma ae_eq_integral (D : set T) (g f : T -> \bar R) :
 Proof.
 move=> mD mf mg /ae_eq_funeposneg[Dfgp Dfgn].
 rewrite integralE// [in RHS]integralE//; congr (_ - _).
-  by apply: ge0_ae_eq_integral => //; [exact: emeasurable_fun_funepos|
-                                      exact: emeasurable_fun_funepos].
-by apply: ge0_ae_eq_integral => //; [exact: emeasurable_fun_funeneg|
-                                    exact: emeasurable_fun_funeneg].
+  by apply: ge0_ae_eq_integral => //; [exact: measurable_funepos|
+                                       exact: measurable_funepos].
+by apply: ge0_ae_eq_integral => //; [exact: measurable_funeneg|
+                                     exact: measurable_funeneg].
 Qed.
 
 End ae_eq_integral.
@@ -3557,17 +3545,17 @@ Lemma le_integral_comp_abse d (T : measurableType d) (R : realType)
   (f a%:E) * mu (D `&` [set x | (`|g x| >= a%:E)%E]) <= \int[mu]_(x in D) f `|g x|.
 Proof.
 move=> mg a0; have ? : measurable (D `&` [set x | (a%:E <= `|g x|)%E]).
-  by apply: emeasurable_fun_c_infty => //; exact: measurable_funT_comp.
+  by apply: emeasurable_fun_c_infty => //; exact: measurableT_comp.
 apply: (@le_trans _ _ (\int[mu]_(x in D `&` [set x | `|g x| >= a%:E]) f `|g x|)).
   rewrite -integral_cst//; apply: ge0_le_integral => //.
   - by move=> x _ /=; rewrite f0 // lee_fin ltW.
   - by move=> x _ /=; rewrite f0.
-  - apply: measurable_funT_comp => //; apply: measurable_funT_comp => //.
+  - apply: measurableT_comp => //; apply: measurableT_comp => //.
     exact: measurable_funS mg.
   - by move=> x /= [Dx]; apply: f_nd;
       rewrite inE /= in_itv /= andbT// lee_fin ltW.
 apply: subset_integral => //; last by move=> x _ /=; rewrite f0.
-by apply: measurable_funT_comp => //; exact: measurable_funT_comp.
+by apply: measurableT_comp => //; exact: measurableT_comp.
 Qed.
 
 Local Close Scope ereal_scope.
@@ -3755,7 +3743,7 @@ Variable (mu : {measure set T -> \bar R}).
 Lemma integrable_abse (D : set T) (f : T -> \bar R) :
   mu.-integrable D f -> mu.-integrable D (abse \o f).
 Proof.
-move=> [mf foo]; split; first exact: measurable_funT_comp.
+move=> [mf foo]; split; first exact: measurableT_comp.
 by under eq_integral do rewrite abse_id.
 Qed.
 
@@ -3847,8 +3835,8 @@ split => //; have Dfg x : D x -> `| f x | <= g x.
   - by apply: is_cvg_abse; apply/cvg_ex; eexists; exact: f_f.
   - by apply: nearW => n; exact: absfg.
 move: ig => [mg]; apply: le_lt_trans; apply: ge0_le_integral => //.
-- exact: measurable_funT_comp.
-- exact: measurable_funT_comp.
+- exact: measurableT_comp.
+- exact: measurableT_comp.
 - by move=> x Dx /=; rewrite (gee0_abs (g0 Dx)); exact: Dfg.
 Qed.
 
@@ -3885,7 +3873,7 @@ Qed.
 Let mgg n : measurable_fun D (fun x => 2%:E * g x - g_ n x).
 Proof.
 apply/emeasurable_funB => //; first by apply: measurable_funeM; case: ig.
-by apply/measurable_funT_comp => //; exact: emeasurable_funB.
+by apply/measurableT_comp => //; exact: emeasurable_funB.
 Qed.
 
 Let gg_ge0 n x : D x -> 0 <= 2%:E * g x - g_ n x.
@@ -3915,17 +3903,16 @@ rewrite [X in _ <= X -> _](_ : _ = \int[mu]_(x in D) (2%:E * g x)  + -
     - by rewrite -integral_ge0N// => x Dx//; rewrite /g_.
     - exact: integrablerM.
     - have integrable_normfn : mu.-integrable D (abse \o f_ n).
-        apply: le_integrable ig => //.
-        - exact: measurable_funT_comp.
-        - by move=> x Dx /=; rewrite abse_id (le_trans (absfg _ Dx))// lee_abs.
+        apply: le_integrable ig => //; first exact: measurableT_comp.
+        by move=> x Dx /=; rewrite abse_id (le_trans (absfg _ Dx))// lee_abs.
       suff: mu.-integrable D (fun x => `|f_ n x| + `|f x|).
         apply: le_integrable => //.
-        - by apply: measurable_funT_comp => //; exact: emeasurable_funB.
+        - by apply: measurableT_comp => //; exact: emeasurable_funB.
         - move=> x Dx.
           by rewrite /g_ abse_id (le_trans (lee_abs_sub _ _))// lee_abs.
       apply: integrableD; [by []| by []|].
       apply: le_integrable dominated_integrable => //.
-      - exact: measurable_funT_comp.
+      - exact: measurableT_comp.
       - by move=> x Dx; rewrite /= abse_id.
   rewrite lim_einf_shift // -lim_einfN; congr (_ + lim_einf _).
   by rewrite funeqE => n /=; rewrite -integral_ge0N// => x Dx; rewrite /g_.
@@ -4008,16 +3995,16 @@ split.
   split => //.
   move: if' => [?]; apply: le_lt_trans.
   rewrite le_eqVlt; apply/orP; left; apply/eqP/ae_eq_integral => //;
-    [exact: measurable_funT_comp|exact: measurable_funT_comp|].
+    [exact: measurableT_comp|exact: measurableT_comp|].
   exists N; split => //; rewrite -(setCK N); apply: subsetC => x Nx Dx.
   by rewrite /f' /restrict mem_set.
 - have := @dominated_cvg0 _ _ _ _ _ mD _ _ _ mu_ f_f' finv ig' f_g'.
   set X := (X in _ -> X --> _); rewrite [X in X --> _ -> _](_ : _ = X) //.
   apply/funext => n; apply: ae_eq_integral => //.
-  + apply: measurable_funT_comp => //; apply: emeasurable_funB => //.
+  + apply: measurableT_comp => //; apply: emeasurable_funB => //.
     apply/(measurable_restrict _ (measurableD _ _) _ _).1 => //.
     by apply: (measurable_funS mD) => // x [].
-  + by rewrite /g_; apply: measurable_funT_comp => //; exact: emeasurable_funB.
+  + by rewrite /g_; apply: measurableT_comp => //; exact: emeasurable_funB.
   + exists N; split => //; rewrite -(setCK N); apply: subsetC => x /= Nx Dx.
     by rewrite /f_' /f' /restrict mem_set.
 - have := @dominated_cvg _ _ _ _ _ mD _ _ _ mu_ f_f' finv ig' f_g'.
@@ -4072,7 +4059,7 @@ Proof.
 move=> mf mg fg; pose E j := D `&` [set x | f x - g x >= j.+1%:R^-1%:E].
 have mE j : measurable (E j).
   rewrite /E; apply: emeasurable_fun_le => //.
-  by apply/(emeasurable_funD mf.1)/emeasurable_funN; case: mg.
+  by apply/(emeasurable_funD mf.1)/measurableT_comp => //; case: mg.
 have muE j : mu (E j) = 0.
   apply/eqP; rewrite eq_le measure_ge0// andbT.
   have fg0 : \int[mu]_(x in E j) (f \- g) x = 0.
@@ -4082,7 +4069,7 @@ have muE j : mu (E j) = 0.
     rewrite fg// subee// fin_num_abs (le_lt_trans (le_abse_integral _ _ _))//.
       by apply: measurable_funS mg.1 => //; first exact: subIsetl.
     apply: le_lt_trans mg.2; apply: subset_integral => //; last exact: subIsetl.
-    exact: measurable_funT_comp mg.1.
+    exact: measurableT_comp mg.1.
   suff : mu (E j) <= j.+1%:R%:E * \int[mu]_(x in E j) (f \- g) x.
     by rewrite fg0 mule0.
   apply: (@le_trans _ _ (j.+1%:R%:E * \int[mu]_(x in E j) j.+1%:R^-1%:E)).
@@ -4137,13 +4124,13 @@ Implicit Types (A : set (T1 * T2)).
 Lemma measurable_xsection A x : measurable A -> measurable (xsection A x).
 Proof.
 move=> mA; rewrite (xsection_indic R) -(setTI (_ @^-1` _)).
-exact: measurable_fun_prod1.
+exact: measurableT_comp.
 Qed.
 
 Lemma measurable_ysection A y : measurable A -> measurable (ysection A y).
 Proof.
 move=> mA; rewrite (ysection_indic R) -(setTI (_ @^-1` _)).
-exact: measurable_fun_prod2.
+exact: measurableT_comp.
 Qed.
 
 End measurable_section.
@@ -4417,7 +4404,7 @@ rewrite (eq_integral (fun x => m2 A2 * (\1_A1 x)%:E)); last first.
     [rewrite in_xsectionM// mule1|rewrite mule0 notin_xsectionM].
 rewrite ge0_integralM//; last by move=> x _; rewrite lee_fin.
 - by rewrite muleC integral_indic// setIT.
-- exact: measurable_funT_comp.
+- exact: measurableT_comp.
 Qed.
 
 End product_measure1E.
@@ -4517,7 +4504,7 @@ have mA1A2 : measurable (A1 `*` A2) by apply: measurableM.
 transitivity (\int[m2]_y (m1 \o ysection (A1 `*` A2)) y) => //.
 rewrite (_ : _ \o _ = fun y => m1 A1 * (\1_A2 y)%:E).
   rewrite ge0_integralM//; last 2 first.
-    - exact: measurable_funT_comp.
+    - exact: measurableT_comp.
     - by move=> y _; rewrite lee_fin.
   by rewrite integral_indic ?setIT ?mul1e.
 rewrite funeqE => y; rewrite indicE.
@@ -4613,14 +4600,14 @@ Proof.
 rewrite funeqE => x; rewrite /F /fubini_F [in LHS]/=.
 under eq_fun do rewrite fimfunE -fsumEFin//.
 rewrite ge0_integral_fsum //; last 2 first.
-  - move=> i; apply/EFin_measurable_fun / measurable_funT_comp => //=.
-    exact/measurable_fun_prod1/measurable_fun_indic.
+  - move=> i; apply/EFin_measurable_fun/measurableT_comp => //=.
+    exact: measurableT_comp.
   - by move=> r y _; rewrite EFinM nnfun_muleindic_ge0.
 apply: eq_fsbigr => i; rewrite inE => -[/= t _ <-{i}].
 under eq_fun do rewrite EFinM.
 rewrite ge0_integralM//; last by rewrite lee_fin.
 - by rewrite -/((m2 \o xsection _) x) -indic_fubini_tonelli_FE.
-- exact/EFin_measurable_fun/measurable_fun_prod1.
+- exact/EFin_measurable_fun/measurableT_comp.
 - by move=> y _; rewrite lee_fin.
 Qed.
 
@@ -4636,14 +4623,14 @@ Proof.
 rewrite funeqE => y; rewrite /G /fubini_G [in LHS]/=.
 under eq_fun do rewrite fimfunE -fsumEFin//.
 rewrite ge0_integral_fsum //; last 2 first.
-  - move=> i; apply/EFin_measurable_fun/ measurable_funT_comp => //=.
-    exact/measurable_fun_prod2.
+  - move=> i; apply/EFin_measurable_fun/measurableT_comp => //=.
+    exact: measurableT_comp.
   - by move=> r x _; rewrite EFinM nnfun_muleindic_ge0.
 apply: eq_fsbigr => i; rewrite inE => -[/= t _ <-{i}].
 under eq_fun do rewrite EFinM.
 rewrite ge0_integralM//; last by rewrite lee_fin.
 - by rewrite -/((m1 \o ysection _) y) -indic_fubini_tonelli_GE.
-- exact/EFin_measurable_fun/measurable_fun_prod2.
+- exact/EFin_measurable_fun/measurableT_comp.
 - by move=> x _; rewrite lee_fin.
 Qed.
 
@@ -4662,7 +4649,7 @@ Proof.
 under [LHS]eq_integral
   do rewrite EFinf; rewrite ge0_integral_fsum //; last 2 first.
   - move=> r.
-    apply/EFin_measurable_fun/measurable_funT_comp => //=.
+    apply/EFin_measurable_fun/measurableT_comp => //=.
   - by move=> r /= z _; exact: nnfun_muleindic_ge0.
 transitivity (\sum_(k \in range f)
   \int[m1]_x (k%:E * (fubini_F m2 (EFin \o \1_(f @^-1` [set k])) x))).
@@ -4689,7 +4676,7 @@ Proof.
 under [LHS]eq_integral
   do rewrite EFinf; rewrite ge0_integral_fsum //; last 2 first.
   - move=> i.
-  apply/EFin_measurable_fun/measurable_funT_comp => //=.
+  apply/EFin_measurable_fun/measurableT_comp => //=.
   - by move=> r /= z _; exact: nnfun_muleindic_ge0.
 transitivity (\sum_(k \in range f)
   \int[m2]_x (k%:E * (fubini_G m1 (EFin \o \1_(f @^-1` [set k])) x))).
@@ -4742,7 +4729,7 @@ apply: (emeasurable_fun_cvg (F_ g)) => //.
       fun y => lim (EFin \o g ^~ (x, y))); last first.
     by rewrite funeqE => y; apply/esym/cvg_lim => //; exact: g_f.
   apply: cvg_monotone_convergence => //.
-  - by move=> n; apply/EFin_measurable_fun => //; exact/measurable_fun_prod1.
+  - by move=> n; apply/EFin_measurable_fun => //; exact/measurableT_comp.
   - by move=> n y _; rewrite lee_fin//; exact: fun_ge0.
   - by move=> y _ a b ab; rewrite lee_fin; exact/lefP/g_nd.
 Qed.
@@ -4756,7 +4743,7 @@ apply: (emeasurable_fun_cvg (G_ g)) => //.
       fun x => lim (EFin \o g ^~ (x, y))); last first.
     by rewrite funeqE => x; apply/esym/cvg_lim => //; exact: g_f.
   apply: cvg_monotone_convergence => //.
-  - by move=> n; apply/EFin_measurable_fun => //; exact/measurable_fun_prod2.
+  - by move=> n; apply/EFin_measurable_fun => //; exact/measurableT_comp.
   - by move=> n x _; rewrite lee_fin; exact: fun_ge0.
   - by move=> x _ a b ab; rewrite lee_fin; exact/lefP/g_nd.
 Qed.
@@ -4767,7 +4754,7 @@ have [g [g_nd /= g_f]] := approximation measurableT mf (fun x _ => f0 x).
 have F_F x : F x = lim (F_ g ^~ x).
   rewrite [RHS](_ : _ = lim (fun n => \int[m2]_y (EFin \o g n) (x, y)))//.
   rewrite -monotone_convergence//; last 3 first.
-    - by move=> n; exact/EFin_measurable_fun/measurable_fun_prod1.
+    - by move=> n; exact/EFin_measurable_fun/measurableT_comp.
     - by move=> n /= y _; rewrite lee_fin; exact: fun_ge0.
     - by move=> y /= _ a b; rewrite lee_fin => /g_nd/lefP; exact.
   by apply: eq_integral => y _; apply/esym/cvg_lim => //; exact: g_f.
@@ -4787,9 +4774,9 @@ rewrite -monotone_convergence //; first exact: eq_integral.
   exact: fun_ge0.
 - move=> x /= _ a b ab; apply: ge0_le_integral => //.
   + by move=> y _; rewrite lee_fin; exact: fun_ge0.
-  + exact/EFin_measurable_fun/measurable_fun_prod1.
+  + exact/EFin_measurable_fun/measurableT_comp.
   + by move=> *; rewrite lee_fin; exact: fun_ge0.
-  + exact/EFin_measurable_fun/measurable_fun_prod1.
+  + exact/EFin_measurable_fun/measurableT_comp.
   + by move=> y _; rewrite lee_fin; move/g_nd : ab => /lefP; exact.
 Qed.
 
@@ -4800,7 +4787,7 @@ have G_G y : G y = lim (G_ g ^~ y).
   rewrite /G /fubini_G.
   rewrite [RHS](_ : _ = lim (fun n => \int[m1]_x (EFin \o g n) (x, y)))//.
   rewrite -monotone_convergence//; last 3 first.
-    - by move=> n; exact/EFin_measurable_fun/measurable_fun_prod2.
+    - by move=> n; exact/EFin_measurable_fun/measurableT_comp.
     - by move=> n /= x _; rewrite lee_fin; exact: fun_ge0.
     - by move=> x /= _ a b; rewrite lee_fin => /g_nd/lefP; exact.
   by apply: eq_integral => x _; apply/esym/cvg_lim => //; exact: g_f.
@@ -4820,9 +4807,9 @@ rewrite -monotone_convergence //; first exact: eq_integral.
 - by move=> n y _; apply: integral_ge0 => // x _ /=; rewrite lee_fin fun_ge0.
 - move=> y /= _ a b ab; apply: ge0_le_integral => //.
   + by move=> x _; rewrite lee_fin fun_ge0.
-  + exact/EFin_measurable_fun/measurable_fun_prod2.
+  + exact/EFin_measurable_fun/measurableT_comp.
   + by move=> *; rewrite lee_fin fun_ge0.
-  + exact/EFin_measurable_fun/measurable_fun_prod2.
+  + exact/EFin_measurable_fun/measurableT_comp.
   + by move=> x _; rewrite lee_fin; move/g_nd : ab => /lefP; exact.
 Qed.
 
@@ -4854,28 +4841,28 @@ Lemma fubini1a :
   (m1 \x m2).-integrable setT f <-> \int[m1]_x \int[m2]_y `|f (x, y)| < +oo.
 Proof.
 split=> [[_]|] ioo.
-- by rewrite -(fubini_tonelli1 (abse \o f))//=; exact: measurable_funT_comp.
-- by split=> //; rewrite fubini_tonelli1//; exact: measurable_funT_comp.
+- by rewrite -(fubini_tonelli1 (abse \o f))//=; exact: measurableT_comp.
+- by split=> //; rewrite fubini_tonelli1//; exact: measurableT_comp.
 Qed.
 
 Lemma fubini1b :
   (m1 \x m2).-integrable setT f <-> \int[m2]_y \int[m1]_x `|f (x, y)| < +oo.
 Proof.
 split=> [[_]|] ioo.
-- by rewrite -(fubini_tonelli2 (abse \o f))//=; exact: measurable_funT_comp.
-- by split=> //; rewrite fubini_tonelli2//; exact: measurable_funT_comp.
+- by rewrite -(fubini_tonelli2 (abse \o f))//=; exact: measurableT_comp.
+- by split=> //; rewrite fubini_tonelli2//; exact: measurableT_comp.
 Qed.
 
 Let measurable_fun1 : measurable_fun setT (fun x => \int[m2]_y `|f (x, y)|).
 Proof.
 apply: (measurable_fun_fubini_tonelli_F (abse \o f)) => //=.
-exact: measurable_funT_comp.
+exact: measurableT_comp.
 Qed.
 
 Let measurable_fun2 : measurable_fun setT (fun y => \int[m1]_x `|f (x, y)|).
 Proof.
 apply: (measurable_fun_fubini_tonelli_G (abse \o f)) => //=.
-exact: measurable_funT_comp.
+exact: measurableT_comp.
 Qed.
 (* /NB: only relies on mf *)
 
@@ -4884,11 +4871,11 @@ Lemma ae_integrable1 :
 Proof.
 have : m1.-integrable setT (fun x => \int[m2]_y `|f (x, y)|).
   split => //; rewrite (le_lt_trans _  (fubini1a.1 imf))// ge0_le_integral //.
-  - exact: measurable_funT_comp.
+  - exact: measurableT_comp.
   - by move=> *; exact: integral_ge0.
   - by move=> *; rewrite gee0_abs//; exact: integral_ge0.
 move/integrable_ae => /(_ measurableT); apply: filterS => x /= /(_ I) im2f.
-by split; [exact/measurable_fun_prod1|by move/fin_numPlt : im2f => /andP[]].
+by split; [exact/measurableT_comp|by move/fin_numPlt : im2f => /andP[]].
 Qed.
 
 Lemma ae_integrable2 :
@@ -4896,11 +4883,11 @@ Lemma ae_integrable2 :
 Proof.
 have : m2.-integrable setT (fun y => \int[m1]_x `|f (x, y)|).
   split => //; rewrite (le_lt_trans _ (fubini1b.1 imf))// ge0_le_integral //.
-  - exact: measurable_funT_comp.
+  - exact: measurableT_comp.
   - by move=> *; exact: integral_ge0.
   - by move=> *; rewrite gee0_abs//; exact: integral_ge0.
 move/integrable_ae => /(_ measurableT); apply: filterS => x /= /(_ I) im2f.
-by split; [exact/measurable_fun_prod2|move/fin_numPlt : im2f => /andP[]].
+by split; [exact/measurableT_comp|move/fin_numPlt : im2f => /andP[]].
 Qed.
 
 Let F := fubini_F m2 f.
@@ -4912,12 +4899,12 @@ Let FE : F = Fplus \- Fminus. Proof. apply/funext=> x; exact: integralE. Qed.
 
 Let measurable_Fplus : measurable_fun setT Fplus.
 Proof.
-by apply: measurable_fun_fubini_tonelli_F => //; exact: emeasurable_fun_funepos.
+by apply: measurable_fun_fubini_tonelli_F => //; exact: measurable_funepos.
 Qed.
 
 Let measurable_Fminus : measurable_fun setT Fminus.
 Proof.
-by apply: measurable_fun_fubini_tonelli_F => //; exact: emeasurable_fun_funeneg.
+by apply: measurable_fun_fubini_tonelli_F => //; exact: measurable_funeneg.
 Qed.
 
 Lemma measurable_fubini_F : measurable_fun setT F.
@@ -4929,30 +4916,30 @@ Qed.
 Let integrable_Fplus : m1.-integrable setT Fplus.
 Proof.
 split=> //; apply: le_lt_trans (fubini1a.1 imf); apply: ge0_le_integral => //.
-- exact: measurable_funT_comp.
+- exact: measurableT_comp.
 - by move=> x _; exact: integral_ge0.
 - move=> x _; apply: le_trans.
-    apply: le_abse_integral => //; apply: emeasurable_fun_funepos => //.
-    exact: measurable_fun_prod1.
+    apply: le_abse_integral => //; apply: measurable_funepos => //.
+    exact: measurableT_comp.
   apply: ge0_le_integral => //.
-  - apply: measurable_funT_comp => //.
-    by apply: emeasurable_fun_funepos => //; exact: measurable_fun_prod1.
-  - by apply: measurable_funT_comp => //; exact/measurable_fun_prod1.
+  - apply: measurableT_comp => //.
+    by apply: measurable_funepos => //; exact: measurableT_comp.
+  - by apply: measurableT_comp => //; exact/measurableT_comp.
   - by move=> y _; rewrite gee0_abs// -/((abse \o f) (x, y)) fune_abse lee_addl.
 Qed.
 
 Let integrable_Fminus : m1.-integrable setT Fminus.
 Proof.
 split=> //; apply: le_lt_trans (fubini1a.1 imf); apply: ge0_le_integral => //.
-- exact: measurable_funT_comp.
+- exact: measurableT_comp.
 - by move=> *; exact: integral_ge0.
 - move=> x _; apply: le_trans.
-    apply: le_abse_integral => //; apply: emeasurable_fun_funeneg => //.
-    exact: measurable_fun_prod1.
+    apply: le_abse_integral => //; apply: measurable_funeneg => //.
+    exact: measurableT_comp.
   apply: ge0_le_integral => //.
-  + apply: measurable_funT_comp => //; apply: emeasurable_fun_funeneg => //.
-    exact: measurable_fun_prod1.
-  + by apply: measurable_funT_comp => //; exact: measurable_fun_prod1.
+  + apply: measurableT_comp => //; apply: measurable_funeneg => //.
+    exact: measurableT_comp.
+  + by apply: measurableT_comp => //; exact: measurableT_comp.
   + by move=> y _; rewrite gee0_abs// -/((abse \o f) (x, y)) fune_abse lee_addr.
 Qed.
 
@@ -4968,12 +4955,12 @@ Let GE : G = Gplus \- Gminus. Proof. apply/funext=> x; exact: integralE. Qed.
 
 Let measurable_Gplus : measurable_fun setT Gplus.
 Proof.
-by apply: measurable_fun_fubini_tonelli_G => //; exact: emeasurable_fun_funepos.
+by apply: measurable_fun_fubini_tonelli_G => //; exact: measurable_funepos.
 Qed.
 
 Let measurable_Gminus : measurable_fun setT Gminus.
 Proof.
-by apply: measurable_fun_fubini_tonelli_G => //; exact: emeasurable_fun_funeneg.
+by apply: measurable_fun_fubini_tonelli_G => //; exact: measurable_funeneg.
 Qed.
 
 Lemma measurable_fubini_G : measurable_fun setT G.
@@ -4982,30 +4969,30 @@ Proof. by rewrite GE; exact: emeasurable_funB. Qed.
 Let integrable_Gplus : m2.-integrable setT Gplus.
 Proof.
 split=> //; apply: le_lt_trans (fubini1b.1 imf); apply: ge0_le_integral => //.
-- exact: measurable_funT_comp.
+- exact: measurableT_comp.
 - by move=> *; exact: integral_ge0.
 - move=> y _; apply: le_trans.
-    apply: le_abse_integral => //; apply: emeasurable_fun_funepos => //.
-    exact: measurable_fun_prod2.
+    apply: le_abse_integral => //; apply: measurable_funepos => //.
+    exact: measurableT_comp.
   apply: ge0_le_integral => //.
-  - apply: measurable_funT_comp => //.
-    by apply: emeasurable_fun_funepos => //; exact: measurable_fun_prod2.
-  - by apply: measurable_funT_comp => //; exact: measurable_fun_prod2.
+  - apply: measurableT_comp => //.
+    by apply: measurable_funepos => //; exact: measurableT_comp.
+  - by apply: measurableT_comp => //; exact: measurableT_comp.
   - by move=> x _; rewrite gee0_abs// -/((abse \o f) (x, y)) fune_abse lee_addl.
 Qed.
 
 Let integrable_Gminus : m2.-integrable setT Gminus.
 Proof.
 split=> //; apply: le_lt_trans (fubini1b.1 imf); apply: ge0_le_integral => //.
-- exact: measurable_funT_comp.
+- exact: measurableT_comp.
 - by move=> *; exact: integral_ge0.
 - move=> y _; apply: le_trans.
-    apply: le_abse_integral => //; apply: emeasurable_fun_funeneg => //.
-    exact: measurable_fun_prod2.
+    apply: le_abse_integral => //; apply: measurable_funeneg => //.
+    exact: measurableT_comp.
   apply: ge0_le_integral => //.
-  + apply: measurable_funT_comp => //.
-    by apply: emeasurable_fun_funeneg => //; exact: measurable_fun_prod2.
-  + by apply: measurable_funT_comp => //; exact: measurable_fun_prod2.
+  + apply: measurableT_comp => //.
+    by apply: measurable_funeneg => //; exact: measurableT_comp.
+  + by apply: measurableT_comp => //; exact: measurableT_comp.
   + by move=> x _; rewrite gee0_abs// -/((abse \o f) (x, y)) fune_abse lee_addr.
 Qed.
 
@@ -5013,14 +5000,14 @@ Lemma fubini1 : \int[m1]_x F x = \int[m1 \x m2]_z f z.
 Proof.
 rewrite FE integralB; [|by[]|exact: integrable_Fplus|exact: integrable_Fminus].
 by rewrite [in RHS]integralE ?fubini_tonelli1//;
-  [exact: emeasurable_fun_funeneg|exact: emeasurable_fun_funepos].
+  [exact: measurable_funeneg|exact: measurable_funepos].
 Qed.
 
 Lemma fubini2 : \int[m2]_x G x = \int[m1 \x m2]_z f z.
 Proof.
 rewrite GE integralB; [|by[]|exact: integrable_Gplus|exact: integrable_Gminus].
 by rewrite [in RHS]integralE ?fubini_tonelli2//;
-  [exact: emeasurable_fun_funeneg|exact: emeasurable_fun_funepos].
+  [exact: measurable_funeneg|exact: measurable_funepos].
 Qed.
 
 Theorem Fubini :
@@ -5053,11 +5040,11 @@ transitivity (\sum_(n <oo) \int[s1 n]_x \sum_(m <oo) \int[s2 m]_y f (x, y)).
     rewrite [X in measurable_fun _ X](_ : _ =
         fun x => \sum_(n <oo) \int[s2 n]_y f (x, y)); last first.
       apply/funext => x.
-      by rewrite ge0_integral_measure_series//; exact/measurable_fun_prod1.
+      by rewrite ge0_integral_measure_series//; exact/measurableT_comp.
     apply: ge0_emeasurable_fun_sum; first by move=> k x; exact: integral_ge0.
     by move=> k; apply: measurable_fun_fubini_tonelli_F.
   apply: eq_eseriesr => n _; apply: eq_integral => x _.
-  by rewrite ge0_integral_measure_series//; exact/measurable_fun_prod1.
+  by rewrite ge0_integral_measure_series//; exact/measurableT_comp.
 transitivity (\sum_(n <oo) \sum_(m <oo) \int[s1 n]_x \int[s2 m]_y f (x, y)).
   apply: eq_eseriesr => n _; rewrite integral_nneseries//.
     by move=> m; exact: measurable_fun_fubini_tonelli_F.
@@ -5075,7 +5062,7 @@ transitivity (\int[mseries s2 0]_y \sum_(n <oo) \int[s1 n]_x f (x, y)).
   by move=> n y _; exact: integral_ge0.
 transitivity (\int[mseries s2 0]_y \int[mseries s1 0]_x f (x, y)).
   apply: eq_integral => y _.
-  by rewrite ge0_integral_measure_series//; exact/measurable_fun_prod2.
+  by rewrite ge0_integral_measure_series//; exact/measurableT_comp.
 transitivity (\int[m2]_y \int[mseries s1 0]_x f (x, y)).
   by apply: eq_measure_integral => A mA _ /=; rewrite sfinite_measure_seqP.
 apply: eq_integral => y _; apply: eq_measure_integral => A mA _ /=.

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -674,7 +674,7 @@ This was producing a warning but the alternative was failing with Coq 8.12 with
   # Please report at http://coq.inria.fr/bugs/.
 *)
 
-Lemma measurable_EFin (A : set R) : measurableR A -> measurable (EFin @` A).
+Lemma measurable_image_EFin (A : set R) : measurableR A -> measurable (EFin @` A).
 Proof.
 by move=> mA; exists A => //; exists set0; [constructor|rewrite setU0].
 Qed.
@@ -682,7 +682,7 @@ Qed.
 Lemma emeasurable_set1 (x : \bar R) : measurable [set x].
 Proof.
 case: x => [r| |].
-- by rewrite -image_set1; apply: measurable_EFin; apply: measurable_set1.
+- by rewrite -image_set1; apply: measurable_image_EFin; apply: measurable_set1.
 - exists set0 => //; [exists [set +oo%E]; [by constructor|]].
   by rewrite image_set0 set0U.
 - exists set0 => //; [exists [set -oo%E]; [by constructor|]].
@@ -741,7 +741,7 @@ Definition elebesgue_measure : set \bar R -> \bar R :=
 Lemma elebesgue_measure0 : elebesgue_measure set0 = 0%E.
 Proof. by rewrite /elebesgue_measure set0D image_set0 measure0. Qed.
 
-Lemma measurable_fine (X : set \bar R) : measurable X ->
+Lemma measurable_image_fine (X : set \bar R) : measurable X ->
   measurable [set fine x | x in X `\` [set -oo; +oo]%E].
 Proof.
 case => Y mY [X' [ | <-{X} | <-{X} | <-{X} ]].
@@ -778,9 +778,9 @@ apply: (@measure_semi_sigma_additive _ _ _ [the measure _ _ of (@lebesgue_measur
   (fun n => fine @` (F n `\` [set -oo; +oo]%E))).
 - move=> n; have := mF n.
   move=> [X mX [X' mX']] XX'Fn.
-  apply: measurable_fine.
+  apply: measurable_image_fine.
   rewrite -XX'Fn.
-  apply: measurableU; first exact: measurable_EFin.
+  apply: measurableU; first exact: measurable_image_EFin.
   by case: mX' => //; exact: measurableU.
 - move=> i j _ _ [x [[a [Fia aoo ax] [b [Fjb boo] bx]]]].
   move: tF => /(_ i j Logic.I Logic.I); apply.
@@ -837,14 +837,12 @@ End salgebra_R_ssets.
 #[global]
 Hint Extern 0 (measurable [set _]) => solve [apply: measurable_set1|
                                             apply: emeasurable_set1] : core.
-#[deprecated(since="mathcomp-analysis 0.6.2",
-  note="use `emeasurable_itv` instead")]
+#[deprecated(since="mathcomp-analysis 0.6.2", note="use `emeasurable_itv` instead")]
 Notation emeasurable_itv_bnd_pinfty := emeasurable_itv.
-#[deprecated(since="mathcomp-analysis 0.6.2",
-  note="use `emeasurable_itv` instead")]
+#[deprecated(since="mathcomp-analysis 0.6.2", note="use `emeasurable_itv` instead")]
 Notation emeasurable_itv_ninfty_bnd := emeasurable_itv.
 
-Lemma measurable_fun_fine (R : realType) (D : set (\bar R)) : measurable D ->
+Lemma measurable_fine (R : realType) (D : set (\bar R)) : measurable D ->
   measurable_fun D fine.
 Proof.
 move=> mD _ /= B mB; rewrite [X in measurable X](_ : _ `&` _ = if 0%R \in B then
@@ -856,11 +854,13 @@ move=> mD _ /= B mB; rewrite [X in measurable X](_ : _ `&` _ = if 0%R \in B then
   - by case: ifPn => [_ [Dr [[s + [sr]]|[]//]]|_ [Dr [s + [sr]]]]; rewrite sr.
   - by case: ifPn => [/[!inE] B0 [Doo [[]//|]] [//|_]|B0 [Doo//] []].
   - by case: ifPn => [/[!inE] B0 [Doo [[]//|]] [//|_]|B0 [Doo//] []].
-case: ifPn => B0; apply/measurableI => //; last exact: measurable_EFin.
-by apply: measurableU; [exact: measurable_EFin|exact: measurableU].
+case: ifPn => B0; apply/measurableI => //; last exact: measurable_image_EFin.
+by apply: measurableU; [exact: measurable_image_EFin|exact: measurableU].
 Qed.
 #[global] Hint Extern 0 (measurable_fun _ fine) =>
-  solve [exact: measurable_fun_fine] : core.
+  solve [exact: measurable_fine] : core.
+#[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_fine` instead")]
+Notation measurable_fun_fine := measurable_fine.
 
 Section lebesgue_measure_itv.
 Variable R : realType.
@@ -1534,13 +1534,13 @@ Section standard_measurable_fun.
 Variable R : realType.
 Implicit Types D : set R.
 
-Lemma measurable_funN D : measurable_fun D (-%R).
+Lemma measurable_oppr D : measurable_fun D (-%R).
 Proof.
 apply: measurable_funTS => /=; apply: continuous_measurable_fun.
 exact: (@opp_continuous R [the normedModType R of R^o]).
 Qed.
 
-Lemma measurable_fun_normr D : measurable_fun D (@normr _ R).
+Lemma measurable_normr D : measurable_fun D (@normr _ R).
 Proof.
 move=> mD; apply: (measurability (RGenOInfty.measurableE R)) => //.
 move=> /= _ [_ [x ->] <-]; apply: measurableI => //.
@@ -1559,13 +1559,13 @@ rewrite [X in measurable X](_ : _ = setT)// predeqE => r.
 by split => // _; rewrite /= in_itv /= andbT (lt_le_trans x0).
 Qed.
 
-Lemma measurable_funrM D (k : R) : measurable_fun D ( *%R k).
+Lemma measurable_mulrl D (k : R) : measurable_fun D ( *%R k).
 Proof.
 apply: measurable_funTS => /=.
 by apply: continuous_measurable_fun; exact: mulrl_continuous.
 Qed.
 
-Lemma measurable_fun_exprn D n : measurable_fun D (fun x => x ^+ n).
+Lemma measurable_exprn D n : measurable_fun D (fun x => x ^+ n).
 Proof.
 apply measurable_funTS => /=.
 by apply continuous_measurable_fun; exact: exprn_continuous.
@@ -1573,19 +1573,25 @@ Qed.
 
 End standard_measurable_fun.
 #[global] Hint Extern 0 (measurable_fun _ (-%R)) =>
-  solve [exact: measurable_funN] : core.
+  solve [exact: measurable_oppr] : core.
 #[global] Hint Extern 0 (measurable_fun _ normr) =>
-  solve [exact: measurable_fun_normr] : core.
+  solve [exact: measurable_normr] : core.
 #[global] Hint Extern 0 (measurable_fun _ ( *%R _)) =>
-  solve [exact: measurable_funrM] : core.
+  solve [exact: measurable_mulrl] : core.
 #[global] Hint Extern 0 (measurable_fun _ (fun x => x ^+ _)) =>
-  solve [exact: measurable_fun_exprn] : core.
-#[deprecated(since="mathcomp-analysis 0.6.3",
-  note="use `measurable_fun_exprn` instead")]
-Notation measurable_fun_sqr := measurable_fun_exprn.
-#[deprecated(since="mathcomp-analysis 0.6.3",
-  note="use `measurable_funN` instead")]
-Notation measurable_fun_opp := measurable_funN.
+  solve [exact: measurable_exprn] : core.
+#[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_exprn` instead")]
+Notation measurable_fun_sqr := measurable_exprn.
+#[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_oppr` instead")]
+Notation measurable_fun_opp := measurable_oppr.
+#[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_oppr` instead")]
+Notation measurable_funN := measurable_oppr.
+#[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_normr` instead")]
+Notation measurable_fun_normr := measurable_normr.
+#[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_exprn` instead")]
+Notation measurable_fun_exprn := measurable_exprn.
+#[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_mulrl` instead")]
+Notation measurable_funrM := measurable_mulrl.
 
 Section measurable_fun_realType.
 Context d (T : measurableType d) (R : realType).
@@ -1611,9 +1617,7 @@ Qed.
 
 Lemma measurable_funB D f g : measurable_fun D f ->
   measurable_fun D g -> measurable_fun D (f \- g).
-Proof.
-by move=> mf mg; apply: measurable_funD => //; exact: measurable_funT_comp.
-Qed.
+Proof. by move=> ? ?; apply: measurable_funD =>//; exact: measurableT_comp. Qed.
 
 Lemma measurable_funM D f g :
   measurable_fun D f -> measurable_fun D g -> measurable_fun D (f \* g).
@@ -1621,19 +1625,18 @@ Proof.
 move=> mf mg; rewrite (_ : (_ \* _) = (fun x => 2%:R^-1 * (f x + g x) ^+ 2)
   \- (fun x => 2%:R^-1 * (f x ^+ 2)) \- (fun x => 2%:R^-1 * (g x ^+ 2))).
   apply: measurable_funB; first apply: measurable_funB.
-  - apply: measurable_funT_comp => //.
-    apply: measurable_funT_comp (measurable_fun_exprn _) _.
-    exact: measurable_funD.
-  - apply: measurable_funT_comp => //.
-    exact: measurable_funT_comp (measurable_fun_exprn _) _.
-  - apply: measurable_funT_comp => //.
-    exact: measurable_funT_comp (measurable_fun_exprn _) _.
+  - apply: measurableT_comp => //.
+    by apply: measurableT_comp (measurable_exprn _) _; exact: measurable_funD.
+  - apply: measurableT_comp => //.
+    exact: measurableT_comp (measurable_exprn _) _.
+  - apply: measurableT_comp => //.
+    exact: measurableT_comp (measurable_exprn _) _.
 rewrite funeqE => x /=; rewrite -2!mulrBr sqrrD (addrC (f x ^+ 2)) -addrA.
 rewrite -(addrA (f x * g x *+ 2)) -opprB opprK (addrC (g x ^+ 2)) addrK.
 by rewrite -(mulr_natr (f x * g x)) -(mulrC 2) mulrA mulVr ?mul1r// unitfE.
 Qed.
 
-Lemma measurable_fun_max D f g :
+Lemma measurable_maxr D f g :
   measurable_fun D f -> measurable_fun D g -> measurable_fun D (f \max g).
 Proof.
 move=> mf mg mD; apply (measurability (RGenCInfty.measurableE R)) => //.
@@ -1703,7 +1706,7 @@ Qed.
 
 End measurable_fun_realType.
 
-Lemma measurable_fun_ln (R : realType) : measurable_fun [set~ (0:R)] (@ln R).
+Lemma measurable_ln (R : realType) : measurable_fun [set~ (0:R)] (@ln R).
 Proof.
 rewrite (_ : [set~ 0] = `]-oo, 0[ `|` `]0, +oo[); last first.
   by rewrite -(setCitv `[0, 0]); apply/seteqP; split => [|]x/=;
@@ -1718,38 +1721,43 @@ apply/measurable_funU; [exact: measurable_itv|exact: measurable_itv|split].
   by move/subspace_continuous_measurable_fun; apply; exact: measurable_itv.
 Qed.
 #[global] Hint Extern 0 (measurable_fun _ (@ln _)) =>
-  solve [apply: measurable_fun_ln] : core.
+  solve [apply: measurable_ln] : core.
+#[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_ln` instead")]
+Notation measurable_fun_ln := measurable_ln.
 
-Lemma measurable_fun_expR (R : realType) : measurable_fun [set: R] expR.
+Lemma measurable_expR (R : realType) : measurable_fun [set: R] expR.
 Proof. by apply: continuous_measurable_fun; exact: continuous_expR. Qed.
 #[global] Hint Extern 0 (measurable_fun _ expR) =>
-  solve [apply: measurable_fun_expR] : core.
+  solve [apply: measurable_expR] : core.
 
-Lemma measurable_fun_power_pos (R : realType) p :
+Lemma measurable_power_pos (R : realType) p :
   measurable_fun [set: R] (@power_pos R ^~ p).
 Proof.
 apply: measurable_fun_if => //.
 - apply: (measurable_fun_bool true); rewrite (_ : _ @^-1` _ = [set 0])//.
   by apply/seteqP; split => [_ /eqP ->//|_ -> /=]; rewrite eqxx.
-- rewrite setTI; apply: measurable_funT_comp => //.
-  rewrite (_ : _ @^-1` _ = [set~ 0]); last first.
-    by apply/seteqP; split => [x /negP/negP/eqP|x x0]//=; exact/negbTE/eqP.
-  exact: measurable_funT_comp.
+- rewrite setTI; apply: measurableT_comp => //.
+  rewrite (_ : _ @^-1` _ = [set~ 0]); first exact: measurableT_comp.
+  by apply/seteqP; split => [x /negP/negP/eqP|x x0]//=; exact/negbTE/eqP.
 Qed.
 #[global] Hint Extern 0 (measurable_fun _ (@power_pos _ ^~ _)) =>
-  solve [apply: measurable_fun_power_pos] : core.
+  solve [apply: measurable_power_pos] : core.
+#[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_power_pos` instead")]
+Notation measurable_fun_power_pos := measurable_power_pos.
+#[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_maxr` instead")]
+Notation measurable_fun_max := measurable_maxr.
 
 Section standard_emeasurable_fun.
 Variable R : realType.
 
-Lemma measurable_fun_EFin (D : set R) : measurable_fun D EFin.
+Lemma measurable_EFin (D : set R) : measurable_fun D EFin.
 Proof.
 move=> mD; apply: (measurability (ErealGenOInfty.measurableE R)) => //.
 move=> /= _ [_ [x ->]] <-; apply: measurableI => //.
 by rewrite preimage_itv_o_infty EFin_itv; exact: measurable_itv.
 Qed.
 
-Lemma measurable_fun_abse (D : set (\bar R)) : measurable_fun D abse.
+Lemma measurable_abse (D : set (\bar R)) : measurable_fun D abse.
 Proof.
 move=> mD; apply: (measurability (ErealGenOInfty.measurableE R)) => //.
 move=> /= _ [_ [x ->] <-].
@@ -1758,7 +1766,7 @@ apply: measurableU; last first.
   by rewrite preimage_abse_pinfty; apply: measurableI => //; exact: measurableU.
 apply: measurableI => //; exists (normr @^-1` `]x, +oo[%classic).
   rewrite -[X in measurable X]setTI.
-  by apply: measurable_fun_normr => //; exact: measurable_itv.
+  by apply: measurable_normr => //; exact: measurable_itv.
 exists set0; first by constructor.
 rewrite setU0 predeqE => -[y| |]; split => /= => -[r];
   rewrite ?/= /= ?in_itv /= ?andbT => xr//.
@@ -1766,7 +1774,7 @@ rewrite setU0 predeqE => -[y| |]; split => /= => -[r];
   + by move=> [ry]; exists y => //=; rewrite /= in_itv/= andbT -ry.
 Qed.
 
-Lemma emeasurable_fun_minus (D : set (\bar R)) :
+Lemma measurable_oppe (D : set (\bar R)) :
   measurable_fun D (-%E : \bar R -> \bar R).
 Proof.
 move=> mD; apply: (measurability (ErealGenCInfty.measurableE R)) => //.
@@ -1777,25 +1785,31 @@ Qed.
 
 End standard_emeasurable_fun.
 #[global] Hint Extern 0 (measurable_fun _ abse) =>
-  solve [exact: measurable_fun_abse] : core.
+  solve [exact: measurable_abse] : core.
 #[global] Hint Extern 0 (measurable_fun _ EFin) =>
-  solve [exact: measurable_fun_EFin] : core.
+  solve [exact: measurable_EFin] : core.
 #[global] Hint Extern 0 (measurable_fun _ (-%E)) =>
-  solve [exact: emeasurable_fun_minus] : core.
+  solve [exact: measurable_oppe] : core.
+#[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_oppe` instead")]
+Notation emeasurable_fun_minus := measurable_oppe.
+#[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_abse` instead")]
+Notation measurable_fun_abse := measurable_abse.
+#[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_EFin` instead")]
+Notation measurable_fun_EFin := measurable_EFin.
 
 (* NB: real-valued function *)
 Lemma EFin_measurable_fun d (T : measurableType d) (R : realType) (D : set T)
     (g : T -> R) :
   measurable_fun D (EFin \o g) <-> measurable_fun D g.
 Proof.
-split=> [mf mD A mA|]; last by move=> mg; exact: measurable_funT_comp.
+split=> [mf mD A mA|]; last by move=> mg; exact: measurableT_comp.
 rewrite [X in measurable X](_ : _ = D `&` (EFin \o g) @^-1` (EFin @` A)).
   by apply: mf => //; exists A => //; exists set0; [constructor|rewrite setU0].
 congr (_ `&` _);rewrite eqEsubset; split=> [|? []/= _ /[swap] -[->//]].
 by move=> ? ?; exact: preimage_image.
 Qed.
 
-Lemma measurable_fun_er_map d (T : measurableType d) (R : realType) (f : R -> R)
+Lemma measurable_er_map d (T : measurableType d) (R : realType) (f : R -> R)
   : measurable_fun setT f -> measurable_fun [set: \bar R] (er_map f).
 Proof.
 move=> mf;rewrite (_ : er_map _ =
@@ -1805,8 +1819,10 @@ apply: measurable_fun_ifT => //=.
 + apply: (measurable_fun_bool true).
   rewrite /preimage/= -[X in measurable X]setTI.
   exact/emeasurable_fin_num.
-+ exact/EFin_measurable_fun/measurable_funT_comp.
++ exact/EFin_measurable_fun/measurableT_comp.
 Qed.
+#[deprecated(since="mathcomp-analysis 0.6.3", note="renamed `measurable_er_map`")]
+Notation measurable_fun_er_map := measurable_er_map.
 
 Section emeasurable_fun.
 Local Open Scope ereal_scope.
@@ -1832,7 +1848,7 @@ move=> _ [_ [x ->] <-];rewrite esups_preimage setI_bigcupr.
 by apply: bigcup_measurable => ? ?; exact/mf/emeasurable_itv.
 Qed.
 
-Lemma emeasurable_fun_max D (f g : T -> \bar R) :
+Lemma measurable_maxe D (f g : T -> \bar R) :
   measurable_fun D f -> measurable_fun D g ->
   measurable_fun D (fun x => maxe (f x) (g x)).
 Proof.
@@ -1847,23 +1863,21 @@ move=> _ [_ [x ->] <-]; rewrite [X in measurable X](_ : _ =
 by apply: measurableU; [exact/mf/emeasurable_itv| exact/mg/emeasurable_itv].
 Qed.
 
-Lemma emeasurable_fun_funepos D (f : T -> \bar R) :
+Lemma measurable_funepos D (f : T -> \bar R) :
   measurable_fun D f -> measurable_fun D f^\+.
-Proof. by move=> mf; apply: emeasurable_fun_max. Qed.
+Proof. by move=> mf; exact: measurable_maxe. Qed.
 
-Lemma emeasurable_fun_funeneg D (f : T -> \bar R) :
+Lemma measurable_funeneg D (f : T -> \bar R) :
   measurable_fun D f -> measurable_fun D f^\-.
-Proof.
-by move=> mf; apply: emeasurable_fun_max => //; exact: measurable_funT_comp.
-Qed.
+Proof. by move=> mf; apply: measurable_maxe => //; exact: measurableT_comp. Qed.
 
-Lemma emeasurable_fun_min D (f g : T -> \bar R) :
+Lemma measurable_mine D (f g : T -> \bar R) :
   measurable_fun D f -> measurable_fun D g ->
   measurable_fun D (fun x => mine (f x) (g x)).
 Proof.
 move=> mf mg; rewrite (_ : (fun _ => _) = (fun x => - maxe (- f x) (- g x))).
-  apply: measurable_funT_comp => //.
-  by apply: emeasurable_fun_max; exact: measurable_funT_comp.
+  apply: measurableT_comp => //.
+  by apply: measurable_maxe; exact: measurableT_comp.
 by rewrite funeqE => x; rewrite oppe_max !oppeK.
 Qed.
 
@@ -1880,10 +1894,6 @@ rewrite [X in _ --> X](_ : _ = ereal_inf (range (esups (f^~t)))).
 by congr (ereal_inf [set _ | _ in _]); rewrite predeqE.
 Qed.
 
-#[deprecated(since="mathcomp-analysis 0.6.0",
-  note="renamed `measurable_fun_lim_esup`")]
-Notation measurable_fun_elim_sup := measurable_fun_lim_esup.
-
 Lemma emeasurable_fun_cvg D (f_ : (T -> \bar R)^nat) (f : T -> \bar R) :
   (forall m, measurable_fun D (f_ m)) ->
   (forall x, D x -> f_ ^~ x --> f x) -> measurable_fun D f.
@@ -1897,7 +1907,15 @@ Qed.
 
 End emeasurable_fun.
 Arguments emeasurable_fun_cvg {d T R D} f_.
-
-#[deprecated(since="mathcomp-analysis 0.6.3",
-  note="use `measurable_funT_comp` instead")]
-Notation emeasurable_funN := measurable_funT_comp.
+#[deprecated(since="mathcomp-analysis 0.6.0", note="renamed `measurable_fun_lim_esup`")]
+Notation measurable_fun_elim_sup := measurable_fun_lim_esup.
+#[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurableT_comp` instead")]
+Notation emeasurable_funN := measurableT_comp.
+#[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_maxe` instead")]
+Notation emeasurable_fun_max := measurable_maxe.
+#[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_mine` instead")]
+Notation emeasurable_fun_min := measurable_mine.
+#[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_funepos` instead")]
+Notation emeasurable_fun_funepos := measurable_funepos.
+#[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_funeneg` instead")]
+Notation emeasurable_fun_funeneg := measurable_funeneg.

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -1002,10 +1002,10 @@ Context d1 d2 d3 (T1 : measurableType d1) (T2 : measurableType d2)
         (T3 : measurableType d3).
 Implicit Type D E : set T1.
 
-Lemma measurable_fun_id D : measurable_fun D id.
+Lemma measurable_id D : measurable_fun D id.
 Proof. by move=> mD A mA; apply: measurableI. Qed.
 
-Lemma measurable_fun_comp F (f : T2 -> T3) E (g : T1 -> T2) :
+Lemma measurable_comp F (f : T2 -> T3) E (g : T1 -> T2) :
   measurable F -> g @` E `<=` F ->
   measurable_fun F f -> measurable_fun E g -> measurable_fun E (f \o g).
 Proof.
@@ -1017,9 +1017,9 @@ rewrite (_ : _ `&` _ = E `&` g @^-1` (F `&` f @^-1` A)); last first.
 by apply/mg => //; exact: mf.
 Qed.
 
-Lemma measurable_funT_comp (f : T2 -> T3) E (g : T1 -> T2) :
+Lemma measurableT_comp (f : T2 -> T3) E (g : T1 -> T2) :
   measurable_fun setT f -> measurable_fun E g -> measurable_fun E (f \o g).
-Proof. exact: measurable_fun_comp. Qed.
+Proof. exact: measurable_comp. Qed.
 
 Lemma eq_measurable_fun D (f g : T1 -> T2) :
   {in D, f =1 g} -> measurable_fun D f -> measurable_fun D g.
@@ -1028,7 +1028,7 @@ by move=> fg mf mD A mA; rewrite [X in measurable X](_ : _ = D `&` f @^-1` A);
   [exact: mf|exact/esym/eq_preimage].
 Qed.
 
-Lemma measurable_fun_cst D (r : T2) : measurable_fun D (cst r : T1 -> _).
+Lemma measurable_cst D (r : T2) : measurable_fun D (cst r : T1 -> _).
 Proof.
 by move=> mD /= Y mY; rewrite preimage_cst; case: ifPn; rewrite ?setIT ?setI0.
 Qed.
@@ -1126,17 +1126,24 @@ have [-> _|-> _|-> _ |-> _] := subset_set2 YT.
 Qed.
 
 End measurable_fun.
+#[global] Hint Extern 0 (measurable_fun _ (fun=> _)) =>
+  solve [apply: measurable_cst] : core.
+#[global] Hint Extern 0 (measurable_fun _ (cst _)) =>
+  solve [apply: measurable_cst] : core.
+#[global] Hint Extern 0 (measurable_fun _ id) =>
+  solve [apply: measurable_id] : core.
 Arguments eq_measurable_fun {d1 d2 T1 T2 D} f {g}.
+Arguments measurable_fun_bool {d1 T1 D f} b.
 #[deprecated(since="mathcomp-analysis 0.6.2", note="renamed `eq_measurable_fun`")]
 Notation measurable_fun_ext := eq_measurable_fun.
-Arguments measurable_fun_bool {d1 T1 D f} b.
-
-#[global] Hint Extern 0 (measurable_fun _ (fun=> _)) =>
-  solve [apply: measurable_fun_cst] : core.
-#[global] Hint Extern 0 (measurable_fun _ (cst _)) =>
-  solve [apply: measurable_fun_cst] : core.
-#[global] Hint Extern 0 (measurable_fun _ id) =>
-  solve [apply: measurable_fun_id] : core.
+#[deprecated(since="mathcomp-analysis 0.6.3", note="renamed `measurable_id`")]
+Notation measurable_fun_id := measurable_id.
+#[deprecated(since="mathcomp-analysis 0.6.3", note="renamed `measurable_cst`")]
+Notation measurable_fun_cst := measurable_cst.
+#[deprecated(since="mathcomp-analysis 0.6.3", note="renamed `measurable_comp`")]
+Notation measurable_fun_comp := measurable_comp.
+#[deprecated(since="mathcomp-analysis 0.6.3", note="renamed `measurableT_comp`")]
+Notation measurable_funT_comp := measurableT_comp.
 
 Section measurability.
 
@@ -4060,47 +4067,53 @@ apply: (@iff_trans _ (preimage_classes (fst \o h) (snd \o h) `<=` measurable)).
   by rewrite subUset; split=> [|] A [C mC <-]; [exact: mf1|exact: mf2].
 Qed.
 
-Lemma measurable_fun_pair (f : T -> T1) (g : T -> T2) :
+Lemma measurable_fun_prod (f : T -> T1) (g : T -> T2) :
   measurable_fun setT f -> measurable_fun setT g ->
   measurable_fun setT (fun x => (f x, g x)).
-Proof. by move=> mf mg; apply/prod_measurable_funP. Qed.
+Proof. by move=> mf mg; exact/prod_measurable_funP. Qed.
 
 End prod_measurable_fun.
+#[deprecated(since="mathcomp-analysis 0.6.3", note="renamed `measurable_fun_prod`")]
+Notation measurable_fun_pair := measurable_fun_prod.
 
 Section prod_measurable_proj.
 Context d1 d2 (T1 : measurableType d1) (T2 : measurableType d2).
 
-Lemma measurable_fun_fst : measurable_fun setT (@fst T1 T2).
+Lemma measurable_fst : measurable_fun [set: T1 * T2] fst.
 Proof.
 by have /prod_measurable_funP[] :=
-  @measurable_fun_id _ [the measurableType _ of (T1 * T2)%type] setT.
+  @measurable_id _ [the measurableType _ of (T1 * T2)%type] setT.
 Qed.
+#[local] Hint Resolve measurable_fst : core.
 
-Lemma measurable_fun_snd : measurable_fun setT (@snd T1 T2).
+Lemma measurable_snd : measurable_fun [set: T1 * T2] snd.
 Proof.
 by have /prod_measurable_funP[] :=
-  @measurable_fun_id _ [the measurableType _ of (T1 * T2)%type] setT.
+  @measurable_id _ [the measurableType _ of (T1 * T2)%type] setT.
 Qed.
+#[local] Hint Resolve measurable_snd : core.
 
-Lemma measurable_fun_swap : measurable_fun [set: T1 * T2] (@swap T1 T2).
-Proof.
-by apply/prod_measurable_funP => /=; split;
-  [exact: measurable_fun_snd|exact: measurable_fun_fst].
-Qed.
+Lemma measurable_swap : measurable_fun [set: _] (@swap T1 T2).
+Proof. exact: measurable_fun_prod. Qed.
 
 End prod_measurable_proj.
+#[deprecated(since="mathcomp-analysis 0.6.3", note="renamed `measurable_fst`")]
+Notation measurable_fun_fst := measurable_fst.
+#[deprecated(since="mathcomp-analysis 0.6.3", note="renamed `measurable_snd`")]
+Notation measurable_fun_snd := measurable_snd.
+#[deprecated(since="mathcomp-analysis 0.6.3", note="renamed `measurable_swap`")]
+Notation measurable_fun_swap := measurable_swap.
+#[global] Hint Extern 0 (measurable_fun _ fst) =>
+  solve [apply: measurable_fst] : core.
+#[global] Hint Extern 0 (measurable_fun _ snd) =>
+  solve [apply: measurable_snd] : core.
 
 Lemma measurable_fun_if_pair d d' (X : measurableType d)
     (Y : measurableType d') (x y : X -> Y) :
   measurable_fun setT x -> measurable_fun setT y ->
   measurable_fun setT (fun tb => if tb.2 then x tb.1 else y tb.1).
 Proof.
-move=> mx my.
-have {}mx : measurable_fun [set: X * bool] (x \o fst).
-  by apply: measurable_funT_comp => //; exact: measurable_fun_fst.
-have {}my : measurable_fun [set: X * bool] (y \o fst).
-  by apply: measurable_funT_comp => //; exact: measurable_fun_fst.
-by apply: measurable_fun_ifT => //=; exact: measurable_fun_snd.
+by move=> mx my; apply: measurable_fun_ifT => //=; exact: measurableT_comp.
 Qed.
 
 Section partial_measurable_fun.
@@ -4108,24 +4121,22 @@ Context d d1 d2 (T : measurableType d) (T1 : measurableType d1)
   (T2 : measurableType d2).
 Variable f : T1 * T2 -> T.
 
-Lemma measurable_fun_prod1 x :
-  measurable_fun setT f -> measurable_fun setT (fun y => f (x, y)).
+Lemma measurable_pair1 (x : T1) : measurable_fun [set: T2] (pair x).
 Proof.
-move=> mf; pose pairx := fun y : T2 => (x, y).
-have m1pairx : measurable_fun setT (fst \o pairx) by exact/measurable_fun_cst.
-have m2pairx : measurable_fun setT (snd \o pairx) by exact/measurable_fun_id.
-have ? : measurable_fun setT pairx by exact/(proj2 (prod_measurable_funP _)).
-exact: (measurable_fun_comp _ _ mf).
+have m1pairx : measurable_fun [set: T2] (fst \o pair x) by exact/measurable_cst.
+have m2pairx : measurable_fun [set: T2] (snd \o pair x) by exact/measurable_id.
+exact/(prod_measurable_funP _).
 Qed.
 
-Lemma measurable_fun_prod2 y :
-  measurable_fun setT f -> measurable_fun setT (fun x => f (x, y)).
+Lemma measurable_pair2 (y : T2) : measurable_fun [set: T1] (pair^~ y).
 Proof.
-move=> mf; pose pairy := fun x : T1 => (x, y).
-have m1pairy : measurable_fun setT (fst \o pairy) by exact/measurable_fun_id.
-have m2pairy : measurable_fun setT (snd \o pairy) by exact/measurable_fun_cst.
-have : measurable_fun setT pairy by exact/(proj2 (prod_measurable_funP _)).
-exact: (measurable_fun_comp _ _ mf).
+have m1pairy : measurable_fun [set: T1] (fst \o pair^~ y) by exact/measurable_id.
+have m2pairy: measurable_fun [set: T1] (snd \o pair^~ y) by exact/measurable_cst.
+exact/(prod_measurable_funP _).
 Qed.
 
 End partial_measurable_fun.
+#[global] Hint Extern 0 (measurable_fun _ (pair _)) =>
+  solve [apply: measurable_pair1] : core.
+#[global] Hint Extern 0 (measurable_fun _ (pair^~ _)) =>
+  solve [apply: measurable_pair2] : core.

--- a/theories/probability.v
+++ b/theories/probability.v
@@ -233,7 +233,7 @@ Proof.
 move=> e0 mf f0 f_nd; rewrite -(setTI [set _ | _]).
 apply: (le_trans (@le_integral_comp_abse d T R P setT measurableT (EFin \o X)
   eps (er_map f) _ _ _ _ e0)) => //=.
-- exact: measurable_fun_er_map.
+- exact: measurable_er_map.
 - by case => //= r _; exact: f0.
 - by move=> [x| |] [y| |] xP yP xy//=; rewrite ?leey ?leNye// lee_fin f_nd.
 - exact/EFin_measurable_fun.
@@ -254,7 +254,7 @@ have h (Y : {RV P >-> R}) :
     - move=> x y; rewrite !inE !mksetE !in_itv/= !andbT => x0 y0.
       by rewrite ler_sqr.
   apply: expectation_le => //.
-  - by apply: measurable_funT_comp => //; exact: measurable_funT_comp.
+    - by apply: measurableT_comp => //; exact: measurableT_comp.
   - by move=> x /=; apply: sqr_ge0.
   - by move=> x /=; apply: sqr_ge0.
   - by apply/aeW => t /=; rewrite real_normK// num_real.


### PR DESCRIPTION
##### Motivation for this change

- name lemmas measurable_operator instead of measurable_fun_operator
- fixes #916 

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [ ] added corresponding documentation in the headers~~

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 2.0

<!-- MathComp-Analysis is compatible with MathComp < 2.0 (branch `master`) and
     MathComp 2.0 ([branch `hierarchy-builder`](https://github.com/math-comp/analysis/pull/698)).

     If this PR targets `master` and if it is merged, the merged commit will also be
     cherry-picked on the branch `hierarchy-builder`.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `hierarchy-builder` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: HB port to record divergences between `master` and `hierarchy-builder` -->

- [x] I added the label `TODO: HB port` to make sure someone ports this PR to
      the `hierarchy-builder` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
