### PR TITLE
minor fixes and additions to `exp.v`

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -42,7 +42,11 @@
 - in `lebesgue_integral.v`:
   + lemmas `integrableP`, `measurable_int`
 - in `exp.v`:
-  + lemmas `power_posrM`, `gt0_ler_power_pos`
+  + lemmas `power_posrM`, `gt0_ler_power_pos`,
+    `gt0_power_pos`, `norm_power_pos`, `lt0_norm_power_pos`,
+    `power_posB`
+  + lemmas `powere_posrM`, `powere_posAC`, `gt0_powere_pos`,
+    `powere_pos_eqy`, `eqy_powere_pos`, `powere_posD`, `powere_posB`
 
 - in `mathcomp_extra.v`:
   + definition `min_fun`, notation `\min`

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -42,7 +42,7 @@
 - in `lebesgue_integral.v`:
   + lemmas `integrableP`, `measurable_int`
 - in `exp.v`:
-  + lemmas `power_posrM`
+  + lemmas `power_posrM`, `gt0_ler_power_pos`
 
 - in `mathcomp_extra.v`:
   + definition `min_fun`, notation `\min`

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -26,21 +26,7 @@
 - in file `lebesgue_measure.v`,
   + new lemmas `pointwise_almost_uniform`, and 
     `ae_pointwise_almost_uniform`.
-- in `measure.v`:
-  + lemmas `measurable_pair1`, `measurable_pair2`
-  + lemma `covariance_le`
-- in `mathcomp_extra.v`
-  + definition `coefE` (will be in MC 2.1/1.18)
-  + lemmas `deg2_poly_canonical`, `deg2_poly_factor`, `deg2_poly_min`,
-    `deg2_poly_minE`, `deg2_poly_ge0`, `Real.deg2_poly_factor`,
-    `deg_le2_poly_delta_ge0`, `deg_le2_poly_ge0`
-    (will be in MC 2.1/1.18)
-  + lemma `deg_le2_ge0`
-  + new lemmas `measurable_subring`, and `semiring_sigma_additive`.
-  + added factory `Content_SubSigmaAdditive_isMeasure`
 
-- in `lebesgue_integral.v`:
-  + lemmas `integrableP`, `measurable_int`
 - in `exp.v`:
   + lemmas `power_posrM`, `gt0_ler_power_pos`,
     `gt0_power_pos`, `norm_power_pos`, `lt0_norm_power_pos`,
@@ -68,53 +54,6 @@
 - in `boolp.v`:
   + `mextentionality` -> `mextensionality`
   + `extentionality` -> `extensionality`
-- in `derive.v`:
-  + `Rmult_rev` -> `mulr_rev`
-  + `rev_Rmult` -> `rev_mulr`
-  + `Rmult_is_linear` -> `mulr_is_linear`
-  + `Rmult_linear` -> `mulr_linear`
-  + `Rmult_rev_is_linear` -> `mulr_rev_is_linear`
-  + `Rmult_rev_linear` -> `mulr_rev_linear`
-  + `Rmult_bilinear` -> `mulr_bilinear`
-  + `is_diff_Rmult` -> `is_diff_mulr`
-- in `lebesgue_measure.v`
-  + `measurable_funN` -> `measurable_oppr`
-  + `emeasurable_fun_minus` -> `measurable_oppe`
-  + `measurable_fun_abse` -> `measurable_abse`
-  + `measurable_EFin` -> `measurable_image_EFin`
-  + `measurable_fun_EFin` -> `measurable_EFin`
-  + `measurable_fine` -> `measurable_image_fine`
-  + `measurable_fun_fine` -> `measurable_fine`
-  + `measurable_fun_normr` -> `measurable_normr`
-  + `measurable_fun_exprn` -> `measurable_exprn`
-  + `emeasurable_fun_max` -> `measurable_maxe`
-  + `emeasurable_fun_min` -> `measurable_mine`
-  + `measurable_fun_max` -> `measurable_maxr`
-  + `measurable_fun_er_map` -> `measurable_er_map`
-  + `emeasurable_fun_funepos` -> `measurable_funepos`
-  + `emeasurable_fun_funeneg` -> `measurable_funeneg`
-  + `measurable_funrM` -> `measurable_mulrl`
-- in `measure.v`:
-  + `measurable_fun_id` -> `measurable_id`
-  + `measurable_fun_cst` -> `measurable_cst`
-  + `measurable_fun_comp` -> `measurable_comp`
-  + `measurable_funT_comp` -> `measurableT_comp`
-  + `measurable_fun_fst` -> `measurable_fst`
-  + `measurable_fun_snd` -> `measurable_snd`
-  + `measurable_fun_swap` -> `measurable_swap`
-  + `measurable_fun_pair` -> `measurable_fun_prod`
-  + `isMeasure0` -> ``Content_isMeasure`
-- in `lebesgue_integral.v`:
-  + `measurable_fun_indic` -> `measurable_indic`
-- in `measure.v`:
-  + `Hahn_ext` -> `measure_extension`
-  + `Hahn_ext_ge0` -> `measure_extension_ge0`
-  + `Hahn_ext_sigma_additive` -> `measure_extension_semi_sigma_additive`
-  + `Hahn_ext_unique` -> `measure_extension_unique`
-  + `RingOfSets_from_semiRingOfSets` -> `SemiRingOfSets_isRingOfSets`
-  + `AlgebraOfSets_from_RingOfSets` -> `RingOfSets_isAlgebraOfSets`
-  + `Measurable_from_algebraOfSets` -> `AlgebraOfSets_isMeasurable`
-  + `ring_sigma_additive` -> `ring_semi_sigma_additive`
 - in `exp.v`:
   + `expK` -> `expRK`
 
@@ -125,9 +64,6 @@
 
 ### Deprecated
 
-- in `lebesgue_measure.v`:
-  + lemma `measurable_fun_sqr` (use `measurable_exprn` instead)
-  + lemma `measurable_fun_opp` (use `measurable_oppr` instead)
 - in `exp.v`:
   + lemmas `convex_expR`, `ler_power_pos`
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -60,12 +60,11 @@
 ### Generalized
 
 - in `exp.v`:
+  + lemmas `convex_expR`, `ler_power_pos`
+- in `exp.v`:
   + lemma `ln_power_pos`
 
 ### Deprecated
-
-- in `exp.v`:
-  + lemmas `convex_expR`, `ler_power_pos`
 
 ### Removed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -26,6 +26,23 @@
 - in file `lebesgue_measure.v`,
   + new lemmas `pointwise_almost_uniform`, and 
     `ae_pointwise_almost_uniform`.
+- in `measure.v`:
+  + lemmas `measurable_pair1`, `measurable_pair2`
+  + lemma `covariance_le`
+- in `mathcomp_extra.v`
+  + definition `coefE` (will be in MC 2.1/1.18)
+  + lemmas `deg2_poly_canonical`, `deg2_poly_factor`, `deg2_poly_min`,
+    `deg2_poly_minE`, `deg2_poly_ge0`, `Real.deg2_poly_factor`,
+    `deg_le2_poly_delta_ge0`, `deg_le2_poly_ge0`
+    (will be in MC 2.1/1.18)
+  + lemma `deg_le2_ge0`
+  + new lemmas `measurable_subring`, and `semiring_sigma_additive`.
+  + added factory `Content_SubSigmaAdditive_isMeasure`
+
+- in `lebesgue_integral.v`:
+  + lemmas `integrableP`, `measurable_int`
+- in `exp.v`:
+  + lemmas `power_posrM`
 
 - in `mathcomp_extra.v`:
   + definition `min_fun`, notation `\min`
@@ -47,6 +64,55 @@
 - in `boolp.v`:
   + `mextentionality` -> `mextensionality`
   + `extentionality` -> `extensionality`
+- in `derive.v`:
+  + `Rmult_rev` -> `mulr_rev`
+  + `rev_Rmult` -> `rev_mulr`
+  + `Rmult_is_linear` -> `mulr_is_linear`
+  + `Rmult_linear` -> `mulr_linear`
+  + `Rmult_rev_is_linear` -> `mulr_rev_is_linear`
+  + `Rmult_rev_linear` -> `mulr_rev_linear`
+  + `Rmult_bilinear` -> `mulr_bilinear`
+  + `is_diff_Rmult` -> `is_diff_mulr`
+- in `lebesgue_measure.v`
+  + `measurable_funN` -> `measurable_oppr`
+  + `emeasurable_fun_minus` -> `measurable_oppe`
+  + `measurable_fun_abse` -> `measurable_abse`
+  + `measurable_EFin` -> `measurable_image_EFin`
+  + `measurable_fun_EFin` -> `measurable_EFin`
+  + `measurable_fine` -> `measurable_image_fine`
+  + `measurable_fun_fine` -> `measurable_fine`
+  + `measurable_fun_normr` -> `measurable_normr`
+  + `measurable_fun_exprn` -> `measurable_exprn`
+  + `emeasurable_fun_max` -> `measurable_maxe`
+  + `emeasurable_fun_min` -> `measurable_mine`
+  + `measurable_fun_max` -> `measurable_maxr`
+  + `measurable_fun_er_map` -> `measurable_er_map`
+  + `emeasurable_fun_funepos` -> `measurable_funepos`
+  + `emeasurable_fun_funeneg` -> `measurable_funeneg`
+  + `measurable_funrM` -> `measurable_mulrl`
+- in `measure.v`:
+  + `measurable_fun_id` -> `measurable_id`
+  + `measurable_fun_cst` -> `measurable_cst`
+  + `measurable_fun_comp` -> `measurable_comp`
+  + `measurable_funT_comp` -> `measurableT_comp`
+  + `measurable_fun_fst` -> `measurable_fst`
+  + `measurable_fun_snd` -> `measurable_snd`
+  + `measurable_fun_swap` -> `measurable_swap`
+  + `measurable_fun_pair` -> `measurable_fun_prod`
+  + `isMeasure0` -> ``Content_isMeasure`
+- in `lebesgue_integral.v`:
+  + `measurable_fun_indic` -> `measurable_indic`
+- in `measure.v`:
+  + `Hahn_ext` -> `measure_extension`
+  + `Hahn_ext_ge0` -> `measure_extension_ge0`
+  + `Hahn_ext_sigma_additive` -> `measure_extension_semi_sigma_additive`
+  + `Hahn_ext_unique` -> `measure_extension_unique`
+  + `RingOfSets_from_semiRingOfSets` -> `SemiRingOfSets_isRingOfSets`
+  + `AlgebraOfSets_from_RingOfSets` -> `RingOfSets_isAlgebraOfSets`
+  + `Measurable_from_algebraOfSets` -> `AlgebraOfSets_isMeasurable`
+  + `ring_sigma_additive` -> `ring_semi_sigma_additive`
+- in `exp.v`:
+  + `expK` -> `expRK`
 
 ### Generalized
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -120,6 +120,9 @@
 
 ### Generalized
 
+- in `exp.v`:
+  + lemma `ln_power_pos`
+
 ### Deprecated
 
 - in `lebesgue_measure.v`:

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -52,6 +52,12 @@
 
 ### Deprecated
 
+- in `lebesgue_measure.v`:
+  + lemma `measurable_fun_sqr` (use `measurable_exprn` instead)
+  + lemma `measurable_fun_opp` (use `measurable_oppr` instead)
+- in `exp.v`:
+  + lemmas `convex_expR`, `ler_power_pos`
+
 ### Removed
 
 ### Infrastructure

--- a/theories/exp.v
+++ b/theories/exp.v
@@ -469,14 +469,20 @@ by exists (-y); rewrite expRN H3y invrK.
 Qed.
 
 Local Open Scope convex_scope.
-Lemma convex_expR (t : {i01 R}) (a b : R^o) : a <= b ->
+Lemma convex_expR (t : {i01 R}) (a b : R^o) :
   expR (a <| t |> b) <= (expR a : R^o) <| t |> (expR b : R^o).
 Proof.
-move=> ab; apply: second_derivative_convex => //.
-- by move=> x axb; rewrite derive_expR derive_val expR_ge0.
-- exact/cvg_at_left_filter/continuous_expR.
-- exact/cvg_at_right_filter/continuous_expR.
-- by move=> z zab; rewrite derive_expR; exact: derivable_expR.
+have [ab|/ltW ba] := leP a b.
+- apply: second_derivative_convex => //.
+  + by move=> x axb; rewrite derive_expR derive_val expR_ge0.
+  + exact/cvg_at_left_filter/continuous_expR.
+  + exact/cvg_at_right_filter/continuous_expR.
+  + by move=> z zab; rewrite derive_expR; exact: derivable_expR.
+- rewrite convC [leRHS]convC; apply: second_derivative_convex => //.
+  + by move=> x axb; rewrite derive_expR derive_val expR_ge0.
+  + exact/cvg_at_left_filter/continuous_expR.
+  + exact/cvg_at_right_filter/continuous_expR.
+  + by move=> z zab; rewrite derive_expR; exact: derivable_expR.
 Qed.
 Local Close Scope convex_scope.
 
@@ -628,10 +634,10 @@ rewrite /power_pos. have [->|_] := eqVneq x 0 => //.
 by move: (expR_gt0 (p * ln x)) => /gt_eqF /eqP.
 Qed.
 
-Lemma ler_power_pos a : 1 < a -> {homo power_pos a : x y / x <= y}.
+Lemma ler_power_pos a : 1 <= a -> {homo power_pos a : x y / x <= y}.
 Proof.
 move=> a1 x y xy.
-by rewrite /power_pos gt_eqF ?(le_lt_trans _ a1)// ler_expR ler_pmul2r// ln_gt0.
+by rewrite /power_pos gt_eqF ?(lt_le_trans _ a1)// ler_expR ler_wpmul2r ?ln_ge0.
 Qed.
 
 Lemma power_posM x y r : 0 <= x -> 0 <= y -> (x * y) `^ r = x `^ r * y `^ r.
@@ -823,13 +829,11 @@ Proof. by move=> ?; rewrite /riemannR invr_gt0 power_pos_gt0. Qed.
 
 Lemma dvg_riemannR a : 0 <= a <= 1 -> ~ cvg (series (riemannR a)).
 Proof.
-case/andP => a0; rewrite le_eqVlt => /predU1P[->|a1].
-  rewrite (_ : riemannR 1 = harmonic); first exact: dvg_harmonic.
-  by rewrite funeqE => i /=; rewrite power_posr1.
+move=> /andP[a0 a1].
 have : forall n, harmonic n <= riemannR a n.
-  case=> /= [|n]; first by rewrite power_pos1 invr1.
-  rewrite -[leRHS]div1r ler_pdivl_mulr ?power_pos_gt0 // mulrC ler_pdivr_mulr //.
-  by rewrite mul1r -[leRHS]power_posr1 // (ler_power_pos) // ?ltr1n // ltW.
+  move=> [/=|n]; first by rewrite power_pos1 invr1.
+  rewrite -[leRHS]div1r ler_pdivl_mulr ?power_pos_gt0// mulrC ler_pdivr_mulr//.
+  by rewrite mul1r -[leRHS]power_posr1// (ler_power_pos)// ler1n.
 move/(series_le_cvg harmonic_ge0 (fun i => ltW (riemannR_gt0 i a0))).
 by move/contra_not; apply; exact: dvg_harmonic.
 Qed.

--- a/theories/exp.v
+++ b/theories/exp.v
@@ -617,12 +617,12 @@ move=> x0 a0; rewrite /power_pos; case: ifPn => [_|a_neq0 _].
 by rewrite lt_neqAle a0 andbT eq_sym.
 Qed.
 
-Lemma power_pos0 x : 0 `^ x = (x == 0)%:R.
-Proof. by rewrite /power_pos eqxx. Qed.
+Lemma power_pos0 x : x != 0 -> 0 `^ x = 0.
+Proof. by move=> x0; rewrite /power_pos eqxx (negbTE x0). Qed.
 
 Lemma power_posr1 a : 0 <= a -> a `^ 1 = a.
 Proof.
-rewrite le_eqVlt => /predU1P[<-|a0]; first by rewrite power_pos0 oner_eq0.
+rewrite le_eqVlt => /predU1P[<-|a0]; first by rewrite power_pos0// oner_eq0.
 by rewrite /power_pos gt_eqF// mul1r lnK// posrE.
 Qed.
 
@@ -650,7 +650,7 @@ Proof.
 rewrite le_eqVlt => /predU1P[<- x y _ _ _|]; first by rewrite !power_posr0.
 move=> a0 x y; rewrite !in_itv/= !andbT !le_eqVlt => /predU1P[<-|x0].
   move=> /predU1P[<- _|y0 _]; first by rewrite eqxx.
-  by rewrite !power_pos0 (gt_eqF a0) power_pos_gt0 ?orbT.
+  by rewrite !power_pos0 ?(gt_eqF a0)// power_pos_gt0 ?orbT.
 move=> /predU1P[<-|y0]; first by rewrite gt_eqF//= ltNge (ltW x0).
 move=> /predU1P[->//|xy]; first by rewrite eqxx.
 by apply/orP; right; rewrite /power_pos !gt_eqF// ltr_expR ltr_pmul2l// ltr_ln.
@@ -658,11 +658,9 @@ Qed.
 
 Lemma power_posM x y r : 0 <= x -> 0 <= y -> (x * y) `^ r = x `^ r * y `^ r.
 Proof.
+have [->|r0] := eqVneq r 0; first by rewrite !power_posr0 mulr1.
 rewrite 2!le_eqVlt.
-move=> /predU1P[<-|x0] /predU1P[<-|y0]; rewrite ?(mulr0, mul0r,power_pos0).
-- by rewrite -natrM; case: eqP.
-- by case: eqP => [->|]/=; rewrite ?mul0r ?power_posr0 ?mulr1.
-- by case: eqP => [->|]/=; rewrite ?mulr0 ?power_posr0 ?mulr1.
+move=> /predU1P[<-|x0] /predU1P[<-|y0]; rewrite ?(mulr0, mul0r, power_pos0)//.
 - rewrite /power_pos mulf_eq0; case: eqP => [->|x0']/=.
     rewrite (@gt_eqF _ _ y)//.
     by case: eqP => /=; rewrite ?mul0r ?mul1r// => ->; rewrite mul0r expR0.
@@ -703,7 +701,7 @@ have [->|s0] := eqVneq s 0%R; first by rewrite subr0 oppr0 power_posr0 mulr1.
 have [x0|x0|<-] := ltgtP 0 x.
 - by rewrite /power_pos gt_eqF// mulrDl expRD.
 - by rewrite /power_pos lt_eqF// -expRD -mulrDl.
-- by rewrite !power_pos0 subr_eq0 (negbTE rs) (negbTE r0) mul0r.
+- by rewrite !power_pos0 ?mulr0// ?subr_eq0// oppr_eq0.
 Qed.
 
 Lemma power_pos_mulrn a n : 0 <= a -> a `^ n%:R = a ^+ n.
@@ -711,14 +709,13 @@ Proof.
 move=> a0; elim: n => [|n ih].
   by rewrite mulr0n expr0 power_posr0//; apply: lt0r_neq0.
 move: a0; rewrite le_eqVlt => /predU1P[<-|a0].
-  by rewrite !power_pos0 mulrn_eq0/= oner_eq0/= expr0n.
+  by rewrite !power_pos0 ?mulrn_eq0//= expr0n.
 by rewrite -natr1 power_posD// ih power_posr1// ?exprS 1?mulrC// ltW.
 Qed.
 
 Lemma power_pos_inv1 a : 0 <= a -> a `^ (-1) = a ^-1.
 Proof.
-rewrite le_eqVlt => /predU1P[<-|a0].
-  by rewrite power_pos0 invr0 oppr_eq0 oner_eq0.
+rewrite le_eqVlt => /predU1P[<-|a0]; first by rewrite power_pos0// invr0.
 apply/(@mulrI _ a); first by rewrite unitfE gt_eqF.
 rewrite -[X in X * _ = _](power_posr1 (ltW a0)) -power_posD// subrr.
 by rewrite power_posr0 divff// gt_eqF.
@@ -729,7 +726,7 @@ Proof.
 move=> a0; elim: n => [|n ih].
   by rewrite -mulNrn mulr0n power_posr0 -exprVn expr0.
 move: a0; rewrite le_eqVlt => /predU1P[<-|a0].
-  by rewrite power_pos0 oppr_eq0 mulrn_eq0 oner_eq0 orbF exprnN exp0rz oppr_eq0.
+  by rewrite power_pos0 ?mulrn_eq0// exprnN exp0rz oppr_eq0.
 rewrite -natr1 opprD power_posD// (power_pos_inv1 (ltW a0)) ih.
 by rewrite -[in RHS]exprVn exprS [in RHS]mulrC exprVn.
 Qed.
@@ -746,14 +743,14 @@ Qed.
 Lemma ln_power_pos a x : ln (a `^ x) = x * ln a.
 Proof.
 have [->|x0] := eqVneq x 0; first by rewrite power_posr0 ln1// mul0r.
-have [->|a0] := eqVneq a 0; first by rewrite power_pos0 (negbTE x0) ln0// mulr0.
+have [->|a0] := eqVneq a 0; first by rewrite power_pos0// ln0// mulr0.
 by rewrite /power_pos (negbTE a0) expRK.
 Qed.
 
 Lemma power12_sqrt a : 0 <= a -> a `^ (2^-1) = Num.sqrt a.
 Proof.
 rewrite le_eqVlt => /predU1P[<-|a0].
-  by rewrite power_pos0 sqrtr0 invr_eq0 pnatr_eq0.
+  by rewrite power_pos0 ?invr_eq0 ?pnatr_eq0// sqrtr0.
 have /eqP : (a `^ (2^-1)) ^+ 2 = (Num.sqrt a) ^+ 2.
   rewrite sqr_sqrtr; last exact: ltW.
   by rewrite /power_pos gt_eqF// -expRMm mulrA divrr ?mul1r ?unitfE// lnK.
@@ -816,14 +813,17 @@ Proof. by case: x => [x| |] //=; case: ifP. Qed.
 Lemma eqy_powere_pos x r : (0 < r)%R -> x = +oo -> x `^ r = +oo.
 Proof. by move: x => [| |]//= r0 _; rewrite gt_eqF. Qed.
 
-Lemma powere_pos0r r : 0 `^ r = (r == 0)%:R%:E.
-Proof. by rewrite powere_pos_EFin power_pos0. Qed.
+Lemma powere_pos0r r : r != 0%R -> 0 `^ r = 0.
+Proof. by move=> r0; rewrite powere_pos_EFin power_pos0. Qed.
 
 Lemma powere_pos1r r : 1 `^ r = 1.
 Proof. by rewrite powere_pos_EFin power_pos1. Qed.
 
 Lemma fine_powere_pos x r : fine (x `^ r) = ((fine x) `^ r)%R.
-Proof. by move: x => [x| |]//=; rewrite power_pos0; case: ifPn. Qed.
+Proof.
+by move: x => [x| |]//=; case: ifPn => [/eqP ->|?];
+  rewrite ?power_posr0 ?power_pos0.
+Qed.
 
 Lemma powere_pos_ge0 x r : 0 <= x `^ r.
 Proof.
@@ -854,12 +854,12 @@ move: x y => [x| |] [y| |]//=; first by move=> x0 y0; rewrite -EFinM power_posM.
 - move=> x0 _; case: ifPn => /= [/eqP ->|r0].
   + by rewrite mule1 power_posr0 powere_pose0.
   + move: x0; rewrite le_eqVlt => /predU1P[[]<-|/[1!(@lte_fin R)] x0].
-    * by rewrite mul0e powere_pos0r power_pos0 (negbTE r0)/= mul0e.
+    * by rewrite mul0e powere_pos0r// power_pos0// mul0e.
     * by rewrite mulry [RHS]mulry !gtr0_sg ?power_pos_gt0// !mul1e powere_posyr.
 - move=> _ y0; case: ifPn => /= [/eqP ->|r0].
   + by rewrite power_posr0 powere_pose0 mule1.
   + move: y0; rewrite le_eqVlt => /predU1P[[]<-|/[1!(@lte_fin R)] u0].
-    by rewrite mule0 powere_pos0r power_pos0 (negbTE r0) mule0.
+    by rewrite mule0 powere_pos0r// power_pos0// mule0.
   + by rewrite 2!mulyr !gtr0_sg ?power_pos_gt0// mul1e powere_posyr.
 - move=> _ _; case: ifPn => /= [/eqP ->|r0].
   + by rewrite powere_pose0 mule1.
@@ -874,7 +874,7 @@ case: x => [x| |]/=; first by rewrite power_posrM.
   by rewrite mulf_eq0 (negbTE s0) orbF (negbTE r0) ?powere_posyr.
 - have [->|r0] := eqVneq r 0%R; first by rewrite mul0r eqxx powere_pos1r.
   have [->|s0] := eqVneq s 0%R; first by rewrite mulr0 eqxx powere_pose0.
-  by rewrite mulf_eq0 (negbTE s0) orbF (negbTE r0) powere_pos0r (negbTE s0).
+  by rewrite mulf_eq0 (negbTE s0) orbF (negbTE r0) powere_pos0r.
 Qed.
 
 Lemma powere_posAC x r s : (x `^ r) `^ s = (x `^ s) `^ r.
@@ -883,8 +883,8 @@ case: x => [x| |]/=; first by rewrite power_posAC.
 - case: ifPn => [/eqP ->|r0] /=; first by rewrite powere_pose0 power_pos1.
   by case: ifPn => //; rewrite ?powere_pos1r// powere_posyr.
 case: ifPn => [/eqP ->|r0] /=; first by rewrite power_pos1 powere_pose0.
-rewrite power_pos0; case: ifPn; rewrite ?powere_pos1r//=.
-by rewrite power_pos0 (negbTE r0).
+case: ifPn => [/eqP ->|s0]; first by rewrite power_posr0 powere_pos1r.
+by rewrite power_pos0// powere_pos0r.
 Qed.
 
 Lemma powere_posD x r s : 0 < x -> (0 <= r)%R -> (0 <= s)%R ->

--- a/theories/exp.v
+++ b/theories/exp.v
@@ -404,7 +404,7 @@ elim: n x => [x|n IH x] /=; first by rewrite mul0r expr0 expR0.
 by rewrite exprS -nat1r mulrDl mul1r expRD IH.
 Qed.
 
-Lemma expR_gt1 x:  (1 < expR x) = (0 < x).
+Lemma expR_gt1 x : (1 < expR x) = (0 < x).
 Proof.
 case: ltrgt0P => [x_gt0| xN|->]; last by rewrite expR0.
 - by rewrite (pexpR_gt1 x_gt0).
@@ -413,7 +413,7 @@ case: ltrgt0P => [x_gt0| xN|->]; last by rewrite expR0.
   by rewrite ltW // pexpR_gt1 // lter_oppE.
 Qed.
 
-Lemma expR_lt1 x:  (expR x < 1) = (x < 0).
+Lemma expR_lt1 x : (expR x < 1) = (x < 0).
 Proof.
 case: ltrgt0P => [x_gt0|xN|->]; last by rewrite expR0.
 - by apply/idP/negP; rewrite -leNgt ltW // expR_gt1.
@@ -502,7 +502,7 @@ rewrite /ln; case: xgetP => //= y _ /eqP yx x0.
 by have := expR_gt0 y; rewrite yx => /(le_lt_trans x0); rewrite ltxx.
 Qed.
 
-Lemma expK : cancel exp ln.
+Lemma expRK : cancel exp ln.
 Proof.
 by move=> x; rewrite /ln; case: xgetP => [x1 _ /eqP/expR_inj //|/(_ x)[]/=].
 Qed.
@@ -581,14 +581,14 @@ Qed.
 Lemma continuous_ln x : 0 < x -> {for x, continuous ln}.
 Proof.
 move=> x_gt0; rewrite -[x]lnK//.
-apply: nbhs_singleton (near_can_continuous _ _); near=> z; first exact: expK.
+apply: nbhs_singleton (near_can_continuous _ _); near=> z; first exact: expRK.
 by apply: continuous_expR.
 Unshelve. all: by end_near. Qed.
 
 Global Instance is_derive1_ln (x : R) : 0 < x -> is_derive x 1 ln x^-1.
 Proof.
 move=> x_gt0; rewrite -[x]lnK//.
-apply: (@is_derive_inverse R expR); first by near=> z; apply: expK.
+apply: (@is_derive_inverse R expR); first by near=> z; apply: expRK.
   by near=>z; apply: continuous_expR.
 by rewrite lnK // lt0r_neq0.
 Unshelve. all: by end_near. Qed.
@@ -666,11 +666,21 @@ have [->/=|z0] := eqVneq z 0; rewrite ?mul0r.
   have [x0|x0] := eqVneq x 0; rewrite ?eqxx ?oner_eq0 ?ln1 ?mulr0 ?expR0.
     by [].
   rewrite gt_eqF ?expR_gt0// gt_eqF; last by rewrite expR_gt0.
-  by rewrite !expK mulrCA.
+  by rewrite !expRK mulrCA.
 Qed.
 
 Lemma power_posD a : 0 < a -> {morph power_pos a : x y / x + y >-> x * y}.
 Proof. by move=> a0 x y; rewrite /power_pos gt_eqF// mulrDl expRD. Qed.
+
+Lemma power_posrM (x y z : R) : x `^ (y * z) = x `^ y `^ z.
+Proof.
+rewrite /power_pos; have [->/=|y0] := eqVneq y 0.
+  by rewrite !mul0r expR0 eqxx/= if_same oner_eq0 ln1 mulr0 expR0.
+have [->/=|z0] := eqVneq z 0.
+  by rewrite !mulr0 !mul0r expR0 eqxx 2!if_same.
+case: ifPn => [_/=|x0]; first by rewrite eqxx mulf_eq0 (negbTE y0) (negbTE z0).
+by rewrite gt_eqF ?expR_gt0// expRK mulrCA mulrA.
+Qed.
 
 Lemma power_pos_mulrn a n : 0 <= a -> a `^ n%:R = a ^+ n.
 Proof.
@@ -710,7 +720,7 @@ by rewrite -exprnN -power_pos_inv// nmulrn.
 Qed.
 
 Lemma ln_power_pos s r : s != 0 -> ln (s `^ r) = r * ln s.
-Proof. by move=> s0; rewrite /power_pos (negbTE s0) expK. Qed.
+Proof. by move=> s0; rewrite /power_pos (negbTE s0) expRK. Qed.
 
 Lemma power12_sqrt a : 0 <= a -> a `^ (2^-1) = Num.sqrt a.
 Proof.

--- a/theories/exp.v
+++ b/theories/exp.v
@@ -640,6 +640,17 @@ move=> a1 x y xy.
 by rewrite /power_pos gt_eqF ?(lt_le_trans _ a1)// ler_expR ler_wpmul2r ?ln_ge0.
 Qed.
 
+Lemma gt0_ler_power_pos (a : R) : 0 < a ->
+  {in `[0, +oo[ &, {homo power_pos ^~ a : x y / x <= y >-> x <= y}}.
+Proof.
+move=> a0 x y; rewrite !in_itv/= !andbT !le_eqVlt => /predU1P[<-|x0].
+  move=> /predU1P[<- _|y0 _]; first by rewrite eqxx.
+  by rewrite !power_pos0 (gt_eqF a0) power_pos_gt0 ?orbT.
+move=> /orP[/eqP<-|y0]; first by rewrite gt_eqF//= ltNge (ltW x0).
+move=> /predU1P[->//|xy]; first by rewrite eqxx.
+by apply/orP; right; rewrite /power_pos !gt_eqF// ltr_expR ltr_pmul2l// ltr_ln.
+Qed.
+
 Lemma power_posM x y r : 0 <= x -> 0 <= y -> (x * y) `^ r = x `^ r * y `^ r.
 Proof.
 rewrite 2!le_eqVlt.


### PR DESCRIPTION
##### Motivation for this change

These fixes and lemmas are used in a proof of Hoelder's inequality to be PRed soon.

@hoheinzollern 

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 2.0

<!-- MathComp-Analysis is compatible with MathComp < 2.0 (branch `master`) and
     MathComp 2.0 ([branch `hierarchy-builder`](https://github.com/math-comp/analysis/pull/698)).

     If this PR targets `master` and if it is merged, the merged commit will also be
     cherry-picked on the branch `hierarchy-builder`.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `hierarchy-builder` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: HB port to record divergences between `master` and `hierarchy-builder` -->

- [x] I added the label `TODO: HB port` to make sure someone ports this PR to
      the `hierarchy-builder` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
