### PR TITLE
Fix deprecation warnings from MC 2.0 and 1.17

### DIFF
--- a/classical/boolp.v
+++ b/classical/boolp.v
@@ -362,14 +362,11 @@ Proof. by move=> + G Gs x => /(_ x)/cid[x' <-]. Qed.
 Arguments canon {T U sort} x.
 
 Lemma Peq : canonical Type eqType.
-Proof. by apply: canon => T; exists  [eqType of {classic T}]. Qed.
+Proof. by apply: canon => T; exists {classic T}. Qed.
 Lemma Pchoice : canonical Type choiceType.
-Proof. by apply: canon => T; exists [choiceType of {classic T}]. Qed.
+Proof. by apply: canon => T; exists {classic T}. Qed.
 Lemma eqPchoice : canonical eqType choiceType.
-Proof.
-apply: canon => T; exists [choiceType of {eclassic T}].
-by case: T => //= T [?]//.
-Qed.
+Proof. by apply: canon => T; exists {eclassic T}; case: T => //= T [?]//. Qed.
 
 Lemma not_True : (~ True) = False. Proof. exact/propext. Qed.
 Lemma not_False : (~ False) = True. Proof. by apply/propext; split=> _. Qed.

--- a/classical/cardinality.v
+++ b/classical/cardinality.v
@@ -644,7 +644,7 @@ Proof. exact/card_le_finite/card_le_setD. Qed.
 Lemma finite_setU T (A B : set T) :
   finite_set (A `|` B) = (finite_set A /\ finite_set B).
 Proof.
-pose fP := @finite_fsetP [choiceType of {classic T}]; rewrite propeqE; split.
+pose fP := @finite_fsetP {classic T}; rewrite propeqE; split.
   by move=> finAUB; split; apply: sub_finite_set finAUB.
 by case=> /fP[X->]/fP[Y->]; apply/fP; exists (X `|` Y)%fset; rewrite set_fsetU.
 Qed.
@@ -1103,7 +1103,7 @@ Lemma choicePcountable {T : choiceType} : countable [set: T] ->
   {T' : countType | T = T' :> Type}.
 Proof.
 move=> /pcard_leP/unsquash f.
-pose TcM := PcanCountMixin (in1TT 'funoK_f).
+pose TcM := PCanIsCountable (in1TT 'funoK_f).
 pose TC : countType := HB.pack T TcM.
 by exists TC.
 Qed.
@@ -1316,7 +1316,7 @@ split=> [|f g]; rewrite !inE/=; first exact: finite_image_cst.
 by move=> fA gA; apply: (finite_image11 (fun x y => x - y)).
 Qed.
 HB.instance Definition _ :=
-  GRing.isZmodClosed.Build [zmodType of aT -> rT] fimfun fimfun_zmod_closed.
+  GRing.isZmodClosed.Build (aT -> rT) fimfun fimfun_zmod_closed.
 HB.instance Definition _ :=
   [SubChoice_isSubZmodule of {fimfun aT >-> rT} by <:].
 

--- a/classical/functions.v
+++ b/classical/functions.v
@@ -1275,7 +1275,7 @@ Lemma val_bij_subproof : OInv_Can2 sT T setT [set` P] val.
 Proof.
 apply: (OInv_Can2.Build _ _ _ _ val (fun x  _ => valP x)
         _ (in1W valK) (in1W (insubK _))).
-by move=> x Px /=; exists (sub x Px) => //; rewrite oinv_val insubT.
+by move=> x Px /=; exists (Sub x Px) => //; rewrite oinv_val insubT.
 Qed.
 HB.instance Definition _ := val_bij_subproof.
 

--- a/classical/mathcomp_extra.v
+++ b/classical/mathcomp_extra.v
@@ -195,8 +195,8 @@ Implicit Types i : interval R.
 Lemma mem_miditv i : (i.1 < i.2)%O -> miditv i \in i.
 Proof.
 move: i => [[ba a|[]] [bb b|[]]] //= ab; first exact: mid_in_itv.
-  by rewrite !in_itv -lteif_subl_addl subrr lteif01.
-by rewrite !in_itv lteif_subl_addr -lteif_subl_addl subrr lteif01.
+  by rewrite !in_itv -lteifBlDl subrr lteif01.
+by rewrite !in_itv lteifBlDr -lteifBlDl subrr lteif01.
 Qed.
 
 Lemma miditv_le_left i b : (i.1 < i.2)%O -> (BSide b (miditv i) <= i.2)%O.
@@ -236,7 +236,7 @@ End itv_porderType.
 
 Lemma sumr_le0 (R : numDomainType) I (r : seq I) (P : pred I) (F : I -> R) :
   (forall i, P i -> F i <= 0)%R -> (\sum_(i <- r | P i) F i <= 0)%R.
-Proof. by move=> F0; elim/big_rec : _ => // i x Pi; apply/ler_naddl/F0. Qed.
+Proof. by move=> F0; elim/big_rec : _ => // i x Pi; apply/ler_wnDl/F0. Qed.
 
 Lemma enum_ord0 : enum 'I_0 = [::].
 Proof. by apply/eqP; rewrite -size_eq0 size_enum_ord. Qed.
@@ -372,10 +372,10 @@ Proof. by rewrite -mulr2n -mulr_natr mulfVK //= pnatr_eq0. Qed.
 
 Lemma ler_addgt0Pr x y : reflect (forall e, e > 0 -> x <= y + e) (x <= y).
 Proof.
-apply/(iffP idP)=> [lexy e e_gt0 | lexye]; first by rewrite ler_paddr// ltW.
+apply/(iffP idP)=> [lexy e e_gt0 | lexye]; first by rewrite ler_wpDr// ltW.
 have [||ltyx]// := comparable_leP.
   rewrite (@comparabler_trans _ (y + 1))// /Order.comparable ?lexye ?ltr01//.
-  by rewrite ler_addl ler01 orbT.
+  by rewrite lerDl ler01 orbT.
 have /midf_lt [_] := ltyx; rewrite le_gtF//.
 rewrite -(subrKA y) addrACA 2!mulrDl -splitr lexye//.
 by rewrite addrC divr_gt0// ?ltr0n// subr_gt0.
@@ -390,9 +390,9 @@ Lemma in_segment_addgt0Pr x y z :
   reflect (forall e, e > 0 -> y \in `[x - e, z + e]) (y \in `[x, z]).
 Proof.
 apply/(iffP idP)=> [xyz e /[dup] e_gt0 /ltW e_ge0 | xyz_e].
-  by rewrite in_itv /= ler_subl_addr !ler_paddr// (itvP xyz).
+  by rewrite in_itv /= lerBlDr !ler_wpDr// (itvP xyz).
 by rewrite in_itv /= ; apply/andP; split; apply/ler_addgt0Pr => ? /xyz_e;
-   rewrite in_itv /= ler_subl_addr => /andP [].
+   rewrite in_itv /= lerBlDr => /andP [].
 Qed.
 
 Lemma in_segment_addgt0Pl x y z :
@@ -404,14 +404,14 @@ Qed.
 
 Lemma lt_le a b : (forall x, x < a -> x < b) -> a <= b.
 Proof.
-move=> ab; apply/ler_addgt0Pr => e e_gt0; rewrite -ler_subl_addr ltW//.
-by rewrite ab // ltr_subl_addr -ltr_subl_addl subrr.
+move=> ab; apply/ler_addgt0Pr => e e_gt0; rewrite -lerBlDr ltW//.
+by rewrite ab // ltrBlDr -ltrBlDl subrr.
 Qed.
 
 Lemma gt_ge a b : (forall x, b < x -> a < x) -> a <= b.
 Proof.
 move=> ab; apply/ler_addgt0Pr => e e_gt0.
-by rewrite ltW// ab// -ltr_subl_addl subrr.
+by rewrite ltW// ab// -ltrBlDl subrr.
 Qed.
 
 End lt_le_gt_ge.
@@ -491,10 +491,10 @@ Lemma onem_ge0 r : r <= 1 -> 0 <= `1-r.
 Proof. by rewrite le_eqVlt => /predU1P[->|/onem_gt0/ltW]; rewrite ?onem1. Qed.
 
 Lemma onem_le1 r : 0 <= r -> `1-r <= 1.
-Proof. by rewrite ler_subl_addr ler_addl. Qed.
+Proof. by rewrite lerBlDr lerDl. Qed.
 
 Lemma onem_lt1 r : 0 < r -> `1-r < 1.
-Proof. by rewrite ltr_subl_addr ltr_addl. Qed.
+Proof. by rewrite ltrBlDr ltrDl. Qed.
 
 Lemma onemX_ge0 r n : 0 <= r -> r <= 1 -> 0 <= `1-(r ^+ n).
 Proof. by move=> ? ?; rewrite subr_ge0 exprn_ile1. Qed.
@@ -525,15 +525,15 @@ Lemma ler_gtP (R : numFieldType) (x y : R) :
 Proof.
 apply: (equivP (ler_addgt0Pr _ _)); split=> [xy z|xz e e_gt0].
   by rewrite -subr_gt0 => /xy; rewrite addrC addrNK.
-by apply: xz; rewrite -[ltLHS]addr0 ler_lt_add.
+by apply: xz; rewrite -[ltLHS]addr0 ler_ltD.
 Qed.
 
 Lemma ler_ltP (R : numFieldType) (x y : R) :
   reflect (forall z, z < x -> z <= y) (x <= y).
 Proof.
 apply: (equivP (ler_addgt0Pr _ _)); split=> [xy z|xz e e_gt0].
-  by rewrite -subr_gt0 => /xy; rewrite addrCA -[leLHS]addr0 ler_add2l subr_ge0.
-by rewrite -ler_subl_addr xz// -[ltRHS]subr0 ler_lt_sub.
+  by rewrite -subr_gt0 => /xy; rewrite addrCA -[leLHS]addr0 lerD2l subr_ge0.
+by rewrite -lerBlDr xz// -[ltRHS]subr0 ler_ltB.
 Qed.
 
 Definition inv_fun T (R : unitRingType) (f : T -> R) x := (f x)^-1%R.
@@ -709,7 +709,7 @@ Let a4gt0 : 0 < 4%:R * a. Proof. by rewrite mulr_gt0 ?ltr0n. Qed.
 Lemma deg2_poly_min x : p.[- b / (2%:R * a)] <= p.[x].
 Proof.
 rewrite [p]deg2_poly_canonical ?pnatr_eq0// -/a -/b -/c /delta !hornerE/=.
-by rewrite ler_pmul2l// ler_add2r addrC mulNr subrr ?mulr0 ?expr0n sqr_ge0.
+by rewrite ler_pM2l// lerD2r addrC mulNr subrr ?mulr0 ?expr0n sqr_ge0.
 Qed.
 
 Lemma deg2_poly_minE : p.[- b / (2%:R * a)] = - delta / (4%:R * a).
@@ -722,9 +722,9 @@ Qed.
 Lemma deg2_poly_ge0 : reflect (forall x, 0 <= p.[x]) (delta <= 0).
 Proof.
 apply/(iffP idP) => [dlt0 x | /(_ (- b / (2%:R * a)))]; last first.
-  by rewrite deg2_poly_minE ler_pdivl_mulr// mul0r oppr_ge0.
+  by rewrite deg2_poly_minE ler_pdivlMr// mul0r oppr_ge0.
 apply: le_trans (deg2_poly_min _).
-by rewrite deg2_poly_minE ler_pdivl_mulr// mul0r oppr_ge0.
+by rewrite deg2_poly_minE ler_pdivlMr// mul0r oppr_ge0.
 Qed.
 
 End Pdeg2RealConvex.
@@ -809,7 +809,7 @@ pose r2 := (- b + Num.sqrt delta) / (2%:R * a).
 pose x0 := Num.max (r1 + 1) (r2 + 1).
 move: (pge0 x0); rewrite (Real.deg2_poly_factor degp' (ltW dge0)).
 rewrite !hornerE/= -mulrA nmulr_rge0// leNgt => /negbTE<-.
-by apply: mulr_gt0; rewrite subr_gt0 lt_maxr ltr_addl ltr01 ?orbT.
+by apply: mulr_gt0; rewrite subr_gt0 lt_maxr ltrDl ltr01 ?orbT.
 Qed.
 
 End Degle2PolyRealClosedConvex.

--- a/classical/set_interval.v
+++ b/classical/set_interval.v
@@ -191,8 +191,8 @@ Qed.
 Lemma lb_ubN E x : lbound E x <-> ubound (-%R @` E) (- x).
 Proof.
 split=> [/lbP xlbE|/ubP xlbE].
-by move=> _ [z Ez <-]; rewrite ler_oppr opprK; apply xlbE.
-by move=> y Ey; rewrite -(opprK x) ler_oppl; apply xlbE; exists y.
+by move=> _ [z Ez <-]; rewrite lerNr opprK; apply xlbE.
+by move=> y Ey; rewrite -(opprK x) lerNl; apply xlbE; exists y.
 Qed.
 
 Lemma ub_lbN E x : ubound E x <-> lbound (-%R @` E) (- x).
@@ -238,10 +238,10 @@ Qed.
 Lemma has_lbPn E : ~ has_lbound E <-> (forall x, exists2 y, E y & y < x).
 Proof.
 split=> [/has_lb_ubN /has_ubPn NEnub x|Enlb /has_lb_ubN].
-  have [y ENy ltxy] := NEnub (- x); exists (- y); rewrite 1?ltr_oppl //.
+  have [y ENy ltxy] := NEnub (- x); exists (- y); rewrite 1?ltrNl //.
   by case: ENy => z Ez <-; rewrite opprK.
 apply/has_ubPn => x; have [y Ey ltyx] := Enlb (- x).
-exists (- y); last by rewrite ltr_oppr.
+exists (- y); last by rewrite ltrNr.
 by exists y => //; rewrite opprK.
 Qed.
 
@@ -252,10 +252,10 @@ move: a => [b r|[|]] _ //.
   suff: ~ has_lbound `]-oo, r[%classic.
     by case: b => //; apply/contra_not/subset_has_lbound => x /ltW.
   apply/has_lbPn => x; exists (minr (r - 1) (x - 1)).
-    by rewrite !set_itvE/= lt_minl ltr_subl_addr ltr_addl ltr01.
-  by rewrite lt_minl orbC ltr_subl_addr ltr_addl ltr01.
+    by rewrite !set_itvE/= lt_minl ltrBlDr ltrDl ltr01.
+  by rewrite lt_minl orbC ltrBlDr ltrDl ltr01.
 case=> r /(_ (r - 1)) /=; rewrite in_itv /= => /(_ erefl).
-by apply/negP; rewrite -ltNge ltr_subl_addr ltr_addl.
+by apply/negP; rewrite -ltNge ltrBlDr ltrDl.
 Qed.
 
 Lemma hasNubound_itv (a : itv_bound R) : a != +oo%O ->
@@ -266,9 +266,9 @@ move: a => [b r|[|]] _ //.
     case: b => //; apply/contra_not/subset_has_ubound => x.
     by rewrite !set_itvE => /ltW.
   apply/has_ubPn => x; rewrite !set_itvE; exists (maxr (r + 1) (x + 1));
-  by rewrite ?in_itv /= ?andbT lt_maxr ltr_addl ltr01 // orbT.
+  by rewrite ?in_itv /= ?andbT lt_maxr ltrDl ltr01 // orbT.
 case=> r /(_ (r + 1)) /=; rewrite in_itv /= => /(_ erefl).
-by apply/negP; rewrite -ltNge ltr_addl.
+by apply/negP; rewrite -ltNge ltrDl.
 Qed.
 
 End interval_hasNbound.
@@ -285,9 +285,9 @@ Lemma opp_itv_bnd_infty (R : numDomainType) (x : R) b :
   [set` Interval -oo%O (BSide (negb b) (- x))].
 Proof.
 rewrite predeqE => /= r; split=> [[y xy <-]|xr].
-  by case: b xy; rewrite !in_itv/= andbT (ler_opp2, ltr_opp2).
+  by case: b xy; rewrite !in_itv/= andbT (lerN2, ltrN2).
 exists (- r); rewrite ?opprK //.
-by case: b xr; rewrite !in_itv/= andbT (ler_oppr, ltr_oppr).
+by case: b xr; rewrite !in_itv/= andbT (lerNr, ltrNr).
 Qed.
 
 Lemma opp_itv_infty_bnd (R : numDomainType) (x : R) b :
@@ -295,9 +295,9 @@ Lemma opp_itv_infty_bnd (R : numDomainType) (x : R) b :
   [set` Interval (BSide (negb b) (- x)) +oo%O].
 Proof.
 rewrite predeqE => /= r; split=> [[y xy <-]|xr].
-  by case: b xy; rewrite !in_itv/= andbT (ler_opp2, ltr_opp2).
+  by case: b xy; rewrite !in_itv/= andbT (lerN2, ltrN2).
 exists (- r); rewrite ?opprK //.
-by case: b xr; rewrite !in_itv/= andbT (ler_oppl, ltr_oppl).
+by case: b xr; rewrite !in_itv/= andbT (lerNl, ltrNl).
 Qed.
 
 Lemma opp_itv_bnd_bnd (R : numDomainType) a b (x y : R) :
@@ -305,17 +305,17 @@ Lemma opp_itv_bnd_bnd (R : numDomainType) a b (x y : R) :
   [set` Interval (BSide (~~ b) (- y)) (BSide (~~ a) (- x))].
 Proof.
 rewrite predeqE => /= r; split => [[{}r + <-]|].
-  by rewrite !in_itv/= 2!lteif_opp2 negbK andbC.
+  by rewrite !in_itv/= 2!lteifN2 negbK andbC.
 rewrite in_itv/= negbK => yrab.
-by exists (- r); rewrite ?opprK// !in_itv lteif_oppr andbC lteif_oppl.
+by exists (- r); rewrite ?opprK// !in_itv lteifNr andbC lteifNl.
 Qed.
 
 Lemma opp_itvoo (R : numDomainType) (x y : R) :
   -%R @` `]x, y[%classic = `](- y), (- x)[%classic.
 Proof.
 rewrite predeqE => /= r; split => [[{}r + <-]|].
-  by rewrite !in_itv/= !ltr_opp2 andbC.
-by exists (- r); rewrite ?opprK// !in_itv/= ltr_oppl ltr_oppr andbC.
+  by rewrite !in_itv/= !ltrN2 andbC.
+by exists (- r); rewrite ?opprK// !in_itv/= ltrNl ltrNr andbC.
 Qed.
 
 (* lemmas between itv and set-theoretic operations *)
@@ -352,7 +352,7 @@ Variable R : numDomainType.
 Implicit Types (a b t r : R) (A : set R).
 
 Lemma mem_1B_itvcc t : (1 - t \in `[0, 1]) = (t \in `[0, 1]).
-Proof. by rewrite !in_itv/= subr_ge0 ger_addl oppr_le0 andbC. Qed.
+Proof. by rewrite !in_itv/= subr_ge0 gerDl oppr_le0 andbC. Qed.
 
 Definition line_path a b t : R := (1 - t) * a + t * b.
 
@@ -385,14 +385,14 @@ Proof. by apply/funext => t; rewrite line_pathEl subrr mulr0 add0r. Qed.
 
 Lemma leW_line_path a b : a <= b -> {homo line_path a b : x y / x <= y}.
 Proof.
-by move=> ? ? ? ?; rewrite !line_pathEl ler_add ?ler_wpmul2r// subr_ge0.
+by move=> ? ? ? ?; rewrite !line_pathEl lerD ?ler_wpM2r// subr_ge0.
 Qed.
 
 Definition factor a b x := (x - a) / (b - a).
 
 Lemma leW_factor a b : a <= b -> {homo factor a b : x y / x <= y}.
 Proof.
-by move=> ? ? ? ?; rewrite /factor ler_wpmul2r ?ler_add// invr_ge0 subr_ge0.
+by move=> ? ? ? ?; rewrite /factor ler_wpM2r ?lerD// invr_ge0 subr_ge0.
 Qed.
 
 Lemma factor_flat a : factor a a = cst 0.
@@ -469,9 +469,9 @@ Proof.
 move=> ltab; rewrite -ndline_pathE.
 apply: bij_subr => //=; rewrite setTI ?ndline_pathE.
 apply/predeqP => t /=; rewrite !in_itv/= {1}line_pathEl line_pathEr.
-rewrite -lteif_subl_addr subrr -lteif_pdivr_mulr ?subr_gt0// mul0r.
-rewrite -lteif_subr_addr subrr -lteif_ndivr_mulr ?subr_lt0// mul0r.
-by rewrite lteif_subr_addl addr0.
+rewrite -lteifBlDr subrr -lteif_pdivrMr ?subr_gt0// mul0r.
+rewrite -lteifBrDr subrr -lteif_ndivrMr ?subr_lt0// mul0r.
+by rewrite lteifBrDl addr0.
 Qed.
 
 Lemma factor_itv_bij ba bb a b : a < b ->

--- a/theories/Rstruct.v
+++ b/theories/Rstruct.v
@@ -461,7 +461,7 @@ Proof. elim: n => // n IH; by rewrite S_INR IH RplusE -addn1 natrD. Qed.
 Lemma RsqrtE x : 0 <= x -> sqrt x = Num.sqrt x.
 Proof.
 move => x0; apply/eqP; have [t1 t2] := conj (sqrtr_ge0 x) (sqrt_pos x).
-rewrite eq_sym -(eqr_expn2 (_: 0 < 2)%N t1) //; last by apply /RleP.
+rewrite eq_sym -(eqrXn2 (_: 0 < 2)%N t1) //; last by apply /RleP.
 rewrite sqr_sqrtr // !exprS expr0 mulr1 -RmultE ?sqrt_sqrt //; by apply/RleP.
 Qed.
 
@@ -558,7 +558,7 @@ Proof.
 move=> k0; elim: s => /= [|h [/=|h' t ih]].
 by rewrite bigmaxr_nil mulr0.
 by rewrite !bigmaxr_un.
-by rewrite bigmaxr_cons {}ih bigmaxr_cons maxr_pmulr.
+by rewrite bigmaxr_cons {}ih bigmaxr_cons maxr_pMr.
 Qed.
 
 #[deprecated(note="To be removed. Use topology.v's bigmax/min lemmas instead.")]

--- a/theories/Rstruct.v
+++ b/theories/Rstruct.v
@@ -142,9 +142,7 @@ Proof. by move=> /Rmult_integral []->; rewrite eqxx ?orbT. Qed.
 HB.instance Definition _ := GRing.ComUnitRing_isIntegral.Build R
   R_idomainMixin.
 
-Lemma R_fieldMixin : GRing.field_axiom [unitRingType of R].
-Proof. by done. Qed.
-
+Lemma R_fieldMixin : GRing.field_axiom R. Proof. by []. Qed.
 HB.instance Definition _ := GRing.UnitRing_isField.Build R R_fieldMixin.
 
 (** Reflect the order on the reals to bool *)

--- a/theories/altreals/distr.v
+++ b/theories/altreals/distr.v
@@ -175,7 +175,7 @@ Lemma isdistr_finP {R : realType} {I : finType} (mu : I -> R) :
 Proof. split=> -[ ge0_mu le1]; split=> //.
 + by apply/le1; rewrite /index_enum -enumT enum_uniq.
 + move=> J uqJ; rewrite big_uniq 1?(le_trans _ le1) //=.
-  by rewrite [X in _<=X](bigID (mem J)) /= ler_addl sumr_ge0.
+  by rewrite [X in _<=X](bigID (mem J)) /= lerDl sumr_ge0.
 Qed.
 
 Lemma le1_mu1
@@ -268,7 +268,7 @@ Local Lemma has_sup_mrat s J : uniq J -> \sum_(i <- J) mrat s i <= 1.
 Proof.
 move=> uqJ; rewrite -mulr_suml /= -natr_sum; case: (size s =P 0%N).
   by move=> ->; rewrite invr0 mulr0 ler01.
-move=> /eqP nz_s; rewrite ler_pdivr_mulr ?ltr0n ?lt0n // mul1r.
+move=> /eqP nz_s; rewrite ler_pdivrMr ?ltr0n ?lt0n // mul1r.
 rewrite ler_nat (bigID (mem s)) /= [X in (_+X)%N]big1 ?addn0.
    by move=> i /count_memPn.
 have ->: (size s = \sum_(i <- undup s) count_mem i s)%N.
@@ -363,10 +363,10 @@ Proof.
 split=> [x|J uqJ]; first by apply/ge0_psum.
 rewrite /mlet psum_bigop; first by move=> y x; rewrite mulr_ge0.
   move=> u; apply/(le_summable (F2 := mu)) => //.
-  by move=> x; rewrite mulr_ge0 //= ler_pimulr ?le1_mu1.
+  by move=> x; rewrite mulr_ge0 //= ler_piMr ?le1_mu1.
 apply/(le_trans _ (le1_mu mu))/le_psum => //.
 move=> x; rewrite sumr_ge0 /= => [y _|]; first by rewrite mulr_ge0.
-rewrite -mulr_sumr ler_pimulr //; apply/(le_trans _ (le1_mu (f x))).
+rewrite -mulr_sumr ler_piMr //; apply/(le_trans _ (le1_mu (f x))).
 have := summable_mu (f x) => /gerfinseq_psum => /(_ _ uqJ).
 by apply/(le_trans _)/ler_sum=> y _; apply/ler_norm.
 Qed.
@@ -438,7 +438,7 @@ Proof.                          (* summable -> refactor *)
 move=> le_f; unlock dlet=> y /=; apply/le_psum/summable_mlet.
 move=> x; rewrite mulr_ge0 //=; case: (mu x =P 0).
   by move=> ->; rewrite !mul0r.
-by move/dinsuppPn/le_f/(_ y) => h; rewrite ler_pmul.
+by move/dinsuppPn/le_f/(_ y) => h; rewrite ler_pM.
 Qed.
 
 Lemma le_mu_dlet f mu nu : mu <=1 nu -> dlet f mu <=1 dlet f nu.
@@ -446,7 +446,7 @@ Proof.
 move=> le_mu x; unlock dlet; rewrite /= /mlet.
 apply/le_psum/summable_mlet => y; rewrite mulr_ge0 //=.
 case: (mu y =P 0) => [->|]; first by rewrite mul0r mulr_ge0.
-by move=>/dinsuppPn=> h; rewrite ler_pmul.
+by move=>/dinsuppPn=> h; rewrite ler_pM.
 Qed.
 
 Lemma le_dlet f g mu nu :
@@ -496,7 +496,7 @@ Proof.
 unlock dlet; rewrite /= /mlet => /eq0_psum h x /dinsuppP /eqP mu_x.
 have {}/h: summable (fun x => mu x * F x y).
   apply/(le_summable (F2 := mu)) => // z.
-  by rewrite mulr_ge0 //= ler_pimulr // le1_mu1.
+  by rewrite mulr_ge0 //= ler_piMr // le1_mu1.
 by move/(_ x)/eqP; rewrite mulf_eq0 (negbTE mu_x) /= => /eqP.
 Qed.
 End BindTheory.
@@ -516,9 +516,9 @@ rewrite (eq_psum (F2 := fun y => psum (S^~ y))) => [x|].
 rewrite __admitted__interchange_psum.
 + by move=> x; apply/summableZ/summable_mlet.
 + rewrite {}/S; apply/(le_summable (F2 := mu)) => //.
-  move=> x; rewrite ge0_psum /= psumZ ?ler_pimulr //.
+  move=> x; rewrite ge0_psum /= psumZ ?ler_piMr //.
   apply/(le_trans _ (le1_mu (f1 x)))/le_psum => //.
-  by move=> y; rewrite mulr_ge0 //= ler_pimulr ?le1_mu1.
+  by move=> y; rewrite mulr_ge0 //= ler_piMr ?le1_mu1.
 apply/eq_psum=> y /=; rewrite -psumZr //.
 by apply/eq_psum=> x /=; rewrite {}/S mulrA.
 Qed.
@@ -861,7 +861,7 @@ Implicit Types (mu : {distr T / R}) (A B E : pred T).
 Lemma summable_pr E mu : summable (fun x => (E x)%:R * mu x).
 Proof.
 apply/(le_summable (F2 := mu)) => [x|]; last by apply/summable_mu.
-  by rewrite mulr_ge0 ?ler0n //= ler_pimull // lern1 leq_b1.
+  by rewrite mulr_ge0 ?ler0n //= ler_piMl // lern1 leq_b1.
 Qed.
 
 Lemma pr_pred0 mu : \P_[mu] pred0 = 0.
@@ -1000,7 +1000,7 @@ Proof.
 move=> le_BA; apply/le_psum; last first.
   apply/summableMl => //; exists 1=> // x.
   by rewrite ger0_norm ?(ler0n, lern1) ?leq_b1.
-move=> x; rewrite mulr_ge0 ?ler0n ?ler_wpmul2r //.
+move=> x; rewrite mulr_ge0 ?ler0n ?ler_wpM2r //.
 rewrite ler_nat; have := le_BA x; rewrite -!topredE /=.
 by case: (B x) => // ->.
 Qed.
@@ -1015,7 +1015,7 @@ Lemma le_exp mu f1 f2: \E?_[mu] f1 -> \E?_[mu] f2 ->
   f1 <=1 f2 -> \E_[mu] f1 <= \E_[mu] f2.
 Proof.
 move=> sm1 sm2 le_f; apply/le_sum => //.
-by move=> x; rewrite ler_wpmul2r.
+by move=> x; rewrite ler_wpM2r.
 Qed.
 
 Lemma le_in_pr E1 E2 mu :
@@ -1024,7 +1024,7 @@ Lemma le_in_pr E1 E2 mu :
 Proof.
 move=> le; rewrite /pr; apply/le_psum; last by apply/summable_pr.
 move=> x; rewrite mulr_ge0 ?ler0n //=; case/boolP: (x \in dinsupp mu).
-  move/le; rewrite -!topredE /= => E12; rewrite ler_wpmul2r //.
+  move/le; rewrite -!topredE /= => E12; rewrite ler_wpM2r //.
   by rewrite ler_nat; case: (E1 x) E12 => // ->.
 by move/dinsuppPn=> ->; rewrite !mulr0.
 Qed.
@@ -1044,7 +1044,7 @@ Lemma le1_prc A B mu : \P_[mu, B] A <= 1.
 Proof.
 have := ge0_pr B mu; rewrite /prc le_eqVlt.
 case/orP=> [/eqP<-|]; first by rewrite invr0 mulr0 ler01.
-by move/ler_pdivr_mulr=> ->; rewrite mul1r le_in_pr // => x _ /andP[].
+by move/ler_pdivrMr=> ->; rewrite mul1r le_in_pr // => x _ /andP[].
 Qed.
 
 Lemma prc_sum A mu : 0 < \P_[mu] A ->
@@ -1137,11 +1137,11 @@ Proof. by rewrite pr_or opprB addrCA subrr addr0. Qed.
 
 Lemma ler_pr_or A B mu :
   \P_[mu] [predU A & B] <= \P_[mu] A + \P_[mu] B.
-Proof. by rewrite pr_or ler_subl_addr ler_addl ge0_pr. Qed.
+Proof. by rewrite pr_or lerBlDr lerDl ge0_pr. Qed.
 
 Lemma ler_pr_and A B mu :
   \P_[mu] [predI A & B] <= \P_[mu] A + \P_[mu] B.
-Proof. by rewrite pr_and ler_subl_addr ler_addl ge0_pr. Qed.
+Proof. by rewrite pr_and lerBlDr lerDl ge0_pr. Qed.
 
 Lemma pr_predC E mu: \P_[mu](predC E) = \P_[mu] predT - \P_[mu] E.
 Proof.
@@ -1174,11 +1174,11 @@ case=> M ltM; rewrite /has_esp; apply/summable_seqP.
 exists (Num.max M 0); first by rewrite le_maxr lexx orbT.
 move=> J uqJ; apply/(@le_trans _ _ (\sum_(j <- J) M * mu j)).
   apply/ler_sum=> j _; rewrite normrM [X in _*X]ger0_norm //.
-  by apply/ler_wpmul2r=> //; apply/ltW.
+  by apply/ler_wpM2r=> //; apply/ltW.
 case: (ltrP M 0) => [lt0_M|ge0_M].
   rewrite ?(ltW lt0_M) // -mulr_sumr.
   by rewrite nmulr_rle0 //; apply/sumr_ge0.
-by rewrite -mulr_sumr ler_pimulr // -pr_mem ?le1_pr.
+by rewrite -mulr_sumr ler_piMr // -pr_mem ?le1_pr.
 Qed.
 
 Lemma bounded_has_exp mu F :
@@ -1199,7 +1199,7 @@ move=> ge0M bd; apply/(@le_trans _ _ (\E_[mu] (fun _ => M))).
   + by apply/bounded_has_exp; exists M.
   + by apply/has_expC.
   + by move=> x; apply/(le_trans _ (bd x))/ler_norm.
-by rewrite exp_cst ler_pimull // le1_pr.
+by rewrite exp_cst ler_piMl // le1_pr.
 Qed.
 
 Lemma __admitted__exp_dlet mu (nu : T -> {distr U / R}) F :
@@ -1246,19 +1246,19 @@ rewrite !big_cons; have := ge0_l j; rewrite le_eqVlt.
 case/orP => [/eqP<-|gt0_lj].
   by rewrite !Monoid.simpm /= !Monoid.simpm; apply/ih.
 rewrite !addrA => eq1; pose z := (li * xi + l j * x j) / (li + l j).
-have nz_lij: li + l j != 0 by rewrite gt_eqF ?ltr_paddl.
+have nz_lij: li + l j != 0 by rewrite gt_eqF ?ltr_wpDl.
 have/ih := eq1 => -/(_ _ z); rewrite [_ * (_ / _)]mulrC.
 rewrite mulfVK // => {}ih; apply/(le_trans (ih _)).
   by rewrite addr_ge0 ?ge0_l.
-rewrite ler_add2r {ih}/z [_ / _]mulrDl ![_*_/_]mulrAC.
+rewrite lerD2r {ih}/z [_ / _]mulrDl ![_*_/_]mulrAC.
 set c1 : R := _ / _; set c2 : R := _ / _; have eqc2: c2 = 1 - c1.
   apply/(mulfI nz_lij); rewrite mulrBr mulr1 ![(li + l j)*_]mulrC.
   by apply/eqP; rewrite !mulfVK // eq_sym subr_eq addrC.
 set c := (li + l j); pose z := (c * c1 * f xi + c * c2 * f (x j)).
 apply/(@le_trans _ _ z); last by rewrite /z ![_*(_/_)]mulrC !mulfVK.
-rewrite {}/z -![c * _ * _]mulrA -mulrDr ler_wpmul2l ?addr_ge0 //.
+rewrite {}/z -![c * _ * _]mulrA -mulrDr ler_wpM2l ?addr_ge0 //.
 rewrite eqc2 cvx_f // ?leNye ?leey // divr_ge0 ?addr_ge0 //=.
-by rewrite ler_pdivr_mulr ?mul1r ?ler_addl ?ltr_paddl.
+by rewrite ler_pdivrMr ?mul1r ?lerDl ?ltr_wpDl.
 Qed.
 End Jensen.
 End Jensen.

--- a/theories/altreals/realseq.v
+++ b/theories/altreals/realseq.v
@@ -112,17 +112,17 @@ case: l1 l2 => [l1||] [l2||] //= lt_l12; last first.
 + exists (NNInf 0), (NPInf 1) => x y; rewrite !inE => lt1 lt2.
   by apply/(lt_trans lt1)/(lt_trans ltr01).
 + exists (NNInf (l2-1)), (B1 l2) => x y; rewrite !inE.
-  rewrite ltr_norml [-1 < _]ltr_subr_addl.
+  rewrite ltr_norml [-1 < _]ltrBrDl.
   by move => lt1 /andP[lt2 _]; apply/(lt_trans lt1).
 + exists (B1 l1), (NPInf (l1+1)) => x y; rewrite !inE.
-  rewrite ltr_norml ltr_subl_addr [1+_]addrC => /andP[_].
+  rewrite ltr_norml ltrBlDr [1+_]addrC => /andP[_].
   by move=> lt1 lt2; apply/(lt_trans lt1).
 pose e := l2 - l1; exists (B l1 (e/2%:R)), (B l2 (e/2%:R)).
 have gt0_e: 0 < e by rewrite subr_gt0.
 move=> x y; rewrite !inE/= /eclamp pmulr_rle0 // invr_le0.
 rewrite lern0 /= !ltr_distl => /andP[_ lt1] /andP[lt2 _].
 apply/(lt_trans lt1)/(le_lt_trans _ lt2).
-by rewrite ler_subr_addl addrCA -splitr /e addrCA subrr addr0.
+by rewrite lerBrDl addrCA -splitr /e addrCA subrr addr0.
 Qed.
 
 Lemma separable {R : realType} (l1 l2 : \bar R) :
@@ -209,14 +209,14 @@ Lemma ncvg_nbounded u x : ncvg u x%:E -> nbounded u.
 Proof.                   (* FIXME: factor out `sup` of a finite set *)
 case/(_ (B x 1)) => K cu; pose S := [seq `|u n| | n <- iota 0 K].
 pose M : R := sup [set x : R | x \in S]; pose e := Num.max (`|x| + 1) (M + 1).
-apply/asboolP/nboundedP; exists e => [|n]; first by rewrite lt_maxr ltr_paddl.
+apply/asboolP/nboundedP; exists e => [|n]; first by rewrite lt_maxr ltr_wpDl.
 case: (ltnP n K); last first.
   move/cu; rewrite inE eclamp_id ?ltr01 // => ltunBx1.
   rewrite lt_maxr; apply/orP; left; rewrite -[u n](addrK x) addrAC.
-  by apply/(le_lt_trans (ler_norm_add _ _)); rewrite addrC ltr_add2l.
+  by apply/(le_lt_trans (ler_normD _ _)); rewrite addrC ltrD2l.
 move=> lt_nK; have: `|u n| \in S; first by apply/map_f; rewrite mem_iota.
 move=> un_S; rewrite lt_maxr; apply/orP; right.
-case E: {+}K lt_nK => [|k] // lt_nSk; apply/ltr_spaddr; first apply/ltr01.
+case E: {+}K lt_nK => [|k] // lt_nSk; apply/ltr_pwDr; first apply/ltr01.
 suff : has_sup (fun x : R => x \in S) by move/sup_upper_bound/ubP => ->.
 split; first by exists `|u 0%N|; rewrite /S E inE eqxx.
 elim: {+}S => [|v s [ux /ubP hux]]; first by exists 0; apply/ubP.
@@ -228,7 +228,7 @@ Qed.
 Lemma nboundedC c : nbounded c%:S.
 Proof.
 apply/asboolP/nboundedP; exists (`|c| + 1).
-  by rewrite ltr_spaddr. by move=> _; rewrite ltr_addl.
+  by rewrite ltr_pwDr. by move=> _; rewrite ltrDl.
 Qed.
 
 Lemma ncvgC c : ncvg c%:S c%:E.
@@ -243,10 +243,10 @@ Proof.
 move=> cu cv; elim/nbh_finW => e /= gt0_e; pose z := e / 2%:R.
 case: (cu (B lu z)) (cv (B lv z)) => [ku {}cu] [kv {}cv].
 exists (maxn ku kv) => n; rewrite geq_max => /andP[leu lev].
-rewrite inE opprD addrACA (le_lt_trans (ler_norm_add _ _)) //.
+rewrite inE opprD addrACA (le_lt_trans (ler_normD _ _)) //.
 move: (cu _ leu) (cv _ lev); rewrite !inE eclamp_id.
   by rewrite mulr_gt0 // invr_gt0 ltr0Sn.
-move=> cu' cv'; suff ->: e = z + z by rewrite ltr_add.
+move=> cu' cv'; suff ->: e = z + z by rewrite ltrD.
 exact: splitr.
 Qed.
 
@@ -254,9 +254,9 @@ Lemma ncvgN u lu : ncvg u lu -> ncvg (- u) (- lu).
 Proof.
 case: lu => [lu||] cu /=; first last.
 + elim/nbh_pinfW=> M; case: (cu (NNInf (-M))) => K {}cu.
-  by exists K => n /cu; rewrite !inE ltr_oppr.
+  by exists K => n /cu; rewrite !inE ltrNr.
 + elim/nbh_ninfW=> M; case: (cu (NPInf (-M))) => K {}cu.
-  by exists K => n /cu; rewrite !inE ltr_oppl.
+  by exists K => n /cu; rewrite !inE ltrNl.
 elim/nbh_finW => e /= gt0_e; case: (cu (B lu e)).
 by move=> K {}cu; exists K=> n /cu; rewrite !inE -opprD normrN eclamp_id.
 Qed.
@@ -285,10 +285,10 @@ Lemma ncvgMl u v : ncvg u 0%:E -> nbounded v -> ncvg (u \* v) 0%:E.
 move=> cu /asboolP/nboundedP [M gt0_M ltM]; elim/nbh_finW => e /= gt0_e.
 case: (cu (B 0 (e / (M + 1)))) => K {}cu; exists K => n le_Kn.
 rewrite inE subr0 normrM; apply/(@lt_trans _ _ (e / (M + 1) * M)).
-  apply/ltr_pmul => //; have /cu := le_Kn; rewrite inE subr0 eclamp_id //.
+  apply/ltr_pM => //; have /cu := le_Kn; rewrite inE subr0 eclamp_id //.
   by rewrite mulr_gt0 // invr_gt0 addr_gt0.
-rewrite -mulrAC -mulrA gtr_pmulr // ltr_pdivr_mulr ?addr_gt0 //.
-by rewrite mul1r ltr_addl.
+rewrite -mulrAC -mulrA gtr_pMr // ltr_pdivrMr ?addr_gt0 //.
+by rewrite mul1r ltrDl.
 Qed.
 
 Lemma ncvgMr u v : ncvg v 0%:E -> nbounded u -> ncvg (u \* v) 0%:E.
@@ -541,7 +541,7 @@ elim/nbh_finW=> /= e gt0_e; have sS: has_sup S.
 have /sup_adherent := sS => /(_ _ gt0_e) [r] [N ->] lt_uN.
 exists N => n le_Nn; rewrite !inE distrC ger0_norm ?subr_ge0.
   by move/ubP : (sup_upper_bound sS) => -> //; exists n.
-by rewrite ltr_subl_addr -ltr_subl_addl (lt_le_trans lt_uN) ?mn_u.
+by rewrite ltrBlDr -ltrBlDl (lt_le_trans lt_uN) ?mn_u.
 Qed.
 
 End LimOp.

--- a/theories/altreals/realsum.v
+++ b/theories/altreals/realsum.v
@@ -70,7 +70,7 @@ Proof. by move=> x; rewrite /fpos /fneg -{1}oppr0 -oppr_min normrN. Qed.
 Lemma fposZ f c : 0 <= c -> fpos (c \*o f) =1 c \*o fpos f.
 Proof.
 move=> ge0_c x; rewrite /fpos /= -{1}(mulr0 c).
-by rewrite -maxr_pmulr // normrM ger0_norm.
+by rewrite -maxr_pMr // normrM ger0_norm.
 Qed.
 
 Lemma fnegZ f c : 0 <= c -> fneg (c \*o f) =1 c \*o fneg f.
@@ -83,7 +83,7 @@ Lemma fpos_natrM f (n : T -> nat) x :
   fpos (fun x => (n x)%:R * f x) x = (n x)%:R * fpos f x.
 Proof.
 rewrite /fpos -[in RHS]normr_nat -normrM.
-by rewrite maxr_pmulr ?ler0n // mulr0.
+by rewrite maxr_pMr ?ler0n // mulr0.
 Qed.
 
 Lemma fneg_natrM f (n : T -> nat) x :
@@ -143,7 +143,7 @@ case/summableP=> M ge0_M bM; pose E (p : nat) := [pred x | `|f x| > 1 / p.+1%:~R
 set F := [pred x | _]; have le: {subset F <= [pred x | `[< exists p, x \in E p >]]}.
   move=> x; rewrite !inE => nz_fx.
   pose j := `|floor (1 / `|f x|)|%N; exists j; rewrite inE.
-  rewrite ltr_pdivr_mulr ?ltr0z // -ltr_pdivr_mull ?normr_gt0 //.
+  rewrite ltr_pdivrMr ?ltr0z // -ltr_pdivrMl ?normr_gt0 //.
   rewrite mulr1 /j div1r -addn1 /= PoszD intrD mulr1z.
   rewrite gez0_abs ?floor_ge0 ?invr_ge0 ?normr_ge0 //.
   by rewrite -RfloorE; apply lt_succ_Rfloor.
@@ -185,7 +185,7 @@ elim/nbh_finW=>e /= gt0_e.
 case: (sup_adherent gt0_e supE)=> x [K ->] lt_uK.
 exists K=> n le_Kn; rewrite inE distrC ger0_norm ?subr_ge0.
   by move/ubP: (sup_upper_bound supE); apply; exists n.
-rewrite ltr_subl_addr addrC -ltr_subl_addr.
+rewrite ltrBlDr addrC -ltrBlDr.
 by rewrite (lt_le_trans lt_uK) //; apply/mono_u.
 Qed.
 
@@ -444,15 +444,15 @@ Hypothesis smS   : summable S.
 Lemma ptsum_homo x y : (x <= y)%N -> (\sum_(i < x) S i <= \sum_(i < y) S i).
 Proof.
 move=> le_xy; rewrite -!(big_mkord predT) -(subnKC le_xy) /=.
-by rewrite /index_iota !subn0 iotaD big_cat /= ler_addl sumr_ge0.
+by rewrite /index_iota !subn0 iotaD big_cat /= lerDl sumr_ge0.
 Qed.
 
 Lemma psummable_ptbounded : nbounded (fun n => \sum_(i < n) S i).
 Proof.
 apply/asboolP/nboundedP; exists (psum S + 1).
-  rewrite ltr_spaddr ?ltr01 1?(le_trans (normr_ge0 (S 0%N))) //.
+  rewrite ltr_pwDr ?ltr01 1?(le_trans (normr_ge0 (S 0%N))) //.
   by apply/ger1_psum.
-move=> n; rewrite ltr_spaddr ?ltr01 // ger0_norm ?sumr_ge0 //.
+move=> n; rewrite ltr_pwDr ?ltr01 // ger0_norm ?sumr_ge0 //.
 apply/(le_trans _ (ger_big_ord_psum _ n)) => //.
 by apply/ler_sum=> /= i _; apply/ler_norm.
 Qed.
@@ -506,9 +506,9 @@ have bd_v n : v n <= psum S.
   by move=> J _; apply/ler_norm.
 case: (ncvg_mono_bnd hm_v) => [|l cv].
   apply/asboolP/nboundedP; exists (psum S + 1) => //.
-    by apply/(le_lt_trans (ge0_psum S)); rewrite ltr_addl ltr01.
+    by apply/(le_lt_trans (ge0_psum S)); rewrite ltrDl ltr01.
   move=> n; rewrite ger0_norm ?sumr_ge0 //.
-  by rewrite (le_lt_trans (bd_v n)) // ltr_addl ltr01.
+  by rewrite (le_lt_trans (bd_v n)) // ltrDl ltr01.
 have le_lS: l <= psum S by rewrite -lee_fin (ncvg_leC _ cv).
 rewrite (nlimE cv) /= (rwP eqP) eq_le le_lS andbT.
 rewrite leNgt; apply/negP=> {le_lS} /(lt_psum smS)[J].
@@ -564,8 +564,8 @@ Proof.
 case=> [M1 h1] [M2 h2]; exists (M1 + M2) => J /=.
 pose M := \sum_(x : J) (`|S1 (val x)| + `|S2 (val x)|).
 rewrite (@le_trans _ _ M) // ?ler_sum // => [K _|].
-  by rewrite ler_norm_add.
-by rewrite /M big_split ler_add ?(h1, h2).
+  by rewrite ler_normD.
+by rewrite /M big_split lerD ?(h1, h2).
 Qed.
 
 (* -------------------------------------------------------------------- *)
@@ -606,7 +606,7 @@ Qed.
 Lemma summableZ (S : T -> R) c : summable S -> summable (c \*o S).
 Proof.
 case=> [M h]; exists (`|c| * M) => J; move/(_ J): h => /=.
-move/(ler_wpmul2l (normr_ge0 c)); rewrite mulr_sumr.
+move/(ler_wpM2l (normr_ge0 c)); rewrite mulr_sumr.
 move/(le_trans _); apply; rewrite le_eqVlt; apply/orP.
 by left; apply/eqP/eq_bigr=> j _; rewrite normrM.
 Qed.
@@ -622,7 +622,7 @@ Lemma summableMl (S1 S2 : T -> R) :
 Proof.
 case=> M leM smS2; apply/summable_abs.
 apply/(le_summable (F2 := M \*o \`|S2|)).
-+ by move=> x /=; rewrite normr_ge0 /= normrM ler_wpmul2r.
++ by move=> x /=; rewrite normr_ge0 /= normrM ler_wpM2r.
 + by apply/summableZ/summable_abs.
 Qed.
 
@@ -771,7 +771,7 @@ Lemma le_psum_condl (S : T -> R) (P : pred T) :
   summable S -> psum (fun x => (P x)%:R * S x) <= psum S.
 Proof.
 move=> smS; apply/le_psum_abs=> // x; rewrite normrM.
-by apply/ler_pimull => //; rewrite normr_nat lern1 leq_b1.
+by apply/ler_piMl => //; rewrite normr_nat lern1 leq_b1.
 Qed.
 
 (* -------------------------------------------------------------------- *)
@@ -804,19 +804,19 @@ rewrite !psumE // (rwP eqP) eq_le -(rwP andP); split.
   apply/sup_le_ub.
   + by exists 0, fset0; rewrite big_fset0.
   apply/ubP=> _ [J ->]; rewrite big_split /=.
-  apply/ler_add; rewrite -psumE 1?(le_trans _ (gerfin_psum J _)) //.
+  apply/lerD; rewrite -psumE 1?(le_trans _ (gerfin_psum J _)) //.
   + by apply/ler_sum=> j _ /=; apply/ler_norm.
   + by apply/ler_sum=> j _ /=; apply/ler_norm.
-rewrite -ler_subr_addr; apply/sup_le_ub.
+rewrite -lerBrDr; apply/sup_le_ub.
 + by exists 0, fset0; rewrite big_fset0.
-apply/ubP=> _ [J1 ->]; rewrite ler_subr_addr addrC.
-rewrite -ler_subr_addr; apply/sup_le_ub.
+apply/ubP=> _ [J1 ->]; rewrite lerBrDr addrC.
+rewrite -lerBrDr; apply/sup_le_ub.
 + by exists 0, fset0; rewrite big_fset0.
-apply/ubP=> _ [J2 ->]; rewrite ler_subr_addr addrC.
+apply/ubP=> _ [J2 ->]; rewrite lerBrDr addrC.
 pose J := J1 `|` J2; rewrite -psumE ?(le_trans _ (gerfin_psum J _)) //.
 pose D := \sum_(j : J) (S1 (val j) + S2 (val j)).
 apply/(@le_trans _ _ D); last by apply/ler_sum=> i _; apply/ler_norm.
-rewrite /D big_split /=; apply/ler_add; apply/big_fset_subset=> //.
+rewrite /D big_split /=; apply/lerD; apply/big_fset_subset=> //.
 + by apply/fsubsetP/fsubsetUl. + by apply/fsubsetP/fsubsetUr.
 Qed.
 
@@ -839,13 +839,13 @@ have smZ := summableZ c smS; rewrite (rwP eqP) eq_le.
 apply/andP; split; first rewrite {1}/psum asboolT //.
   apply/sup_le_ub.
   + by exists 0, fset0; rewrite big_fset0.
-  apply/ubP=> _ [J ->]; rewrite -ler_pdivr_mull //.
+  apply/ubP=> _ [J ->]; rewrite -ler_pdivrMl //.
   rewrite mulr_sumr (le_trans _ (gerfin_psum J _)) //.
   apply/ler_sum=> /= j _; rewrite normrM.
   by rewrite gtr0_norm // mulKf ?gt_eqF.
-rewrite -ler_pdivl_mull // {1}/psum asboolT //; apply/sup_le_ub.
+rewrite -ler_pdivlMl // {1}/psum asboolT //; apply/sup_le_ub.
 + by exists 0, fset0; rewrite big_fset0.
-apply/ubP=> _ [J ->]; rewrite ler_pdivl_mull //.
+apply/ubP=> _ [J ->]; rewrite ler_pdivlMl //.
 rewrite mulr_sumr; apply/(le_trans _ (gerfin_psum J _))=> //.
 by apply/ler_sum=> /= j _; rewrite normrM (gtr0_norm gt0_c).
 Qed.
@@ -903,7 +903,7 @@ move=> eq_r ler; set s := RHS; have h J: uniq J -> \sum_(x <- J) `|S x| <= s.
   rewrite (perm_big [seq x <- r | x \in J]) /=.
     apply/uniq_perm; rewrite ?filter_uniq // => x.
     by rewrite !mem_filter andbC.
-  by rewrite big_filter ler_addl sumr_ge0.
+  by rewrite big_filter lerDl sumr_ge0.
 case/summable_of_bd: h => smS le_psum; apply/eqP.
 by rewrite eq_le le_psum /=; apply/gerfinseq_psum.
 Qed.
@@ -1146,12 +1146,12 @@ Lemma le_sum S1 S2 :
   summable S1 -> summable S2 -> (S1 <=1 S2) ->
     sum S1 <= sum S2.
 Proof.
-move=> smS1 smS2 leS; rewrite /sum ler_sub //.
+move=> smS1 smS2 leS; rewrite /sum lerB //.
   apply/le_psum/summable_fpos => // x.
   by rewrite ge0_fpos /= le_fpos.
 apply/le_psum/summable_fneg => // x.
 rewrite -!fposN ge0_fpos le_fpos // => y.
-by rewrite ler_opp2.
+by rewrite lerN2.
 Qed.
 
 Lemma sum0 : sum (fun _ : T => 0) = 0 :> R.

--- a/theories/altreals/xfinmap.v
+++ b/theories/altreals/xfinmap.v
@@ -25,11 +25,11 @@ Proof. by case: J => J /= /canonical_uniq. Qed.
 
 (* -------------------------------------------------------------------- *)
 Lemma enum_fset0 (T : choiceType) :
-  enum [finType of fset0] = [::] :> seq (@fset0 T).
+  enum (fset0 : finType) = [::] :> seq (@fset0 T).
 Proof. by rewrite enumT unlock. Qed.
 
 Lemma enum_fset1 (T : choiceType) (x : T) :
-  enum [finType of [fset x]] = [:: [`fset11 x]].
+  enum ([fset x] : finType) = [:: [`fset11 x]].
 Proof.
 apply/perm_small_eq=> //; apply/uniq_perm => //.
   by apply/enum_uniq.

--- a/theories/altreals/xfinmap.v
+++ b/theories/altreals/xfinmap.v
@@ -125,7 +125,7 @@ Lemma big_fset_subset (I J : {fset T}) (F : T -> R) :
 Proof.
 move=> ge0_F le_IJ; rewrite !big_fset_seq /=.
 rewrite [X in _<=X](bigID [pred j : T | j \in I]) /=.
-rewrite ler_paddr ?sumr_ge0 // -[X in _<=X]big_filter.
+rewrite ler_wpDr ?sumr_ge0 // -[X in _<=X]big_filter.
 rewrite le_eqVlt; apply/orP; left; apply/eqP/perm_big.
 apply/uniq_perm; rewrite ?filter_uniq //; last move=> i.
 rewrite mem_filter; case/boolP: (_ \in _) => //=.

--- a/theories/charge.v
+++ b/theories/charge.v
@@ -407,7 +407,7 @@ have /ereal_sup_gt/cid2[_ [B/= [mB BDA <- mnuB]]] : m < t_ A.
   rewrite -(@fineK _ (t_ A)); last first.
     by rewrite ge0_fin_numE// ?(ltW d_gt0)// lt_neqAle dn1oo leey.
   rewrite -EFinM -fine_min// lte_fin lt_minl; apply/orP; left.
-  by rewrite ltr_pdivr_mulr// ltr_pmulr ?ltr1n// fine_gt0// d_gt0/= ltey.
+  by rewrite ltr_pdivrMr// ltr_pMr ?ltr1n// fine_gt0// d_gt0/= ltey.
 by exists B; split => //; rewrite (le_trans _ (ltW mnuB)).
 Qed.
 
@@ -421,9 +421,9 @@ move/cvgrPdist_lt : minr_cvg => /[apply] -[M _ hM].
 near=> n; rewrite sub0r normrN.
 have /hM : (M <= n)%N by near: n; exists M.
 rewrite sub0r normrN !ger0_norm// ?le_minr ?divr_ge0//=.
-rewrite -[X in minr _ X](@divrr _ 2) ?unitfE -?minr_pmull//.
-rewrite -[X in (_ < minr _ X)%R](@divrr _ 2) ?unitfE -?minr_pmull//.
-by rewrite ltr_pmul2r//; exact: lt_min_lt.
+rewrite -[X in minr _ X](@divrr _ 2) ?unitfE -?minr_pMl//.
+rewrite -[X in (_ < minr _ X)%R](@divrr _ 2) ?unitfE -?minr_pMl//.
+by rewrite ltr_pM2r//; exact: lt_min_lt.
 Unshelve. all: by end_near. Qed.
 
 Let mine_cvg_0_cvg_fin_num (x : (\bar R)^nat) : (forall k, 0 <= x k) ->
@@ -581,7 +581,7 @@ have /ereal_inf_lt/cid2[_ [B/= [mB BU] <-] nuBm] : s_ U < m.
   rewrite -(@fineK _ (s_ U)); last first.
     by rewrite le0_fin_numE// ?(ltW s_lt0)// lt_neqAle leNye eq_sym s0oo.
   rewrite -EFinM -fine_max// lte_fin lt_maxr; apply/orP; left.
-  by rewrite ltr_pdivl_mulr// gtr_nmulr ?ltr1n// fine_lt0// s_lt0/= ltNye andbT.
+  by rewrite ltr_pdivlMr// gtr_nMr ?ltr1n// fine_lt0// s_lt0/= ltNye andbT.
 have [C [CB nsC nuCB]] := hahn_decomposition_lemma nu mB.
 exists C; split => //; first exact: (subset_trans CB).
 by rewrite (le_trans nuCB)// (le_trans (ltW nuBm)).
@@ -627,7 +627,7 @@ have not_s_cvg_0 : ~ (z_ \o v) n @[n --> \oo]  --> 0.
   have /hM : (M <= n)%N by near: n; exists M.
   rewrite sub0r normrN /= ler0_norm ?fine_le0// ltr0_norm//; last first.
     by rewrite fine_lt0// nuD0 andbT ltNye_eq fin_num_measure.
-  rewrite ltr_opp2; apply/negP; rewrite -leNgt fine_le ?fin_num_measure//.
+  rewrite ltrN2; apply/negP; rewrite -leNgt fine_le ?fin_num_measure//.
   by near: n; exact.
 have nuN : nu N = \sum_(n <oo) nu (A_ (v n)).
   apply/esym/cvg_lim => //.

--- a/theories/constructive_ereal.v
+++ b/theories/constructive_ereal.v
@@ -180,7 +180,7 @@ End ERealChoice.
 Section ERealCount.
 Variable (R : countType).
 
-HB.instance Definition _ := PcanCountMixin (@codeK R).
+HB.instance Definition _ := PCanIsCountable (@codeK R).
 
 End ERealCount.
 

--- a/theories/constructive_ereal.v
+++ b/theories/constructive_ereal.v
@@ -1036,7 +1036,7 @@ Proof. by move: x y => [r0| |] [r1| |] // ? ?; rewrite !lee_fin addr_ge0. Qed.
 
 Lemma adde_le0 x y : x <= 0 -> y <= 0 -> x + y <= 0.
 Proof.
-move: x y => [r0||] [r1||]// ? ?; rewrite !lee_fin -(addr0 0%R); exact: ler_add.
+move: x y => [r0||] [r1||]// ? ?; rewrite !lee_fin -(addr0 0%R); exact: lerD.
 Qed.
 
 Lemma oppe_gt0 x : (0 < - x) = (x < 0).
@@ -1163,7 +1163,7 @@ Lemma mule_lt0_gt0 x y : x < 0 -> 0 < y -> x * y < 0.
 Proof. by move=> x0 y0; rewrite muleC mule_gt0_lt0. Qed.
 
 Lemma gte_opp x : 0 < x -> - x < x.
-Proof. by case: x => //= r; rewrite !lte_fin; apply: gtr_opp. Qed.
+Proof. by case: x => //= r; rewrite !lte_fin; apply: gtrN. Qed.
 
 Lemma realMe x y : (0%E >=< x)%O -> (0%E >=< y)%O -> (0%E >=< x * y)%O.
 Proof.
@@ -1431,7 +1431,7 @@ rewrite oppe_ge0; exact: u0.
 Qed.
 
 Lemma gte_dopp (r : \bar^d R) : (0 < r)%E -> (- r < r)%E.
-Proof. by case: r => //= r; rewrite !lte_fin; apply: gtr_opp. Qed.
+Proof. by case: r => //= r; rewrite !lte_fin; apply: gtrN. Qed.
 
 Lemma ednatmul_pinfty n : +oo *+ n.+1 = +oo :> \bar^d R.
 Proof. by elim: n => //= n ->. Qed.
@@ -1491,8 +1491,8 @@ split=> [-> // A A0|Ax]; first by rewrite leey.
 apply/eqP; rewrite eq_le leey /= leNgt; apply/negP.
 case: x Ax => [x Ax _|//|/(_ _ ltr01)//].
 suff: ~ x%:E < (Order.max 0 x + 1)%:E.
-  by apply; rewrite lte_fin ltr_spaddr// le_maxr lexx orbT.
-by apply/negP; rewrite -leNgt; apply/Ax/ltr_spaddr; rewrite // le_maxr lexx.
+  by apply; rewrite lte_fin ltr_pwDr// le_maxr lexx orbT.
+by apply/negP; rewrite -leNgt; apply/Ax/ltr_pwDr; rewrite // le_maxr lexx.
 Qed.
 
 #[deprecated(since="mathcomp-analysis 0.6.0", note="renamed `eqyP`")]
@@ -1561,22 +1561,22 @@ Proof. by move=> /orP[?|?]; [rewrite suber_ge0|rewrite subre_ge0]. Qed.
 
 Lemma lte_oppl x y : (- x < y) = (- y < x).
 Proof.
-by move: x y => [r| |] [r'| |] //=; rewrite ?(ltry, ltNyr)// !lte_fin ltr_oppl.
+by move: x y => [r| |] [r'| |] //=; rewrite ?(ltry, ltNyr)// !lte_fin ltrNl.
 Qed.
 
 Lemma lte_oppr x y : (x < - y) = (y < - x).
 Proof.
-by move: x y => [r| |] [r'| |] //=; rewrite ?(ltry, ltNyr)// !lte_fin ltr_oppr.
+by move: x y => [r| |] [r'| |] //=; rewrite ?(ltry, ltNyr)// !lte_fin ltrNr.
 Qed.
 
 Lemma lee_oppr x y : (x <= - y) = (y <= - x).
 Proof.
-by move: x y => [r0| |] [r1| |] //=; rewrite ?(leey, leNye)// !lee_fin ler_oppr.
+by move: x y => [r0| |] [r1| |] //=; rewrite ?(leey, leNye)// !lee_fin lerNr.
 Qed.
 
 Lemma lee_oppl x y : (- x <= y) = (- y <= x).
 Proof.
-by move: x y => [r0| |] [r1| |] //=; rewrite ?(leey, leNye)// !lee_fin ler_oppl.
+by move: x y => [r0| |] [r1| |] //=; rewrite ?(leey, leNye)// !lee_fin lerNl.
 Qed.
 
 Lemma muleN x y : x * - y = - (x * y).
@@ -1698,13 +1698,13 @@ Proof. by rewrite lte_oppl oppeK. Qed.
 Lemma lte_add a b x y : a < b -> x < y -> a + x < b + y.
 Proof.
 move: a b x y=> [a| |] [b| |] [x| |] [y| |]; rewrite ?(ltry,ltNyr)//.
-by rewrite !lte_fin; exact: ltr_add.
+by rewrite !lte_fin; exact: ltrD.
 Qed.
 
 Lemma lee_addl x y : 0 <= y -> x <= x + y.
 Proof.
 move: x y => -[ x [y| |]//= | [| |]// | [| | ]//];
-  by [rewrite !lee_fin ler_addl | move=> _; exact: leey].
+  by [rewrite !lee_fin lerDl | move=> _; exact: leey].
 Qed.
 
 Lemma lee_addr x y : 0 <= y -> x <= y + x.
@@ -1713,7 +1713,7 @@ Proof. by rewrite addeC; exact: lee_addl. Qed.
 Lemma gee_addl x y : y <= 0 -> x + y <= x.
 Proof.
 move: x y => -[ x [y| |]//= | [| |]// | [| | ]//];
-  by [rewrite !lee_fin ger_addl | move=> _; exact: leNye].
+  by [rewrite !lee_fin gerDl | move=> _; exact: leNye].
 Qed.
 
 Lemma gee_addr x y : y <= 0 -> y + x <= x.
@@ -1721,7 +1721,7 @@ Proof. rewrite addeC; exact: gee_addl. Qed.
 
 Lemma lte_addl y x : y \is a fin_num -> (y < y + x) = (0 < x).
 Proof.
-by move: x y => [x| |] [y| |] _ //; rewrite ?ltry ?ltNyr // !lte_fin ltr_addl.
+by move: x y => [x| |] [y| |] _ //; rewrite ?ltry ?ltNyr // !lte_fin ltrDl.
 Qed.
 
 Lemma lte_addr y x : y \is a fin_num -> (y < x + y) = (0 < x).
@@ -1730,7 +1730,7 @@ Proof. rewrite addeC; exact: lte_addl. Qed.
 Lemma gte_subl y x : y \is a fin_num -> (y - x < y) = (0 < x).
 Proof.
 move: y x => [x| |] [y| |] _ //; rewrite addeC /= ?ltNyr ?ltry//.
-by rewrite !lte_fin gtr_addr ltr_oppl oppr0.
+by rewrite !lte_fin gtrDr ltrNl oppr0.
 Qed.
 
 Lemma gte_subr y x : y \is a fin_num -> (- x + y < y) = (0 < x).
@@ -1738,7 +1738,7 @@ Proof. by rewrite addeC; exact: gte_subl. Qed.
 
 Lemma gte_addl x y : x \is a fin_num -> (x + y < x) = (y < 0).
 Proof.
-by move: x y => [r| |] [s| |]// _; [rewrite !lte_fin gtr_addl|rewrite !ltNyr].
+by move: x y => [r| |] [s| |]// _; [rewrite !lte_fin gtrDl|rewrite !ltNyr].
 Qed.
 
 Lemma gte_addr x y : x \is a fin_num -> (y + x < x) = (y < 0).
@@ -1747,13 +1747,13 @@ Proof. by rewrite addeC; exact: gte_addl. Qed.
 Lemma lte_add2lE x a b : x \is a fin_num -> (x + a < x + b) = (a < b).
 Proof.
 move: a b x => [a| |] [b| |] [x| |] _ //; rewrite ?(ltry, ltNyr)//.
-by rewrite !lte_fin ltr_add2l.
+by rewrite !lte_fin ltrD2l.
 Qed.
 
 Lemma lee_add2l x a b : a <= b -> x + a <= x + b.
 Proof.
 move: a b x => -[a [b [x /=|//|//] | []// |//] | []// | ].
-- by rewrite !lee_fin ler_add2l.
+- by rewrite !lee_fin lerD2l.
 - by move=> r _; exact: leey.
 - by move=> -[b [|  |]// | []// | //] r oob; exact: leNye.
 Qed.
@@ -1761,7 +1761,7 @@ Qed.
 Lemma lee_add2lE x a b : x \is a fin_num -> (x + a <= x + b) = (a <= b).
 Proof.
 move: a b x => [a| |] [b| |] [x| |] _ //; rewrite ?(leey, leNye)//.
-by rewrite !lee_fin ler_add2l.
+by rewrite !lee_fin lerD2l.
 Qed.
 
 Lemma lee_add2r x a b : a <= b -> a + x <= b + x.
@@ -1770,13 +1770,13 @@ Proof. rewrite addeC (addeC b); exact: lee_add2l. Qed.
 Lemma lee_add a b x y : a <= b -> x <= y -> a + x <= b + y.
 Proof.
 move: a b x y => [a| |] [b| |] [x| |] [y| |]; rewrite ?(leey, leNye)//.
-by rewrite !lee_fin; exact: ler_add.
+by rewrite !lee_fin; exact: lerD.
 Qed.
 
 Lemma lte_le_add a b x y : b \is a fin_num -> a < x -> b <= y -> a + b < x + y.
 Proof.
 move: x y a b => [x| |] [y| |] [a| |] [b| |] _ //=; rewrite ?(ltry, ltNyr)//.
-by rewrite !lte_fin; exact: ltr_le_add.
+by rewrite !lte_fin; exact: ltr_leD.
 Qed.
 
 Lemma lee_lt_add a b x y : a \is a fin_num -> a <= x -> b < y -> a + b < x + y.
@@ -1785,20 +1785,20 @@ Proof. by move=> afin xa yb; rewrite (addeC a) (addeC x) lte_le_add. Qed.
 Lemma lee_sub x y z u : x <= y -> u <= z -> x - z <= y - u.
 Proof.
 move: x y z u => -[x| |] -[y| |] -[z| |] -[u| |] //=; rewrite ?(leey,leNye)//.
-by rewrite !lee_fin; exact: ler_sub.
+by rewrite !lee_fin; exact: lerB.
 Qed.
 
 Lemma lte_le_sub z u x y : u \is a fin_num ->
   x < z -> u <= y -> x - y < z - u.
 Proof.
 move: z u x y => [z| |] [u| |] [x| |] [y| |] _ //=; rewrite ?(ltry, ltNyr)//.
-by rewrite !lte_fin => xltr tley; apply: ltr_le_add; rewrite // ler_oppl opprK.
+by rewrite !lte_fin => xltr tley; apply: ltr_leD; rewrite // lerNl opprK.
 Qed.
 
 Lemma lte_pmul2r z : z \is a fin_num -> 0 < z -> {mono *%E^~ z : x y / x < y}.
 Proof.
 move: z => [z| |] _ // z0 [x| |] [y| |] //.
-- by rewrite !lte_fin ltr_pmul2r.
+- by rewrite !lte_fin ltr_pM2r.
 - by rewrite mulr_infty gtr0_sg// mul1e 2!ltry.
 - by rewrite mulr_infty gtr0_sg// mul1e ltNge leNye ltNge leNye.
 - by rewrite mulr_infty gtr0_sg// mul1e ltNge leey ltNge leey.
@@ -1937,7 +1937,7 @@ Qed.
 Lemma lte_subl_addr x y z : y \is a fin_num -> (x - y < z) = (x < z + y).
 Proof.
 move: x y z => [x| |] [y| |] [z| |] _ //=; rewrite ?ltry ?ltNyr //.
-by rewrite !lte_fin ltr_subl_addr.
+by rewrite !lte_fin ltrBlDr.
 Qed.
 
 Lemma lte_subl_addl x y z : y \is a fin_num -> (x - y < z) = (x < y + z).
@@ -1946,7 +1946,7 @@ Proof. by move=> ?; rewrite lte_subl_addr// addeC. Qed.
 Lemma lte_subr_addr x y z : z \is a fin_num -> (x < y - z) = (x + z < y).
 Proof.
 move: x y z => [x| |] [y| |] [z| |] _ //=; rewrite ?ltNyr ?ltry //.
-by rewrite !lte_fin ltr_subr_addr.
+by rewrite !lte_fin ltrBrDr.
 Qed.
 
 Lemma lte_subr_addl x y z : z \is a fin_num -> (x < y - z) = (z + x < y).
@@ -1955,7 +1955,7 @@ Proof. by move=> ?; rewrite lte_subr_addr// addeC. Qed.
 Lemma lte_subel_addr x y z : x \is a fin_num -> (x - y < z) = (x < z + y).
 Proof.
 move: x y z => [x| |] [y| |] [z| |] _ //=; rewrite ?ltNyr ?ltry //.
-by rewrite !lte_fin ltr_subl_addr.
+by rewrite !lte_fin ltrBlDr.
 Qed.
 
 Lemma lte_subel_addl x y z : x \is a fin_num -> (x - y < z) = (x < y + z).
@@ -1964,7 +1964,7 @@ Proof. by move=> ?; rewrite lte_subel_addr// addeC. Qed.
 Lemma lte_suber_addr x y z : x \is a fin_num -> (x < y - z) = (x + z < y).
 Proof.
 move: x y z => [x| |] [y| |] [z| |] _ //=; rewrite ?ltNyr ?ltry //.
-by rewrite !lte_fin ltr_subr_addr.
+by rewrite !lte_fin ltrBrDr.
 Qed.
 
 Lemma lte_suber_addl x y z : x \is a fin_num -> (x < y - z) = (z + x < y).
@@ -1973,7 +1973,7 @@ Proof. by move=> ?; rewrite lte_suber_addr// addeC. Qed.
 Lemma lee_subl_addr x y z : y \is a fin_num -> (x - y <= z) = (x <= z + y).
 Proof.
 move: x y z => [x| |] [y| |] [z| |] _ //=; rewrite ?leey ?leNye //.
-by rewrite !lee_fin ler_subl_addr.
+by rewrite !lee_fin lerBlDr.
 Qed.
 
 Lemma lee_subl_addl x y z : y \is a fin_num -> (x - y <= z) = (x <= y + z).
@@ -1982,7 +1982,7 @@ Proof. by move=> ?; rewrite lee_subl_addr// addeC. Qed.
 Lemma lee_subr_addr x y z : z \is a fin_num -> (x <= y - z) = (x + z <= y).
 Proof.
 move: y x z => [y| |] [x| |] [z| |] _ //=; rewrite ?leNye ?leey //.
-by rewrite !lee_fin ler_subr_addr.
+by rewrite !lee_fin lerBrDr.
 Qed.
 
 Lemma lee_subr_addl x y z : z \is a fin_num -> (x <= y - z) = (z + x <= y).
@@ -1991,7 +1991,7 @@ Proof. by move=> ?; rewrite lee_subr_addr// addeC. Qed.
 Lemma lee_subel_addr x y z : z \is a fin_num -> (x - y <= z) = (x <= z + y).
 Proof.
 move: x y z => [x| |] [y| |] [z| |] _ //=; rewrite ?leey ?leNye //.
-by rewrite !lee_fin ler_subl_addr.
+by rewrite !lee_fin lerBlDr.
 Qed.
 
 Lemma lee_subel_addl x y z : z \is a fin_num -> (x - y <= z) = (x <= y + z).
@@ -2000,7 +2000,7 @@ Proof. by move=> ?; rewrite lee_subel_addr// addeC. Qed.
 Lemma lee_suber_addr x y z : y \is a fin_num -> (x <= y - z) = (x + z <= y).
 Proof.
 move: y x z => [y| |] [x| |] [z| |] _ //=; rewrite ?leNye ?leey //.
-by rewrite !lee_fin ler_subr_addr.
+by rewrite !lee_fin lerBrDr.
 Qed.
 
 Lemma lee_suber_addl x y z : y \is a fin_num -> (x <= y - z) = (z + x <= y).
@@ -2132,7 +2132,7 @@ rewrite /mule/=; move: x y z => [r| |] [s| |] [t| |] //= s0 t0.
 - by case: ltgtP => //; rewrite adde0.
 - rewrite !eqe paddr_eq0 //; move: s0; rewrite lee_fin.
   case: (ltgtP s) => //= [s0|->{s}] _; rewrite ?add0e.
-  + rewrite lte_fin -[in LHS](addr0 0%R) ltr_le_add // lte_fin s0.
+  + rewrite lte_fin -[in LHS](addr0 0%R) ltr_leD // lte_fin s0.
     by case: ltgtP t0 => // [t0|[<-{t}]] _; [rewrite gt_eqF|rewrite eqxx].
   + by move: t0; rewrite lee_fin; case: (ltgtP t).
 - by rewrite ltry; case: ltgtP s0.
@@ -2140,7 +2140,7 @@ rewrite /mule/=; move: x y z => [r| |] [s| |] [t| |] //= s0 t0.
 - by rewrite ltry.
 - rewrite !eqe paddr_eq0 //; move: s0; rewrite lee_fin.
   case: (ltgtP s) => //= [s0|->{s}] _; rewrite ?add0e.
-  + rewrite lte_fin -[in LHS](addr0 0%R) ltr_le_add // lte_fin s0.
+  + rewrite lte_fin -[in LHS](addr0 0%R) ltr_leD // lte_fin s0.
     by case: ltgtP t0 => // [t0|[<-{t}]].
   + by move: t0; rewrite lee_fin; case: (ltgtP t).
 - by rewrite ltry; case: ltgtP s0.
@@ -2160,7 +2160,7 @@ rewrite /mule/=; move: x y z => [r| |] [s| |] [t| |] //= s0 t0.
 - by case: ltgtP => //; rewrite adde0.
 - rewrite !eqe naddr_eq0 //; move: s0; rewrite lee_fin.
   case: (ltgtP s) => //= [s0|->{s}] _; rewrite ?add0e.
-  + rewrite !lte_fin -[in LHS](addr0 0%R) ltNge ler_add // ?ltW //=.
+  + rewrite !lte_fin -[in LHS](addr0 0%R) ltNge lerD // ?ltW //=.
     by rewrite !ltNge ltW //.
   + by case: (ltgtP t).
 - by rewrite ltry; case: ltgtP s0.
@@ -2168,7 +2168,7 @@ rewrite /mule/=; move: x y z => [r| |] [s| |] [t| |] //= s0 t0.
 - by rewrite ltry.
 - rewrite !eqe naddr_eq0 //; move: s0; rewrite lee_fin.
   case: (ltgtP s) => //= [s0|->{s}] _; rewrite ?add0e.
-  + rewrite !lte_fin -[in LHS](addr0 0%R) ltNge ler_add // ?ltW //=.
+  + rewrite !lte_fin -[in LHS](addr0 0%R) ltNge lerD // ?ltW //=.
     by rewrite !ltNge ltW // -lee_fin t0; case: eqP.
   + by case: (ltgtP t).
 - by rewrite ltNge s0 /=; case: eqP.
@@ -2181,7 +2181,7 @@ Proof. by move=> y0 z0; rewrite !(muleC x) le0_muleDl. Qed.
 Lemma gee_pmull y x : y \is a fin_num -> 0 < x -> y <= 1 -> y * x <= x.
 Proof.
 move: x y => [x| |] [y| |] _ //=.
-- by rewrite lte_fin => x0 r0; rewrite /mule/= lee_fin ger_pmull.
+- by rewrite lte_fin => x0 r0; rewrite /mule/= lee_fin ger_pMl.
 - by move=> _; rewrite /mule/= eqe => r1; rewrite leey.
 Qed.
 
@@ -2189,7 +2189,7 @@ Lemma lee_wpmul2r x : 0 <= x -> {homo *%E^~ x : y z / y <= z}.
 Proof.
 move: x => [x|_|//].
   rewrite lee_fin le_eqVlt => /predU1P[<- y z|x0]; first by rewrite 2!mule0.
-  move=> [y| |] [z| |]//; first by rewrite !lee_fin// ler_pmul2r.
+  move=> [y| |] [z| |]//; first by rewrite !lee_fin// ler_pM2r.
   - by move=> _; rewrite mulr_infty gtr0_sg// mul1e leey.
   - by move=> _; rewrite mulr_infty gtr0_sg// mul1e leNye.
   - by move=> _; rewrite 2!mulr_infty gtr0_sg// 2!mul1e.
@@ -2284,7 +2284,7 @@ Qed.
 
 Lemma lee_abs_add x y : `|x + y| <= `|x| + `|y|.
 Proof.
-by move: x y => [x| |] [y| |] //; rewrite /abse -EFinD lee_fin ler_norm_add.
+by move: x y => [x| |] [y| |] //; rewrite /abse -EFinD lee_fin ler_normD.
 Qed.
 
 Lemma lee_abs_sum (I : Type) (s : seq I) (F : I -> \bar R) (P : pred I) :
@@ -2296,7 +2296,7 @@ Qed.
 
 Lemma lee_abs_sub x y : `|x - y| <= `|x| + `|y|.
 Proof.
-by move: x y => [x| |] [y| |] //; rewrite /abse -EFinD lee_fin ler_norm_sub.
+by move: x y => [x| |] [y| |] //; rewrite /abse -EFinD lee_fin ler_normB.
 Qed.
 
 Lemma abseM : {morph @abse R : x y / x * y}.
@@ -2415,7 +2415,7 @@ Proof. by move=> zfin z0; rewrite muleC mineMr// !(muleC z). Qed.
 Lemma lee_pemull x y : 0 <= y -> 1 <= x -> y <= x * y.
 Proof.
 move: x y => [x| |] [y| |] //; last by rewrite mulyy.
-- by rewrite -EFinM 3!lee_fin; exact: ler_pemull.
+- by rewrite -EFinM 3!lee_fin; exact: ler_peMl.
 - move=> _; rewrite lee_fin => x1.
   by rewrite mulr_infty gtr0_sg ?mul1e// (lt_le_trans _ x1).
 - rewrite lee_fin le_eqVlt => /predU1P[<- _|y0 _]; first by rewrite mule0.
@@ -2425,7 +2425,7 @@ Qed.
 Lemma lee_nemull x y : y <= 0 -> 1 <= x -> x * y <= y.
 Proof.
 move: x y => [x| |] [y| |] //; last by rewrite mulyNy.
-- by rewrite -EFinM 3!lee_fin; exact: ler_nemull.
+- by rewrite -EFinM 3!lee_fin; exact: ler_neMl.
 - move=> _; rewrite lee_fin => x1.
   by rewrite mulr_infty gtr0_sg ?mul1e// (lt_le_trans _ x1).
 - rewrite lee_fin le_eqVlt => /predU1P[-> _|y0 _]; first by rewrite mule0.
@@ -2452,7 +2452,7 @@ Lemma lte_pmul x1 y1 x2 y2 :
 Proof.
 move: x1 y1 x2 y2 => [x1| |] [y1| |] [x2| |] [y2| |] //;
     rewrite !(lte_fin,lee_fin).
-- by move=> *; rewrite ltr_pmul.
+- by move=> *; rewrite ltr_pM.
 - move=> x10 x20 xy1 xy2.
   by rewrite mulry gtr0_sg ?mul1e -?EFinM ?ltry// (le_lt_trans _ xy1).
 - move=> x10 x20 xy1 xy2.
@@ -2464,7 +2464,7 @@ Lemma lee_pmul x1 y1 x2 y2 : 0 <= x1 -> 0 <= x2 -> x1 <= y1 -> x2 <= y2 ->
   x1 * x2 <= y1 * y2.
 Proof.
 move: x1 y1 x2 y2 => [x1| |] [y1| |] [x2| |] [y2| |] //; rewrite !lee_fin.
-- exact: ler_pmul.
+- exact: ler_pM.
 - rewrite le_eqVlt => /predU1P[<- x20 y10 _|x10 x20 xy1 _].
     by rewrite mul0e mule_ge0// leey.
   by rewrite mulr_infty gtr0_sg// ?mul1e ?leey// (lt_le_trans x10).
@@ -2491,7 +2491,7 @@ Qed.
 Lemma lee_pmul2l x : x \is a fin_num -> 0 < x -> {mono *%E x : x y / x <= y}.
 Proof.
 move: x => [x _|//|//] /[!(@lte_fin R)] x0 [y| |] [z| |].
-- by rewrite -2!EFinM 2!lee_fin ler_pmul2l.
+- by rewrite -2!EFinM 2!lee_fin ler_pM2l.
 - by rewrite mulry gtr0_sg// mul1e 2!leey.
 - by rewrite mulrNy gtr0_sg// mul1e 2!leeNy_eq.
 - by rewrite mulry gtr0_sg// mul1e 2!leye_eq.
@@ -2551,13 +2551,13 @@ Proof. by move=> *; rewrite addeC lte_paddl. Qed.
 Lemma lte_spaddre z x y : z \is a fin_num -> 0 < y -> z <= x -> z < x + y.
 Proof.
 move: z y x => [z| |] [y| |] [x| |] _ //=; rewrite ?(lte_fin,ltry)//.
-exact: ltr_spaddr.
+exact: ltr_pwDr.
 Qed.
 
 Lemma lte_spadder z x y : x \is a fin_num -> 0 < y -> z <= x -> z < x + y.
 Proof.
 move: z y x => [z| |] [y| |] [x| |] _ //=; rewrite ?(lte_fin,ltry,ltNyr)//.
-exact: ltr_spaddr.
+exact: ltr_pwDr.
 Qed.
 
 End ERealArithTh_realDomainType.
@@ -2927,7 +2927,7 @@ Qed.
 
 Lemma lee_abs_dadd x y : `|x + y| <= `|x| + `|y|.
 Proof.
-by move: x y => [x| |] [y| |] //; rewrite /abse -dEFinD lee_fin ler_norm_add.
+by move: x y => [x| |] [y| |] //; rewrite /abse -dEFinD lee_fin ler_normD.
 Qed.
 
 Lemma lee_abs_dsum (I : Type) (s : seq I) (F : I -> \bar^d R) (P : pred I) :
@@ -2939,7 +2939,7 @@ Qed.
 
 Lemma lee_abs_dsub x y : `|x - y| <= `|x| + `|y|.
 Proof.
-by move: x y => [x| |] [y| |] //; rewrite /abse -dEFinD lee_fin ler_norm_sub.
+by move: x y => [x| |] [y| |] //; rewrite /abse -dEFinD lee_fin ler_normB.
 Qed.
 
 Lemma dadde_minl : left_distributive (@GRing.add (\bar^d R)) mine.
@@ -2966,13 +2966,13 @@ Proof. by move=> *; rewrite daddeC lte_pdaddl. Qed.
 Lemma lte_spdaddre z x y : z \is a fin_num -> 0 < y -> z <= x -> z < x + y.
 Proof.
 move: z y x => [z| |] [y| |] [x| |] _ //=; rewrite ?(lte_fin,ltry,ltNyr)//.
-exact: ltr_spaddr.
+exact: ltr_pwDr.
 Qed.
 
 Lemma lte_spdadder z x y : x \is a fin_num -> 0 < y -> z <= x -> z < x + y.
 Proof.
 move: z y x => [z| |] [y| |] [x| |] _ //=; rewrite ?(lte_fin,ltry,ltNyr)//.
-exact: ltr_spaddr.
+exact: ltr_pwDr.
 Qed.
 
 End DualERealArithTh_realDomainType.
@@ -2987,14 +2987,14 @@ End DualAddTheoryRealDomain.
 
 Lemma lee_opp2 {R : numDomainType} : {mono @oppe R : x y /~ x <= y}.
 Proof.
-move=> x y; case: x y => [?||] [?||] //; first by rewrite !lee_fin !ler_opp2.
+move=> x y; case: x y => [?||] [?||] //; first by rewrite !lee_fin !lerN2.
   by rewrite  /Order.le/= realN.
 by rewrite /Order.le/= realN.
 Qed.
 
 Lemma lte_opp2 {R : numDomainType} : {mono @oppe R : x y /~ x < y}.
 Proof.
-move=> x y; case: x y => [?||] [?||] //; first by rewrite !lte_fin !ltr_opp2.
+move=> x y; case: x y => [?||] [?||] //; first by rewrite !lte_fin !ltrN2.
   by rewrite  /Order.lt/= realN.
 by rewrite /Order.lt/= realN.
 Qed.
@@ -3011,10 +3011,10 @@ move: x y => [x||] [y||] // xleye; rewrite ?leNye ?leey//; last first.
 - by move: (!! xleye 1%:pos%R).
 - by move: (!! xleye 1%:pos%R).
 rewrite leNgt; apply/negP => yltx.
-have xmy_gt0 : (0 < (x - y) / 2)%R by rewrite ltr_pdivl_mulr// mul0r subr_gt0.
+have xmy_gt0 : (0 < (x - y) / 2)%R by rewrite ltr_pdivlMr// mul0r subr_gt0.
 move: (xleye (PosNum xmy_gt0)); apply/negP; rewrite -ltNge /= -EFinD lte_fin.
 rewrite [Y in (Y + _)%R]splitr [X in (_ < X)%R]splitr.
-by rewrite -!mulrDl ltr_pmul2r// addrCA addrK ltr_add2l.
+by rewrite -!mulrDl ltr_pM2r// addrCA addrK ltrD2l.
 Qed.
 
 Lemma lee_mul01Pr x y : 0 <= x ->
@@ -3032,7 +3032,7 @@ move: x y => [x||] [y||] // in x0 h *.
   rewrite lee_fin leNgt; apply/negP => yx.
   have /h : (0 < (y + x) / (2 * x) < 1)%R.
     apply/andP; split; first by rewrite divr_gt0 // ?addr_gt0// ?mulr_gt0.
-    by rewrite ltr_pdivr_mulr ?mulr_gt0// mul1r mulr_natl mulr2n ltr_add2r.
+    by rewrite ltr_pdivrMr ?mulr_gt0// mul1r mulr_natl mulr2n ltrD2r.
   rewrite -(EFinM _ x) lee_fin invrM ?unitfE// ?gt_eqF// -mulrA mulrAC.
   by rewrite mulVr ?unitfE ?gt_eqF// mul1r; apply/negP; rewrite -ltNge midf_lt.
 - by rewrite leey.
@@ -3044,7 +3044,7 @@ Qed.
 Lemma lte_pdivr_mull r x y : (0 < r)%R -> (r^-1%:E * y < x) = (y < r%:E * x).
 Proof.
 move=> r0; move: x y => [x| |] [y| |] //=.
-- by rewrite 2!lte_fin ltr_pdivr_mull.
+- by rewrite 2!lte_fin ltr_pdivrMl.
 - by rewrite mulr_infty sgrV gtr0_sg// mul1e 2!ltNge 2!leey.
 - by rewrite mulr_infty sgrV gtr0_sg// mul1e -EFinM 2!ltNyr.
 - by rewrite mulr_infty gtr0_sg// mul1e 2!ltry.
@@ -3061,7 +3061,7 @@ Proof. by move=> r0; rewrite muleC lte_pdivr_mull// muleC. Qed.
 Lemma lte_pdivl_mull r y x : (0 < r)%R -> (x < r^-1%:E * y) = (r%:E * x < y).
 Proof.
 move=> r0; move: x y => [x| |] [y| |] //=.
-- by rewrite 2!lte_fin ltr_pdivl_mull.
+- by rewrite 2!lte_fin ltr_pdivlMl.
 - by rewrite mulr_infty sgrV gtr0_sg// mul1e 2!ltry.
 - by rewrite mulr_infty sgrV gtr0_sg// mul1e.
 - by rewrite mulr_infty gtr0_sg// mul1e.
@@ -3077,7 +3077,7 @@ Proof. by move=> r0; rewrite muleC lte_pdivl_mull// muleC. Qed.
 
 Lemma lte_ndivl_mulr r x y : (r < 0)%R -> (x < y * r^-1%:E) = (y < x * r%:E).
 Proof.
-rewrite -oppr0 ltr_oppr => r0; rewrite -{1}(opprK r) invrN.
+rewrite -oppr0 ltrNr => r0; rewrite -{1}(opprK r) invrN.
 by rewrite EFinN muleN lte_oppr lte_pdivr_mulr// EFinN muleNN.
 Qed.
 
@@ -3086,7 +3086,7 @@ Proof. by move=> r0; rewrite muleC lte_ndivl_mulr// muleC. Qed.
 
 Lemma lte_ndivr_mull r x y : (r < 0)%R -> (r^-1%:E * y < x) = (r%:E * x < y).
 Proof.
-rewrite -oppr0 ltr_oppr => r0; rewrite -{1}(opprK r) invrN.
+rewrite -oppr0 ltrNr => r0; rewrite -{1}(opprK r) invrN.
 by rewrite EFinN mulNe lte_oppl lte_pdivl_mull// EFinN muleNN.
 Qed.
 
@@ -3119,7 +3119,7 @@ Proof. by move=> r0; rewrite muleC lee_pdivl_mull// muleC. Qed.
 
 Lemma lee_ndivl_mulr r x y : (r < 0)%R -> (x <= y * r^-1%:E) = (y <= x * r%:E).
 Proof.
-rewrite -oppr0 ltr_oppr => r0; rewrite -{1}(opprK r) invrN.
+rewrite -oppr0 ltrNr => r0; rewrite -{1}(opprK r) invrN.
 by rewrite EFinN muleN lee_oppr lee_pdivr_mulr// EFinN muleNN.
 Qed.
 
@@ -3128,7 +3128,7 @@ Proof. by move=> r0; rewrite muleC lee_ndivl_mulr// muleC. Qed.
 
 Lemma lee_ndivr_mull r x y : (r < 0)%R -> (r^-1%:E * y <= x) = (r%:E * x <= y).
 Proof.
-rewrite -oppr0 ltr_oppr => r0; rewrite -{1}(opprK r) invrN.
+rewrite -oppr0 ltrNr => r0; rewrite -{1}(opprK r) invrN.
 by rewrite EFinN mulNe lee_oppl lee_pdivl_mull// EFinN muleNN.
 Qed.
 
@@ -3511,8 +3511,8 @@ Definition contract x : R :=
 Lemma contract_lt1 r : (`|contract r%:E| < 1)%R.
 Proof.
 rewrite normrM normrV ?unitfE //.
-rewrite ltr_pdivr_mulr // ?mul1r//; last by rewrite gtr0_norm.
-by rewrite [ltRHS]gtr0_norm ?ltr_addr// ltr_spaddl.
+rewrite ltr_pdivrMr // ?mul1r//; last by rewrite gtr0_norm.
+by rewrite [ltRHS]gtr0_norm ?ltrDr// ltr_pwDl.
 Qed.
 
 Lemma contract_le1 x : (`|contract x| <= 1)%R.
@@ -3538,15 +3538,15 @@ Proof. by move=> r1; rewrite /expand r1. Qed.
 Lemma expandN r : expand (- r)%R = - expand r.
 Proof.
 rewrite /expand; case: ifPn => [r1|].
-  rewrite ifF; [by rewrite ifT // -ler_oppr|apply/negbTE].
-  by rewrite -ltNge -(opprK r) -ltr_oppl (lt_le_trans _ r1) // -subr_gt0 opprK.
-rewrite -ltNge => r1; case: ifPn; rewrite ler_oppl opprK; [by move=> ->|].
-by rewrite -ltNge leNgt => ->; rewrite leNgt -ltr_oppl r1 /= mulNr normrN.
+  rewrite ifF; [by rewrite ifT // -lerNr|apply/negbTE].
+  by rewrite -ltNge -(opprK r) -ltrNl (lt_le_trans _ r1) // -subr_gt0 opprK.
+rewrite -ltNge => r1; case: ifPn; rewrite lerNl opprK; [by move=> ->|].
+by rewrite -ltNge leNgt => ->; rewrite leNgt -ltrNl r1 /= mulNr normrN.
 Qed.
 
 Lemma expandN1 r : (r <= -1)%R -> expand r = -oo.
 Proof.
-by rewrite ler_oppr => /expand1/eqP; rewrite expandN eqe_oppLR => /eqP.
+by rewrite lerNr => /expand1/eqP; rewrite expandN eqe_oppLR => /eqP.
 Qed.
 
 Lemma expand0 : expand 0%R = 0.
@@ -3557,7 +3557,7 @@ Proof.
 move=> r; rewrite inE le_eqVlt => /orP[|r1].
   rewrite eqr_norml => /andP[/orP[]/eqP->{r}] _;
     by [rewrite expand1|rewrite expandN1].
-rewrite /expand 2!leNgt ltr_oppl; case/ltr_normlP : (r1) => -> -> /=.
+rewrite /expand 2!leNgt ltrNl; case/ltr_normlP : (r1) => -> -> /=.
 have r_pneq0 : (1 + r / (1 - r) != 0)%R.
   rewrite -[X in (X + _)%R](@divrr _ (1 - r)%R) -?mulrDl; last first.
     by rewrite unitfE subr_eq0 eq_sym lt_eqF // ltr_normlW.
@@ -3583,16 +3583,16 @@ Qed.
 Lemma le_contract : {mono contract : x y / (x <= y)%O}.
 Proof.
 apply: le_mono; move=> -[r0 | | ] [r1 | _ | _] //=.
-- rewrite lte_fin => r0r1; rewrite ltr_pdivr_mulr ?ltr_paddr//.
-  rewrite mulrAC ltr_pdivl_mulr ?ltr_paddr// 2?mulrDr 2?mulr1.
+- rewrite lte_fin => r0r1; rewrite ltr_pdivrMr ?ltr_wpDr//.
+  rewrite mulrAC ltr_pdivlMr ?ltr_wpDr// 2?mulrDr 2?mulr1.
   have [r10|?] := ler0P r1; last first.
-    rewrite ltr_le_add // mulrC; have [r00|//] := ler0P r0.
+    rewrite ltr_leD // mulrC; have [r00|//] := ler0P r0.
     by rewrite (@le_trans _ _ 0%R) // ?pmulr_rle0// mulr_ge0// ?oppr_ge0// ltW.
-  have [?|r00] := ler0P r0; first by rewrite ltr_le_add // 2!mulrN mulrC.
+  have [?|r00] := ler0P r0; first by rewrite ltr_leD // 2!mulrN mulrC.
   by move: (le_lt_trans r10 (lt_trans r00 r0r1)); rewrite ltxx.
-- by rewrite ltr_pdivr_mulr ?ltr_paddr// mul1r ltr_spaddl // ler_norm.
-- rewrite ltr_pdivl_mulr ?mulN1r ?ltr_paddr// => _.
-  by rewrite ltr_oppl ltr_spaddl // ler_normr lexx orbT.
+- by rewrite ltr_pdivrMr ?ltr_wpDr// mul1r ltr_pwDl // ler_norm.
+- rewrite ltr_pdivlMr ?mulN1r ?ltr_wpDr// => _.
+  by rewrite ltrNl ltr_pwDl // ler_normr lexx orbT.
 - by rewrite -subr_gt0 opprK.
 Qed.
 
@@ -3609,7 +3609,7 @@ Definition expand_inj := mono_inj_in lexx le_anti le_expand_in.
 Lemma fine_expand r : (`|r| < 1)%R ->
   (fine (expand r))%:E = expand r.
 Proof.
-by move=> r1; rewrite /expand 2!leNgt ltr_oppl; case/ltr_normlP : r1 => -> ->.
+by move=> r1; rewrite /expand 2!leNgt ltrNl; case/ltr_normlP : r1 => -> ->.
 Qed.
 
 Lemma le_expand : {homo expand : x y / (x <= y)%O}.
@@ -3617,9 +3617,9 @@ Proof.
 move=> x y xy; have [x1|] := lerP `|x| 1.
   have [y_le1|/ltW /expand1->] := leP y 1%R; last by rewrite leey.
   rewrite le_expand_in ?inE// ler_norml y_le1 (le_trans _ xy)//.
-  by rewrite ler_oppl (ler_normlP _ _ _).
+  by rewrite lerNl (ler_normlP _ _ _).
 rewrite ltr_normr => /orP[|] x1; last first.
-  by rewrite expandN1 // ?leNye // ler_oppr ltW.
+  by rewrite expandN1 // ?leNye // lerNr ltW.
 by rewrite expand1; [rewrite expand1 // (le_trans _ xy) // ltW | exact: ltW].
 Qed.
 
@@ -3650,7 +3650,7 @@ Lemma ereal_ball_triangle x y z r1 r2 :
   ereal_ball x r1 y -> ereal_ball y r2 z -> ereal_ball x (r1 + r2) z.
 Proof.
 rewrite /ereal_ball => h1 h2; rewrite -[X in (X - _)%R](subrK (contract y)).
-by rewrite -addrA (le_lt_trans (ler_norm_add _ _)) // ltr_add.
+by rewrite -addrA (le_lt_trans (ler_normD _ _)) // ltrD.
 Qed.
 
 Lemma ereal_ballN x y (e : {posnum R}) :
@@ -3661,7 +3661,7 @@ Lemma ereal_ball_ninfty_oversize (e : {posnum R}) x :
   (2 < e%:num)%R -> ereal_ball -oo e%:num x.
 Proof.
 move=> e2; rewrite /ereal_ball /= (le_lt_trans _ e2) // -opprB normrN opprK.
-rewrite (le_trans (ler_norm_add _ _)) // normr1 -ler_subr_addr.
+rewrite (le_trans (ler_normD _ _)) // normr1 -lerBrDr.
 by rewrite (le_trans (contract_le1 _)) // (_ : 2 = 1 + 1)%R // addrK.
 Qed.
 
@@ -3670,7 +3670,7 @@ Lemma contract_ereal_ball_pinfty r (e : {posnum R}) :
 Proof.
 move=> re1; rewrite /ereal_ball; rewrite [contract +oo]/= ler0_norm; last first.
   by rewrite subr_le0; case/ler_normlP: (contract_le1 r%:E).
-by rewrite opprB ltr_subl_addl.
+by rewrite opprB ltrBlDl.
 Qed.
 
 End ereal_PseudoMetric.
@@ -3692,9 +3692,9 @@ move=> [:wlog]; case: a b => [a||] [b||] //= ltax ltxb.
     rewrite -subr_gt0 opprD addrA {1}[(b - r)%R]splitr addrK.
     by rewrite divr_gt0 ?subr_gt0.
   by rewrite -subr_gt0 addrAC {1}[(r - a)%R]splitr addrK divr_gt0 ?subr_gt0.
-- have [//||d dP] := wlog a (r + 1)%R; rewrite ?lte_fin ?ltr_addl //.
+- have [//||d dP] := wlog a (r + 1)%R; rewrite ?lte_fin ?ltrDl //.
   by exists d => y /dP /andP[->] /= /lt_le_trans; apply; rewrite leey.
-- have [//||d dP] := wlog (r - 1)%R b; rewrite ?lte_fin ?gtr_addl ?ltrN10 //.
+- have [//||d dP] := wlog (r - 1)%R b; rewrite ?lte_fin ?gtrDl ?ltrN10 //.
   by exists d => y /dP /andP[_ ->] /=; rewrite ltNyr.
 - by exists 1%:pos%R => ? ?; rewrite ltNyr ltry.
 Qed.

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -642,8 +642,8 @@ Qed.
 Global Instance is_diff_id (x : V) : is_diff x id id.
 Proof.
 apply: DiffDef.
-  by apply: (@linear_differentiable _ _ [linear of idfun]) => ? //.
-by rewrite (@diff_lin _ _ [linear of idfun]) // => ? //.
+  by apply: (@linear_differentiable _ _ idfun) => ? //.
+by rewrite (@diff_lin _ _ idfun) // => ? //.
 Qed.
 
 Global Instance is_diff_scaler (k : R) (x : V) : is_diff x ( *:%R k) ( *:%R k).
@@ -821,35 +821,29 @@ by move=> fc; apply/diff_locallyP; rewrite diff_bilin //; apply: dbilin p fc.
 Qed.
 
 Definition mulr_rev (y x : R) := x * y.
-Canonical rev_mulr := @RevOp _ _ _ mulr_rev (@GRing.mul [ringType of R])
-  (fun _ _ => erefl).
+Canonical rev_mulr := @RevOp _ _ _ mulr_rev (@GRing.mul R) (fun _ _ => erefl).
 
-Lemma mulr_is_linear x : linear (@GRing.mul [ringType of R] x : R -> R).
+Lemma mulr_is_linear x : linear (@GRing.mul R x : R -> R).
 Proof. by move=> ???; rewrite mulrDr scalerAr. Qed.
-HB.instance Definition _ x :=
-  GRing.isLinear.Build R
-    [the lalgType R of R : Type] [ringType of R] _ ( *%R x) (mulr_is_linear x).
+HB.instance Definition _ x := GRing.isLinear.Build R R R _ ( *%R x)
+  (mulr_is_linear x).
 
 Lemma mulr_rev_is_linear y : linear (mulr_rev y : R -> R).
 Proof. by move=> ???; rewrite /mulr_rev mulrDl scalerAl. Qed.
-HB.instance Definition _ y :=
-  GRing.isLinear.Build R
-    [the lmodType R of R : Type] [the lalgType R of R : Type] _ (mulr_rev y)
-    (mulr_rev_is_linear y).
+HB.instance Definition _ y := GRing.isLinear.Build R R R _ (mulr_rev y)
+  (mulr_rev_is_linear y).
 
 Lemma mulr_is_bilinear :
   bilinear_for
     (GRing.Scale.Law.clone _ _ *:%R _) (GRing.Scale.Law.clone _ _ *:%R _)
-    (@GRing.mul [ringType of R]).
+    (@GRing.mul R).
 Proof.
 split=> [u'|u] a x y /=.
 - by rewrite mulrDl scalerAl.
 - by rewrite mulrDr scalerAr.
 Qed.
-HB.instance Definition _ :=
-  bilinear_isBilinear.Build R
-    [the lmodType R of R : Type]  [the lmodType R of R : Type] R _ _
-    (@GRing.mul R) mulr_is_bilinear.
+HB.instance Definition _ := bilinear_isBilinear.Build R R R R _ _ (@GRing.mul R)
+  mulr_is_bilinear.
 
 Global Instance is_diff_mulr (p : R * R) :
   is_diff p (fun q => q.1 * q.2) (fun q => p.1 * q.2 + q.1 * p.2).
@@ -983,8 +977,7 @@ Unshelve. all: by end_near. Qed.
 Lemma diff_Rinv (x : R) : x != 0 ->
   'd GRing.inv x = (fun h : R => - x ^- 2 *: h) :> (R -> R).
 Proof.
-move=> xn0; have -> : (fun h : R => - x ^- 2 *: h) =
-  [linear of *:%R (- x ^- 2)] by [].
+move=> xn0; have -> : (fun h : R => - x ^- 2 *: h) = ( *:%R (- x ^- 2)) by [].
 by apply: diff_unique; have [] := dinv xn0.
 Qed.
 
@@ -1603,7 +1596,7 @@ Proof. exact/diff_derivable. Qed.
 Global Instance is_derive_id (x v : V) : is_derive x v id v.
 Proof.
 apply: (DeriveDef (@derivable_id _ _)).
-rewrite deriveE// (@diff_lin _ _ _ [linear of idfun])//=.
+rewrite deriveE// (@diff_lin _ _ _ idfun)//=.
 by rewrite /continuous_at.
 Qed.
 

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -185,7 +185,7 @@ Variables (X Y Z : normedModType R).
 Lemma normm_littleo x (f : X -> Y) : `| [o_(x \near x) (1 : R) of f x]| = 0.
 Proof.
 rewrite /cst /=; have [e /(_ (`|e x|/2) _)/nbhs_singleton /=] := littleo.
-rewrite pmulr_lgt0 // [`|1|]normr1 mulr1 [leLHS]splitr ger_addr pmulr_lle0 //.
+rewrite pmulr_lgt0 // [`|1|]normr1 mulr1 [leLHS]splitr gerDr pmulr_lle0 //.
 by move=> /implyP; case : real_ltgtP; rewrite ?realE ?normrE //= lexx.
 Qed.
 
@@ -244,7 +244,7 @@ rewrite /= opprD -![(_ + _ : _ -> _) _]/(_ + _) -![(- _ : _ -> _) _]/(- _).
 rewrite /cst /= [`|1|]normr1 mulr1 => dfv.
 rewrite addrA -[X in X + _]scale1r -(@mulVf _ h) //.
 rewrite mulrC -scalerA -scalerBr normrZ.
-rewrite -ler_pdivl_mull; last by rewrite normr_gt0.
+rewrite -ler_pdivlMl; last by rewrite normr_gt0.
 by rewrite mulrCA mulVf ?mulr1; last by rewrite normr_eq0.
 Unshelve. all: by end_near. Qed.
 
@@ -261,7 +261,7 @@ rewrite /= !(near_simpl, near_withinE); apply: filter_app; near=> h.
 rewrite /= opprD -![(_ + _ : _ -> _) _]/(_ + _) -![(- _ : _ -> _) _]/(- _).
 rewrite /cst /= [`|1|]normr1 mulr1 addrA => dfv hN0.
 rewrite -[X in _ - X]scale1r -(@mulVf _ h) //.
-rewrite -scalerA -scalerBr normrZ normfV ler_pdivr_mull ?normr_gt0 //.
+rewrite -scalerA -scalerBr normrZ normfV ler_pdivrMl ?normr_gt0 //.
 by rewrite mulrC.
 Unshelve. all: by end_near. Qed.
 
@@ -316,15 +316,15 @@ have /(littleoP [littleo of k]) /nbhs_ballP[i i0 Hi] : 0 < e / (2 * `|v|).
   by rewrite divr_gt0 // pmulr_rgt0 // normr_gt0.
 exists (i / `|v|); first by rewrite /= divr_gt0 // normr_gt0.
 move=> /= j; rewrite /ball /= /ball_ add0r normrN.
-rewrite ltr_pdivl_mulr ?normr_gt0 // => jvi j0.
-rewrite add0r normrN normrZ -ltr_pdivl_mull ?normr_gt0 ?invr_neq0 //.
+rewrite ltr_pdivlMr ?normr_gt0 // => jvi j0.
+rewrite add0r normrN normrZ -ltr_pdivlMl ?normr_gt0 ?invr_neq0 //.
 have /Hi/le_lt_trans -> // : ball 0 i (j *: v).
    by rewrite -ball_normE/= add0r normrN (le_lt_trans _ jvi) // normrZ.
-rewrite -(mulrC e) -mulrA -ltr_pdivl_mull // mulrA mulVr ?unitfE ?gt_eqF //.
-rewrite normrV ?unitfE // div1r invrK ltr_pdivr_mull; last first.
+rewrite -(mulrC e) -mulrA -ltr_pdivlMl // mulrA mulVr ?unitfE ?gt_eqF //.
+rewrite normrV ?unitfE // div1r invrK ltr_pdivrMl; last first.
   by rewrite pmulr_rgt0 // normr_gt0.
 rewrite normrZ mulrC -mulrA.
-by rewrite ltr_pmull ?ltr1n // pmulr_rgt0 ?normm_gt0 // normr_gt0.
+by rewrite ltr_pMl ?ltr1n // pmulr_rgt0 ?normm_gt0 // normr_gt0.
 Qed.
 
 End DifferentialR_numFieldType.
@@ -450,9 +450,9 @@ have /bigO_exP [_ /posnumP[k]] := bigOP [bigO of [O_ (0 : U) id of f]].
 have := littleoP [littleo of [o_ (0 : V') id of g]].
 move=>  /(_ (e%:num / k%:num)) /(_ _) /nbhs_ballP [//|_ /posnumP[d] hd].
 apply: filter_app; near=> x => leOxkx; apply: le_trans (hd _ _) _; last first.
-  rewrite -ler_pdivl_mull //; apply: le_trans leOxkx _.
+  rewrite -ler_pdivlMl //; apply: le_trans leOxkx _.
   by rewrite invf_div mulrA -[_ / _ * _]mulrA mulVf // mulr1.
-by rewrite -ball_normE /= distrC subr0 (le_lt_trans leOxkx) // -ltr_pdivl_mull.
+by rewrite -ball_normE /= distrC subr0 (le_lt_trans leOxkx) // -ltr_pdivlMl.
 Unshelve. all: by end_near. Qed.
 
 Lemma compoO_eqox (U V' W' : normedModType R) (f : U -> V')
@@ -471,8 +471,8 @@ move=> /nbhs_ballP [_ /posnumP[d] hd].
 have ekgt0 : e%:num / k%:num > 0 by [].
 have /(_ _ ekgt0) := littleoP [littleo of [o_ (0 : U) id of f]].
 apply: filter_app; near=> x => leoxekx; apply: le_trans (hd _ _) _; last first.
-  by rewrite -ler_pdivl_mull // mulrA [_^-1 * _]mulrC.
-by rewrite -ball_normE /= distrC subr0 (le_lt_trans leoxekx)// -ltr_pdivl_mull //.
+  by rewrite -ler_pdivlMl // mulrA [_^-1 * _]mulrC.
+by rewrite -ball_normE /= distrC subr0 (le_lt_trans leoxekx)// -ltr_pdivlMl //.
 Unshelve. all: by end_near. Qed.
 
 End DifferentialR3.
@@ -486,17 +486,17 @@ Proof.
 move/eqoP => oid.
 rewrite funeqE => x; apply/eqP; have [|xn0] := real_le0P (normr_real x).
   by rewrite normr_le0 => /eqP ->; rewrite linear0.
-rewrite -normr_le0 -(mul0r `|x|) -ler_pdivr_mulr //.
-apply/ler_gtP => _ /posnumP[e]; rewrite ler_pdivr_mulr //.
+rewrite -normr_le0 -(mul0r `|x|) -ler_pdivrMr //.
+apply/ler_gtP => _ /posnumP[e]; rewrite ler_pdivrMr //.
 have /oid /nbhs_ballP [_ /posnumP[d] dfe] := !! gt0 e.
 set k := ((d%:num / 2) / (PosNum xn0)%:num)^-1.
 rewrite -{1}(@scalerKV _ _ k _ x) /k // linearZZ normrZ.
-rewrite -ler_pdivl_mull; last by rewrite gtr0_norm.
+rewrite -ler_pdivlMl; last by rewrite gtr0_norm.
 rewrite mulrCA (@le_trans _ _ (e%:num * `|k^-1 *: x|)) //; last first.
-  by rewrite ler_pmul // normrZ normfV.
+  by rewrite ler_pM // normrZ normfV.
 apply: dfe; rewrite -ball_normE /= sub0r normrN normrZ.
-rewrite invrK -ltr_pdivl_mulr // ger0_norm // ltr_pdivr_mulr //.
-by rewrite -mulrA mulVf ?lt0r_neq0 // mulr1 [ltRHS]splitr ltr_addl.
+rewrite invrK -ltr_pdivlMr // ger0_norm // ltr_pdivrMr //.
+by rewrite -mulrA mulVf ?lt0r_neq0 // mulr1 [ltRHS]splitr ltrDl.
 Qed.
 
 Lemma diff_unique (V W : normedModType R) (f : V -> W)
@@ -683,13 +683,13 @@ have [|xn0] := real_le0P (normr_real x).
 set k := 2 / e%:num * (PosNum xn0)%:num.
 have kn0 : k != 0 by rewrite /k.
 have abskgt0 : `|k| > 0 by rewrite normr_gt0.
-rewrite -[x in leLHS](scalerKV kn0) linearZZ normrZ -ler_pdivl_mull //.
+rewrite -[x in leLHS](scalerKV kn0) linearZZ normrZ -ler_pdivlMl //.
 suff /he : ball 0 e%:num (k^-1 *: x).
   rewrite -ball_normE /= distrC subr0 => /ltW /le_trans; apply.
   by rewrite ger0_norm /k // mulVf.
 rewrite -ball_normE /= distrC subr0 normrZ.
 rewrite normfV ger0_norm /k // invrM ?unitfE // mulrAC mulVf //.
-by rewrite invf_div mul1r [ltRHS]splitr; apply: ltr_spaddr.
+by rewrite invf_div mul1r [ltRHS]splitr; apply: ltr_pwDr.
 Qed.
 
 Lemma linear_eqO (V' W' : normedModType R) (f : {linear V' -> W'}) :
@@ -755,12 +755,12 @@ rewrite -[`|u|]/((PosNum un0)%:num) -[`|v|]/((PosNum vn0)%:num).
 set ku := 2 / e%:num * (PosNum un0)%:num.
 set kv := 2 / e%:num * (PosNum vn0)%:num.
 rewrite -[X in f X](@scalerKV _ _ ku) /ku // linearZl_LR normrZ.
-rewrite gtr0_norm // -ler_pdivl_mull //.
+rewrite gtr0_norm // -ler_pdivlMl //.
 rewrite -[X in f _ X](@scalerKV _ _ kv) /kv // linearZr_LR normrZ.
-rewrite gtr0_norm // -ler_pdivl_mull //.
+rewrite gtr0_norm // -ler_pdivlMl //.
 suff /he : ball 0 e%:num (ku^-1 *: u, kv^-1 *: v).
   rewrite -ball_normE /= distrC subr0 => /ltW /le_trans; apply.
-  rewrite ler_pdivl_mull 1?pmulr_lgt0// mulr1 ler_pdivl_mull 1?pmulr_lgt0//.
+  rewrite ler_pdivlMl 1?pmulr_lgt0// mulr1 ler_pdivlMl 1?pmulr_lgt0//.
   by rewrite mulrA [ku * _]mulrAC expr2.
 rewrite -ball_normE /= distrC subr0.
 have -> : (ku^-1 *: u, kv^-1 *: v) =
@@ -768,7 +768,7 @@ have -> : (ku^-1 *: u, kv^-1 *: v) =
   rewrite invrM ?unitfE // [kv ^-1]invrM ?unitfE //.
   rewrite mulrC -[_ *: u]scalerA [X in X *: v]mulrC -[_ *: v]scalerA.
   by rewrite invf_div.
-rewrite normrZ ger0_norm // -mulrA gtr_pmulr // ltr_pdivr_mull // mulr1.
+rewrite normrZ ger0_norm // -mulrA gtr_pMr // ltr_pdivrMl // mulr1.
 by rewrite prod_normE/= !normrZ !normfV !normr_id !mulVf ?gt_eqF// maxxx ltr1n.
 Qed.
 
@@ -777,8 +777,8 @@ Lemma bilinear_eqo (U V' W' : normedModType R) (f : {bilinear U -> V' -> W'}) :
 Proof.
 move=> fc; have [_ /posnumP[k] fschwarz] := bilinear_schwarz fc.
 apply/eqoP=> _ /posnumP[e]; near=> x; rewrite (le_trans (fschwarz _ _))//.
-rewrite ler_pmul ?pmulr_rge0 //; last by rewrite num_le_maxr /= lexx orbT.
-rewrite -ler_pdivl_mull //.
+rewrite ler_pM ?pmulr_rge0 //; last by rewrite num_le_maxr /= lexx orbT.
+rewrite -ler_pdivlMl //.
 suff : `|x| <= k%:num ^-1 * e%:num by apply: le_trans; rewrite num_le_maxr /= lexx.
 near: x; rewrite !near_simpl; apply/nbhs_le_nbhs_norm.
 by exists (k%:num ^-1 * e%:num) => //= ? /=; rewrite /= distrC subr0 => /ltW.
@@ -957,20 +957,20 @@ rewrite mulrA expr_div_n expr1n mulf_div mulr1 [_ ^+ 2 * _]mulrC -mulrA.
 rewrite -mulrDr mulrBr [1 / _ * _]mulrC normrM.
 rewrite mulrDl mulrDl opprD addrACA addrA [x * _]mulrC expr2 2!subrK.
 rewrite div1r normfV [X in _ / X]normrM invfM [X in _ * X]mulrC.
-rewrite mulrA mulrAC ler_pdivr_mulr ?normr_gt0 ?mulf_neq0 //.
-rewrite mulrAC ler_pdivr_mulr ?normr_gt0 //.
+rewrite mulrA mulrAC ler_pdivrMr ?normr_gt0 ?mulf_neq0 //.
+rewrite mulrAC ler_pdivrMr ?normr_gt0 //.
 have : `|h * h| <= `|x / 2| * (e%:num * `|x * x| * `|h|).
   rewrite !mulrA; near: h; exists (`|x / 2| * e%:num * `|x * x|).
     by rewrite /= !pmulr_rgt0 // normr_gt0 mulf_neq0.
-  by move=> h /ltW; rewrite distrC subr0 [`|h * _|]normrM => /ler_pmul; apply.
-move=> /le_trans -> //; rewrite [leLHS]mulrC ler_pmul ?mulr_ge0 //.
+  by move=> h /ltW; rewrite distrC subr0 [`|h * _|]normrM => /ler_pM; apply.
+move=> /le_trans -> //; rewrite [leLHS]mulrC ler_pM ?mulr_ge0 //.
 near: h; exists (`|x| / 2); first by rewrite /= divr_gt0 ?normr_gt0.
 move=> h; rewrite /= distrC subr0 => lthhx; rewrite addrC -[h]opprK.
 apply: le_trans (@ler_dist_dist  _ R  _ _).
 rewrite normrN [leRHS]ger0_norm; last first.
   rewrite subr_ge0; apply: ltW; apply: lt_le_trans lthhx _.
-  by rewrite ler_pdivr_mulr // -{1}(mulr1 `|x|) ler_pmul // ler1n.
-rewrite ler_subr_addr -ler_subr_addl (splitr `|x|).
+  by rewrite ler_pdivrMr // -{1}(mulr1 `|x|) ler_pM // ler1n.
+rewrite lerBrDr -lerBrDl (splitr `|x|).
 by rewrite normrM normfV (@ger0_norm _ 2) // -addrA subrr addr0; apply: ltW.
 Unshelve. all: by end_near. Qed.
 
@@ -1345,7 +1345,7 @@ have imf_sup : has_sup imf.
   have [M [Mreal imfltM]] : bounded_set (f @` `[a, b]).
     by apply/compact_bounded/continuous_compact => //; exact: segment_compact.
   exists (M + 1) => y /imfltM yleM.
-  by rewrite (le_trans _ (yleM _ _)) ?ler_norm ?ltr_addl.
+  by rewrite (le_trans _ (yleM _ _)) ?ler_norm ?ltrDl.
 have [|imf_ltsup] := pselect (exists2 c, c \in `[a, b]%R & f c = sup imf).
   move=> [c cab fceqsup]; exists c => // t tab; rewrite fceqsup.
   by apply/sup_upper_bound => //; exact/imageP.
@@ -1363,9 +1363,9 @@ have /ex_strict_bound_gt0 [k k_gt0 /= imVfltk] : bounded_set (g @` `[a, b]).
   exact: invf_continuous.
 have [_ [t tab <-]] : exists2 y, imf y & sup imf - k^-1 < y.
   by apply: sup_adherent => //; rewrite invr_gt0.
-rewrite ltr_subl_addr -ltr_subl_addl.
+rewrite ltrBlDr -ltrBlDl.
 suff : sup imf - f t > k^-1 by move=> /ltW; rewrite leNgt => /negbTE ->.
-rewrite -[ltRHS]invrK ltf_pinv// ?qualifE/= ?invr_gt0 ?subr_gt0 ?imf_ltsup//.
+rewrite -[ltRHS]invrK ltf_pV2// ?qualifE/= ?invr_gt0 ?subr_gt0 ?imf_ltsup//.
 by rewrite (le_lt_trans (ler_norm _) _) ?imVfltk//; exact: imageP.
 Qed.
 
@@ -1376,7 +1376,7 @@ Proof.
 move=> leab fcont.
 have /(EVT_max leab) [c clr fcmax] : {within `[a, b], continuous (- f)}.
   by move=> ?; apply: continuousN => ?; exact: fcont.
-by exists c => // ? /fcmax; rewrite ler_opp2.
+by exists c => // ? /fcmax; rewrite lerN2.
 Qed.
 
 Lemma cvg_at_rightE (R : numFieldType) (V : normedModType R) (f : R -> V) x :
@@ -1440,8 +1440,8 @@ apply/eqP; rewrite eq_le; apply/andP; split.
     by rewrite invr_ge0; apply: ltW; near: h; exists 1 => /=.
   rewrite subr_le0 [_%:A]mulr1; apply: cmax; near: h.
   exists (b - c); first by rewrite /= subr_gt0 (itvP cab).
-  move=> h; rewrite /= distrC subr0 /= in_itv /= -ltr_subr_addr.
-  move=> /(le_lt_trans (ler_norm _)) -> /ltr_spsaddl -> //.
+  move=> h; rewrite /= distrC subr0 /= in_itv /= -ltrBrDr.
+  move=> /(le_lt_trans (ler_norm _)) -> /ltr_pDl -> //.
   by rewrite (itvP cab).
 rewrite ['D_1 f c]cvg_at_leftE; last exact: fdrvbl.
 apply: limr_ge.
@@ -1454,8 +1454,8 @@ near=> h; apply: mulr_le0.
 rewrite subr_le0 [_%:A]mulr1; apply: cmax; near: h.
 exists (c - a); first by rewrite /= subr_gt0 (itvP cab).
 move=> h; rewrite /= distrC subr0.
-move=> /ltr_normlP []; rewrite ltr_subr_addl ltr_subl_addl in_itv /= => -> _.
-by move=> /ltr_snsaddl -> //; rewrite (itvP cab).
+move=> /ltr_normlP []; rewrite ltrBrDl ltrBlDl in_itv /= => -> _.
+by move=> /ltr_nDl -> //; rewrite (itvP cab).
 Unshelve. all: by end_near. Qed.
 
 Lemma derive1_at_min (R : realFieldType) (f : R -> R) (a b c : R) :
@@ -1467,7 +1467,7 @@ apply/eqP; rewrite -oppr_eq0; apply/eqP.
 rewrite -deriveN; last exact: fdrvbl.
 suff df : is_derive c 1 (- f) 0 by rewrite derive_val.
 apply: derive1_at_max leab _ (cab) _ => t tab; first exact/derivableN/fdrvbl.
-by rewrite ler_opp2; apply: cmin.
+by rewrite lerN2; apply: cmin.
 Qed.
 
 Lemma Rolle (R : realType) (f : R -> R) (a b : R) :
@@ -1567,7 +1567,7 @@ Lemma le0r_derive1_ndecr (R : realType) (f : R -> R) (a b : R) :
   {within `[a,b], continuous f} ->
   forall x y, a <= x -> x <= y -> y <= b -> f x <= f y.
 Proof.
-move=> fdrvbl dfge0 fcont x y; rewrite -[f _ <= _]ler_opp2.
+move=> fdrvbl dfge0 fcont x y; rewrite -[f _ <= _]lerN2.
 apply (@ler0_derive1_nincr _ (- f)) => t tab; first exact/derivableN/fdrvbl.
   rewrite derive1E deriveN; last exact: fdrvbl.
   by rewrite oppr_le0 -derive1E; apply: dfge0.

--- a/theories/ereal.v
+++ b/theories/ereal.v
@@ -621,7 +621,7 @@ case=> [x||].
   by move=> P Q PQ /xS; apply => y /PQ.
 - apply Build_ProperFilter.
     move=> P [x [xr xP]] //; exists (x + 1)%:E; apply xP => /=.
-    by rewrite lte_fin ltr_addl.
+    by rewrite lte_fin ltrDl.
   split=> /= [|P Q [MP [MPr gtMP]] [MQ [MQr gtMQ]] |P Q sPQ [M [Mr gtM]]].
   + by exists 0%R.
   + have [MP0|MP0] := eqVneq MP 0%R.
@@ -647,7 +647,7 @@ case=> [x||].
   + by exists M; split => // ? /gtM /sPQ.
 - apply Build_ProperFilter.
   + move=> P [M [Mr ltMP]]; exists (M - 1)%:E.
-    by apply: ltMP; rewrite lte_fin gtr_addl oppr_lt0.
+    by apply: ltMP; rewrite lte_fin gtrDl oppr_lt0.
   + split=> /= [|P Q [MP [MPr ltMP]] [MQ [MQr ltMQ]] |P Q sPQ [M [Mr ltM]]].
     * by exists 0%R.
     * have [MP0|MP0] := eqVneq MP 0%R.
@@ -656,25 +656,25 @@ case=> [x||].
           [apply/ltMP; rewrite MP0 | apply/ltMQ; rewrite MQ0].
         exists (- `|MQ|)%R; rewrite realN realE normr_ge0; split => // x xMQ.
         split.
-          by apply ltMP; rewrite (lt_le_trans xMQ)// lee_fin MP0 ler_oppl oppr0.
-       apply ltMQ; rewrite (lt_le_trans xMQ) // lee_fin ler_oppl -normrN.
+          by apply ltMP; rewrite (lt_le_trans xMQ)// lee_fin MP0 lerNl oppr0.
+       apply ltMQ; rewrite (lt_le_trans xMQ) // lee_fin lerNl -normrN.
        by rewrite real_ler_normr ?realN // lexx.
     * have [MQ0|MQ0] := eqVneq MQ 0%R.
         exists (- `|MP|)%R; rewrite realN realE normr_ge0; split => // x MPx.
         split.
-          apply ltMP; rewrite (lt_le_trans MPx) // lee_fin ler_oppl -normrN.
+          apply ltMP; rewrite (lt_le_trans MPx) // lee_fin lerNl -normrN.
           by rewrite real_ler_normr ?realN // lexx.
-        by apply ltMQ; rewrite (lt_le_trans MPx) // lee_fin MQ0 ler_oppl oppr0.
+        by apply ltMQ; rewrite (lt_le_trans MPx) // lee_fin MQ0 lerNl oppr0.
       have {}MP0 : (0 < `|MP|)%R by rewrite normr_gt0.
       have {}MQ0 : (0 < `|MQ|)%R by rewrite normr_gt0.
       exists (- (Num.max (PosNum MP0) (PosNum MQ0))%:num)%R.
       rewrite realN realE /= ge0 /=; split => //.
       case=> [r|//|].
-      - rewrite lte_fin ltr_oppr num_max num_lt_maxl => /andP[].
-        rewrite ltr_oppr => MPx; rewrite ltr_oppr => MQx; split.
-          apply/ltMP; rewrite lte_fin (lt_le_trans MPx) //= ler_oppl -normrN.
+      - rewrite lte_fin ltrNr num_max num_lt_maxl => /andP[].
+        rewrite ltrNr => MPx; rewrite ltrNr => MQx; split.
+          apply/ltMP; rewrite lte_fin (lt_le_trans MPx) //= lerNl -normrN.
           by rewrite real_ler_normr ?realN // lexx.
-        apply/ltMQ; rewrite lte_fin (lt_le_trans MQx) //= ler_oppl -normrN.
+        apply/ltMQ; rewrite lte_fin (lt_le_trans MQx) //= lerNl -normrN.
         by rewrite real_ler_normr ?realN // lexx.
       - by move=> _; split; [apply/ltMP | apply/ltMQ].
     * by exists M; split => // x /ltM /sPQ.
@@ -747,10 +747,10 @@ move: p => -[p| [M [Mreal MA]] | [M [Mreal MA]]] //=.
   rewrite lte_fin => M'x /=.
   apply/nbhs_ballP; exists 1%R => //= y x1y.
   apply MA; rewrite lte_fin.
-  rewrite addrC -ltr_subr_addl in M'x.
-  rewrite (lt_le_trans M'x) // ler_subl_addl addrC -ler_subl_addl.
+  rewrite addrC -ltrBrDl in M'x.
+  rewrite (lt_le_trans M'x) // lerBlDl addrC -lerBlDl.
   rewrite (le_trans _ (ltW x1y)) // real_ler_norm // realB //.
-    rewrite ltr_subr_addr in M'x.
+    rewrite ltrBrDr in M'x.
     rewrite -comparabler0 (@comparabler_trans _ (M + 1)%R) //.
       by rewrite /Order.comparable (ltW M'x) orbT.
     by rewrite comparabler0 realD.
@@ -760,11 +760,11 @@ move: p => -[p| [M [Mreal MA]] | [M [Mreal MA]]] //=.
   rewrite lte_fin => M'x /=.
   apply/nbhs_ballP; exists 1%R => //= y x1y.
   apply MA; rewrite lte_fin.
-  rewrite ltr_subr_addl in M'x.
-  rewrite (le_lt_trans _ M'x) // addrC -ler_subl_addl.
+  rewrite ltrBrDl in M'x.
+  rewrite (le_lt_trans _ M'x) // addrC -lerBlDl.
   rewrite (le_trans _ (ltW x1y)) // distrC real_ler_norm // realB //.
     by rewrite num_real. (* where we really use realFieldType *)
-  rewrite addrC -ltr_subr_addr in M'x.
+  rewrite addrC -ltrBrDr in M'x.
   rewrite -comparabler0 (@comparabler_trans _ (M - 1)%R) //.
     by rewrite /Order.comparable (ltW M'x).
   by rewrite comparabler0 realB.
@@ -883,7 +883,7 @@ case=> x Sx; rewrite ler_norml; apply/andP; split; last first.
   apply sup_le_ub; first by exists (contract x), x.
   by move=> r [y Sy] <-; case/ler_normlP : (contract_le1 y).
 rewrite (@le_trans _ _ (contract x)) //.
-  by case/ler_normlP : (contract_le1 x); rewrite ler_oppl.
+  by case/ler_normlP : (contract_le1 x); rewrite lerNl.
 apply sup_ub; last by exists x.
 by exists 1%R => r [y Sy <-]; case/ler_normlP : (contract_le1 y).
 Qed.
@@ -910,12 +910,12 @@ split => [r [y Sy <-{r}]|].
   apply sup_ub; last by exists y.
   by exists 1%R => r [z Sz <-]; case/ler_normlP : (contract_le1 z).
 rewrite ler_norml; apply/andP; split; last first.
-  rewrite ler_pdivr_mulr // mul1r (_ : 2 = 1 + 1)%R // ler_add //.
+  rewrite ler_pdivrMr // mul1r (_ : 2 = 1 + 1)%R // lerD //.
   by case/ler_normlP : (sup_contract_le1 S0).
   by case/ler_normlP : (contract_le1 (ereal_sup S)).
-rewrite ler_pdivl_mulr // (_ : 2 = 1 + 1)%R // mulN1r opprD ler_add //.
-by case/ler_normlP : (sup_contract_le1 S0); rewrite ler_oppl.
-by case/ler_normlP : (contract_le1 (ereal_sup S)); rewrite ler_oppl.
+rewrite ler_pdivlMr // (_ : 2 = 1 + 1)%R // mulN1r opprD lerD //.
+by case/ler_normlP : (sup_contract_le1 S0); rewrite lerNl.
+by case/ler_normlP : (contract_le1 (ereal_sup S)); rewrite lerNl.
 Qed.
 
 Lemma contract_inf S : S !=set0 -> contract (ereal_inf S) = inf (contract @` S).
@@ -938,8 +938,8 @@ Lemma expand_ereal_ball_pinfty {e : {posnum R}} r : (e%:num <= 1)%R ->
 Proof.
 move=> e1 er; rewrite /ereal_ball gtr0_norm ?subr_gt0; last first.
   by case/ltr_normlP : (contract_lt1 r).
-rewrite ltr_subl_addl addrC -ltr_subl_addl -[ltLHS]expandK ?lt_contract//.
-by rewrite inE ger0_norm ?ler_subl_addl ?ler_addr // subr_ge0.
+rewrite ltrBlDl addrC -ltrBlDl -[ltLHS]expandK ?lt_contract//.
+by rewrite inE ger0_norm ?lerBlDl ?lerDr // subr_ge0.
 Qed.
 
 Lemma contract_ereal_ball_fin_le r r' (e : {posnum R}) : (r <= r')%R ->
@@ -947,7 +947,7 @@ Lemma contract_ereal_ball_fin_le r r' (e : {posnum R}) : (r <= r')%R ->
 Proof.
 rewrite le_eqVlt => /predU1P[<-{r'} _|rr' re1]; first exact: ereal_ball_center.
 rewrite /ereal_ball ltr0_norm; last by rewrite subr_lt0 lt_contract lte_fin.
-rewrite opprB ltr_subl_addl (lt_le_trans _ re1) //.
+rewrite opprB ltrBlDl (lt_le_trans _ re1) //.
 by case/ltr_normlP : (contract_lt1 r').
 Qed.
 
@@ -956,7 +956,7 @@ Lemma contract_ereal_ball_fin_lt r r' (e : {posnum R}) : (r' < r)%R ->
 Proof.
 move=> r'r reN1; rewrite /ereal_ball.
 rewrite gtr0_norm ?subr_gt0 ?lt_contract ?lte_fin//.
-rewrite ltr_subl_addl addrC -ltr_subl_addl (le_lt_trans reN1) //.
+rewrite ltrBlDl addrC -ltrBlDl (le_lt_trans reN1) //.
 by move: (contract_lt1 r'); rewrite ltr_norml => /andP[].
 Qed.
 
@@ -966,7 +966,7 @@ Lemma expand_ereal_ball_fin_lt r' r (e : {posnum R}) : (r' < r)%R ->
 Proof.
 move=> r'r ? r'e'r.
 rewrite /ereal_ball gtr0_norm ?subr_gt0 ?lt_contract ?lte_fin//.
-by rewrite ltr_subl_addl addrC -ltr_subl_addl -lt_expandLR ?inE ?ltW.
+by rewrite ltrBlDl addrC -ltrBlDl -lt_expandLR ?inE ?ltW.
 Qed.
 
 Lemma ball_ereal_ball_fin_lt r r' (e : {posnum R}) :
@@ -979,9 +979,9 @@ move=> e' re'r' rr' X; rewrite /ereal_ball.
 rewrite gtr0_norm ?subr_gt0// ?lt_contract ?lte_fin//.
 move: re'r'.
 rewrite /ball /= gtr0_norm // ?subr_gt0// /e'.
-rewrite -ltr_subl_addl addrAC subrr add0r ltr_oppl opprK -lte_fin.
+rewrite -ltrBlDl addrAC subrr add0r ltrNl opprK -lte_fin.
 rewrite fine_expand // lt_expandLR ?inE ?ltW//.
-by rewrite ltr_subl_addl addrC -ltr_subl_addl.
+by rewrite ltrBlDl addrC -ltrBlDl.
 Qed.
 
 Lemma ball_ereal_ball_fin_le r r' (e : {posnum R}) :
@@ -995,8 +995,8 @@ move: rr'; rewrite le_eqVlt => /predU1P[->|rr']; first by rewrite subrr normr0.
 rewrite /ball /= ltr0_norm ?subr_lt0// opprB in r'e'r.
 rewrite ltr0_norm ?subr_lt0 ?lt_contract ?lte_fin//.
 rewrite opprB; move: r'e'r.
-rewrite /e' -ltr_subl_addr opprK subrK -lte_fin fine_expand //.
-by rewrite lt_expandRL ?inE ?ltW// ltr_subl_addl.
+rewrite /e' -ltrBlDr opprK subrK -lte_fin fine_expand //.
+by rewrite lt_expandRL ?inE ?ltW// ltrBlDl.
 Qed.
 
 Lemma nbhs_oo_up_e1 (A : set (\bar R)) (e : {posnum R}) : (e%:num <= 1)%R ->
@@ -1006,7 +1006,7 @@ move=> e1 ooeA.
 exists (fine (expand (1 - e%:num)%R)); rewrite num_real; split => //.
 case => [r | | //].
 - rewrite fine_expand; last first.
-    by rewrite ger0_norm ?ltr_subl_addl ?ltr_addr // subr_ge0.
+    by rewrite ger0_norm ?ltrBlDl ?ltrDr // subr_ge0.
   by move=> ?; exact/ooeA/expand_ereal_ball_pinfty.
 - by move=> _; exact/ooeA/ereal_ball_center.
 Qed.
@@ -1030,13 +1030,13 @@ move=> e1 reA; have [e2{e1}|e2] := ltrP 2 e%:num.
   rewrite predeqE => x; split => // _; apply reA.
   exact/ereal_ballN/ereal_ball_ninfty_oversize.
 have /andP[e10 e11] : (0 < e%:num - 1 <= 1)%R.
-  by rewrite subr_gt0 e1 /= ler_subl_addl.
+  by rewrite subr_gt0 e1 /= lerBlDl.
 apply nbhsNKe.
 have : ((PosNum e10)%:num <= 1)%R by [].
 move/(@nbhs_oo_down_e1 (-%E @` A) (PosNum e10)); apply.
 move=> y ye; exists (- y); last by rewrite oppeK.
 apply/reA/ereal_ballN; rewrite oppeK /=.
-by apply: le_ereal_ball ye => /=; rewrite ler_subl_addl ler_addr.
+by apply: le_ereal_ball ye => /=; rewrite lerBlDl lerDr.
 Qed.
 
 Lemma nbhs_oo_down_1e (A : set (\bar R)) (e : {posnum R}) : (1 < e%:num)%R ->
@@ -1046,13 +1046,13 @@ move=> e1 reA; have [e2{e1}|e2] := ltrP 2 e%:num.
   suff -> : A = setT by exists 0%R.
   by rewrite predeqE => x; split => // _; exact/reA/ereal_ball_ninfty_oversize.
 have /andP[e10 e11] : (0 < e%:num - 1 <= 1)%R.
-  by rewrite subr_gt0 e1 /= ler_subl_addl.
+  by rewrite subr_gt0 e1 /= lerBlDl.
 apply nbhsNKe.
 have : ((PosNum e10)%:num <= 1)%R by [].
 move/(@nbhs_oo_up_e1 (-%E @` A) (PosNum e10)); apply.
 move=> y ye; exists (- y); last by rewrite oppeK.
 apply/reA/ereal_ballN; rewrite /= oppeK.
-by apply: le_ereal_ball ye => /=; rewrite ler_subl_addl ler_addr.
+by apply: le_ereal_ball ye => /=; rewrite lerBlDl lerDr.
 Qed.
 
 Lemma nbhs_fin_out_above r (e : {posnum R}) (A : set (\bar R)) :
@@ -1063,13 +1063,13 @@ Lemma nbhs_fin_out_above r (e : {posnum R}) (A : set (\bar R)) :
 Proof.
 move=> reA reN1 re1.
 have er1 : (`|contract r%:E - e%:num| < 1)%R.
-  rewrite ltr_norml reN1 andTb ltr_subl_addl ltr_spaddl //.
+  rewrite ltr_norml reN1 andTb ltrBlDl ltr_pwDl //.
   by move: (contract_le1 r%:E); rewrite ler_norml => /andP[].
 pose e' := (r - fine (expand (contract r%:E - e%:num)))%R.
 have e'0 : (0 < e')%R.
   rewrite subr_gt0 -lte_fin -[ltRHS](contractK r%:E).
   rewrite fine_expand // lt_expand ?inE ?contract_le1// ?ltW//.
-  by rewrite ltr_subl_addl ltr_addr.
+  by rewrite ltrBlDl ltrDr.
 apply/nbhs_ballP; exists e' => // r' re'r'; apply reA.
 by have [?|?] := lerP r r';
   [exact: contract_ereal_ball_fin_le | exact: ball_ereal_ball_fin_lt].
@@ -1083,12 +1083,12 @@ Lemma nbhs_fin_out_below r (e : {posnum R}) (A : set (\bar R)) :
 Proof.
 move=> reA reN1 re1.
 have ? : (`|contract r%:E + e%:num| < 1)%R.
-  rewrite ltr_norml re1 andbT (@lt_le_trans _ _ (contract r%:E)) // ?ler_addl //.
+  rewrite ltr_norml re1 andbT (@lt_le_trans _ _ (contract r%:E)) // ?lerDl //.
   by move: (contract_lt1 r); rewrite ltr_norml => /andP[].
 pose e' : R := (fine (expand (contract r%:E + e%:num)) - r)%R.
 have e'0 : (0 < e')%R.
   rewrite /e' subr_gt0 -lte_fin -[in ltLHS](contractK r%:E).
-  by rewrite fine_expand // lt_expand ?inE ?contract_le1 ?ltr_addl ?ltW.
+  by rewrite fine_expand // lt_expand ?inE ?contract_le1 ?ltrDl ?ltW.
 apply/nbhs_ballP; exists e' => // r' r'e'r; apply reA.
 by have [?|?] := lerP r r';
   [exact: ball_ereal_ball_fin_le | exact: contract_ereal_ball_fin_lt].
@@ -1108,7 +1108,7 @@ case: x => [r'| |] //.
   + by apply contract_ereal_ball_fin_lt => //; exact/ltW.
 - exact/contract_ereal_ball_pinfty.
 - apply/ereal_ballN/contract_ereal_ball_pinfty.
-  by rewrite EFinN contractN -(opprK 1%R) ltr_oppl opprD opprK.
+  by rewrite EFinN contractN -(opprK 1%R) ltrNl opprD opprK.
 Qed.
 
 Lemma nbhs_fin_inbound r (e : {posnum R}) (A : set (\bar R)) :
@@ -1127,8 +1127,8 @@ have [|reN1] := boolP (contract r%:E - e%:num == -1)%R.
   rewrite neq_lt => /orP[re1|re1].
     by apply (@nbhs_fin_out_below _ e) => //; rewrite reN1 addrAC subrr sub0r.
   have e1 : (1 < e%:num)%R.
-    move: re1; rewrite reN1 addrAC ltr_subr_addl -!mulr2n -(mulr_natl e%:num).
-    by rewrite -{1}(mulr1 2) => ?; rewrite -(@ltr_pmul2l _ 2).
+    move: re1; rewrite reN1 addrAC ltrBrDl -!mulr2n -(mulr_natl e%:num).
+    by rewrite -{1}(mulr1 2) => ?; rewrite -(@ltr_pM2l _ 2).
   have Aoo : setT `\ -oo `<=` A.
     move=> x [_]; rewrite /set1 /= => xnoo; apply reA.
     case: x xnoo => [r' _ | _ |//].
@@ -1148,11 +1148,11 @@ move: reN1; rewrite eq_sym neq_lt => /orP[reN1|reN1].
     by apply (@nbhs_fin_out_above _ e) => //; rewrite re1.
   move: re1; rewrite neq_lt => /orP[re1|re1].
     have ? : (`|contract r%:E - e%:num| < 1)%R.
-      rewrite ltr_norml reN1 andTb ltr_subl_addl.
-      rewrite (@lt_le_trans _ _ 1%R) // ?ler_addr//.
+      rewrite ltr_norml reN1 andTb ltrBlDl.
+      rewrite (@lt_le_trans _ _ 1%R) // ?lerDr//.
       by case/ltr_normlP : (contract_lt1 r).
     have ? : (`|contract r%:E + e%:num| < 1)%R.
-      rewrite ltr_norml re1 andbT -(addr0 (-1)) ler_lt_add //.
+      rewrite ltr_norml re1 andbT -(addr0 (-1)) ler_ltD //.
       by move: (contract_le1 r%:E); rewrite ler_norml => /andP[].
     pose e' : R := Num.min
       (r - fine (expand (contract r%:E - e%:num)))%R
@@ -1161,15 +1161,15 @@ move: reN1; rewrite eq_sym neq_lt => /orP[reN1|reN1].
       rewrite /e' lt_minr; apply/andP; split.
         rewrite subr_gt0 -lte_fin -[in ltRHS](contractK r%:E).
         rewrite fine_expand // lt_expand// ?inE ?contract_le1 ?ltW//.
-        by rewrite ltr_subl_addl ltr_addr.
+        by rewrite ltrBlDl ltrDr.
       rewrite subr_gt0 -lte_fin -[in ltLHS](contractK r%:E).
-      by rewrite fine_expand// lt_expand ?inE ?contract_le1 ?ltr_addl ?ltW.
+      by rewrite fine_expand// lt_expand ?inE ?contract_le1 ?ltrDl ?ltW.
     apply/nbhs_ballP; exists e' => // r' re'r'; apply reA.
     have [|r'r] := lerP r r'.
       move=> rr'; apply: ball_ereal_ball_fin_le => //.
       by apply: le_ball re'r'; rewrite le_minl lexx orbT.
     move: re'r'; rewrite /ball /= lt_minr => /andP[].
-    rewrite gtr0_norm ?subr_gt0 // -ltr_subl_addl addrAC subrr add0r ltr_oppl.
+    rewrite gtr0_norm ?subr_gt0 // -ltrBlDl addrAC subrr add0r ltrNl.
     rewrite opprK -lte_fin fine_expand // => r'e'r _.
     exact: expand_ereal_ball_fin_lt.
   by apply (@nbhs_fin_out_above _ e) => //; rewrite ltW.
@@ -1180,24 +1180,24 @@ move: re1; rewrite le_eqVlt => /orP[re1|re1].
     by move: re1; rewrite eq_sym -subr_eq => /eqP <-.
   have e1 : (1 < e%:num)%R.
     move: reN1.
-    rewrite re1 -addrA -opprD ltr_subl_addl ltr_subr_addl -!mulr2n.
+    rewrite re1 -addrA -opprD ltrBlDl ltrBrDl -!mulr2n.
     rewrite -(mulr_natl e%:num) -{1}(mulr1 2) => ?.
-    by rewrite -(@ltr_pmul2l _ 2).
+    by rewrite -(@ltr_pM2l _ 2).
   have Aoo : (setT `\ +oo `<=` A).
     move=> x [_]; rewrite /set1 /= => xpoo; apply reA.
     case: x xpoo => [r' _ | // |_].
       rewrite /ereal_ball.
       have [rr'|r'r] := lerP (contract r%:E) (contract r'%:E).
-        rewrite re1 opprB addrCA -[ltRHS]addr0 ltr_add2 subr_lt0.
+        rewrite re1 opprB addrCA -[ltRHS]addr0 ltrD2 subr_lt0.
         by case/ltr_normlP : (contract_lt1 r').
       rewrite /ereal_ball.
-      rewrite re1 addrAC ltr_subl_addl ltr_add // (lt_trans _ e1) // ltr_oppl.
+      rewrite re1 addrAC ltrBlDl ltrD // (lt_trans _ e1) // ltrNl.
       by move: (contract_lt1 r'); rewrite ltr_norml => /andP[].
     rewrite /ereal_ball.
     rewrite [contract -oo]/= opprK gtr0_norm ?subr_gt0; last first.
-      rewrite -ltr_subl_addl add0r ltr_oppl.
+      rewrite -ltrBlDl add0r ltrNl.
       by move: (contract_lt1 r); rewrite ltr_norml => /andP[].
-    by rewrite re1 addrAC ltr_subl_addl ltr_add.
+    by rewrite re1 addrAC ltrBlDl ltrD.
    have : nbhs r%:E (setT `\ +oo) by exists 1%R => /=.
    case => _/posnumP[x] /=; rewrite /ball_ => h.
    by exists x%:num => //= y /h; exact: Aoo.
@@ -1215,8 +1215,8 @@ rewrite predeq2E => x A; split.
     exists (diag e'); rewrite /diag.
       exists e' => //.
       rewrite /= /e' lt_minr; apply/andP; split.
-        by rewrite subr_gt0 lt_contract lte_fin ltr_subl_addr ltr_addl.
-      by rewrite subr_gt0 lt_contract lte_fin ltr_addl.
+        by rewrite subr_gt0 lt_contract lte_fin ltrBlDr ltrDl.
+      by rewrite subr_gt0 lt_contract lte_fin ltrDl.
     case=> [r' /= re'r'| |]/=.
     * rewrite /ereal_ball in re'r'.
       have [r'r|rr'] := lerP (contract r'%:E) (contract r%:E).
@@ -1224,35 +1224,35 @@ rewrite predeq2E => x A; split.
         rewrite ger0_norm ?subr_ge0// in re'r'.
         have : (contract (r%:E - e%:num%:E) < contract r'%:E)%R.
           move: re'r'; rewrite /e' lt_minr => /andP[+ _].
-          rewrite /e' ltr_subr_addl addrC -ltr_subr_addl => /lt_le_trans.
+          rewrite /e' ltrBrDl addrC -ltrBrDl => /lt_le_trans.
           by apply; rewrite opprB addrCA subrr addr0.
         rewrite -lt_expandRL ?inE ?contract_le1 // !contractK lte_fin.
-        rewrite ltr_subl_addr addrC -ltr_subl_addr => ->; rewrite andbT.
-        rewrite (@lt_le_trans _ _ 0%R)// 1?ltr_oppl 1?oppr0// subr_ge0.
+        rewrite ltrBlDr addrC -ltrBlDr => ->; rewrite andbT.
+        rewrite (@lt_le_trans _ _ 0%R)// 1?ltrNl 1?oppr0// subr_ge0.
         by rewrite -lee_fin -le_contract.
       apply: reA; rewrite /ball /= real_ltr_norml // ?num_real //.
       rewrite ltr0_norm ?subr_lt0// opprB in re'r'.
       apply/andP; split; last first.
         by rewrite (@lt_trans _ _ 0%R) // subr_lt0 -lte_fin -lt_contract.
-      rewrite ltr_oppl opprB.
+      rewrite ltrNl opprB.
       rewrite /e' in re'r'.
       have r're : (contract r'%:E < contract (r%:E + e%:num%:E))%R.
         move: re'r'; rewrite lt_minr => /andP[_].
-        by rewrite ltr_subl_addr subrK.
-      rewrite ltr_subl_addr -lte_fin -(contractK (_ + r)%:E)%R.
+        by rewrite ltrBlDr subrK.
+      rewrite ltrBlDr -lte_fin -(contractK (_ + r)%:E)%R.
       by rewrite addrC -(contractK r'%:E) // lt_expand ?inE ?contract_le1.
     * rewrite /ereal_ball [contract +oo]/=.
       rewrite lt_minr => /andP[re'1 re'2].
       have [cr0|cr0] := lerP 0 (contract r%:E).
         move: re'2; rewrite ler0_norm; last first.
           by rewrite subr_le0; case/ler_normlP : (contract_le1 r%:E).
-        rewrite opprB ltr_subr_addl addrCA subrr addr0 => h.
+        rewrite opprB ltrBrDl addrCA subrr addr0 => h.
         exfalso.
         move: h; apply/negP; rewrite -leNgt.
         by case/ler_normlP : (contract_le1 (r%:E + e%:num%:E)).
       move: re'2; rewrite ler0_norm; last first.
         by rewrite subr_le0; case/ler_normlP : (contract_le1 r%:E).
-      rewrite opprB ltr_subr_addl addrCA subrr addr0 => h.
+      rewrite opprB ltrBrDl addrCA subrr addr0 => h.
       exfalso.
       move: h; apply/negP; rewrite -leNgt.
       by case/ler_normlP : (contract_le1 (r%:E + e%:num%:E)).
@@ -1260,11 +1260,11 @@ rewrite predeq2E => x A; split.
       rewrite lt_minr => /andP[re'1 _].
       move: re'1.
       rewrite ger0_norm; last first.
-        rewrite addrC -ler_subl_addl add0r.
+        rewrite addrC -lerBlDl add0r.
         by move: (contract_le1 r%:E); rewrite ler_norml => /andP[].
-      rewrite ltr_add2l => h.
+      rewrite ltrD2l => h.
       exfalso.
-      move: h; apply/negP; rewrite -leNgt -ler_oppl.
+      move: h; apply/negP; rewrite -leNgt -lerNl.
       by move: (contract_le1 (r%:E - e%:num%:E)); rewrite ler_norml => /andP[].
   + exists (diag (1 - contract M%:E))%R; rewrite /diag.
       exists (1 - contract M%:E)%R => //=.
@@ -1274,33 +1274,33 @@ rewrite predeq2E => x A; split.
       apply: MA; rewrite lte_fin.
       rewrite ger0_norm in rM1; last first.
         by rewrite subr_ge0 // (le_trans _ (contract_le1 r%:E)) // ler_norm.
-      rewrite ltr_subl_addr addrC addrCA addrC -ltr_subl_addr subrr in rM1.
+      rewrite ltrBlDr addrC addrCA addrC -ltrBlDr subrr in rM1.
       rewrite subr_gt0 in rM1.
       by rewrite -lte_fin -lt_contract.
     * by rewrite /ereal_ball /= subrr normr0 => h; exact: MA.
     * rewrite /ereal_ball /= opprK => h {MA}.
       exfalso.
       move: h; apply/negP.
-      rewrite -leNgt [in leRHS]ger0_norm // ler_subl_addr.
-      rewrite -/(contract M%:E) addrC -ler_subl_addr opprD addrA subrr sub0r.
+      rewrite -leNgt [in leRHS]ger0_norm // lerBlDr.
+      rewrite -/(contract M%:E) addrC -lerBlDr opprD addrA subrr sub0r.
       by move: (contract_le1 M%:E); rewrite ler_norml => /andP[].
   + exists (diag (1 + contract M%:E)%R); rewrite /diag.
       exists (1 + contract M%:E)%R => //=.
-      rewrite -ltr_subl_addl sub0r.
+      rewrite -ltrBlDl sub0r.
       by move: (contract_lt1 M); rewrite ltr_norml => /andP[].
     case=> [r| |].
     * rewrite /ereal_ball => /= rM1.
       apply MA.
       rewrite lte_fin.
       rewrite ler0_norm in rM1; last first.
-        rewrite ler_subl_addl addr0 ltW //.
+        rewrite lerBlDl addr0 ltW //.
         by move: (contract_lt1 r); rewrite ltr_norml => /andP[].
-      rewrite opprB opprK -ltr_subl_addl addrK in rM1.
+      rewrite opprB opprK -ltrBlDl addrK in rM1.
       by rewrite -lte_fin -lt_contract.
     * rewrite /ereal_ball /= -opprD normrN => h {MA}.
       exfalso.
       move: h; apply/negP.
-      rewrite -leNgt [in leRHS]ger0_norm// -ler_subl_addr addrAC.
+      rewrite -leNgt [in leRHS]ger0_norm// -lerBlDr addrAC.
       rewrite subrr add0r -/(contract M%:E).
       by rewrite (le_trans _ (ltW (contract_lt1 M))) // ler_norm.
     * rewrite /ereal_ball /= => _; exact: MA.
@@ -1363,7 +1363,7 @@ case: x => /= [x [_/posnumP[d] dP] |[d [dreal dP]] |[d [dreal dP]]]; last 2 firs
     by apply; rewrite (lt_le_trans (lt_succ_floor _))// Nfloor natr1 ler_nat.
   have /ZnatP [N Nfloor] : floor (Num.max (- d)%R 0%R) \is a Znat.
     by rewrite Znat_def floor_ge0 le_maxr lexx orbC.
-  exists N.+1 => // n ltNn; apply: dP; rewrite lte_fin ltr_oppl.
+  exists N.+1 => // n ltNn; apply: dP; rewrite lte_fin ltrNl.
   have /le_lt_trans : (- d <= Num.max (- d) 0)%R by rewrite le_maxr lexx.
   by apply; rewrite (lt_le_trans (lt_succ_floor _))// Nfloor natr1 ler_nat.
 have /ZnatP [N Nfloor] : floor (d%:num^-1) \is a Znat.
@@ -1371,6 +1371,6 @@ have /ZnatP [N Nfloor] : floor (d%:num^-1) \is a Znat.
 exists N => // n leNn; apply: dP; last first.
   by rewrite eq_sym addrC -subr_eq subrr eq_sym; exact/invr_neq0/lt0r_neq0.
 rewrite /= opprD addrA subrr distrC subr0 gtr0_norm; last by rewrite invr_gt0.
-rewrite -[ltLHS]mulr1 ltr_pdivr_mull // -ltr_pdivr_mulr // div1r.
-by rewrite (lt_le_trans (lt_succ_floor _))// Nfloor ler_add// ler_nat.
+rewrite -[ltLHS]mulr1 ltr_pdivrMl // -ltr_pdivrMr // div1r.
+by rewrite (lt_le_trans (lt_succ_floor _))// Nfloor lerD// ler_nat.
 Qed.

--- a/theories/exp.v
+++ b/theories/exp.v
@@ -60,10 +60,10 @@ apply: series_le_cvg Kzxn _ _ => [//=| /= n|].
   rewrite (_ : `|_ * _| = `|f n * x ^+ n| * `|z ^+ n| / `|x ^+ n|); last first.
     rewrite !normrM normr_id mulrAC mulfK // normr_eq0 expf_eq0 andbC.
     by case: ltrgt0P zLx; rewrite //= normr_lt0.
-  do! (apply: ler_pmul || apply: mulr_ge0 || rewrite invr_ge0) => //.
-  by apply Kf => //; rewrite (lt_le_trans _ (ler_norm _))// ltr_addl.
+  do! (apply: ler_pM || apply: mulr_ge0 || rewrite invr_ge0) => //.
+  by apply Kf => //; rewrite (lt_le_trans _ (ler_norm _))// ltrDl.
 have F : `|z / x| < 1.
-  by rewrite normrM normfV ltr_pdivr_mulr ?mul1r // (le_lt_trans _ zLx).
+  by rewrite normrM normfV ltr_pdivrMr ?mul1r // (le_lt_trans _ zLx).
 rewrite (_ : (fun _ => _) = geometric `|K + 1| `|z / x|); last first.
   by apply/funext => i /=; rewrite normrM exprMn mulrA normfV !normrX exprVn.
 by apply: is_cvg_geometric_series; rewrite normr_id.
@@ -156,7 +156,7 @@ Let pseries_diffs_P3 (z h : R) n K :
 Proof.
 move=> hNZ zLK zhLk.
 rewrite pseries_diffs_P2// normrM mulrC.
-rewrite ler_pmul2r ?normr_gt0//.
+rewrite ler_pM2r ?normr_gt0//.
 rewrite (le_trans (ler_norm_sum _ _ _))//.
 rewrite -mulrA mulrC -mulrA mulr_natl -[X in _ *+ X]subn0 -sumr_const_nat.
 apply ler_sum_nat => i /=.
@@ -167,15 +167,15 @@ rewrite -[(n - i)%nat]prednK ?subn_gt0// predn_sub -/d.
 rewrite -(subnK (_ : i <= n.-1)%nat) -/d; last first.
   by rewrite -ltnS prednK// (leq_ltn_trans _ ni).
 rewrite addnC exprD mulrAC -mulrA.
-apply: ler_pmul => //.
-  by rewrite normrX ler_expn2r// qualifE/= (le_trans _ zLK).
+apply: ler_pM => //.
+  by rewrite normrX lerXn2r// qualifE/= (le_trans _ zLK).
 apply: le_trans (_ : d.+1%:R * K ^+ d <= _); last first.
-  rewrite ler_wpmul2r //; first by rewrite exprn_ge0 // (le_trans _ zLK).
+  rewrite ler_wpM2r //; first by rewrite exprn_ge0 // (le_trans _ zLK).
   by rewrite ler_nat ltnS /d -subn1 -subnDA leq_subr.
 rewrite (le_trans (ler_norm_sum _ _ _))//.
 rewrite mulr_natl -[X in _ *+ X]subn0 -sumr_const_nat ler_sum_nat//= => j jd1.
 rewrite -[in leRHS](subnK (_ : j <= d)%nat) -1?ltnS // addnC exprD normrM.
-by rewrite ler_pmul// normrX ler_expn2r// qualifE/= (le_trans _ zLK).
+by rewrite ler_pM// normrX lerXn2r// qualifE/= (le_trans _ zLK).
 Qed.
 
 Lemma pseries_snd_diffs (c : R^nat) K x :
@@ -208,13 +208,13 @@ suff Cc : limn (h^-1 *: (series (shx h - sx))) @[h --> 0^'] --> limn (series s).
   rewrite normr_le0 subr_eq0 -/sx -/(shx _); apply/eqP.
   have Cshx' : cvgn (series (shx h)).
     apply: is_cvg_pseries_inside Ck _.
-    rewrite (le_lt_trans (ler_norm_add _ _))// -(subrK  `|x| `|K|) ltr_add2r.
+    rewrite (le_lt_trans (ler_normD _ _))// -(subrK  `|x| `|K|) ltrD2r.
     near: h.
     apply/nbhs_ballP => /=; exists ((`|K| - `|x|) /2) => /=.
       by rewrite divr_gt0 // subr_gt0.
     move=> t; rewrite /ball /= sub0r normrN => H tNZ.
-    rewrite (lt_le_trans H)// ler_pdivr_mulr // mulr2n mulrDr mulr1.
-    by rewrite ler_paddr // subr_ge0 ltW.
+    rewrite (lt_le_trans H)// ler_pdivrMr // mulr2n mulrDr mulr1.
+    by rewrite ler_wpDr // subr_ge0 ltW.
   rewrite limZr; last exact/is_cvg_seriesB/Csx.
   by rewrite lim_seriesB; last exact: Csx.
 apply: cvg_zero => /=.
@@ -231,13 +231,13 @@ suff Cc : limn
   set s1 := (fun i => _) in Cs1.
   have Cshx : cvgn (series (shx h)).
     apply: is_cvg_pseries_inside Ck _.
-    rewrite (le_lt_trans (ler_norm_add _ _))// -(subrK  `|x| `|K|) ltr_add2r.
+    rewrite (le_lt_trans (ler_normD _ _))// -(subrK  `|x| `|K|) ltrD2r.
     near: h.
     apply/nbhs_ballP => /=; exists ((`|K| - `|x|) /2) => /=.
       by rewrite divr_gt0 // subr_gt0.
     move=> t; rewrite /ball /= sub0r normrN => H tNZ.
-    rewrite (lt_le_trans H)// ler_pdivr_mulr // mulr2n mulrDr mulr1.
-    by rewrite ler_paddr // subr_ge0 ltW.
+    rewrite (lt_le_trans H)// ler_pdivrMr // mulr2n mulrDr mulr1.
+    by rewrite ler_wpDr // subr_ge0 ltW.
   have C1 := is_cvg_seriesB Cshx Csx.
   have Ckf := @is_cvg_seriesZ _ _ h^-1 C1.
   have Cu : (series (h^-1 *: (shx h - sx)) - series s1) x0 @[x0 --> \oo] -->
@@ -257,8 +257,8 @@ suff Cc : limn
     by apply/funext => i; rewrite /series /= -scaler_sumr.
   exact/esym/cvg_lim.
 pose r := (`|x| + `|K|) / 2.
-have xLr : `|x| < r by rewrite ltr_pdivl_mulr // mulr2n mulrDr mulr1 ltr_add2l.
-have rLx : r < `|K| by rewrite ltr_pdivr_mulr // mulr2n mulrDr mulr1 ltr_add2r.
+have xLr : `|x| < r by rewrite ltr_pdivlMr // mulr2n mulrDr mulr1 ltrD2l.
+have rLx : r < `|K| by rewrite ltr_pdivrMr // mulr2n mulrDr mulr1 ltrD2r.
 have r_gt0 : 0 < r by apply: le_lt_trans xLr.
 have rNZ : r != 0by case: ltrgt0P r_gt0.
 apply: (@lim_cvg_to_0_linear _
@@ -291,9 +291,9 @@ apply: (@lim_cvg_to_0_linear _
   rewrite mul1r !mulrA; congr (_ * _).
   by rewrite mulrC mulrA.
 - move=> h /andP[h_gt0 hLrBx] n.
-  rewrite normrM -!mulrA ler_wpmul2l //.
+  rewrite normrM -!mulrA ler_wpM2l //.
   rewrite (le_trans (pseries_diffs_P3 _ _ (ltW xLr) _))// ?mulrA -?normr_gt0//.
-  by rewrite (le_trans (ler_norm_add _ _))// -(subrK `|x| r) ler_add2r ltW.
+  by rewrite (le_trans (ler_normD _ _))// -(subrK `|x| r) lerD2r ltW.
 Unshelve. all: by end_near.
 Qed.
 
@@ -378,7 +378,7 @@ Proof. by rewrite -[X in _ X * _ = _]addr0 expRxDyMexpx expR0. Qed.
 
 Lemma pexpR_gt1 x : 0 < x -> 1 < expR x.
 Proof.
-by move=> x_gt0; rewrite (lt_le_trans _ (expR_ge1Dx (ltW x_gt0)))// ltr_addl.
+by move=> x_gt0; rewrite (lt_le_trans _ (expR_ge1Dx (ltW x_gt0)))// ltrDl.
 Qed.
 
 Lemma expR_gt0 x : 0 < expR x.
@@ -416,14 +416,14 @@ case: ltrgt0P => [x_gt0| xN|->]; last by rewrite expR0.
 - by rewrite (pexpR_gt1 x_gt0).
 - apply/idP/negP.
   rewrite -[x]opprK expRN -leNgt invf_cp1 ?expR_gt0 //.
-  by rewrite ltW // pexpR_gt1 // lter_oppE.
+  by rewrite ltW // pexpR_gt1 // lterNE.
 Qed.
 
 Lemma expR_lt1 x:  (expR x < 1) = (x < 0).
 Proof.
 case: ltrgt0P => [x_gt0|xN|->]; last by rewrite expR0.
 - by apply/idP/negP; rewrite -leNgt ltW // expR_gt1.
-- by rewrite -[x]opprK expRN invf_cp1 ?expR_gt0 // expR_gt1 lter_oppE.
+- by rewrite -[x]opprK expRN invf_cp1 ?expR_gt0 // expR_gt1 lterNE.
 Qed.
 
 Lemma expRB x y : expR (x - y) = expR x / expR y.
@@ -432,7 +432,7 @@ Proof. by rewrite expRD expRN. Qed.
 Lemma ltr_expR : {mono (@expR R) : x y / x < y}.
 Proof.
 move=> x y.
-by  rewrite -[in LHS](subrK x y) expRD ltr_pmull ?expR_gt0 // expR_gt1 subr_gt0.
+by  rewrite -[in LHS](subrK x y) expRD ltr_pMl ?expR_gt0 // expR_gt1 subr_gt0.
 Qed.
 
 Lemma ler_expR : {mono (@expR R) : x y / x <= y}.
@@ -457,10 +457,10 @@ have [x1 x1Ix| |x1 _ /eqP] := @IVT _ (fun y => expR y - x) _ _ 0 x_ge0.
 - apply: continuousB => // y1; last exact: cst_continuous.
   by apply/continuous_subspaceT=> ?; exact: continuous_expR.
 - rewrite expR0; have [_| |] := ltrgtP (1- x) (expR x - x).
-  + by rewrite subr_le0 x_ge1 subr_ge0 (le_trans _ (expR_ge1Dx _)) ?ler_addr.
-  + by rewrite ltr_add2r expR_lt1 ltNge x_ge0.
+  + by rewrite subr_le0 x_ge1 subr_ge0 (le_trans _ (expR_ge1Dx _)) ?lerDr.
+  + by rewrite ltrD2r expR_lt1 ltNge x_ge0.
   + rewrite subr_le0 x_ge1 => -> /=; rewrite subr_ge0.
-    by rewrite (le_trans _ (expR_ge1Dx x_ge0)) ?ler_addr.
+    by rewrite (le_trans _ (expR_ge1Dx x_ge0)) ?lerDr.
 - rewrite subr_eq0 => /eqP x1_x; exists x1; split => //.
   + by rewrite -ler_expR expR0 x1_x.
   + by rewrite -x1_x expR_ge1Dx // -ler_expR x1_x expR0.
@@ -558,13 +558,13 @@ Qed.
 Lemma le_ln1Dx x : 0 <= x -> ln (1 + x) <= x.
 Proof.
 move=> x_ge0; rewrite -ler_expR lnK ?expR_ge1Dx //.
-by apply: lt_le_trans (_ : 0 < 1) _; rewrite // ler_addl.
+by apply: lt_le_trans (_ : 0 < 1) _; rewrite // lerDl.
 Qed.
 
 Lemma ln_sublinear x : 0 < x -> ln x < x.
 Proof.
 move=> x_gt0; apply: lt_le_trans (_ : ln (1 + x) <= _).
-  by rewrite -ltr_expR !lnK ?qualifE/= ?addr_gt0 // ltr_addr.
+  by rewrite -ltr_expR !lnK ?qualifE/= ?addr_gt0 // ltrDr.
 by rewrite -ler_expR lnK ?qualifE/= ?addr_gt0// expR_ge1Dx // ltW.
 Qed.
 
@@ -637,7 +637,7 @@ Qed.
 Lemma ler_power_pos a : 1 < a -> {homo power_pos a : x y / x <= y}.
 Proof.
 move=> a1 x y xy.
-by rewrite /power_pos gt_eqF ?(le_lt_trans _ a1)// ler_expR ler_pmul2r// ln_gt0.
+by rewrite /power_pos gt_eqF ?(le_lt_trans _ a1)// ler_expR ler_pM2r// ln_gt0.
 Qed.
 
 Lemma power_posM x y r : 0 <= x -> 0 <= y -> (x * y) `^ r = x `^ r * y `^ r.
@@ -834,7 +834,7 @@ case/andP => a0; rewrite le_eqVlt => /predU1P[->|a1].
   by rewrite funeqE => i /=; rewrite power_posr1.
 have : forall n, harmonic n <= riemannR a n.
   case=> /= [|n]; first by rewrite power_pos1 invr1.
-  rewrite -[leRHS]div1r ler_pdivl_mulr ?power_pos_gt0 // mulrC ler_pdivr_mulr //.
+  rewrite -[leRHS]div1r ler_pdivlMr ?power_pos_gt0 // mulrC ler_pdivrMr //.
   by rewrite mul1r -[leRHS]power_posr1 // (ler_power_pos) // ?ltr1n // ltW.
 move/(series_le_cvg harmonic_ge0 (fun i => ltW (riemannR_gt0 i a0))).
 by move/contra_not; apply; exact: dvg_harmonic.

--- a/theories/forms.v
+++ b/theories/forms.v
@@ -481,8 +481,8 @@ End Sesquilinear.
 
 Notation "eps_theta .-sesqui" := (sesqui _ eps_theta) : ring_scope.
 
-Notation symmetric_form := (false, [rmorphism of idfun]).-sesqui.
-Notation skew := (true, [rmorphism of idfun]).-sesqui.
+Notation symmetric_form := (false, idfun).-sesqui.
+Notation skew := (true, idfun).-sesqui.
 Notation hermitian := (false, @Num.conj_op _).-sesqui.
 
 (* Section ClassificationForm. *)

--- a/theories/itv.v
+++ b/theories/itv.v
@@ -345,7 +345,7 @@ Lemma opp_itv_boundr_subproof (x : R) b :
   (BRight (- x)%R <= Itv.map_itv_bound intr (opp_itv_bound_subdef b))%O
   = (Itv.map_itv_bound intr b <= BLeft x)%O.
 Proof.
-by case: b => [[] b | []//]; rewrite /= !bnd_simp mulrNz ?ler_opp2 // ltr_opp2.
+by case: b => [[] b | []//]; rewrite /= !bnd_simp mulrNz ?lerN2 // ltrN2.
 Qed.
 
 Lemma opp_itv_le0_subproof b :
@@ -362,7 +362,7 @@ Lemma opp_itv_boundl_subproof (x : R) b :
   (Itv.map_itv_bound intr (opp_itv_bound_subdef b) <= BLeft (- x)%R)%O
   = (BRight x <= Itv.map_itv_bound intr b)%O.
 Proof.
-by case: b => [[] b | []//]; rewrite /= !bnd_simp mulrNz ?ler_opp2 // ltr_opp2.
+by case: b => [[] b | []//]; rewrite /= !bnd_simp mulrNz ?lerN2 // ltrN2.
 Qed.
 
 Definition opp_itv_subdef (i : interval int) : interval int :=
@@ -376,9 +376,9 @@ Lemma opp_inum_subproof (i : interval int)
 Proof.
 rewrite {}/r; move: i x => [l u] [x /= /andP[xl xu]]; apply/andP; split.
 - by case: u xu => [[] b i | [] //] /=; rewrite /Order.le/= mulrNz;
-    do ?[by rewrite ler_oppl opprK|by rewrite ltr_oppl opprK].
+    do ?[by rewrite lerNl opprK|by rewrite ltrNl opprK].
 - by case: l xl => [[] b i | [] //] /=; rewrite /Order.le/= mulrNz;
-    do ?[by rewrite ltr_oppl opprK|by rewrite ler_oppl opprK].
+    do ?[by rewrite ltrNl opprK|by rewrite lerNl opprK].
 Qed.
 
 Canonical opp_inum (i : interval int) (x : {itv R & i}) :=
@@ -414,10 +414,10 @@ move: xi x yi y => [lx ux] [x /= /andP[xl xu]] [ly uy] [y /= /andP[yl yu]].
 rewrite /Itv.itv_cond in_itv; apply/andP; split.
 - move: lx ly xl yl => [xb lx | //] [yb ly | //].
   by move: xb yb => [] []; rewrite /Order.le/= rmorphD/=;
-    do ?[exact: ler_add|exact: ler_lt_add|exact: ltr_le_add|exact: ltr_add].
+    do ?[exact: lerD|exact: ler_ltD|exact: ltr_leD|exact: ltrD].
 - move: ux uy xu yu => [xb ux | //] [yb uy | //].
   by move: xb yb => [] []; rewrite /Order.le/= rmorphD/=;
-    do ?[exact: ler_add|exact: ler_lt_add|exact: ltr_le_add|exact: ltr_add].
+    do ?[exact: lerD|exact: ler_ltD|exact: ltr_leD|exact: ltrD].
 Qed.
 
 Canonical add_inum (xi yi : interval int)
@@ -511,19 +511,19 @@ move: b1 b2 => [[] b1 | []//] [[] b2 | []//] /=; rewrite 4!bnd_simp.
   have -> : bl = BLeft (b1 * b2).
     rewrite {}/bl; move: b1 b2 => [[|p1]|p1] [[|p2]|p2]; congr BLeft.
     by rewrite mulr0.
-  rewrite -2!(ler0z R) bnd_simp intrM; exact: ler_pmul.
+  rewrite -2!(ler0z R) bnd_simp intrM; exact: ler_pM.
 - case: b1 => [[|p1]|//]; rewrite -2!(ler0z R) !bnd_simp ?intrM.
     by move=> _ geb2 ? ?; apply: mulr_ge0 => //; apply/(le_trans geb2)/ltW.
   move=> p1gt0 b2ge0 lep1x1 ltb2x2.
   have: (Posz p1.+1)%:~R * x2 <= x1 * x2.
-    by rewrite ler_pmul2r //; apply: le_lt_trans ltb2x2.
-  by apply: lt_le_trans; rewrite ltr_pmul2l // ltr0z.
+    by rewrite ler_pM2r //; apply: le_lt_trans ltb2x2.
+  by apply: lt_le_trans; rewrite ltr_pM2l // ltr0z.
 - case: b2 => [[|p2]|//]; rewrite -2!(ler0z R) !bnd_simp ?intrM.
     by move=> geb1 _ ? ?; apply: mulr_ge0 => //; apply/(le_trans geb1)/ltW.
   move=> b1ge0 p2gt0 ltb1x1 lep2x2.
-  have: b1%:~R * x2 < x1 * x2; last exact/le_lt_trans/ler_pmul.
-  by rewrite ltr_pmul2r //; apply: lt_le_trans lep2x2; rewrite ltr0z.
-- rewrite -2!(ler0z R) bnd_simp intrM; exact: ltr_pmul.
+  have: b1%:~R * x2 < x1 * x2; last exact/le_lt_trans/ler_pM.
+  by rewrite ltr_pM2r //; apply: lt_le_trans lep2x2; rewrite ltr0z.
+- rewrite -2!(ler0z R) bnd_simp intrM; exact: ltr_pM.
 Qed.
 
 Lemma mul_itv_boundrC_subproof b1 b2 :
@@ -558,16 +558,16 @@ case: b1 => [[|p1]|p1].
     by move: (conj l l') => /andP/le_anti <-; rewrite mulr0.
   + move: b1b b2b => [] []; rewrite !bnd_simp;
       rewrite -[intRing.mulz ?[a] ?[b]]/((Posz ?[a]) * ?[b])%R intrM.
-    * exact: ltr_pmul.
+    * exact: ltr_pM.
     * move=> x1ge0 x2ge0 ltx1p1 lex2p2.
       have: x1 * p2.+1%:~R < p1.+1%:~R * p2.+1%:~R.
-        by rewrite ltr_pmul2r // ltr0z.
-      exact/le_lt_trans/ler_pmul.
+        by rewrite ltr_pM2r // ltr0z.
+      exact/le_lt_trans/ler_pM.
     * move=> x1ge0 x2ge0 lex1p1 ltx2p2.
       have: p1.+1%:~R * x2 < p1.+1%:~R * p2.+1%:~R.
-        by rewrite ltr_pmul2l // ltr0z.
-      exact/le_lt_trans/ler_pmul.
-    * exact: ler_pmul.
+        by rewrite ltr_pM2l // ltr0z.
+      exact/le_lt_trans/ler_pM.
+    * exact: ler_pM.
   + case: b2b => _ + _; rewrite 2!bnd_simp => l l'.
       by move: (le_lt_trans l l'); rewrite ltr0z.
     by move: (le_trans l l'); rewrite ler0z.

--- a/theories/landau.v
+++ b/theories/landau.v
@@ -473,10 +473,10 @@ Lemma bigO_exP (F : set_system T) (f : T -> V) (g : T -> W) :
 Proof.
 split=> [[k k0 fOg] | [k [kreal fOg]]].
   exists k; rewrite realE (ltW k0) /=; split=> // l ltkl; move: fOg.
-  by apply: filter_app; near=> x => /le_trans; apply; rewrite ler_wpmul2r // ltW.
+  by apply: filter_app; near=> x => /le_trans; apply; rewrite ler_wpM2r // ltW.
 exists (Num.max 1 `|k + 1|) => //.
 apply: fOg; rewrite (@lt_le_trans _ _ `|k + 1|) //.
-  by rewrite (@lt_le_trans _ _ (k + 1)) ?ltr_addl // real_ler_norm ?realD.
+  by rewrite (@lt_le_trans _ _ (k + 1)) ?ltrDl // real_ler_norm ?realD.
 by rewrite comparable_le_maxr ?real_comparable// lexx orbT.
 Unshelve. end_near. Qed.
 
@@ -595,8 +595,8 @@ Proof. by move: x; rewrite -/(- _ =1 _) {1}oppO. Qed.
 Lemma add_bigO_subproof (F : filter_on T) e (df dg : {O_F e}) :
   bigO_def F (df \+ dg) e.
 Proof.
-near=> k; near=> x; apply: le_trans (ler_norm_add _ _) _.
-by rewrite (splitr k) mulrDl ler_add //; near: x; near: k;
+near=> k; near=> x; apply: le_trans (ler_normD _ _) _.
+by rewrite (splitr k) mulrDl lerD //; near: x; near: k;
   [apply: near_pinfty_div2 (bigOP df)|apply: near_pinfty_div2 (bigOP dg)].
 Unshelve. all: by end_near. Qed.
 
@@ -821,7 +821,7 @@ Lemma add_littleo_subproof (F : filter_on T) e (df dg : {o_F e}) :
   littleo_def F (df \+ dg) e.
 Proof.
 by move=> _/posnumP[eps]; near do [
-   rewrite [eps%:num]splitr mulrDl (le_trans (ler_norm_add _ _)) // ler_add //];
+   rewrite [eps%:num]splitr mulrDl (le_trans (ler_normD _ _)) // lerD //];
    apply: littleoP.
 Unshelve. all: by end_near. Qed.
 
@@ -847,7 +847,7 @@ Lemma scale_littleo_subproof (F : filter_on T) e (df : {o_F e}) a :
 Proof.
 have [->|a0] := eqVneq a 0; first  by rewrite scale0r.
 move=> _ /posnumP[eps]; have aa := normr_eq0 a; near=> x => /=.
-rewrite normrZ -ler_pdivl_mull ?lt_def ?aa ?a0 //= mulrA; near: x.
+rewrite normrZ -ler_pdivlMl ?lt_def ?aa ?a0 //= mulrA; near: x.
 by apply: littleoP; rewrite mulr_gt0 // invr_gt0 ?lt_def ?aa ?a0 /=.
 Unshelve. all: by end_near. Qed.
 
@@ -875,7 +875,7 @@ have [->|a0] := eqVneq a 0.
 move=> _/posnumP[eps].
 have ea : 0 < eps%:num / `| a | by rewrite divr_gt0 // normr_gt0.
 have [g /(_ _ ea) ?] := littleo; near=> y.
-rewrite normrZ -ler_pdivl_mulr; first by rewrite mulrAC; near: y.
+rewrite normrZ -ler_pdivlMr; first by rewrite mulrAC; near: y.
 by rewrite lt_def normr_eq0 a0 normr_ge0.
 Unshelve. all: by end_near. Qed.
 
@@ -891,7 +891,7 @@ split=> fFl.
 apply/cvgrPdist_lt=> _/posnumP[eps].
 have lt_eps x : x <= (eps%:num / 2%:R) * `|1 : K^o|%real -> x < eps%:num.
   rewrite normr1 mulr1 => /le_lt_trans; apply.
-  by rewrite ltr_pdivr_mulr // ltr_pmulr // ltr1n.
+  by rewrite ltr_pdivrMr // ltr_pMr // ltr1n.
 near=> x do rewrite [X in X x]fFl opprD addNKr normrN lt_eps //.
 by apply: littleoP; rewrite divr_gt0.
 Unshelve. all: by end_near. Qed.
@@ -918,7 +918,7 @@ Lemma littleo_bigO_eqo {F : filter_on T}
 Proof.
 move->; apply/eqoP => _/posnumP[e]; have [k c] := bigO _ g.
 apply: filter_app; near=> x do [
-  rewrite -!ler_pdivr_mull//; apply: le_trans; rewrite ler_pdivr_mull// mulrA].
+  rewrite -!ler_pdivrMl//; apply: le_trans; rewrite ler_pdivrMl// mulrA].
 exact: littleoP.
 Unshelve. all: by end_near. Qed.
 Arguments littleo_bigO_eqo {F}.
@@ -928,7 +928,7 @@ Lemma bigO_littleo_eqo {F : filter_on T} (g : T -> W) (f : T -> V) (h : T -> X) 
 Proof.
 move->; apply/eqoP => _/posnumP[e]; have [k c] := bigO.
 apply: filter_app; near=> x => /le_trans; apply.
-by rewrite -ler_pdivl_mull // mulrA; near: x; apply: littleoP.
+by rewrite -ler_pdivlMl // mulrA; near: x; apply: littleoP.
 Unshelve. all: by end_near. Qed.
 Arguments bigO_littleo_eqo {F}.
 
@@ -976,8 +976,8 @@ Lemma bigO_bigO_eqO {F : filter_on T} (g : T -> W) (f : T -> V) (h : T -> X) :
 Proof.
 move->; apply/eqOP; have [k c1 kOg] := bigO _ g. have [k' c2 k'Ok] := bigO _ k.
 near=> c; move: k'Ok kOg; apply: filter_app2; near=> x => lek'c2k.
-rewrite -(@ler_pmul2l _ c2%:num) // mulrA => /(le_trans lek'c2k) /le_trans.
-by apply; rewrite ler_pmul//; near: c; exact: nbhs_pinfty_ge.
+rewrite -(@ler_pM2l _ c2%:num) // mulrA => /(le_trans lek'c2k) /le_trans.
+by apply; rewrite ler_pM//; near: c; exact: nbhs_pinfty_ge.
 Unshelve. all: by end_near. Qed.
 Arguments bigO_bigO_eqO {F}.
 
@@ -1043,7 +1043,7 @@ Lemma mulo (F : filter_on pT) (h1 h2 f g : pT -> R^o) :
 Proof.
 rewrite [in RHS]littleoE // => _/posnumP[e]; near=> x.
 rewrite [`|_|]normrM -(sqr_sqrtr (ge0 e)) expr2.
-rewrite (@normrM _ (h1 x) (h2 x)) mulrACA ler_pmul //; near: x;
+rewrite (@normrM _ (h1 x) (h2 x)) mulrACA ler_pM //; near: x;
 by have [/= h] := littleo; apply.
 Unshelve. all: by end_near. Qed.
 
@@ -1052,8 +1052,8 @@ Lemma mulO (F : filter_on pT) (h1 h2 f g : pT -> R^o) :
 Proof.
 rewrite [RHS]bigOE//; have [ O1 k1 Oh1] := bigO; have [ O2 k2 Oh2] := bigO.
 near=> k; move: Oh1 Oh2; apply: filter_app2; near=> x => leOh1 leOh2.
-rewrite [`|_|]normrM (le_trans (ler_pmul _ _ leOh1 leOh2)) //.
-by rewrite mulrACA [`|_| in leRHS]normrM ler_wpmul2r // ?mulr_ge0.
+rewrite [`|_|]normrM (le_trans (ler_pM _ _ leOh1 leOh2)) //.
+by rewrite mulrACA [`|_| in leRHS]normrM ler_wpM2r // ?mulr_ge0.
 Unshelve. all: by end_near. Qed.
 
 End rule_of_products_rcfType.
@@ -1068,7 +1068,7 @@ Lemma mulo_numClosedFieldType (F : filter_on pT) (h1 h2 f g : pT -> R^o) :
 Proof.
 rewrite [in RHS]littleoE // => _/posnumP[e]; near=> x.
 rewrite [`|_|]normrM -(sqrCK (ge0 e)) expr2 sqrtCM ?qualifE//=.
-rewrite (@normrM _ (h1 x) (h2 x)) mulrACA ler_pmul //; near: x;
+rewrite (@normrM _ (h1 x) (h2 x)) mulrACA ler_pM //; near: x;
 by have [/= h] := littleo; apply.
 Unshelve. all: by end_near. Qed.
 
@@ -1077,8 +1077,8 @@ Lemma mulO_numClosedFieldType (F : filter_on pT) (h1 h2 f g : pT -> R^o) :
 Proof.
 rewrite [RHS]bigOE//; have [ O1 k1 Oh1] := bigO; have [ O2 k2 Oh2] := bigO.
 near=> k; move: Oh1 Oh2; apply: filter_app2; near=> x => leOh1 leOh2.
-rewrite [`|_|]normrM (le_trans (ler_pmul _ _ leOh1 leOh2)) //.
-by rewrite mulrACA [`|_| in leRHS]normrM ler_wpmul2r // ?mulr_ge0.
+rewrite [`|_|]normrM (le_trans (ler_pM _ _ leOh1 leOh2)) //.
+by rewrite mulrACA [`|_| in leRHS]normrM ler_wpM2r // ?mulr_ge0.
 Unshelve. all: by end_near. Qed.
 
 End rule_of_products_numClosedFieldType.
@@ -1105,7 +1105,7 @@ rewrite (near_shift 0) /= subr0; near=> y => /=.
 rewrite -linearB opprD addrC addrNK linearN normrN; near: y.
 suff flip : \forall k \near +oo, forall x, `|f x| <= k * `|x|.
   near +oo => k; near=> y.
-  rewrite (le_lt_trans (near flip k _ _)) // -ltr_pdivl_mull; last first.
+  rewrite (le_lt_trans (near flip k _ _)) // -ltr_pdivlMl; last first.
     by near: k; exists 0.
   near: y; apply/nbhs_normP.
   eexists; last by move=> ?; rewrite /= sub0r normrN; apply.
@@ -1116,12 +1116,12 @@ case: (ler0P `|y|) => [|y0].
   by rewrite normr_le0 => /eqP->; rewrite linear0 !normr0 mulr0.
 have ky0 : 0 <= k0%:num / (k * `|y|).
   by rewrite pmulr_rge0 // invr_ge0 mulr_ge0 // ltW //; near: k; exists 0.
-rewrite -[leRHS]mulr1 -ler_pdivr_mull ?pmulr_rgt0 //.
-rewrite -(ler_pmul2l [gt0 of k0%:num]) mulr1 mulrA -[_ / _]ger0_norm //.
+rewrite -[leRHS]mulr1 -ler_pdivrMl ?pmulr_rgt0 //.
+rewrite -(ler_pM2l [gt0 of k0%:num]) mulr1 mulrA -[_ / _]ger0_norm //.
 rewrite -normm_s.
 rewrite -linearZ fk //= /= distrC subr0 normmZ ger0_norm //.
-rewrite invfM mulrA mulfVK ?lt0r_neq0 // ltr_pdivr_mulr //.
-by rewrite -ltr_pdivr_mull//.
+rewrite invfM mulrA mulfVK ?lt0r_neq0 // ltr_pdivrMr //.
+by rewrite -ltr_pdivrMl//.
 Unshelve. all: by end_near. Qed.
 
 End Linear3.
@@ -1156,12 +1156,12 @@ Lemma equivoRL (W' : normedModType K) F (f g : T -> V) (h : T -> W') :
   f ~_F g -> [o_F g of h] =o_F f.
 Proof.
 move=> ->; apply/eqoP; move=> _/posnumP[eps]; near=> x.
-rewrite -ler_pdivr_mull // -[X in g + X]opprK oppo.
+rewrite -ler_pdivrMl // -[X in g + X]opprK oppo.
 rewrite (le_trans _ (ler_dist_dist _ _)) //.
-rewrite [leRHS]ger0_norm ?ler_subr_addr ?add0r; last first.
+rewrite [leRHS]ger0_norm ?lerBrDr ?add0r; last first.
   by rewrite -[leRHS]mul1r; near: x; apply: littleoP.
 rewrite [leRHS]splitr [_ / 2]mulrC.
-by rewrite ler_add ?ler_pdivr_mull ?mulrA //; near: x; apply: littleoP.
+by rewrite lerD ?ler_pdivrMl ?mulrA //; near: x; apply: littleoP.
 Unshelve. all: by end_near. Qed.
 
 Lemma equiv_sym F (f g : T -> V) : f ~_F g -> g ~_F f.
@@ -1277,8 +1277,8 @@ rewrite propeqE; split => [| /eqO_exP[x x0 Hx] ];
 [rewrite qualifE => /asboolP[x x0 Hx]; apply/eqO_exP |
 rewrite qualifE; apply/asboolP];
 exists x^-1; rewrite ?invr_gt0 //; near=> y.
-  by rewrite ler_pdivl_mull //; near: y.
-by rewrite ler_pdivr_mull //; near: y.
+  by rewrite ler_pdivlMl //; near: y.
+by rewrite ler_pdivrMl //; near: y.
 Unshelve. all: by end_near. Qed.
 
 Lemma eqOmegaE (F : filter_on T) (f e : T -> V) :
@@ -1314,7 +1314,7 @@ Lemma addOmega (R : realFieldType) (F : filter_on pT) (f g h : _ -> R^o)
 Proof.
 rewrite 2!eqOmegaE !eqOmegaO => /eqOP hOf; apply/eqOP.
 apply: filter_app hOf; near=> k; apply: filter_app; near=> x => /le_trans.
-by apply; rewrite ler_pmul2l // !ger0_norm // ?addr_ge0 // ler_addl.
+by apply; rewrite ler_pM2l // !ger0_norm // ?addr_ge0 // lerDl.
 Unshelve. all: by end_near. Qed.
 
 Lemma mulOmega (R : realFieldType) (F : filter_on pT) (h1 h2 f g : pT -> R^o) :
@@ -1324,10 +1324,10 @@ rewrite eqOmegaE eqOmegaO [in RHS]bigOE //.
 have [W1 k1 ?] := bigOmega; have [W2 k2 ?] := bigOmega.
 near=> k; near=> x; rewrite [`|_|]normrM.
 rewrite (@le_trans _ _ ((k2%:num * k1%:num)^-1 * `|(W1 * W2) x|)) //.
-  rewrite invrM ?unitfE ?gtr_eqF // -mulrA ler_pdivl_mull //.
-  rewrite ler_pdivl_mull // (mulrA k1%:num) mulrCA (@normrM _ (W1 x)).
-  by rewrite ler_pmul ?mulr_ge0 //; near: x.
-by rewrite ler_wpmul2r // ltW //.
+  rewrite invrM ?unitfE ?gtr_eqF // -mulrA ler_pdivlMl //.
+  rewrite ler_pdivlMl // (mulrA k1%:num) mulrCA (@normrM _ (W1 x)).
+  by rewrite ler_pM ?mulr_ge0 //; near: x.
+by rewrite ler_wpM2r // ltW //.
 Unshelve. all: by end_near. Qed.
 
 End big_omega_in_R.
@@ -1474,7 +1474,7 @@ rewrite -eqOmegaE; apply: addOmega.
 - by move=> ?; rewrite /the_bigO val_insubd /=; case: ifP.
 - rewrite eqOmegaE eqOmegaO; have [T1 k1 k2 ? ?] := bigTheta.
   rewrite bigOE //; apply/bigO_exP; exists k1%:num^-1 => //.
-  by near do rewrite ler_pdivl_mull //.
+  by near do rewrite ler_pdivlMl //.
 Unshelve. all: by end_near. Qed.
 
 Lemma mulTheta (F : filter_on pT) (h1 h2 f g : pT -> R^o) :
@@ -1486,10 +1486,10 @@ rewrite eqOmegaO [in RHS]bigOE //.
 have [T1 k1 l1 P1 ?] := bigTheta; have [T2 k2 l2 P2 ?] := bigTheta.
 near=> k; first near=> x.
 rewrite [`|_|]normrM (@le_trans _ _ ((k2%:num * k1%:num)^-1 * `|(T1 * T2) x|)) //.
-  rewrite invrM ?unitfE ?gtr_eqF // -mulrA ler_pdivl_mull //.
-  rewrite ler_pdivl_mull // (mulrA k1%:num) mulrCA (@normrM _ (T1 x)) ler_pmul //;
+  rewrite invrM ?unitfE ?gtr_eqF // -mulrA ler_pdivlMl //.
+  rewrite ler_pdivlMl // (mulrA k1%:num) mulrCA (@normrM _ (T1 x)) ler_pM //;
   by [rewrite mulr_ge0 //|near: x].
-by rewrite ler_wpmul2r // ltW //.
+by rewrite ler_wpM2r // ltW //.
 Unshelve. all: by end_near. Qed.
 
 End big_theta_in_R.

--- a/theories/landau.v
+++ b/theories/landau.v
@@ -1134,7 +1134,7 @@ Lemma linear_continuous (R : realFieldType) (U : normedModType R)
 Proof. by apply: linear_for_continuous => ? ?; rewrite normrZ. Qed.
 
 Lemma linear_for_mul_continuous (R : realFieldType) (U : normedModType R)
-  (f : {linear U -> R^o | (@GRing.mul [ringType of R^o])}) :
+  (f : {linear U -> R^o | @GRing.mul R^o}) :
   (f : _ -> _) =O_ (0 : U) (cst (1 : R^o)) -> continuous f.
 Proof. by apply: linear_for_continuous => ? ?; rewrite normrZ. Qed.
 

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -863,7 +863,7 @@ Let g1 c n : {nnsfun T >-> R} := proj_nnsfun f (mfleg c n).
 
 Let le_ffleg c : {homo (fun p x => g1 c p x): m n / (m <= n)%N >-> (m <= n)%O}.
 Proof.
-move=> m n mn; apply/asboolP => t; rewrite /g1/= ler_pmul// 2!mindicE/= ler_nat.
+move=> m n mn; apply/asboolP => t; rewrite /g1/= ler_pM// 2!mindicE/= ler_nat.
 have [|//] := boolP (t \in fleg c m); rewrite inE => cnt.
 by have := nd_fleg c mn => /subsetPset/(_ _ cnt) cmt; rewrite mem_set.
 Qed.
@@ -875,7 +875,7 @@ have := @fun_ge0 _ _ f x; rewrite le_eqVlt => /predU1P[|] gx0.
   by exists O => //; rewrite /fleg /=; rewrite -gx0 mulr0 fun_ge0.
 have [cf|df] := pselect (cvgn (g^~ x)).
   have cfg : limn (g^~ x) > c * f x.
-    by rewrite (lt_le_trans _ (gf cf)) // gtr_pmull.
+    by rewrite (lt_le_trans _ (gf cf)) // gtr_pMl.
   suff [n cfgn] : exists n, g n x >= c * f x by exists n.
   move/(@lt_lim _ _ _ (nd_g x) cf) : cfg => [n _ nf].
   by exists n; apply: nf => /=.
@@ -1184,7 +1184,7 @@ have [G [Gf rG]] : exists h : {nnsfun T >-> R},
     (forall x, (h x)%:E <= f x) /\ (r%:E <= sintegral mu h).
   have : r%:E < \int[mu]_x (f x).
     move: (mufoo) => /eqyP/(_ _ (addr_gt0 r0 r0)).
-    by apply: lt_le_trans => //; rewrite lte_fin ltr_addr.
+    by apply: lt_le_trans => //; rewrite lte_fin ltrDr.
   rewrite ge0_integralTE// => /ereal_sup_gt[x [/= G Gf Gx rx]].
   by exists G; split => //; rewrite (le_trans (ltW rx)) // Gx.
 have : forall x, cvgn (g^~ x) -> (G x <= limn (g^~ x))%R.
@@ -1225,22 +1225,22 @@ rewrite predeqE => r; split => [/= /[!in_itv]/= /andP[nr rn1]|].
       rewrite -ltez_nat gez0_abs ?floor_ge0; last first.
         by rewrite mulr_ge0// (le_trans _ nr).
       apply: (@le_trans _ _ (floor (n * 2 ^ n.+1)%:R)); last first.
-        by apply: le_floor; rewrite natrM natrX ler_pmul2r.
+        by apply: le_floor; rewrite natrM natrX ler_pM2r.
       by rewrite floor_natz intz.
     rewrite -ltz_nat gez0_abs; last first.
       by rewrite floor_ge0 mulr_ge0// (le_trans _ nr).
     rewrite -(@ltr_int R) (le_lt_trans (floor_le _))//.
-    by rewrite PoszM intrM -natrX ltr_pmul2r.
+    by rewrite PoszM intrM -natrX ltr_pM2r.
   rewrite /= in_itv /=; apply/andP; split.
-    rewrite ler_pdivr_mulr// (le_trans _ (floor_le _))//.
+    rewrite ler_pdivrMr// (le_trans _ (floor_le _))//.
     by rewrite -(@gez0_abs (floor _))// floor_ge0 mulr_ge0// (le_trans _ nr).
-  rewrite ltr_pdivl_mulr// (lt_le_trans (lt_succ_floor _))//.
-  rewrite -[in leRHS]natr1 ler_add2r// -(@gez0_abs (floor _))// floor_ge0.
+  rewrite ltr_pdivlMr// (lt_le_trans (lt_succ_floor _))//.
+  rewrite -[in leRHS]natr1 lerD2r// -(@gez0_abs (floor _))// floor_ge0.
   by rewrite mulr_ge0// (le_trans _ nr).
 - rewrite -bigcup_set => -[/= k] /[!mem_index_iota] /andP[nk kn].
   rewrite in_itv /= => /andP[knr rkn]; rewrite in_itv /=; apply/andP; split.
-    by rewrite (le_trans _ knr)// ler_pdivl_mulr// -natrX -natrM ler_nat.
-  by rewrite (lt_le_trans rkn)// ler_pdivr_mulr// -natrX -natrM ler_nat.
+    by rewrite (le_trans _ knr)// ler_pdivlMr// -natrX -natrM ler_nat.
+  by rewrite (lt_le_trans rkn)// ler_pdivrMr// -natrX -natrM ler_nat.
 Qed.
 
 Lemma dyadic_itv_image n T (f : T -> \bar R) x :
@@ -1296,7 +1296,7 @@ rewrite predeqE => t; split => // -[/=] [_].
 rewrite inE => -[r /=]; rewrite in_itv /= => /andP[r1 r2] rft [_].
 rewrite inE => -[s /=]; rewrite in_itv /= => /andP[s1 s2].
 rewrite -rft => -[sr]; rewrite {}sr {s} in s1 s2.
-by have := le_lt_trans s1 r2; rewrite ltr_pmul2r// ltr_nat ltnS leqNgt ij.
+by have := le_lt_trans s1 r2; rewrite ltr_pM2r// ltr_nat ltnS leqNgt ij.
 Qed.
 
 Let f0_A0 n (i : 'I_(n * 2 ^ n)) x : f x = 0%:E -> i != O :> nat ->
@@ -1304,7 +1304,7 @@ Let f0_A0 n (i : 'I_(n * 2 ^ n)) x : f x = 0%:E -> i != O :> nat ->
 Proof.
 move=> fx0 i0; rewrite indicE memNset// /A ltn_ord => -[Dx/=] /[1!inE]/= -[r].
 rewrite in_itv/= fx0 => + r0; move/eqP : r0 => /[1!eqe] /eqP -> /andP[+ _].
-by rewrite ler_pdivr_mulr// mul0r lern0 (negbTE i0).
+by rewrite ler_pdivrMr// mul0r lern0 (negbTE i0).
 Qed.
 
 Let fgen_A0 n x (i : 'I_(n * 2 ^ n)) : (n%:R%:E <= f x)%E ->
@@ -1312,7 +1312,7 @@ Let fgen_A0 n x (i : 'I_(n * 2 ^ n)) : (n%:R%:E <= f x)%E ->
 Proof.
 move=> fxn; rewrite indicE /A ltn_ord memNset// => -[Dx/=] /[1!inE]/= -[r].
 rewrite in_itv/= => /andP[_ h] rfx; move: fxn; rewrite -rfx lee_fin; apply/negP.
-rewrite -ltNge (lt_le_trans h)// -natrX ler_pdivr_mulr// -natrM ler_nat.
+rewrite -ltNge (lt_le_trans h)// -natrX ler_pdivrMr// -natrM ler_nat.
 by rewrite (leq_trans (ltn_ord i)).
 Qed.
 
@@ -1366,17 +1366,17 @@ rewrite -ltNge => fxn _.
 have K : (`|floor (fine (f x) * 2 ^+ n)| < n * 2 ^ n)%N.
   rewrite -ltz_nat gez0_abs; last by rewrite floor_ge0 mulr_ge0// ltW.
   rewrite -(@ltr_int R); rewrite (le_lt_trans (floor_le _))// PoszM intrM.
-  by rewrite -natrX ltr_pmul2r// -lte_fin (fineK fxfin).
+  by rewrite -natrX ltr_pM2r// -lte_fin (fineK fxfin).
 have /[!mem_index_enum]/(_ isT) := An0 (Ordinal K).
 rewrite implyTb indicE mem_set ?mulr1; last first.
   rewrite /A K /= inE; split=> //=; exists (fine (f x)); last by rewrite fineK.
   rewrite in_itv /=; apply/andP; split.
-    rewrite ler_pdivr_mulr// (le_trans _ (floor_le _))//.
+    rewrite ler_pdivrMr// (le_trans _ (floor_le _))//.
     by rewrite -(@gez0_abs (floor _))// floor_ge0 mulr_ge0// ltW.
-  rewrite ltr_pdivl_mulr// (lt_le_trans (lt_succ_floor _))// -[in leRHS]natr1.
-  by rewrite ler_add2r// -{1}(@gez0_abs (floor _))// floor_ge0// mulr_ge0// ltW.
+  rewrite ltr_pdivlMr// (lt_le_trans (lt_succ_floor _))// -[in leRHS]natr1.
+  by rewrite lerD2r// -{1}(@gez0_abs (floor _))// floor_ge0// mulr_ge0// ltW.
 rewrite mulf_eq0// -exprVn; apply/negP; rewrite negb_or expf_neq0//= andbT.
-rewrite pnatr_eq0 -lt0n absz_gt0 floor_neq0// -ler_pdivr_mulr//.
+rewrite pnatr_eq0 -lt0n absz_gt0 floor_neq0// -ler_pdivrMr//.
 apply/orP; right; apply/ltW; near: n.
 exact: near_infty_natSinv_expn_lt (PosNum fx_gt0).
 Unshelve. all: by end_near. Qed.
@@ -1436,7 +1436,7 @@ have [fxn|fxn] := ltP (f x) n%:R%:E.
     rewrite xAn1k mulr1 big1 ?addr0; last first.
       by move=> i ik2n; rewrite (disj_A0 (Ordinal k2n)) // mulr0.
     rewrite -(natr1 _ k.*2) mulrDl exprS -mul2n natrM -mulf_div divrr ?unitfE//.
-    by rewrite !mul1r ler_addl.
+    by rewrite !mul1r lerDl.
 have /orP[{}fxn|{}fxn] :
     ((n%:R%:E <= f x < n.+1%:R%:E) || (n.+1%:R%:E <= f x))%E.
   - by move: fxn; case: leP => /= [_ _|_ ->//]; rewrite orbT.
@@ -1450,7 +1450,7 @@ have /orP[{}fxn|{}fxn] :
     have xAn1k : x \in A n.+1 k by rewrite inE /A kn2.
     rewrite indicE xAn1k mulr1 big1 ?addr0; last first.
       by move=> i /= ikn2; rewrite (disj_A0 (Ordinal kn2)) // mulr0.
-    by rewrite -natrX ler_pdivl_mulr// mulrC -natrM ler_nat; case/andP : k1.
+    by rewrite -natrX ler_pdivlMr// mulrC -natrM ler_nat; case/andP : k1.
 - have xBn : x \in B n by rewrite /B inE /= (le_trans _ fxn) // lee_fin ler_nat.
   rewrite /approx indicE xBn mulr1.
   have xBn1 : x \in B n.+1 by rewrite /B /= inE.
@@ -1482,9 +1482,9 @@ have [approx_nx0|[k [/andP[k0 kn2n] ? ->]]] := f_ub_approx fxn.
 rewrite inE /= => -[r /=]; rewrite in_itv /= => /andP[k1 k2] rfx.
 rewrite (@le_lt_trans _ _ (1 / 2 ^+ n)) //.
   rewrite ler_norml; apply/andP; split.
-    rewrite ler_subr_addl -mulrBl -lee_fin (fineK fxfin) -rfx lee_fin.
-    by rewrite (le_trans _ k1)// ler_pmul2r// ler_subl_addl ler_addr.
-  by rewrite ler_subl_addr -mulrDl -lee_fin nat1r fineK// ltW// -rfx lte_fin.
+    rewrite lerBrDl -mulrBl -lee_fin (fineK fxfin) -rfx lee_fin.
+    by rewrite (le_trans _ k1)// ler_pM2r// lerBlDl lerDr.
+  by rewrite lerBlDr -mulrDl -lee_fin nat1r fineK// ltW// -rfx lte_fin.
 by near: n; exact: near_infty_natSinv_expn_lt.
 Unshelve. all: by end_near. Qed.
 
@@ -1513,18 +1513,18 @@ case/cvg_ex => /= l; have [l0|l0] := leP 0%R l.
 - move=> /cvgrPdist_lt/(_ _ ltr01) -[n _].
   move=> /(_ (`|ceil l|.+1 + n)%N) /= /(_ (leq_addl _ _)).
   rewrite approx_x.
-  apply/negP; rewrite -leNgt distrC (le_trans _ (ler_sub_norm_add _ _)) //.
-  rewrite normrN ler_subr_addl addSnnS [leRHS]ger0_norm ?ler0n//.
-  rewrite natrD ler_add// ?ler1n// ger0_norm // (le_trans (ceil_ge _)) //.
+  apply/negP; rewrite -leNgt distrC (le_trans _ (lerB_normD _ _)) //.
+  rewrite normrN lerBrDl addSnnS [leRHS]ger0_norm ?ler0n//.
+  rewrite natrD lerD// ?ler1n// ger0_norm // (le_trans (ceil_ge _)) //.
   by rewrite -(@gez0_abs (ceil _)) // ceil_ge0.
 - move/cvgrPdist_lt => /(_ _ ltr01) -[n _].
   move=> /(_ (`|floor l|.+1 + n)%N) /= /(_ (leq_addl _ _)).
   rewrite approx_x.
-  apply/negP; rewrite -leNgt distrC (le_trans _ (ler_sub_norm_add _ _)) //.
-  rewrite normrN ler_subr_addl addSnnS [leRHS]ger0_norm ?ler0n//.
-  rewrite natrD ler_add// ?ler1n// ler0_norm //; last by rewrite ltW.
+  apply/negP; rewrite -leNgt distrC (le_trans _ (lerB_normD _ _)) //.
+  rewrite normrN lerBrDl addSnnS [leRHS]ger0_norm ?ler0n//.
+  rewrite natrD lerD// ?ler1n// ler0_norm //; last by rewrite ltW.
   rewrite (@le_trans _ _ (- floor l)%:~R) //.
-    by rewrite mulrNz ler_oppl opprK floor_le.
+    by rewrite mulrNz lerNl opprK floor_le.
   by rewrite -(@lez0_abs (floor _)) // floor_le0 // ltW.
 Qed.
 
@@ -1607,7 +1607,7 @@ rewrite (@nd_ge0_integral_lim _ _ _ mu (fun x => k%:E * h1 x) kg).
       [exact/(lef_at x nd_g)|exact: gh1].
   by under eq_fun do rewrite (sintegralrM mu k (g _)).
 - by move=> t; rewrite mule_ge0.
-- by move=> x m n mn; rewrite /kg ler_pmul//; exact/lefP/nd_g.
+- by move=> x m n mn; rewrite /kg ler_pM//; exact/lefP/nd_g.
 - move=> x.
   rewrite [X in X @ \oo --> _](_ : _ = (fun n => k%:E * (g n x)%:E)) ?funeqE//.
   by apply: cvgeMl => //; exact: gh1.
@@ -2137,7 +2137,7 @@ transitivity (\int[mu]_(x in D) limn (g^~ x)).
     rewrite /g; case: (f x) fx0 => [r r0|_|//]; last first.
       exists 1%N => // m /= m0.
       by rewrite mulry gtr0_sg// ?mul1e ?leey// ltr0n.
-    near=> n; rewrite lee_fin -ler_pdivr_mulr//.
+    near=> n; rewrite lee_fin -ler_pdivrMr//.
     near: n; exists `|ceil (M / r)|%N => // m /=.
     rewrite -(ler_nat R); apply: le_trans.
     by rewrite natr_absz ger0_norm ?ceil_ge// ceil_ge0// divr_ge0// ?ltW.
@@ -2146,11 +2146,11 @@ transitivity (\int[mu]_(x in D) limn (g^~ x)).
     rewrite /g; case: (f x) fx0 => [r r0|//|_]; last first.
       exists 1%N => // m /= m0.
       by rewrite mulrNy gtr0_sg// ?ltr0n// mul1e ?leNye.
-    near=> n; rewrite lee_fin -ler_ndivr_mulr//.
+    near=> n; rewrite lee_fin -ler_ndivrMr//.
     near: n; exists `|ceil (M / r)|%N => // m /=.
     rewrite -(ler_nat R); apply: le_trans.
     rewrite natr_absz ger0_norm ?ceil_ge// ceil_ge0// -mulrNN.
-    by rewrite mulr_ge0// ler_oppr oppr0// ltW// invr_lt0.
+    by rewrite mulr_ge0// lerNr oppr0// ltW// invr_lt0.
   - rewrite -fx0 mule0 /g -fx0 [X in X @ _ --> _](_ : _ = cst 0).
       exact: cvg_cst.
     by rewrite funeqE => n /=; rewrite mule0.
@@ -3117,7 +3117,7 @@ have [k0|k0] := leP 0 k.
   exact: fin_num_measure.
 - under eq_integral do rewrite /= ltr0_norm//.
   rewrite integral_cstr//= lte_mul_pinfty//.
-    by rewrite lee_fin ler_oppr oppr0 ltW.
+    by rewrite lee_fin lerNr oppr0 ltW.
   by rewrite fin_num_fun_lty//; exact: fin_num_measure.
 Qed.
 
@@ -3170,9 +3170,9 @@ exists `|ceil (M * (fine (mu (E `&` D)))^-1)|%N.+1.
 apply/negP; rewrite -ltNge.
 rewrite -[X in _ * X](@fineK _ (mu (E `&` D))); last first.
   by rewrite fin_numElt muEDoo (lt_le_trans _ (measure_ge0 _ _)).
-rewrite lte_fin -ltr_pdivr_mulr.
+rewrite lte_fin -ltr_pdivrMr.
   rewrite -natr1 natr_absz ger0_norm.
-    by rewrite (le_lt_trans (ceil_ge _))// ltr_addl.
+    by rewrite (le_lt_trans (ceil_ge _))// ltrDl.
   by rewrite ceil_ge0// divr_ge0//; apply/le0R/measure_ge0; exact: measurableI.
 rewrite -lte_fin fineK.
   rewrite lt0e measure_ge0 andbT.
@@ -3207,10 +3207,10 @@ have [r0|r0|->] := ltgtP r 0%R; last first.
 - rewrite [in LHS]integralE// lt0_funeposM// lt0_funenegM//.
   rewrite ge0_integralM_EFin //; last 2 first.
     + exact: measurable_funeneg.
-    + by rewrite -ler_oppr oppr0 ltW.
+    + by rewrite -lerNr oppr0 ltW.
   rewrite ge0_integralM_EFin //; last 2 first.
     + exact: measurable_funepos.
-    + by rewrite -ler_oppr oppr0 ltW.
+    + by rewrite -lerNr oppr0 ltW.
   rewrite -mulNe -EFinN opprK addeC EFinN mulNe -muleBr //; last first.
     exact: integrable_add_def.
   by rewrite [in RHS]integralE.
@@ -3451,13 +3451,13 @@ move=> mf; split=> [iDf0|Df0].
       pose m := `|ceil (fine `|f t|)^-1|%N.
       have ftfin : `|f t|%E \is a fin_num by rewrite ge0_fin_numE// ltey.
       exists m => //; split => //=.
-      rewrite -(@fineK _ `|f t|) // lee_fin -ler_pinv; last 2 first.
+      rewrite -(@fineK _ `|f t|) // lee_fin -ler_pV2; last 2 first.
         - rewrite inE unitfE fine_eq0// abse_eq0 ft0/= fine_gt0//.
           by rewrite lt0e abse_ge0 abse_eq0 ft0 ltey.
         - by rewrite inE unitfE invr_eq0 pnatr_eq0 /= invr_gt0.
       rewrite invrK /m -natr1 natr_absz ger0_norm ?ceil_ge0//.
-      rewrite (@le_trans _ _ ((fine `|f t|)^-1 + 1)%R) ?ler_addl//.
-      by rewrite ler_add2r// ceil_ge.
+      rewrite (@le_trans _ _ ((fine `|f t|)^-1 + 1)%R) ?lerDl//.
+      by rewrite lerD2r// ceil_ge.
     by split => //; apply: contraTN nft => /eqP ->; rewrite abse0 -ltNge.
   transitivity (limn (fun n => mu (D `&` [set x | `|f x| >= n.+1%:R^-1%:E]))).
     apply/esym/cvg_lim => //; apply: nondecreasing_cvg_mu.
@@ -3466,7 +3466,7 @@ move=> mf; split=> [iDf0|Df0].
     - apply: bigcupT_measurable => i.
       by apply: emeasurable_fun_c_infty => //; exact: measurableT_comp.
     - move=> m n mn; apply/subsetPset; apply: setIS => t /=.
-      by apply: le_trans; rewrite lee_fin lef_pinv // ?ler_nat // posrE.
+      by apply: le_trans; rewrite lee_fin lef_pV2 // ?ler_nat // posrE.
   by rewrite (_ : (fun _ => _) = cst 0) ?lim_cst//= funeqE => n /=; rewrite muDf.
 pose f_ := fun n x => mine `|f x| n%:R%:E.
 have -> : (fun x => `|f x|) = (fun x => limn (f_^~ x)).
@@ -4223,7 +4223,7 @@ have muE j : mu (E j) = 0.
     + by apply: measurable_funS msg => //; exact: subIsetl.
 have nd_E : {homo E : n0 m / (n0 <= m)%N >-> (n0 <= m)%O}.
   move=> i j ij; apply/subsetPset => x [Dx /= ifg]; split => //.
-  by move: ifg; apply: le_trans; rewrite lee_fin lef_pinv// ?posrE// ler_nat.
+  by move: ifg; apply: le_trans; rewrite lee_fin lef_pV2// ?posrE// ler_nat.
 rewrite set_lte_bigcup.
 have /cvg_lim h1 : (mu \o E) x @[x --> \oo]--> 0 by apply: cvg_near_cst; exact: nearW.
 have := @nondecreasing_cvg_mu _ _ _ mu E mE (bigcupT_measurable E mE) nd_E.

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -218,7 +218,7 @@ move=> /subset_itvP ij; apply: lee_sub => /=.
 have [lj /=|lj] := asboolP (has_lbound J); last by rewrite leNye.
 have [li /=|li] := asboolP (has_lbound I); last first.
   by move: li; have := subset_has_lbound ij lj.
-rewrite lee_fin ler_oppl opprK le_sup// ?has_inf_supN//; last exact/nonemptyN.
+rewrite lee_fin lerNl opprK le_sup// ?has_inf_supN//; last exact/nonemptyN.
 move=> r [r' Ir' <-{r}]; exists (- r')%R.
 by split => //; exists r' => //; apply: ij.
 Qed.
@@ -356,10 +356,10 @@ pose Aoc i : set ocitv_type :=
 have: `[a.1 + e%:num / 2, a.2] `<=` \bigcup_i Aoo i.
   apply: (@subset_trans _ `]a.1, a.2]).
     move=> x; rewrite /= !in_itv /= => /andP[+ -> //].
-    by move=> /lt_le_trans-> //; rewrite ltr_addl.
+    by move=> /lt_le_trans-> //; rewrite ltrDl.
   apply: (subset_trans lebig); apply: subset_bigcup => i _; rewrite AE /Aoo/=.
   move=> x /=; rewrite !in_itv /= => /andP[-> /le_lt_trans->]//=.
-  by rewrite ltr_addl.
+  by rewrite ltrDl.
 have := @segment_compact _ (a.1 + e%:num / 2) a.2; rewrite compact_cover.
 move=> /[apply]-[i _|X _ Xc]; first exact: interval_open.
 have: `](a.1 + e%:num / 2), a.2] `<=` \bigcup_(i in [set` X]) Aoc i.
@@ -375,7 +375,7 @@ rewrite fsbig_finite//= set_fsetK//.
 rewrite lee_sum // => i _; rewrite ?AE// !hlength_itv/= ?lte_fin -?EFinD/=.
 do !case: ifPn => //= ?; do ?by rewrite ?adde_ge0 ?lee_fin// ?subr_ge0// ?ltW.
   by rewrite addrAC.
-by rewrite addrAC lee_fin ler_add// subr_le0 leNgt.
+by rewrite addrAC lee_fin lerD// subr_le0 leNgt.
 Qed.
 
 HB.instance Definition _ := Content_SubSigmaAdditive_isMeasure.Build _ _ _
@@ -546,11 +546,11 @@ Lemma set1_bigcap_oc (R : realType) (r : R) :
    [set r] = \bigcap_i `]r - i.+1%:R^-1, r]%classic.
 Proof.
 apply/seteqP; split=> [x ->|].
-  by move=> i _/=; rewrite in_itv/= lexx ltr_subl_addr ltr_addl invr_gt0 ltr0n.
+  by move=> i _/=; rewrite in_itv/= lexx ltrBlDr ltrDl invr_gt0 ltr0n.
 move=> x rx; apply/esym/eqP; rewrite eq_le (itvP (rx 0%N _))// andbT.
-apply/ler_addgt0Pl => e e_gt0; rewrite -ler_subl_addl ltW//.
+apply/ler_addgt0Pl => e e_gt0; rewrite -lerBlDl ltW//.
 have := rx `|floor e^-1|%N I; rewrite /= in_itv => /andP[/le_lt_trans->]//.
-rewrite ler_add2l ler_opp2 -lef_pinv ?invrK//; last by rewrite qualifE/=.
+rewrite lerD2l lerN2 -lef_pV2 ?invrK//; last by rewrite qualifE/=.
 rewrite -natr1 natr_absz ger0_norm ?floor_ge0 ?invr_ge0 1?ltW//.
 by rewrite lt_succ_floor.
 Qed.
@@ -561,13 +561,13 @@ Lemma itv_bnd_open_bigcup (R : realType) b (r s : R) :
 Proof.
 apply/seteqP; split => [x/=|]; last first.
   move=> x [n _ /=] /[!in_itv] /andP[-> /le_lt_trans]; apply.
-  by rewrite ltr_subl_addr ltr_addl invr_gt0 ltr0n.
+  by rewrite ltrBlDr ltrDl invr_gt0 ltr0n.
 rewrite in_itv/= => /andP[sx xs]; exists `|ceil ((s - x)^-1)|%N => //=.
-rewrite in_itv/= sx/= ler_subr_addl addrC -ler_subr_addl.
-rewrite -[in X in _ <= X](invrK (s - x)) ler_pinv.
+rewrite in_itv/= sx/= lerBrDl addrC -lerBrDl.
+rewrite -[in X in _ <= X](invrK (s - x)) ler_pV2.
 - rewrite -natr1 natr_absz ger0_norm; last first.
     by rewrite ceil_ge0// invr_ge0 subr_ge0 ltW.
-  by rewrite (@le_trans _ _ (ceil (s - x)^-1)%:~R)// ?ler_addl// ceil_ge.
+  by rewrite (@le_trans _ _ (ceil (s - x)^-1)%:~R)// ?lerDl// ceil_ge.
 - by rewrite inE unitfE ltr0n andbT pnatr_eq0.
 - by rewrite inE invr_gt0 subr_gt0 xs andbT unitfE invr_eq0 subr_eq0 gt_eqF.
 Qed.
@@ -589,7 +589,7 @@ Lemma itv_bnd_infty_bigcup (R : realType) b (x : R) :
 Proof.
 apply/seteqP; split=> y; rewrite /= !in_itv/= andbT; last first.
   by move=> [k _ /=]; move: b => [|] /=; rewrite in_itv/= => /andP[//] /ltW.
-move=> xy; exists `|ceil (y - x)|%N => //=; rewrite in_itv/= xy/= -ler_subl_addl.
+move=> xy; exists `|ceil (y - x)|%N => //=; rewrite in_itv/= xy/= -lerBlDl.
 rewrite !natr_absz/= ger0_norm ?ceil_ge0// ?subr_ge0//; last first.
   by case: b xy => //= /ltW.
 by rewrite -RceilE Rceil_ge.
@@ -876,14 +876,14 @@ rewrite itv_bnd_open_bigcup//; transitivity (limn (lebesgue_measure \o
   - by move=> ?; exact: measurable_itv.
   - by apply: bigcup_measurable => k _; exact: measurable_itv.
   - move=> n m nm; apply/subsetPset => x /=; rewrite !in_itv/= => /andP[->/=].
-    by move/le_trans; apply; rewrite ler_sub// ler_pinv ?ler_nat//;
+    by move/le_trans; apply; rewrite lerB// ler_pV2 ?ler_nat//;
       rewrite inE ltr0n andbT unitfE.
 rewrite (_ : _ \o _ = (fun n => (1 - n.+1%:R^-1)%:E)); last first.
   apply/funext => n /=; rewrite lebesgue_measure_itvoc.
   have [->|n0] := eqVneq n 0%N.
     by rewrite invr1 subrr set_itvoc0 hlength0.
   rewrite hlength_itv/= lte_fin ifT; last first.
-    by rewrite ler_lt_sub// invr_lt1 ?unitfE// ltr1n ltnS lt0n.
+    by rewrite ler_ltB// invr_lt1 ?unitfE// ltr1n ltnS lt0n.
   by rewrite !(EFinB,EFinN) fin_num_oppeB// addeAC addeA subee// add0e.
 apply/cvg_lim => //=; apply/fine_cvgP; split => /=; first exact: nearW.
 apply/(@cvgrPdist_lt _ [the pseudoMetricNormedZmodType R of R^o]) => _/posnumP[e].
@@ -897,10 +897,10 @@ suff : (lebesgue_measure (`]a - 1, a]%classic%R : set R) =
         lebesgue_measure (`]a - 1, a[%classic%R : set R) +
         lebesgue_measure [set a])%E.
   rewrite lebesgue_measure_itvoo_subr1 lebesgue_measure_itvoc => /eqP.
-  rewrite hlength_itv lte_fin ltr_subl_addr ltr_addl ltr01.
+  rewrite hlength_itv lte_fin ltrBlDr ltrDl ltr01.
   rewrite [in X in X == _]/= EFinN EFinB fin_num_oppeB// addeA subee// add0e.
   by rewrite addeC -sube_eq ?fin_num_adde_defl// subee// => /eqP.
-rewrite -setUitv1// ?bnd_simp; last by rewrite ltr_subl_addr ltr_addl.
+rewrite -setUitv1// ?bnd_simp; last by rewrite ltrBlDr ltrDl.
 rewrite measureU//; first exact: measurable_itv.
 apply/seteqP; split => // x []/=; rewrite in_itv/= => + xa.
 by rewrite xa ltxx andbF.
@@ -960,11 +960,11 @@ rewrite itv_bnd_infty_bigcup; transitivity (limn (lebesgue_measure \o
   + by move=> k; exact: measurable_itv.
   + by apply: bigcup_measurable => k _; exact: measurable_itv.
   + move=> m n mn; apply/subsetPset => r/=; rewrite !in_itv/= => /andP[->/=].
-    by move=> /le_trans; apply; rewrite ler_add// ler_nat.
+    by move=> /le_trans; apply; rewrite lerD// ler_nat.
 rewrite (_ : _ \o _ = (fun k => k%:R%:E))//.
 apply/funext => n /=; rewrite lebesgue_measure_itv_bnd hlength_itv/=.
 rewrite lte_fin;  have [->|n0] := eqVneq n 0%N; first by rewrite addr0 ltxx.
-by rewrite ltr_addl ltr0n lt0n n0 EFinD addeAC EFinN subee ?add0e.
+by rewrite ltrDl ltr0n lt0n n0 EFinD addeAC EFinN subee ?add0e.
 Qed.
 
 Let lebesgue_measure_itv_infty_bnd y (b : R) :
@@ -976,11 +976,11 @@ rewrite itv_infty_bnd_bigcup; transitivity (limn (lebesgue_measure \o
   + by move=> k; exact: measurable_itv.
   + by apply: bigcup_measurable => k _; exact: measurable_itv.
   + move=> m n mn; apply/subsetPset => r/=; rewrite !in_itv/= => /andP[+ ->].
-    by rewrite andbT; apply: le_trans; rewrite ler_sub// ler_nat.
+    by rewrite andbT; apply: le_trans; rewrite lerB// ler_nat.
 rewrite (_ : _ \o _ = (fun k : nat => k%:R%:E))//.
 apply/funext => n /=; rewrite lebesgue_measure_itv_bnd hlength_itv/= lte_fin.
 have [->|n0] := eqVneq n 0%N; first by rewrite subr0 ltxx.
-rewrite ltr_subl_addr ltr_addl ltr0n lt0n n0 EFinN EFinB fin_num_oppeB// addeA.
+rewrite ltrBlDr ltrDl ltr0n lt0n n0 EFinN EFinB fin_num_oppeB// addeA.
 by rewrite subee// add0e.
 Qed.
 
@@ -1051,7 +1051,7 @@ rewrite [X in measurable X](_ : _ =
 rewrite predeqE => t; split => [/= [Dt ft]|].
   have [ft0|ft0] := leP 0%R (fine (f t)).
     exists `|ceil (fine (f t))|%N => //=; split => //; split.
-      by rewrite -{2}(fineK ft)// lee_fin (le_trans _ ft0)// ler_oppl oppr0.
+      by rewrite -{2}(fineK ft)// lee_fin (le_trans _ ft0)// lerNl oppr0.
     by rewrite natr_absz ger0_norm ?ceil_ge0// -(fineK ft) lee_fin ceil_ge.
   exists `|floor (fine (f t))|%N => //=; split => //; split.
     rewrite natr_absz ltr0_norm ?floor_lt0// EFinN.
@@ -1264,15 +1264,15 @@ rewrite predeqE => x; split=> [|].
 - move: x => [s /=| _ n _|//].
   + rewrite in_itv /= andbT lee_fin => rs n _ /=; rewrite in_itv/= andbT.
     case: b => /=.
-    * by rewrite lee_fin ler_subl_addl (le_trans rs)// ler_addr.
-    * by rewrite lte_fin ltr_subl_addl (le_lt_trans rs)// ltr_addr.
+    * by rewrite lee_fin lerBlDl (le_trans rs)// lerDr.
+    * by rewrite lte_fin ltrBlDl (le_lt_trans rs)// ltrDr.
   + by rewrite /= in_itv /= andbT; case: b => /=; rewrite lteey.
 - move: x => [s| |/(_ 0%N Logic.I)] /=; rewrite ?in_itv/= ?leey//; last first.
     by case: b.
   move=> h; rewrite lee_fin leNgt andbT; apply/negP => /ltr_add_invr[k skr].
   have {h} := h k Logic.I; rewrite /= in_itv /= andbT; case: b => /=.
-  + by rewrite lee_fin ler_subl_addr leNgt skr.
-  + by rewrite lte_fin ltr_subl_addr ltNge (ltW skr).
+  + by rewrite lee_fin lerBlDr leNgt skr.
+  + by rewrite lte_fin ltrBlDr ltNge (ltW skr).
 Qed.
 
 Lemma eitv_infty_bnd b r : `]-oo, r%:E]%classic =
@@ -1282,8 +1282,8 @@ rewrite predeqE => x; split=> [|].
 - move: x => [s /=|//|_ n _].
   + rewrite in_itv /= lee_fin => sr n _; rewrite /= in_itv /= -EFinD.
     case: b => /=.
-    * by rewrite lte_fin (le_lt_trans sr)// ltr_addl.
-    * by rewrite lee_fin (le_trans sr)// ler_addl.
+    * by rewrite lte_fin (le_lt_trans sr)// ltrDl.
+    * by rewrite lee_fin (le_trans sr)// lerDl.
   + by rewrite /= in_itv /= -EFinD; case: b => //=; rewrite lteNye.
 - move: x => [s|/(_ 0%N Logic.I)|]/=; rewrite !in_itv/= ?leNye//; last first.
     by case: b.
@@ -1300,10 +1300,10 @@ rewrite eqEsubset; split=> [_ -> i _ |]; first by rewrite /= in_itv /= ltNyr.
 move=> [r|/(_ O Logic.I)|]//.
 move=> /(_ `|floor r|%N Logic.I); rewrite /= in_itv/= ltNge.
 rewrite lee_fin; have [r0|r0] := leP 0%R r.
-  by rewrite (le_trans _ r0) // ler_oppl oppr0 ler0n.
-rewrite ler_oppl -abszN natr_absz gtr0_norm; last first.
-  by rewrite ltr_oppr oppr0 floor_lt0.
-by rewrite mulrNz ler_oppl opprK floor_le.
+  by rewrite (le_trans _ r0) // lerNl oppr0 ler0n.
+rewrite lerNl -abszN natr_absz gtr0_norm; last first.
+  by rewrite ltrNr oppr0 floor_lt0.
+by rewrite mulrNz lerNl opprK floor_le.
 Qed.
 
 Lemma eset1y : [set +oo] = \bigcap_k `]k%:R%:E, +oo[%classic :> set (\bar R).
@@ -1542,9 +1542,9 @@ have [x0|x0] := leP 0 x.
   - have [r0|r0] := leP 0 r; [rewrite ger0_norm|rewrite ltr0_norm] => // xr;
       rewrite 2!in_itv/=.
     + by right; rewrite xr.
-    + by left; rewrite ltr_oppr.
+    + by left; rewrite ltrNr.
   - move=> rx /=.
-    by rewrite ler0_norm 1?ltr_oppr// (le_trans (ltW rx))// ler_oppl oppr0.
+    by rewrite ler0_norm 1?ltrNr// (le_trans (ltW rx))// lerNl oppr0.
   - by rewrite in_itv /= andbT => xr; rewrite (lt_le_trans _ (ler_norm _)).
 rewrite [X in measurable X](_ : _ = setT)// predeqE => r.
 by split => // _; rewrite /= in_itv /= andbT (lt_le_trans x0).
@@ -1599,11 +1599,11 @@ rewrite [X in measurable X](_ : _ = \bigcup_(q : rat)
   - by rewrite -preimage_itv_o_infty; apply: mf => //; apply: measurable_itv.
   - by rewrite -preimage_itv_o_infty; apply: mg => //; apply: measurable_itv.
 rewrite predeqE => x; split => [|[r _] []/= [Dx rfx]] /= => [[Dx]|[_]].
-  rewrite -ltr_subl_addr => /rat_in_itvoo[r]; rewrite inE /= => /itvP h.
+  rewrite -ltrBlDr => /rat_in_itvoo[r]; rewrite inE /= => /itvP h.
   exists r => //; rewrite setIACA setIid; split => //; split => /=.
     by rewrite h.
-  by rewrite ltr_subl_addr addrC -ltr_subl_addr h.
-by rewrite ltr_subl_addr=> afg; rewrite (lt_le_trans afg)// addrC ler_add2r ltW.
+  by rewrite ltrBlDr addrC -ltrBlDr h.
+by rewrite ltrBlDr=> afg; rewrite (lt_le_trans afg)// addrC lerD2r ltW.
 Qed.
 
 Lemma measurable_funB D f g : measurable_fun D f ->

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -1864,7 +1864,7 @@ Section measure_count.
 Context d (T : measurableType d) (R : realType).
 Variables (D : set T) (mD : measurable D).
 
-Local Notation counting := (@counting [choiceType of T] R).
+Local Notation counting := (@counting T R).
 
 Let counting0 : counting set0 = 0.
 Proof. by rewrite /counting asboolT// fset_set0. Qed.

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -230,7 +230,7 @@ apply: Build_ProperFilter => A /nbhs_ballP[_/posnumP[e] Ae].
 exists (x + e%:num / 2); apply: Ae; last first.
   by rewrite eq_sym addrC -subr_eq subrr eq_sym.
 rewrite /ball /= opprD addrA subrr distrC subr0 ger0_norm //.
-by rewrite {2}(splitr e%:num) ltr_spaddl.
+by rewrite {2}(splitr e%:num) ltr_pwDl.
 Qed.
 
 #[global] Hint Extern 0 (ProperFilter _^') =>
@@ -260,7 +260,7 @@ Implicit Types r : R.
 Global Instance proper_pinfty_nbhs : ProperFilter (pinfty_nbhs R).
 Proof.
 apply Build_ProperFilter.
-  by move=> P [M [Mreal MP]]; exists (M + 1); apply MP; rewrite ltr_addl.
+  by move=> P [M [Mreal MP]]; exists (M + 1); apply MP; rewrite ltrDl.
 split=> /= [|P Q [MP [MPr gtMP]] [MQ [MQr gtMQ]] |P Q sPQ [M [Mr gtM]]].
 - by exists 0.
 - exists (maxr MP MQ); split=> [|x]; first exact: max_real.
@@ -272,7 +272,7 @@ Global Instance proper_ninfty_nbhs : ProperFilter (ninfty_nbhs R).
 Proof.
 apply Build_ProperFilter.
   move=> P [M [Mr ltMP]]; exists (M - 1).
-  by apply: ltMP; rewrite gtr_addl oppr_lt0.
+  by apply: ltMP; rewrite gtrDl oppr_lt0.
 split=> /= [|P Q [MP [MPr ltMP]] [MQ [MQr ltMQ]] |P Q sPQ [M [Mr ltM]]].
 - by exists 0.
 - exists (Num.min MP MQ); split=> [|x]; first exact: min_real.
@@ -320,7 +320,7 @@ Lemma near_pinfty_div2 (A : set R) :
   (\forall k \near +oo, A k) -> (\forall k \near +oo, A (k / 2)).
 Proof.
 move=> [M [Mreal AM]]; exists (M * 2); split; first by rewrite realM.
-by move=> x; rewrite -ltr_pdivl_mulr //; exact: AM.
+by move=> x; rewrite -ltr_pdivlMr //; exact: AM.
 Qed.
 
 End infty_nbhs_instances.
@@ -440,7 +440,7 @@ Proof. by rewrite cvgrNyPltr. Qed.
 Lemma cvgNry f : (- f @ F --> +oo) <-> (f @ F --> -oo).
 Proof.
 rewrite cvgrNyPler cvgryPger; split=> Foo A Areal;
-by near do rewrite -ler_opp2 ?opprK; apply: Foo; rewrite rpredN.
+by near do rewrite -lerN2 ?opprK; apply: Foo; rewrite rpredN.
 Unshelve. all: end_near. Qed.
 
 Lemma cvgNrNy f : (- f @ F --> -oo) <-> (f @ F --> +oo).
@@ -1045,33 +1045,33 @@ Local Notation "x ^'+" := (at_right x) : classical_set_scope.
 Global Instance at_right_proper_filter (x : R) : ProperFilter x^'+.
 Proof.
 apply: Build_ProperFilter' => -[_/posnumP[d] /(_ (x + d%:num / 2))].
-apply; last (by rewrite ltr_addl); rewrite /=.
+apply; last (by rewrite ltrDl); rewrite /=.
 rewrite opprD !addrA subrr add0r normrN normf_div !ger0_norm //.
-by rewrite ltr_pdivr_mulr // ltr_pmulr // (_ : 1 = 1%:R) // ltr_nat.
+by rewrite ltr_pdivrMr // ltr_pMr // (_ : 1 = 1%:R) // ltr_nat.
 Qed.
 
 Global Instance at_left_proper_filter (x : R) : ProperFilter x^'-.
 Proof.
 apply: Build_ProperFilter' => -[_ /posnumP[d] /(_ (x - d%:num / 2))].
-apply; last (by rewrite ltr_subl_addl ltr_addr); rewrite /=.
+apply; last (by rewrite ltrBlDl ltrDr); rewrite /=.
 rewrite opprD !addrA subrr add0r opprK normf_div !ger0_norm //.
-by rewrite ltr_pdivr_mulr // ltr_pmulr // (_ : 1 = 1%:R) // ltr_nat.
+by rewrite ltr_pdivrMr // ltr_pMr // (_ : 1 = 1%:R) // ltr_nat.
 Qed.
 
 Lemma nbhs_right0P x (P : set R) :
   (\forall y \near x^'+, P y) <-> \forall e \near 0^'+, P (x + e).
 Proof.
 rewrite !near_withinE !near_simpl nbhs0P -propeqE.
-by apply: (@eq_near _ (nbhs (0 : R))) => y; rewrite ltr_addl.
+by apply: (@eq_near _ (nbhs (0 : R))) => y; rewrite ltrDl.
 Qed.
 
 Lemma nbhs_left0P x (P : set R) :
   (\forall y \near x^'-, P y) <-> \forall e \near 0^'+, P (x - e).
 Proof.
 rewrite !near_withinE !near_simpl nbhs0P; split=> Px.
-  rewrite -oppr0 nearN; near=> e; rewrite ltr_opp2 opprK => e_lt0.
-  by apply: (near Px) => //; rewrite gtr_addl.
-by rewrite -oppr0 nearN; near=> e; rewrite gtr_addl oppr_lt0; apply: (near Px).
+  rewrite -oppr0 nearN; near=> e; rewrite ltrN2 opprK => e_lt0.
+  by apply: (near Px) => //; rewrite gtrDl.
+by rewrite -oppr0 nearN; near=> e; rewrite gtrDl oppr_lt0; apply: (near Px).
 Unshelve. all: by end_near. Qed.
 
 Lemma nbhs_right_gt x : \forall y \near x^'+, x < y.
@@ -1095,7 +1095,7 @@ Proof. by rewrite near_withinE; apply: nearW => ?; apply/ltW. Qed.
 Lemma nbhs_right_lt x z : x < z -> \forall y \near x^'+, y < z.
 Proof.
 move=> xz; exists (z - x) => //=; first by rewrite subr_gt0.
-by move=> y /= + xy; rewrite distrC ?ger0_norm ?subr_ge0 1?ltW// ltr_add2r.
+by move=> y /= + xy; rewrite distrC ?ger0_norm ?subr_ge0 1?ltW// ltrD2r.
 Qed.
 
 Lemma nbhs_right_le x z : x < z -> \forall y \near x^'+, y <= z.
@@ -1104,7 +1104,7 @@ Unshelve. all: by end_near. Qed.
 
 Lemma nbhs_left_gt x z : z < x -> \forall y \near x^'-, z < y.
 Proof.
-move=> xz; rewrite nbhs_left0P; near do rewrite -ltr_opp2 opprB ltr_subl_addl.
+move=> xz; rewrite nbhs_left0P; near do rewrite -ltrN2 opprB ltrBlDl.
 by apply: nbhs_right_lt; rewrite subr_gt0.
 Unshelve. all: by end_near. Qed.
 
@@ -1154,7 +1154,7 @@ split=> /nbhs_norm0P[/= _/posnumP[e] /(_ _) Px]; apply/nbhs_norm0P.
   exists e%:num => //= r /= re yr y xyr; rewrite -[y](addrNK x) addrC.
   by apply: Px; rewrite /= distrC (le_lt_trans _ re)// gtr0_norm.
 exists (e%:num / 2) => //= r /= re; apply: (Px (e%:num / 2)) => //=.
-   by rewrite gtr0_norm// ltr_pdivr_mulr// ltr_pmulr// ?(ltr_nat _ 1 2).
+   by rewrite gtr0_norm// ltr_pdivrMr// ltr_pMr// ?(ltr_nat _ 1 2).
 by rewrite opprD addNKr normrN ltW.
 Qed.
 
@@ -1230,8 +1230,8 @@ Proof.
 move=> Fy z zy; near (0:R)^'+ => k; near=> x; have : `|f x - y| < k.
   by near: x; apply: cvgr_distC_lt => //; near: k; apply: nbhs_right_gt.
 move=> /(le_lt_trans (ler_dist_dist _ _)) /real_ltr_normlW.
-rewrite realB// ltr_subl_addl => /(_ _)/lt_le_trans; apply => //.
-by rewrite -ler_subr_addl; near: k; apply: nbhs_right_le; rewrite subr_gt0.
+rewrite realB// ltrBlDl => /(_ _)/lt_le_trans; apply => //.
+by rewrite -lerBrDl; near: k; apply: nbhs_right_le; rewrite subr_gt0.
 Unshelve. all: by end_near. Qed.
 
 Lemma cvgr_norm_le {T} {F : set_system T} {FF : Filter F} (f : T -> V) (y : V) :
@@ -1246,8 +1246,8 @@ Proof.
 move=> Fy z zy; near (0:R)^'+ => k; near=> x; have: `|f x - y| < k.
   by near: x; apply: cvgr_distC_lt => //; near: k; apply: nbhs_right_gt.
 move=> /(le_lt_trans (ler_dist_dist _ _)); rewrite distrC => /real_ltr_normlW.
-rewrite realB// ltr_subl_addl  -ltr_subl_addr => /(_ isT); apply: le_lt_trans.
-rewrite ler_subr_addl -ler_subr_addr; near: k; apply: nbhs_right_le.
+rewrite realB// ltrBlDl  -ltrBlDr => /(_ isT); apply: le_lt_trans.
+rewrite lerBrDl -lerBrDr; near: k; apply: nbhs_right_le.
 by rewrite subr_gt0.
 Unshelve. all: by end_near. Qed.
 
@@ -1319,7 +1319,7 @@ Lemma real_cvgr_lt {T} {F : set_system T} {FF : Filter F} (f : T -> R) (y : R) :
   forall z, z > y -> \forall t \near F, f t \is Num.real -> f t < z.
 Proof.
 move=> yr Fy z zy; near=> x => fxr.
-rewrite -(ltr_add2r (- y)) real_ltr_normlW// ?rpredB//.
+rewrite -(ltrD2r (- y)) real_ltr_normlW// ?rpredB//.
 by near: x; apply: cvgr_distC_lt => //; rewrite subr_gt0.
 Unshelve. all: by end_near. Qed.
 
@@ -1336,7 +1336,7 @@ Lemma real_cvgr_gt {T} {F : set_system T} {FF : Filter F} (f : T -> R) (y : R) :
   forall z, y > z -> \forall t \near F, f t \is Num.real -> f t > z.
 Proof.
 move=> yr Fy z zy; near=> x => fxr.
-rewrite -ltr_opp2 -(ltr_add2l y) real_ltr_normlW// ?rpredB//.
+rewrite -ltrN2 -(ltrD2l y) real_ltr_normlW// ?rpredB//.
 by near: x; apply: cvgr_dist_lt => //; rewrite subr_gt0.
 Unshelve. all: by end_near. Qed.
 
@@ -1367,7 +1367,7 @@ Qed.
 Lemma cvgr_lt {T} {F : set_system T} {FF : Filter F} (f : T -> R) (y : R) :
   f @ F --> y -> forall z, z > y -> \forall t \near F, f t < z.
 Proof.
-move=> Fy z zy; near=> x; rewrite -(ltr_add2r (- y)) ltr_normlW//.
+move=> Fy z zy; near=> x; rewrite -(ltrD2r (- y)) ltr_normlW//.
 by near: x; apply: cvgr_distC_lt => //; rewrite subr_gt0.
 Unshelve. all: by end_near. Qed.
 
@@ -1380,7 +1380,7 @@ Qed.
 Lemma cvgr_gt {T} {F : set_system T} {FF : Filter F} (f : T -> R) (y : R) :
   f @ F --> y -> forall z, y > z -> \forall t \near F, f t > z.
 Proof.
-move=> Fy z zy; near=> x; rewrite -ltr_opp2 -(ltr_add2l y) ltr_normlW//.
+move=> Fy z zy; near=> x; rewrite -ltrN2 -(ltrD2l y) ltr_normlW//.
 by near: x; apply: cvgr_dist_lt => //; rewrite subr_gt0.
 Unshelve. all: by end_near. Qed.
 
@@ -1452,7 +1452,7 @@ have [] := pselect (exists x, (h x != 0) && (`|f x| <= M * `|h x|)); last first.
 case => x0 /andP[hx0_neq0] /(le_trans (normr_ge0 _)) /ger0_real.
 rewrite realrM // ?normr_eq0// => M_real.
 exists M; split => // k Mk; apply: filterS FM => x /le_trans/= ->//.
-by rewrite ler_wpmul2r// ltW.
+by rewrite ler_wpM2r// ltW.
 Qed.
 
 Lemma ex_strict_dom_bound {T : Type} {K : numFieldType}
@@ -1465,7 +1465,7 @@ Proof.
 move=> hN0; rewrite ex_dom_bound /dominated_by /strictly_dominated_by.
 split => -[] M FM; last by exists M; apply: filterS FM => x /ltW.
 exists (M + 1); apply: filterS2 hN0 FM => x hN0 /le_lt_trans/= ->//.
-by rewrite ltr_pmul2r ?normr_gt0// ltr_addl.
+by rewrite ltr_pM2r ?normr_gt0// ltrDl.
 Qed.
 
 Definition bounded_near {T : Type} {K : numFieldType}
@@ -1508,7 +1508,7 @@ Lemma ex_strict_bound_gt0 {T : Type} {K : numFieldType} {V : pseudoMetricNormedZ
   bounded_near f F -> exists2 M, M > 0 & F [set x | `|f x| < M].
 Proof.
 move=> /pinfty_ex_gt0[M M_gt0 FM]; exists (M + 1); rewrite ?addr_gt0//.
-by apply: filterS FM => x /le_lt_trans/= ->//; rewrite ltr_addl.
+by apply: filterS FM => x /le_lt_trans/= ->//; rewrite ltrDl.
 Qed.
 
 Notation "[ 'bounded' E | x 'in' A ]" :=
@@ -1520,7 +1520,7 @@ Lemma bounded_fun_has_ubound (T : Type) (R : realFieldType) (a : T -> R) :
   bounded_fun a -> has_ubound (range a).
 Proof.
 move=> [M [Mreal]]/(_ (`|M| + 1)).
-rewrite (le_lt_trans (ler_norm _)) ?ltr_addl// => /(_ erefl) aM.
+rewrite (le_lt_trans (ler_norm _)) ?ltrDl// => /(_ erefl) aM.
 by exists (`|M| + 1) => _ [n _ <-]; rewrite (le_trans (ler_norm _))// aM.
 Qed.
 
@@ -1543,8 +1543,8 @@ Lemma bounded_funD (T : Type) (R : realFieldType) (a b : T -> R) :
 Proof.
 move=> [M [Mreal Ma]] [N [Nreal Nb]].
 rewrite /bounded_fun/bounded_near; near=> x => y /= _.
-rewrite (le_trans (ler_norm_add _ _))// [x]splitr.
-by rewrite ler_add// (Ma, Nb)// ltr_pdivl_mulr//;
+rewrite (le_trans (ler_normD _ _))// [x]splitr.
+by rewrite lerD// (Ma, Nb)// ltr_pdivlMr//;
    near: x; apply: nbhs_pinfty_gt; rewrite ?rpredM ?rpred_nat.
 Unshelve. all: by end_near. Qed.
 
@@ -1626,7 +1626,7 @@ Proof.
 case => q [q1 ctrfq] Ux Uy fixx fixy; apply/subr0_eq/normr0_eq0/eqP.
 have [->|xyneq] := eqVneq x y; first by rewrite subrr normr0.
 have xypos : 0 < `|x - y| by rewrite normr_gt0 subr_eq0.
-suff : `|x - y| <= q%:num * `|x - y| by rewrite ler_pmull // leNgt q1.
+suff : `|x - y| <= q%:num * `|x - y| by rewrite ler_pMl // leNgt q1.
 by rewrite [in leLHS]fixx [in leLHS]fixy; exact: (ctrfq (_, _)).
 Qed.
 
@@ -1645,8 +1645,8 @@ set r := PosNum ab2; exists (r, r) => /=.
 apply/negPn/negP => /set0P[c] []; rewrite -ball_normE /ball_ => acr bcr.
 have r22 : r%:num * 2 = r%:num + r%:num.
   by rewrite (_ : 2 = 1 + 1) // mulrDr mulr1.
-move: (ltr_add acr bcr); rewrite -r22 (distrC b c).
-move/(le_lt_trans (ler_dist_add c a b)).
+move: (ltrD acr bcr); rewrite -r22 (distrC b c).
+move/(le_lt_trans (ler_distD c a b)).
 by rewrite -mulrA mulVr ?mulr1 ?ltxx // unitfE.
 Qed.
 Hint Extern 0 (hausdorff_space _) => solve[apply: norm_hausdorff] : core.
@@ -1698,7 +1698,7 @@ Proof. by have := @ball_splitl _ _ z x y e; rewrite -ball_normE. Qed.
 
 Lemma normm_leW (x : V) (e : R) : e > 0 -> `|x| <= e / 2 -> `|x| < e.
 Proof.
-by move=> /posnumP[{}e] /le_lt_trans ->//; rewrite [ltRHS]splitr ltr_spaddl.
+by move=> /posnumP[{}e] /le_lt_trans ->//; rewrite [ltRHS]splitr ltr_pwDl.
 Qed.
 
 Lemma normm_lt_split (x y : V) (e : R) :
@@ -1835,8 +1835,8 @@ Lemma ler_mx_norm_add x y : mx_norm (x + y) <= mx_norm x + mx_norm y.
 Proof.
 rewrite !mx_normE [_ <= _%:num]num_le; apply/bigmax_leP.
 split=> [|ij _]; first exact: addr_ge0.
-rewrite mxE; apply: le_trans (ler_norm_add _ _) _.
-by rewrite ler_add// -[leLHS]nngE num_le; exact: le_bigmax.
+rewrite mxE; apply: le_trans (ler_normD _ _) _.
+by rewrite lerD// -[leLHS]nngE num_le; exact: le_bigmax.
 Qed.
 
 Lemma mx_norm_eq0 x : mx_norm x = 0 -> x = 0.
@@ -1928,7 +1928,7 @@ rewrite {1 3}/normr /= !mx_normE
  (eq_bigr (fun i => (`|l| * `|x i.1 i.2|)%:nng)); last first.
   by move=> i _; rewrite mxE //=; apply/eqP; rewrite -num_eq /= normrM.
 elim/big_ind2 : _ => // [|a b c d bE dE]; first by rewrite mulr0.
-by rewrite !num_max bE dE maxr_pmulr.
+by rewrite !num_max bE dE maxr_pMr.
 Qed.
 
 HB.instance Definition _ :=
@@ -1962,7 +1962,7 @@ Section prod_NormedModule.
 Context {K : numDomainType} {U V : normedModType K}.
 
 Lemma prod_norm_scale (l : K) (x : U * V) : `| l *: x | = `|l| * `| x |.
-Proof. by rewrite prod_normE /= !normrZ maxr_pmulr. Qed.
+Proof. by rewrite prod_normE /= !normrZ maxr_pMr. Qed.
 
 HB.instance Definition _ :=
   PseudoMetricNormedZmod_Lmodule_isNormedModule.Build K (U * V)%type
@@ -1975,10 +1975,10 @@ Variables (K : numDomainType).
 
 Example matrix_triangke m n (M N : 'M[K]_(m.+1, n.+1)) :
   `|M + N| <= `|M| + `|N|.
-Proof. apply ler_norm_add. Qed.
+Proof. apply ler_normD. Qed.
 
 Example pair_triangle (x y : K * K) : `|x + y| <= `|x| + `|y|.
-Proof. apply ler_norm_add. Qed.
+Proof. apply ler_normD. Qed.
 
 End example_of_sharing.
 
@@ -2049,7 +2049,7 @@ Lemma natmul_continuous n : continuous (fun x : V => x *+ n).
 Proof.
 case: n => [|n] x; first exact: cvg_cst.
 apply/cvgrPdist_lt=> _/posnumP[e]; near=> a.
-by rewrite -mulrnBl normrMn -mulr_natr -ltr_pdivl_mulr.
+by rewrite -mulrnBl normrMn -mulr_natr -ltr_pdivlMr.
 Unshelve. all: by end_near. Qed.
 
 Lemma norm_continuous : continuous (normr : V -> K).
@@ -2068,9 +2068,9 @@ Proof.
 move=> [/= k x]; apply/cvgrPdist_lt => _/posnumP[e]; near +oo_K => M.
 near=> l z => /=; have M0 : 0 < M by [].
 rewrite (@distm_lt_split _ _ (k *: z)) // -?(scalerBr, scalerBl) normrZ.
-  rewrite (@le_lt_trans _ _ (M * `|x - z|)) ?ler_wpmul2r -?ltr_pdivl_mull//.
+  rewrite (@le_lt_trans _ _ (M * `|x - z|)) ?ler_wpM2r -?ltr_pdivlMl//.
   by near: z; apply: cvgr_dist_lt; rewrite // mulr_gt0 ?invr_gt0.
-rewrite (@le_lt_trans _ _ (`|k - l| * M)) ?ler_wpmul2l -?ltr_pdivl_mulr//.
+rewrite (@le_lt_trans _ _ (`|k - l| * M)) ?ler_wpM2l -?ltr_pdivlMr//.
   by near: z; near: M; apply: cvg_bounded (@cvg_refl _ _).
 by near: l; apply: cvgr_dist_lt; rewrite // divr_gt0.
 Unshelve. all: by end_near. Qed.
@@ -2109,10 +2109,10 @@ move=> x_neq0; have nx_gt0 : `|x| > 0 by rewrite normr_gt0.
 apply/(@cvgrPdist_ltp _ _ _ (nbhs x)); near (0 : K)^'+ => d. near=> e.
 near=> y; have y_neq0 : y != 0 by near: y; apply: (cvgr_neq0 x).
 rewrite /= -div1r -[y^-1]div1r -mulNr addf_div// mul1r mulN1r normrM normfV.
-rewrite ltr_pdivr_mulr ?normr_gt0 ?mulf_neq0// (@lt_le_trans _ _ (e * d))//.
+rewrite ltr_pdivrMr ?normr_gt0 ?mulf_neq0// (@lt_le_trans _ _ (e * d))//.
   by near: y;  apply: cvgr_distC_lt => //; rewrite mulr_gt0.
-rewrite ler_pmul2l => //=; rewrite normrM -ler_pdivr_mull//.
-near: y; apply: (cvgr_norm_ge x) => //; rewrite ltr_pdivr_mull//.
+rewrite ler_pM2l => //=; rewrite normrM -ler_pdivrMl//.
+near: y; apply: (cvgr_norm_ge x) => //; rewrite ltr_pdivrMl//.
 by near: d; apply: nbhs_right_lt; rewrite mulr_gt0.
 Unshelve. all: by end_near. Qed.
 
@@ -2517,13 +2517,13 @@ have yE u v x : u @ F --> +oo -> v @ F --> x%:E -> u \+ v @ F --> +oo.
   near=> A; near=> n; have /(_ _)/wrap[//|Fgn] := near Fg n.
   rewrite -lee_subl_addr// (@le_trans _ _ (A - (x - 1))%:E)//; last by near: n.
   rewrite ?EFinB lee_sub// lee_subl_addr// -[v n]fineK// -EFinD lee_fin.
-  by rewrite ler_distl_addr// ltW//; near: n; apply: cvgr_dist_lt.
+  by rewrite ler_distlDr// ltW//; near: n; apply: cvgr_dist_lt.
 have NyE u v x : u @ F --> -oo -> v @ F --> x%:E -> u \+ v @ F --> -oo.
   move=> /cvgeNyPle/= foo /fine_cvgP -[Fg gb]; apply/cvgeNyPleNy.
   near=> A; near=> n; have /(_ _)/wrap[//|Fgn] := near Fg n.
   rewrite -lee_subr_addr// (@le_trans _ _ (A - (x + 1))%:E)//; first by near: n.
   rewrite ?EFinB ?EFinD lee_sub// -[v n]fineK// -EFinD lee_fin.
-  by rewrite ler_distlC_addr// ltW//; near: n; apply: cvgr_dist_lt.
+  by rewrite ler_distlCDr// ltW//; near: n; apply: cvgr_dist_lt.
 have yyE u v : u @ F --> +oo -> v @ F --> +oo -> u \+ v @ F --> +oo.
   move=> /cvgeyPge foo /cvgeyPge goo; apply/cvgeyPge => A; near=> y.
   by rewrite -[leLHS]adde0 lee_add//; near: y; [apply: foo|apply: goo].
@@ -2808,7 +2808,7 @@ suff -> : [set y | y < +oo] = \bigcup_r [set y : \bar R | y < r%:E].
   exact: bigcup_open.
 rewrite predeqE => -[r | | ]/=.
 - rewrite ltry; split => // _.
-  by exists (r + 1)%R => //=; rewrite lte_fin ltr_addl.
+  by exists (r + 1)%R => //=; rewrite lte_fin ltrDl.
 - by rewrite ltxx; split => // -[] x /=; rewrite ltNge leey.
 - by split => // _; exists 0%R => //=; rewrite ltNye.
 Qed.
@@ -2823,7 +2823,7 @@ suff -> : [set y | -oo < y] = \bigcup_r [set y : \bar R | r%:E < y].
   exact: bigcup_open.
 rewrite predeqE => -[r | | ]/=.
 - rewrite ltNyr; split => // _.
-  by exists (r - 1)%R => //=; rewrite lte_fin ltr_subl_addr ltr_addl.
+  by exists (r - 1)%R => //=; rewrite lte_fin ltrBlDr ltrDl.
 - by split => // _; exists 0%R => //=; rewrite ltey.
 - by rewrite ltxx; split => // -[] x _ /=; rewrite ltNge leNye.
 Qed.
@@ -2855,7 +2855,7 @@ rewrite eqEsubset; split.
 move=> v; rewrite /mkset le_eqVlt => /predU1P[<-{v}|]; last first.
   by move=> ?; exact: subset_closure.
 move=> B [e /= e0 zB]; near (0 : R)^'+ => d.
-exists (z + d); split; rewrite /= ?ltr_addl//; apply: zB => /=.
+exists (z + d); split; rewrite /= ?ltrDl//; apply: zB => /=.
 by rewrite opprD addNKr normrN gtr0_norm//.
 Unshelve. all: by end_near. Qed.
 
@@ -2866,7 +2866,7 @@ rewrite eqEsubset; split.
 move=> v; rewrite /mkset le_eqVlt => /predU1P[<-{z}|]; last first.
   by move=> ?; exact: subset_closure.
 move=> B [e /= e0 vB]; near (0 : R)^'+ => d.
-exists (v - d); split; rewrite /= ?gtr_addl ?oppr_lt0//; apply: vB => /=.
+exists (v - d); split; rewrite /= ?gtrDl ?oppr_lt0//; apply: vB => /=.
 by rewrite opprB addrC addrNK gtr0_norm//; near: d.
 Unshelve. all: by end_near. Qed.
 
@@ -2891,9 +2891,9 @@ have D_has_sup : has_sup D; first split.
 - exists (x0 - 1) => A FA.
   near F => x.
   apply/downP; exists x; first by near: x.
-  by rewrite ler_distl_subl // ltW //; near: x.
+  by rewrite ler_distlBl // ltW //; near: x.
 - exists (x0 + 1); apply/ubP => x /(_ _ x01) /downP [y].
-  rewrite -[ball _ _ _]/(_ (_ < _)) ltr_distl ltr_subl_addr => /andP[/ltW].
+  rewrite -[ball _ _ _]/(_ (_ < _)) ltr_distl ltrBlDr => /andP[/ltW].
   by move=> /(le_trans _) yx01 _ /yx01.
 exists (sup D).
 apply/cvgrPdist_le => /= _ /posnumP[eps]; near=> x.
@@ -2902,12 +2902,12 @@ rewrite ler_distl; move/ubP: (sup_upper_bound D_has_sup) => -> //=.
   have Fxeps : F (ball_ [eta normr] x eps%:num).
     by near: x; apply: nearP_dep; apply: F_cauchy.
   apply/ubP => y /(_ _ Fxeps) /downP[z].
-  rewrite /ball_/= ltr_distl ltr_subl_addr.
+  rewrite /ball_/= ltr_distl ltrBlDr.
   by move=> /andP [/ltW /(le_trans _) le_xeps _ /le_xeps].
 rewrite /D /= => A FA; near F => y.
 apply/downP; exists y.
 by near: y.
-rewrite ler_subl_addl -ler_subl_addr ltW //.
+rewrite lerBlDl -lerBlDr ltW //.
 suff: `|x - y| < eps%:num by rewrite ltr_norml => /andP[_].
 by near: y; near: x; apply: nearP_dep; apply: F_cauchy.
 Unshelve. all: by end_near. Qed.
@@ -2943,11 +2943,11 @@ move=> A0 ?; have [|AsupA] := pselect (A (sup A)); first exact: subset_closure.
 rewrite closure_limit_point; right => U /nbhs_ballP[_ /posnumP[e]] supAeU.
 suff [x [Ax /andP[sAex xsA]]] : exists x, A x /\ sup A - e%:num < x < sup A.
   exists x; split => //; first by rewrite lt_eqF.
-  apply supAeU; rewrite /ball /= ltr_distl (addrC x e%:num) -ltr_subl_addl sAex.
-  by rewrite andbT (le_lt_trans _ xsA) // ler_subl_addl ler_addr.
+  apply supAeU; rewrite /ball /= ltr_distl (addrC x e%:num) -ltrBlDl sAex.
+  by rewrite andbT (le_lt_trans _ xsA) // lerBlDl lerDr.
 apply: contrapT => /forallNP Ax.
 suff /(sup_le_ub A0) : ubound A (sup A - e%:num).
-  by rewrite leNgt => /negP; apply; rewrite ltr_subl_addl ltr_addr.
+  by rewrite leNgt => /negP; apply; rewrite ltrBlDl ltrDr.
 move=> y Ay; have /not_andP[//|/negP] := Ax y.
 rewrite negb_and leNgt => /orP[//|]; apply: contra => sAey.
 rewrite lt_neqAle sup_upper_bound // andbT.
@@ -2957,8 +2957,8 @@ Qed.
 Lemma near_infty_natSinv_lt (R : archiFieldType) (e : {posnum R}) :
   \forall n \near \oo, n.+1%:R^-1 < e%:num.
 Proof.
-near=> n; rewrite -(@ltr_pmul2r _ n.+1%:R) // mulVr ?unitfE //.
-rewrite -(@ltr_pmul2l _ e%:num^-1) // mulr1 mulrA mulVr ?unitfE // mul1r.
+near=> n; rewrite -(@ltr_pM2r _ n.+1%:R) // mulVr ?unitfE //.
+rewrite -(@ltr_pM2l _ e%:num^-1) // mulr1 mulrA mulVr ?unitfE // mul1r.
 rewrite (lt_trans (archi_boundP _)) // ltr_nat.
 by near: n; exists (Num.bound e%:num^-1).
 Unshelve. all: by end_near. Qed.
@@ -2967,9 +2967,9 @@ Lemma near_infty_natSinv_expn_lt (R : archiFieldType) (e : {posnum R}) :
   \forall n \near \oo, 1 / 2 ^+ n < e%:num.
 Proof.
 near=> n.
-rewrite -(@ltr_pmul2r _ (2 ^+ n)) // -?natrX ?ltr0n ?expn_gt0//.
+rewrite -(@ltr_pM2r _ (2 ^+ n)) // -?natrX ?ltr0n ?expn_gt0//.
 rewrite mul1r mulVr ?unitfE ?gt_eqF// ?ltr0n ?expn_gt0//.
-rewrite -(@ltr_pmul2l _ e%:num^-1) // mulr1 mulrA mulVr ?unitfE // mul1r.
+rewrite -(@ltr_pM2l _ e%:num^-1) // mulr1 mulrA mulVr ?unitfE // mul1r.
 rewrite (lt_trans (archi_boundP _)) // natrX upper_nthrootP //.
 near: n; eexists; last by move=> m; exact.
 by [].
@@ -3064,21 +3064,21 @@ move=> -[r| |] // [r' | |] //=.
     rr' _ _ (nbhs_image_EFin rA) (nbhs_image_EFin r'B).
   by rewrite -r0z => -[r1r0]; exists r0; split => //; rewrite -r1r0.
 - have /(@nbhs_open_ereal_lt _ (fun x => x + 1)) loc_r : r < r + 1.
-    by rewrite ltr_addl.
+    by rewrite ltrDl.
   move/(_ _ _ loc_r (nbhs_open_ereal_pinfty (r + 1))) => -[z [zr rz]].
   by move: (lt_trans rz zr); rewrite lte_fin ltxx.
 - have /(@nbhs_open_ereal_gt _ (fun x => x - 1)) loc_r : r - 1 < r.
-    by rewrite ltr_subl_addr ltr_addl.
+    by rewrite ltrBlDr ltrDl.
   move/(_ _ _ loc_r (nbhs_open_ereal_ninfty (r - 1))) => -[z [rz zr]].
   by move: (lt_trans zr rz); rewrite ltxx.
 - have /(@nbhs_open_ereal_lt _ (fun x => x + 1)) loc_r' : r' < r' + 1.
-    by rewrite ltr_addl.
+    by rewrite ltrDl.
   move/(_ _ _ (nbhs_open_ereal_pinfty (r' + 1)) loc_r') => -[z [r'z zr']].
   by move: (lt_trans zr' r'z); rewrite ltxx.
 - move/(_ _ _ (nbhs_open_ereal_pinfty 0) (nbhs_open_ereal_ninfty 0)).
   by move=> -[z [zx xz]]; move: (lt_trans xz zx); rewrite ltxx.
 - have /(@nbhs_open_ereal_gt _ (fun x => x - 1)) yB : r' - 1 < r'.
-    by rewrite ltr_subl_addr ltr_addl.
+    by rewrite ltrBlDr ltrDl.
   move/(_ _ _ (nbhs_open_ereal_ninfty (r' - 1)) yB) => -[z [zr' r'z]].
   by move: (lt_trans r'z zr'); rewrite ltxx.
 - move/(_ _ _ (nbhs_open_ereal_ninfty 0) (nbhs_open_ereal_pinfty 0)).
@@ -3204,10 +3204,10 @@ Proof.
 move=> f_gt0; split; last first.
   move=> /cvgryPgt cvg_f_oo; apply/cvgr0Pnorm_lt => _/posnumP[e].
   near=> i; rewrite gtr0_norm ?invr_gt0//=; last by near: i.
-  by rewrite -ltf_pinv ?qualifE/= ?invr_gt0 ?invrK//=; near: i.
+  by rewrite -ltf_pV2 ?qualifE/= ?invr_gt0 ?invrK//=; near: i.
 move=> /cvgr0Pnorm_lt uB; apply/cvgryPgty.
 near=> M; near=> i; suff: `|(f i)^-1| < M^-1.
-  by rewrite gtr0_norm ?ltf_pinv ?qualifE ?invr_gt0//=; near: i.
+  by rewrite gtr0_norm ?ltf_pV2 ?qualifE ?invr_gt0//=; near: i.
 by near: i; apply: uB; rewrite ?invr_gt0.
 Unshelve. all: by end_near. Qed.
 
@@ -3240,8 +3240,8 @@ Proof.
 move=> fgh l lfa lga; apply/cvgrPdist_lt => e e_gt0.
 near=> x; have /(_ _)/andP[//|fg gh] := near fgh x.
 rewrite distrC ltr_distl (lt_le_trans _ fg) ?(le_lt_trans gh)//=.
-  by near: x; apply: (cvgr_lt l); rewrite // ltr_addl.
-by near: x; apply: (cvgr_gt l); rewrite // gtr_addl oppr_lt0.
+  by near: x; apply: (cvgr_lt l); rewrite // ltrDl.
+by near: x; apply: (cvgr_gt l); rewrite // gtrDl oppr_lt0.
 Unshelve. all: end_near. Qed.
 
 Lemma ger_cvgy f g : (\near a, f a <= g a) ->
@@ -3386,14 +3386,14 @@ suff [q Iqx] : exists q, bigcup_ointsub U q x.
 have : nbhs x U by rewrite nbhsE /=; exists U.
 rewrite -nbhs_ballE /nbhs_ball /nbhs_ball_ => -[_/posnumP[r] xrU].
 have /rat_in_itvoo[q qxxr] : (x - r%:num < x + r%:num)%R.
-  by rewrite ltr_subl_addr -addrA ltr_addl.
+  by rewrite ltrBlDr -addrA ltrDl.
 exists q, `](x - r%:num)%R, (x + r%:num)%R[%classic; last first.
-  by rewrite /= in_itv/= ltr_subl_addl ltr_addr// ltr_addl//; apply/andP.
+  by rewrite /= in_itv/= ltrBlDl ltrDr// ltrDl//; apply/andP.
 split=> //; split; [exact: interval_open|exact: interval_is_interval|].
 move=> y /=; rewrite in_itv/= => /andP[xy yxr]; apply xrU => /=.
 rewrite /ball /= /ball_ /= in xrU *; have [yx|yx] := leP x y.
-  by rewrite ler0_norm ?subr_le0// opprB ltr_subl_addl.
-by rewrite gtr0_norm ?subr_gt0// ltr_subl_addr -ltr_subl_addl.
+  by rewrite ler0_norm ?subr_le0// opprB ltrBlDl.
+by rewrite gtr0_norm ?subr_gt0// ltrBlDr -ltrBlDl.
 Qed.
 
 End open_union_rat.
@@ -3408,9 +3408,9 @@ suff : ~ X^° (sup X) by rewrite supXr.
 case/nbhs_ballP => _/posnumP[e] supXeX.
 have [f XsupXf] : exists f : {posnum R}, X (sup X + f%:num).
   exists (e%:num / 2)%:pos; apply supXeX; rewrite /ball /= opprD addrA subrr.
-  by rewrite sub0r normrN gtr0_norm // ltr_pdivr_mulr // ltr_pmulr // ltr1n.
+  by rewrite sub0r normrN gtr0_norm // ltr_pdivrMr // ltr_pMr // ltr1n.
 have : sup X + f%:num <= sup X by apply sup_ub.
-by apply/negP; rewrite -ltNge; rewrite ltr_addl.
+by apply/negP; rewrite -ltNge; rewrite ltrDl.
 Qed.
 
 Lemma left_bounded_interior (R : realType) (X : set R) :
@@ -3423,9 +3423,9 @@ suff : ~ X^° (inf X) by rewrite -rinfX.
 case/nbhs_ballP => _/posnumP[e] supXeX.
 have [f XsupXf] : exists f : {posnum R}, X (inf X - f%:num).
   exists (e%:num / 2)%:pos; apply supXeX; rewrite /ball /= opprB addrCA subrr.
-  by rewrite addr0 gtr0_norm // ltr_pdivr_mulr // ltr_pmulr // ltr1n.
+  by rewrite addr0 gtr0_norm // ltr_pdivrMr // ltr_pMr // ltr1n.
 have : inf X <= inf X - f%:num by apply inf_lb.
-by apply/negP; rewrite -ltNge; rewrite ltr_subl_addr ltr_addl.
+by apply/negP; rewrite -ltNge; rewrite ltrBlDr ltrDl.
 Qed.
 
 Section interval_realType.
@@ -3592,18 +3592,18 @@ split => [cE x y Ex Ey z /andP[xz zy]|].
   have z1y : z1 <= y.
     rewrite leNgt; apply/negP => yz1.
     suff : (~` closure (A true)) y by apply; exact: subset_closure.
-    apply zcA1; rewrite /ball /= ltr_distl (lt_le_trans zy) // ?ler_addl //.
-    rewrite andbT ltr_subl_addl addrC (lt_trans yz1) // ltr_add2l.
-    by rewrite ltr_pdivr_mulr // ltr_pmulr // ltr1n.
-  rewrite z1y andbT ler_addl; split => //.
+    apply zcA1; rewrite /ball /= ltr_distl (lt_le_trans zy) // ?lerDl //.
+    rewrite andbT ltrBlDl addrC (lt_trans yz1) // ltrD2l.
+    by rewrite ltr_pdivrMr // ltr_pMr // ltr1n.
+  rewrite z1y andbT lerDl; split => //.
   have ncA1z1 : (~` closure (A true)) z1.
     apply zcA1; rewrite /ball /= /z1 opprD addrA subrr add0r normrN.
-    by rewrite ger0_norm // ltr_pdivr_mulr // ltr_pmulr // ltr1n.
+    by rewrite ger0_norm // ltr_pdivrMr // ltr_pMr // ltr1n.
   have nA0z1 : ~ (A false) z1.
-    move=> A0z1; have : z < z1 by rewrite /z1 ltr_addl.
+    move=> A0z1; have : z < z1 by rewrite /z1 ltrDl.
     apply/negP; rewrite -leNgt.
      apply: sup_ub; first by exists y => u [_] /andP[].
-    by split => //; rewrite /mkset /z1 (le_trans xz) /= ?ler_addl // (ltW z1y).
+    by split => //; rewrite /mkset /z1 (le_trans xz) /= ?lerDl // (ltW z1y).
   by rewrite EU => -[//|]; apply: contra_not ncA1z1; exact: subset_closure.
 Qed.
 End interval_realType.
@@ -3642,8 +3642,8 @@ apply: segment_connected.
     by apply/saxUf; rewrite /= in_itv/= (itvP ayz) lezx.
   exists i => //; apply/xe_fi; rewrite /ball_/= distrC ger0_norm.
     have lezy : z <= y by rewrite (itvP ayz).
-    rewrite ltr_subl_addl; apply: le_lt_trans lezy _; rewrite -ltr_subl_addr.
-    by have := xe_y; rewrite /ball_ => /ltr_distlC_subl.
+    rewrite ltrBlDl; apply: le_lt_trans lezy _; rewrite -ltrBlDr.
+    by have := xe_y; rewrite /ball_ => /ltr_distlCBl.
   by rewrite subr_ge0; apply/ltW.
 exists A; last by rewrite predeqE => x; split=> [[] | []].
 move=> x clAx; have abx : x \in `[a, b].
@@ -3660,8 +3660,8 @@ have [lezy|ltyz] := lerP z y.
   by exists j => //=; rewrite inE orbC Dj.
 exists i; first by rewrite /= !inE eq_refl.
 apply/xe_fi; rewrite /ball_/= ger0_norm; last by rewrite subr_ge0 (itvP axz).
-rewrite ltr_subl_addl -ltr_subl_addr; apply: lt_trans ltyz.
-by apply: ltr_distlC_subl; rewrite distrC.
+rewrite ltrBlDl -ltrBlDr; apply: lt_trans ltyz.
+by apply: ltr_distlCBl; rewrite distrC.
 Qed.
 
 End segment.
@@ -3683,7 +3683,7 @@ move=> leab fcont; gen have ivt : f v fcont / f a <= v <= f b ->
   case: (leP (f a) (f b)) => [] _ fabv /=; first exact: ivt.
   have [| |c cab /oppr_inj] := ivt (- f) (- v); last by exists c.
   - by move=> x /=; apply/continuousN/fcont.
-  - by rewrite ler_oppr opprK ler_oppr opprK andbC.
+  - by rewrite lerNr opprK lerNr opprK andbC.
 move=> favfb; suff: is_interval (f @` `[a,b]).
   apply; last exact: favfb.
   - by exists a => //=; rewrite in_itv/= lexx.
@@ -3851,8 +3851,8 @@ have covA : A `<=` \bigcup_(n : int) [set p | `|p| < n%:~R].
 have /Aco [] := covA.
   move=> n _; rewrite openE => p; rewrite /= -subr_gt0 => ltpn.
   apply/nbhs_ballP; exists (n%:~R - `|p|) => // q.
-  rewrite -ball_normE /= ltr_subr_addr distrC; apply: le_lt_trans.
-  by rewrite -{1}(subrK p q) ler_norm_add.
+  rewrite -ball_normE /= ltrBrDr distrC; apply: le_lt_trans.
+  by rewrite -{1}(subrK p q) ler_normD.
 move=> D _ DcovA.
 exists (\big[maxr/0]_(i : D) (fsval i)%:~R).
 rewrite bigmax_real//; last by move=> ? _; rewrite realz.
@@ -3929,7 +3929,7 @@ have Mnco : compact
   by move=> _; apply: segment_compact.
 apply: subclosed_compact Acl Mnco _ => v /normAltM normvleM i.
 suff : `|v ord0 i : R| <= M + 1 by rewrite ler_norml.
-apply: le_trans (normvleM _ _); last by rewrite ltr_addl.
+apply: le_trans (normvleM _ _); last by rewrite ltrDl.
 have /mapP[j Hj ->] : `|v ord0 i| \in [seq `|v x.1 x.2| | x : 'I_1 * 'I_n.+1].
   by apply/mapP; exists (ord0, i) => //=; rewrite mem_enum.
 by rewrite [leRHS]/normr /= mx_normrE; apply/bigmax_geP; right => /=; exists j.
@@ -4008,7 +4008,7 @@ Lemma ball_open (R : numDomainType) (V : normedModType R) (x : V) (r : R) :
   0 < r -> open (ball x r).
 Proof.
 rewrite openE -ball_normE /interior => r0 y /= Bxy; near=> z.
-rewrite /= (le_lt_trans (ler_dist_add y _ _)) // addrC -ltr_subr_addr.
+rewrite /= (le_lt_trans (ler_distD y _ _)) // addrC -ltrBrDr.
 by near: z; apply: cvgr_dist_lt; rewrite // subr_gt0.
 Unshelve. all: by end_near. Qed.
 
@@ -4049,11 +4049,11 @@ exists (y + (s / 2) *: (`|x - y|^-1 *: (x - y))); split; [apply: Be|apply: B0y].
   rewrite /= opprD addrA -[X in `|X - _|](scale1r (x - y)) scalerA -scalerBl.
   rewrite -[X in X - _](@divrr _ `|x - y|) ?unitfE ?normr_eq0 ?subr_eq0//.
   rewrite -mulrBl -scalerA normrZ normfZV ?subr_eq0// mulr1.
-  rewrite gtr0_norm; first by rewrite ltr_subl_addl xye ltr_addr mulr_gt0.
-  by rewrite subr_gt0 xye ltr_pdivr_mulr // mulr_natr mulr2n ltr_spaddl.
+  rewrite gtr0_norm; first by rewrite ltrBlDl xye ltrDr mulr_gt0.
+  by rewrite subr_gt0 xye ltr_pdivrMr // mulr_natr mulr2n ltr_pwDl.
 rewrite -ball_normE /ball_ /= opprD addrA addrN add0r normrN normrZ.
 rewrite normfZV ?subr_eq0// mulr1 normrM (gtr0_norm s0) gtr0_norm //.
-by rewrite ltr_pdivr_mulr // ltr_pmulr // ltr1n.
+by rewrite ltr_pdivrMr // ltr_pMr // ltr1n.
 Qed.
 
 Lemma closed_ball_closed (R : realFieldType) (V : normedModType R) (x : V)
@@ -4082,7 +4082,7 @@ split=> [/nbhs_ballP[_/posnumP[r] xrB]|[e xeB]]; last first.
   exact: (subset_trans (@subset_closure _ _) xeB).
 exists (r%:num / 2)%:sgn.
 apply: (subset_trans (closed_ball_subset _ _) xrB) => //=.
-by rewrite lter_pdivr_mulr // ltr_pmulr // ltr1n.
+by rewrite lter_pdivrMr // ltr_pMr // ltr1n.
 Qed.
 
 Lemma subset_closed_ball (R : realFieldType) (V : normedModType R) (x : V)
@@ -4108,11 +4108,11 @@ have [-> _|nxt] := eqVneq t x; first exact: ballxx.
 near ((0 : R^o)^') => e; rewrite -ball_normE /closed_ball_ => tsxr.
 pose z := t + `|e| *: (t - x); have /tsxr /= : `|t - z| < s.
   rewrite distrC addrAC subrr add0r normrZ normr_id.
-  rewrite -ltr_pdivl_mulr ?(normr_gt0,subr_eq0) //.
+  rewrite -ltr_pdivlMr ?(normr_gt0,subr_eq0) //.
   by near: e; apply/dnbhs0_lt; rewrite divr_gt0 // normr_gt0 subr_eq0.
 rewrite /z opprD addrA -scalerN -{1}(scale1r (x - t)) opprB -scalerDl normrZ.
-apply lt_le_trans; rewrite ltr_pmull; last by rewrite normr_gt0 subr_eq0 eq_sym.
-by rewrite ger0_norm // ltr_addl normr_gt0; near: e; exists 1 => /=.
+apply lt_le_trans; rewrite ltr_pMl; last by rewrite normr_gt0 subr_eq0 eq_sym.
+by rewrite ger0_norm // ltrDl normr_gt0; near: e; exists 1 => /=.
 Unshelve. all: by end_near. Qed.
 
 Lemma open_nbhs_closed_ball (R : realType) (V : normedModType R) (x : V)
@@ -4243,15 +4243,15 @@ Lemma linear_boundedP (f : {linear V -> W}) : bounded_near f (nbhs 0) <->
 Proof.
 split=> [|/pinfty_ex_gt0 [r r0 Bf]]; last first.
   apply/ex_bound; exists r; apply/nbhs_norm0P; exists 1 => //= x /=.
-  by rewrite -(gtr_pmulr _ r0) => /ltW; exact/le_trans/Bf.
+  by rewrite -(gtr_pMr _ r0) => /ltW; exact/le_trans/Bf.
 rewrite /bounded_near => /pinfty_ex_gt0 [M M0 /nbhs_norm0P [_/posnumP[e] efM]].
 near (0 : R)^'+ => d; near=> r => x.
 have[->|x0] := eqVneq x 0; first by rewrite raddf0 !normr0 mulr0.
 have nd0 : d / `|x| > 0 by rewrite divr_gt0 ?normr_gt0.
 have: `|f (d / `|x| *: x)| <= M.
   by apply: efM => /=; rewrite normrZ gtr0_norm// divfK ?normr_eq0//.
-rewrite linearZ/= normrZ gtr0_norm// -ler_pdivl_mull//; move/le_trans; apply.
-rewrite invfM invrK mulrAC ler_wpmul2r//; near: r; apply: nbhs_pinfty_ge.
+rewrite linearZ/= normrZ gtr0_norm// -ler_pdivlMl//; move/le_trans; apply.
+rewrite invfM invrK mulrAC ler_wpM2r//; near: r; apply: nbhs_pinfty_ge.
 by rewrite rpredM// ?rpredV ?gtr0_real.
 Unshelve. all: by end_near. Qed.
 
@@ -4260,7 +4260,7 @@ Lemma continuous_linear_bounded (x : V) (f : {linear V -> W}) :
 Proof.
 rewrite /prop_for/continuous_at linear0 /bounded_near => f0.
 near=> M; apply/nbhs0P.
-near do rewrite /= linearD (le_trans (ler_norm_add _ _))// -ler_subr_addl.
+near do rewrite /= linearD (le_trans (ler_normD _ _))// -lerBrDl.
 by apply: cvgr0_norm_le; rewrite // subr_gt0.
 Unshelve. all: by end_near. Qed.
 
@@ -4273,7 +4273,7 @@ Lemma bounded_linear_continuous (f : {linear V -> W}) :
 Proof.
 move=> /linear_boundedP [y [yreal fr]] x; near +oo_R => r.
 apply/(@cvgrPdist_lt _ _ _ (nbhs x)) => e e_gt0; near=> z; rewrite -linearB.
-rewrite (le_lt_trans (fr r _ _))// -?ltr_pdivl_mull//.
+rewrite (le_lt_trans (fr r _ _))// -?ltr_pdivlMl//.
 by near: z; apply: cvgr_dist_lt => //; rewrite mulrC divr_gt0.
 Unshelve. all: by end_near. Qed.
 
@@ -4301,7 +4301,7 @@ split => [/(_ 1) [M Bf]|/linear_boundedP fr y].
   by rewrite sub0r normrN => x1; exact/Bf/ltW.
 near +oo_R => r; exists (r * y) => x xe.
 rewrite (@le_trans _ _ (r * `|x|)) //; first by move: {xe} x; near: r.
-by rewrite ler_pmul //.
+by rewrite ler_pM //.
 Unshelve. all: by end_near. Qed.
 
 End LinearContinuousBounded.

--- a/theories/numfun.v
+++ b/theories/numfun.v
@@ -187,14 +187,14 @@ Lemma lt0_funeposM r f : (r < 0)%R ->
   (fun x => r%:E * f x)^\+ = (fun x => - r%:E * (f^\- x)).
 Proof.
 move=> r0; rewrite -[in LHS](opprK r); under eq_fun do rewrite EFinN mulNe.
-by rewrite funeposN gt0_funenegM -1?ltr_oppr ?oppr0.
+by rewrite funeposN gt0_funenegM -1?ltrNr ?oppr0.
 Qed.
 
 Lemma lt0_funenegM r f : (r < 0)%R ->
   (fun x => r%:E * f x)^\- = (fun x => - r%:E * (f^\+ x)).
 Proof.
 move=> r0; rewrite -[in LHS](opprK r); under eq_fun do rewrite EFinN mulNe.
-by rewrite funenegN gt0_funeposM -1?ltr_oppr ?oppr0.
+by rewrite funenegN gt0_funeposM -1?ltrNr ?oppr0.
 Qed.
 
 Lemma fune_abse f : abse \o f = f^\+ \+ f^\-.

--- a/theories/probability.v
+++ b/theories/probability.v
@@ -488,7 +488,7 @@ rewrite -sqrteM ?variance_ge0//.
 rewrite lee_sqrE ?sqrte_ge0// sqr_sqrte ?mule_ge0 ?variance_ge0//.
 rewrite -(fineK (variance_fin_num X1 X2)) -(fineK (variance_fin_num Y1 Y2)).
 rewrite -(fineK (covariance_fin_num X1 Y1 XY1)).
-rewrite -EFin_expe -EFinM lee_fin -(@ler_pmul2l _ 4) ?ltr0n// [leRHS]mulrA.
+rewrite -EFin_expe -EFinM lee_fin -(@ler_pM2l _ 4) ?ltr0n// [leRHS]mulrA.
 rewrite [in leLHS](_ : 4 = 2 * 2)%R -natrM// natrM mulrACA -expr2 -subr_le0.
 apply: deg_le2_ge0 => r; rewrite -lee_fin !EFinD.
 rewrite EFinM fineK ?variance_fin_num// muleC -varianceZ//.
@@ -602,11 +602,11 @@ have le (u : R) : (0 <= u)%R ->
     by rewrite (varianceD_cst_r _ Y1 Y2) EFinD fineK ?(variance_fin_num Y1 Y2).
   have le : [set x | lambda%:E <= (X x)%:E - 'E_P[X]]
       `<=` [set x | ((lambda + u)^2)%:E <= ((Y x + u)^+2)%:E].
-    move=> x /= le; rewrite lee_fin; apply: ler_expn2r.
+    move=> x /= le; rewrite lee_fin; apply: lerXn2r.
     - exact: addr_ge0 (ltW lambda_gt0) _.
     - apply/(addr_ge0 _ uge0)/(le_trans (ltW lambda_gt0) _).
       by rewrite -lee_fin EFinB finEK.
-    - by rewrite ler_add2r -lee_fin EFinB finEK.
+    - by rewrite lerD2r -lee_fin EFinB finEK.
   apply: (le_trans (le_measure _ _ _ le)).
   - rewrite -[[set _ | _]]setTI inE; apply: emeasurable_fun_c_infty => [//|].
     by apply: emeasurable_funB => //; exact: measurable_int X1.
@@ -616,7 +616,7 @@ have le (u : R) : (0 <= u)%R ->
     apply/measurableT_comp => //; apply/measurable_funD => //.
     by rewrite -EFin_measurable_fun; apply: measurable_int Y1.
   set eps := ((lambda + u) ^ 2)%R.
-  have peps : (0 < eps)%R by rewrite exprz_gt0 ?ltr_paddr.
+  have peps : (0 < eps)%R by rewrite exprz_gt0 ?ltr_wpDr.
   rewrite (lee_pdivl_mulr _ _ peps) muleC.
   under eq_set => x.
     rewrite -[leRHS]gee0_abs ?lee_fin ?sqr_ge0 -?lee_fin => [|//].
@@ -631,8 +631,8 @@ have u0ge0 : (0 <= u0)%R.
   by apply: divr_ge0 (ltW lambda_gt0); rewrite -lee_fin finVK variance_ge0.
 apply: le_trans (le _ u0ge0) _; rewrite lee_fin le_eqVlt; apply/orP; left.
 rewrite eqr_div; [|apply: lt0r_neq0..]; last 2 first.
-- by rewrite exprz_gt0 -1?[ltLHS]addr0 ?ltr_le_add.
-- by rewrite ltr_paddl ?fine_ge0 ?variance_ge0 ?exprz_gt0.
+- by rewrite exprz_gt0 -1?[ltLHS]addr0 ?ltr_leD.
+- by rewrite ltr_wpDl ?fine_ge0 ?variance_ge0 ?exprz_gt0.
 apply/eqP; have -> : fine 'V_P[X] = (u0 * lambda)%R.
   by rewrite /u0 -mulrA mulVr ?mulr1 ?unitfE ?gt_eqF.
 by rewrite -mulrDl -mulrDr (addrC u0) [in RHS](mulrAC u0) -exprnP expr2 !mulrA.

--- a/theories/prodnormedzmodule.v
+++ b/theories/prodnormedzmodule.v
@@ -24,7 +24,7 @@ Definition norm (x : U * V) : R := Num.max `|x.1| `|x.2|.
 
 Lemma normD x y : norm (x + y) <= norm x + norm y.
 Proof.
-rewrite /norm num_le_maxl !(le_trans (ler_norm_add _ _)) ?ler_add//;
+rewrite /norm num_le_maxl !(le_trans (ler_normD _ _)) ?lerD//;
 by rewrite comparable_le_maxr ?lexx ?orbT// real_comparable.
 Qed.
 
@@ -35,7 +35,7 @@ by case/and3P => /eqP -> /eqP ->.
 Qed.
 
 Lemma normMn x n : norm (x *+ n) = (norm x) *+ n.
-Proof. by rewrite /norm pairMnE -mulr_natl maxr_pmulr ?mulr_natl ?normrMn. Qed.
+Proof. by rewrite /norm pairMnE -mulr_natl maxr_pMr ?mulr_natl ?normrMn. Qed.
 
 Lemma normrN x : norm (- x) = norm x.
 Proof. by rewrite /norm/= !normrN. Qed.

--- a/theories/real_interval.v
+++ b/theories/real_interval.v
@@ -31,7 +31,7 @@ move: b i => [] [[]y|[]]; rewrite ?bnd_simp => xy; split=> //; do 1?[
   by exists ((x + y) / 2); rewrite !set_itvE/= addrC !(midf_le,midf_lt) //;
     exact: ltW
 | by exists (x - 1); rewrite !set_itvE/=
-    !(ltr_subl_addr, ler_subl_addr, ltr_addl,ler_addl)].
+    !(ltrBlDr, lerBlDr, ltrDl,lerDl)].
 Qed.
 
 Lemma has_inf_half x b (i : itv_bound R) : (BSide b x < i)%O ->
@@ -41,7 +41,7 @@ move: b i => [] [[]y|[]]; rewrite ?bnd_simp => xy; do 1?[
   by split=> //; exists ((x + y) / 2);
      rewrite !set_itvE/= !(midf_le,midf_lt) //;
      exact: ltW
- | by split => //; exists (x + 1); rewrite !set_itvE/= !(ltr_addl,ler_addl)].
+ | by split => //; exists (x + 1); rewrite !set_itvE/= !(ltrDl,lerDl)].
 Qed.
 
 End interval_has.
@@ -61,7 +61,7 @@ case: b; last first.
   by rewrite -setUitv1// sup_setU ?sup1// => ? ? ? ->; exact/ltW.
 set s := sup _; apply/eqP; rewrite eq_le; apply/andP; split.
 - apply sup_le_ub; last by move=> ? /ltW.
-  by exists (x - 1); rewrite !set_itvE/= ltr_subl_addr ltr_addl.
+  by exists (x - 1); rewrite !set_itvE/= ltrBlDr ltrDl.
 - rewrite leNgt; apply/negP => sx; pose p := (s + x) / 2.
   suff /andP[?]: (p < x) && (s < p) by apply/negP; rewrite -leNgt sup_ub.
   by rewrite !midf_lt.
@@ -102,7 +102,7 @@ Let inf_itv_bnd_o x y b : (BSide b x < BLeft y)%O ->
 Proof.
 case: b => xy.
   by rewrite -setU1itv// inf_setU ?inf1// => _ ? -> /andP[/ltW].
-by rewrite /inf opp_itv_bnd_bnd sup_itv_o_bnd ?opprK // ltr_oppl opprK.
+by rewrite /inf opp_itv_bnd_bnd sup_itv_o_bnd ?opprK // ltrNl opprK.
 Qed.
 
 Let inf_itv_bounded x y a b : (BSide a x < BSide b y)%O ->
@@ -162,12 +162,12 @@ Lemma itv_c_inftyEbigcap x :
   `[x, +oo[%classic = \bigcap_k `]x - k.+1%:R^-1, +oo[%classic.
 Proof.
 rewrite predeqE => y; split=> /= [|xy].
-  rewrite in_itv /= andbT => xy z _ /=; rewrite in_itv /= andbT ltr_subl_addr.
-  by rewrite (le_lt_trans xy) // ltr_addl invr_gt0 ltr0n.
+  rewrite in_itv /= andbT => xy z _ /=; rewrite in_itv /= andbT ltrBlDr.
+  by rewrite (le_lt_trans xy) // ltrDl invr_gt0 ltr0n.
 rewrite in_itv /= andbT leNgt; apply/negP => yx.
 have {}[k ykx] := ltr_add_invr yx.
 have {xy}/= := xy k Logic.I.
-by rewrite in_itv /= andbT; apply/negP; rewrite -leNgt ler_subr_addr ltW.
+by rewrite in_itv /= andbT; apply/negP; rewrite -leNgt lerBrDr ltW.
 Qed.
 
 Lemma itv_bnd_inftyEbigcup b x : [set` Interval (BSide b x) +oo%O] =
@@ -177,7 +177,7 @@ rewrite predeqE => y; split=> /=; last first.
   by move=> [n _]/=; rewrite in_itv => /andP[xy yn]; rewrite in_itv /= xy.
 rewrite in_itv /= andbT => xy; exists `|floor y|%N.+1 => //=.
 rewrite in_itv /= xy /=.
-have [y0|y0] := ltP 0 y; last by rewrite (le_lt_trans y0)// ltr_spaddr.
+have [y0|y0] := ltP 0 y; last by rewrite (le_lt_trans y0)// ltr_pwDr.
 by rewrite -natr1 natr_absz ger0_norm ?floor_ge0 1?ltW// lt_succ_floor.
 Qed.
 
@@ -189,7 +189,7 @@ rewrite predeqE => y; split => [|[n _]]/=.
   have {}[k xky] := ltr_add_invr xy.
   by exists k => //=; rewrite in_itv /= (ltW xky).
 rewrite in_itv /= andbT => xny.
-by rewrite in_itv /= andbT (lt_le_trans _ xny) // ltr_addl invr_gt0.
+by rewrite in_itv /= andbT (lt_le_trans _ xny) // ltrDl invr_gt0.
 Qed.
 
 Lemma set_itv_setT (i : interval R) : [set` i] = setT -> i = `]-oo, +oo[.
@@ -344,9 +344,9 @@ move fxE : (f x) => fx; case: fx fxE => [fx fxE gxE|fxoo gxE _|//]; last first.
   by exists 0%N => //; rewrite /E/= fxoo gxE// addye// leey.
 rewrite lte_fin -subr_gt0 => fgx; exists `|floor (fx - gx)^-1%R|%N => //.
 rewrite /E/= -natr1 natr_absz ger0_norm ?floor_ge0 ?invr_ge0; last exact/ltW.
-rewrite fxE gxE lee_fin -[leRHS]invrK lef_pinv//.
+rewrite fxE gxE lee_fin -[leRHS]invrK lef_pV2//.
 - by apply/ltW; rewrite lt_succ_floor.
-- by rewrite posrE// ltr_spaddr// ler0z floor_ge0 invr_ge0 ltW.
+- by rewrite posrE// ltr_pwDr// ler0z floor_ge0 invr_ge0 ltW.
 - by rewrite posrE invr_gt0.
 Qed.
 

--- a/theories/realfun.v
+++ b/theories/realfun.v
@@ -124,9 +124,9 @@ have aux a c b : a \in I -> b \in I -> a < c -> c < b ->
     have ofC : {within [set` I], continuous (-f)}.
       move=> ?; apply: continuous_comp; [exact: fC | exact: continuousN].
     have ofI : {in I &, injective (-f)} by move=>> ? ? /oppr_inj/fI ->.
-    rewrite -[X in X < _ -> _](opprK (f b)) ltr_oppl => ofaLofb.
+    rewrite -[X in X < _ -> _](opprK (f b)) ltrNl => ofaLofb.
     have := main _ c ofC ofI a b aI bI ofaLofb aLc cLb.
-    by (do 2 rewrite ltr_oppl opprK); rewrite and_comm.
+    by (do 2 rewrite ltrNl opprK); rewrite and_comm.
   split=> [faLfc|fcLfb].
     suff L : f a < f b by have [] := main f c fC fI a b aI bI L aLc cLb.
     by case: ltgtP decr fanfb => // fbfa []//; case: ltgtP faLfc.
@@ -158,9 +158,9 @@ Lemma itv_continuous_inj_ge f (I : interval R) :
   {in I &, {mono f : x y /~ x <= y}}.
 Proof.
 move=> [a [b [aI bI ab fbfa]]] fC fI x y xI yI.
-suff : (- f) y <= (- f) x = (y <= x) by rewrite ler_oppl opprK.
+suff : (- f) y <= (- f) x = (y <= x) by rewrite lerNl opprK.
 apply: itv_continuous_inj_le xI => // [|x1 x1I | x1 x2 x1I x2I].
-- by exists a, b; split => //; rewrite ler_oppl opprK.
+- by exists a, b; split => //; rewrite lerNl opprK.
 - by apply/continuousN/fC.
 by move/oppr_inj; apply/fI.
 Qed.
@@ -236,9 +236,9 @@ Lemma segment_can_ge a b f g : a <= b ->
     {in `[a, b], cancel f g} ->
   {in `[f b, f a] &, {mono g : x y /~ x <= y}}.
 Proof.
-move=> aLb fC fK x y xfbfa yfbfa; rewrite -ler_opp2.
+move=> aLb fC fK x y xfbfa yfbfa; rewrite -lerN2.
 apply: (@segment_can_le (- b) (- a) (f \o -%R) (- g));
-    rewrite /= ?ler_opp2 ?opprK //.
+    rewrite /= ?lerN2 ?opprK //.
   pose fun_neg : subspace `[-b,-a] -> subspace `[a,b] := itvN_oppr a b.
   move=> z; apply: (@continuous_comp _ _ _ [fun of fun_neg]); last exact: fC.
   exact/subspaceT_continuous/continuous_subspaceT/opp_continuous.
@@ -348,16 +348,16 @@ have fxab : f x \in `[f a, f b] by rewrite in_itv/= !fle.
 have := xabcc; rewrite in_itv //= => /andP [ax xb].
 apply/cvgrPdist_lt => _ /posnumP[e]; rewrite !near_simpl; near=> y.
 rewrite (@le_lt_trans _ _ (e%:num / 2%:R))//; last first.
-  by rewrite ltr_pdivr_mulr// ltr_pmulr// ltr1n.
+  by rewrite ltr_pdivrMr// ltr_pMr// ltr1n.
 rewrite ler_distlC; near: y.
 pose u := minr (f x + e%:num / 2) (f b).
 pose l := maxr (f x - e%:num / 2) (f a).
 have ufab : u \in `[f a, f b].
   rewrite !in_itv /= le_minl ?le_minr lexx ?fle // le_ab orbT ?andbT.
-  by rewrite ler_paddr // fle.
+  by rewrite ler_wpDr // fle.
 have lfab : l \in `[f a, f b].
   rewrite !in_itv/= le_maxl ?le_maxr lexx ?fle// le_ab orbT ?andbT.
-  by rewrite ler_subl_addr ler_paddr// fle // lexx.
+  by rewrite lerBlDr ler_wpDr// fle // lexx.
 have guab : g u \in `[a, b].
   rewrite !in_itv; apply/andP; split; have := ufab; rewrite in_itv => /andP.
     by case; rewrite /= -[f _ <= _]gle // ?fK // bound_itvE fle.
@@ -368,21 +368,21 @@ have glab : g l \in `[a, b].
   by case => _; rewrite -[_ <= f _]gle // ?fK // bound_itvE fle.
 have faltu : f a < u.
   rewrite /u comparable_lt_minr ?real_comparable ?num_real// flt// aLb andbT.
-  by rewrite (@le_lt_trans _ _ (f x)) ?fle// ltr_addl.
+  by rewrite (@le_lt_trans _ _ (f x)) ?fle// ltrDl.
 have lltfb : l < f b.
   rewrite /u comparable_lt_maxl ?real_comparable ?num_real// flt// aLb andbT.
-  by rewrite (@lt_le_trans _ _ (f x)) ?fle// ltr_subl_addr ltr_addl.
+  by rewrite (@lt_le_trans _ _ (f x)) ?fle// ltrBlDr ltrDl.
 case: pselect => // _; rewrite near_withinE; near_simpl.
 have Fnbhs : Filter (nbhs x) by apply: nbhs_filter.
 have := ax; rewrite le_eqVlt => /orP[/eqP|] {}ax.
   near=> y => /[dup] yab; rewrite /= in_itv => /andP[ay yb]; apply/andP; split.
-    by rewrite (@le_trans _ _ (f a)) ?fle// ler_subl_addr ax ler_paddr.
+    by rewrite (@le_trans _ _ (f a)) ?fle// lerBlDr ax ler_wpDr.
   apply: ltW; suff : f y < u by rewrite lt_minr => /andP[->].
   rewrite -?[f y < _]glt// ?fK//; last by rewrite in_itv /= !fle.
   by near: y; near_simpl; apply: open_lt; rewrite /= -flt ?gK// -ax.
 have := xb; rewrite le_eqVlt => /orP[/eqP {}xb {ax}|{}xb].
   near=> y => /[dup] yab; rewrite /= in_itv /= => /andP[ay yb].
-  apply/andP; split; last by rewrite (@le_trans _ _ (f b)) ?fle// xb ler_paddr.
+  apply/andP; split; last by rewrite (@le_trans _ _ (f b)) ?fle// xb ler_wpDr.
   apply: ltW; suff : l < f y by rewrite lt_maxl => /andP[->].
   rewrite -?[_ < f y]glt// ?fK//; last by rewrite in_itv /= !fle.
   by near: y; near_simpl; apply: open_gt; rewrite /= -flt// gK// xb.
@@ -393,7 +393,7 @@ have ? : y \in `[a, b] by apply: subset_itv_oo_cc; near: y; apply: near_in_itv.
 have fyab : f y \in `[f a, f b] by rewrite in_itv/= !fle// ?ltW.
 rewrite -[l <= _]gle -?[_ <= u]gle// ?fK //.
 apply: subset_itv_oo_cc; near: y; apply: near_in_itv; rewrite in_itv /=.
-rewrite -[x]fK // !glt//= lt_minr lt_maxl ?andbT ltr_subl_addr ltr_spaddr //.
+rewrite -[x]fK // !glt//= lt_minr lt_maxl ?andbT ltrBlDr ltr_pwDr //.
 by apply/and3P; split; rewrite // flt.
 Unshelve. all: by end_near. Qed.
 
@@ -406,7 +406,7 @@ move=> fge f_surj; suff: {within `[a, b], continuous (- f)}.
   move=> contNf x xab; rewrite -[f]opprK.
   exact/continuous_comp/opp_continuous/contNf.
 apply: segment_inc_surj_continuous.
-  by move=> x y xab yab; rewrite ler_opp2 fge.
+  by move=> x y xab yab; rewrite lerN2 fge.
 by move=> y /=; rewrite -oppr_itvcc => /f_surj[x ? /(canLR opprK)<-]; exists x.
 Qed.
 
@@ -461,7 +461,7 @@ Lemma near_can_continuousAcan_sym f g (x : R) :
   {near f x, continuous g} /\ {near f x, cancel g f}.
 Proof.
 move=> fK fct; near (0 : R)^'+ => e; have e_gt0 : 0 < e by [].
-have xBeLxDe : x - e <= x + e by rewrite ler_add2l gt0_cp.
+have xBeLxDe : x - e <= x + e by rewrite lerD2l gt0_cp.
 have fcte : {in `[x - e, x + e], continuous f}.
   by near: e; apply/at_right_in_segment.
 have fwcte : {within `[x - e, x + e], continuous f}.

--- a/theories/reals.v
+++ b/theories/reals.v
@@ -78,7 +78,7 @@ Proof. by rewrite predeqE => r; split => // _. Qed.
 Lemma lboundT : lbound [set: R] = set0.
 Proof.
 rewrite predeqE => r; split => // /(_ (r - 1) Logic.I).
-rewrite ler_subr_addl addrC -ler_subr_addl subrr.
+rewrite lerBrDl addrC -lerBrDl subrr.
 by rewrite real_leNgt ?realE ?ler01// ?lexx// ltr01.
 Qed.
 
@@ -185,13 +185,13 @@ Lemma Rint_ler_addr1 (x y : R) : x \is a Rint -> y \is a Rint ->
   (x + 1 <= y) = (x < y).
 Proof.
 move=> /RintP[xi ->] /RintP[yi ->]; rewrite -{2}[1]mulr1z.
-by rewrite -intrD !(ltr_int, ler_int) lez_addr1.
+by rewrite -intrD !(ltr_int, ler_int) lezD1.
 Qed.
 
 Lemma Rint_ltr_addr1 (x y : R) : x \is a Rint -> y \is a Rint ->
   (x < y + 1) = (x <= y).
 move=> /RintP[xi ->] /RintP[yi ->]; rewrite -{3}[1]mulr1z.
-by rewrite -intrD !(ltr_int, ler_int) ltz_addr1.
+by rewrite -intrD !(ltr_int, ler_int) ltzD1.
 Qed.
 
 End IsInt.
@@ -293,11 +293,11 @@ have Dz: 2%:R * z = x + y.
   by rewrite mulrCA divff ?mulr1 // pnatr_eq0.
 have ubE : has_sup E by split => //; exists x.
 have [/downP [t Et lezt] | leyz] := sup_total z ubE.
-  rewrite -(ler_add2l x) -Dz -mulr2n -[leRHS]mulr_natl.
-  rewrite ler_pmul2l ?ltr0Sn //; apply/(le_trans lezt).
+  rewrite -(lerD2l x) -Dz -mulr2n -[leRHS]mulr_natl.
+  rewrite ler_pM2l ?ltr0Sn //; apply/(le_trans lezt).
   by move/ubP : leEx; exact.
-rewrite -(ler_add2r y) -Dz -mulr2n -[leLHS]mulr_natl.
-by rewrite ler_pmul2l ?ltr0Sn.
+rewrite -(lerD2r y) -Dz -mulr2n -[leLHS]mulr_natl.
+by rewrite ler_pM2l ?ltr0Sn.
 Qed.
 
 Lemma sup_setU (A B : set R) : has_sup B ->
@@ -331,7 +331,7 @@ Implicit Types x : R.
 Lemma inf_lower_bound E : has_inf E -> lbound E (inf E).
 Proof.
 move=> /has_inf_supN /sup_upper_bound /ubP inflb; apply/lbP => x.
-by rewrite memNE => /inflb; rewrite ler_oppl.
+by rewrite memNE => /inflb; rewrite lerNl.
 Qed.
 
 Lemma inf_adherent E (eps : R) : 0 < eps ->
@@ -339,7 +339,7 @@ Lemma inf_adherent E (eps : R) : 0 < eps ->
 Proof.
 move=> + /has_inf_supN supNE => /sup_adherent /(_ supNE)[e NEx egtsup].
 exists (- e); first by case: NEx => x Ex <-{}; rewrite opprK.
-by rewrite ltr_oppl -mulN1r mulrDr !mulN1r opprK.
+by rewrite ltrNl -mulN1r mulrDr !mulN1r opprK.
 Qed.
 
 Lemma inf_out E : ~ has_inf E -> inf E = 0.
@@ -366,7 +366,7 @@ Qed.
 
 Lemma lb_le_inf E x : nonempty E -> (lbound E) x -> x <= inf E.
 Proof.
-by move=> /(nonemptyN E) En0 /lb_ubN /(sup_le_ub En0); rewrite ler_oppr.
+by move=> /(nonemptyN E) En0 /lb_ubN /(sup_le_ub En0); rewrite lerNr.
 Qed.
 
 Lemma has_infPn E : nonempty E ->
@@ -381,14 +381,14 @@ Lemma inf_setU (A B : set R) : has_inf A ->
 Proof.
 move=> hiA AB; congr (- _).
 rewrite image_setU setUC sup_setU //; first exact/has_inf_supN.
-by move=> _ _ [] b Bb <-{} [] a Aa <-{}; rewrite ler_oppl opprK; apply AB.
+by move=> _ _ [] b Bb <-{} [] a Aa <-{}; rewrite lerNl opprK; apply AB.
 Qed.
 
 Lemma inf_lt (S : set R) (x : R) : S !=set0 ->
   (inf S < x -> exists2 y, S y & y < x)%R.
 Proof.
-move=> /nonemptyN S0; rewrite /inf ltr_oppl => /sup_gt => /(_ S0)[r [r' Sr']].
-by move=> <-; rewrite ltr_oppr opprK => r'x; exists r'.
+move=> /nonemptyN S0; rewrite /inf ltrNl => /sup_gt => /(_ S0)[r [r' Sr']].
+by move=> <-; rewrite ltrNr opprK => r'x; exists r'.
 Qed.
 
 End InfTheory.
@@ -402,7 +402,7 @@ Implicit Types x y : R.
 Lemma has_sup_floor_set x : has_sup (floor_set x).
 Proof.
 split; [exists (- (Num.bound (-x))%:~R) | exists (Num.bound x)%:~R].
-  rewrite /floor_set/mkset rpredN rpred_int /= ler_oppl.
+  rewrite /floor_set/mkset rpredN rpred_int /= lerNl.
   case: (ger0P (-x)) => [/archi_boundP/ltW//|].
   by move/ltW/le_trans; apply; rewrite ler0z.
 apply/ubP=> y /andP[_] /le_trans; apply.
@@ -415,12 +415,12 @@ Proof.
 have /(sup_adherent ltr01) [y Fy] := has_sup_floor_set x.
 have /sup_upper_bound /ubP /(_ _ Fy) := has_sup_floor_set x.
 rewrite le_eqVlt=> /orP[/eqP<-//| lt_yFx].
-rewrite ltr_subl_addr -ltr_subl_addl => lt1_FxBy.
+rewrite ltrBlDr -ltrBlDl => lt1_FxBy.
 pose e := sup (floor_set x) - y; have := has_sup_floor_set x.
 move/sup_adherent=> -/(_ e) []; first by rewrite subr_gt0.
 move=> z Fz; rewrite /e opprB addrCA subrr addr0 => lt_yz.
 have /sup_upper_bound /ubP /(_ _ Fz) := has_sup_floor_set x.
-rewrite -(ler_add2r (-y)) => /le_lt_trans /(_ lt1_FxBy).
+rewrite -(lerD2r (-y)) => /le_lt_trans /(_ lt1_FxBy).
 case/andP: Fy Fz lt_yz=> /RintP[yi -> _].
 case/andP=> /RintP[zi -> _]; rewrite -rmorphB /= ltrz1 ltr_int.
 rewrite lt_neqAle => /andP[ne_yz le_yz].
@@ -442,7 +442,7 @@ have [|] := pselect ((floor_set x) (Rfloor x + 1)); last first.
   rewrite /floor_set => /negP.
   by rewrite negb_and -ltNge rpredD // ?(Rint1, isint_Rfloor).
 move/ubP : (sup_upper_bound (has_sup_floor_set x)) => h/h.
-by rewrite ger_addl ler10.
+by rewrite gerDl ler10.
 Qed.
 
 Lemma Rfloor_le x : Rfloor x <= x.
@@ -460,12 +460,12 @@ Proof.
 move=> /andP[m1x x_m1] /andP[m2x x_m2].
 wlog suffices: m1 m2 m1x {x_m1 m2x} x_m2 / (m1 <= m2).
   by move=> ih; apply/eqP; rewrite eq_le !ih.
-rewrite -(ler_add2r 1) lez_addr1 -(@ltr_int R) intrD.
+rewrite -(lerD2r 1) lezD1 -(@ltr_int R) intrD.
 exact/(le_lt_trans m1x).
 Qed.
 
 Lemma range1rr x : (range1 x) x.
-Proof. by rewrite /range1/mkset lexx /= ltr_addl ltr01. Qed.
+Proof. by rewrite /range1/mkset lexx /= ltrDl ltr01. Qed.
 
 Lemma range1zP (m : int) x : Rfloor x = m%:~R <-> (range1 m%:~R) x.
 Proof.
@@ -547,7 +547,7 @@ Proof. by rewrite Rfloor_ge_int RfloorE ler_int. Qed.
 Lemma ltr_add_invr (y x : R) : y < x -> exists k, y + k.+1%:R^-1 < x.
 Proof.
 move=> yx; exists `|floor (x - y)^-1|%N.
-rewrite -ltr_subr_addl -{2}(invrK (x - y)%R) ltf_pinv ?qualifE/= ?ltr0n//.
+rewrite -ltrBrDl -{2}(invrK (x - y)%R) ltf_pV2 ?qualifE/= ?ltr0n//.
   by rewrite invr_gt0 subr_gt0.
 rewrite -natr1 natr_absz ger0_norm.
   by rewrite floor_ge0 invr_ge0 subr_ge0 ltW.
@@ -568,10 +568,10 @@ Lemma Rceil0 : Rceil 0 = 0 :> R.
 Proof. by rewrite /Rceil oppr0 Rfloor0 oppr0. Qed.
 
 Lemma Rceil_ge x : x <= Rceil x.
-Proof. by rewrite /Rceil ler_oppr Rfloor_le. Qed.
+Proof. by rewrite /Rceil lerNr Rfloor_le. Qed.
 
 Lemma le_Rceil : {homo (@Rceil R) : x y / x <= y}.
-Proof. by move=> x y ?; rewrite ler_oppl opprK le_Rfloor // ler_oppl opprK. Qed.
+Proof. by move=> x y ?; rewrite lerNl opprK le_Rfloor // lerNl opprK. Qed.
 
 Lemma Rceil_ge0 x : 0 <= x -> 0 <= Rceil x.
 Proof. by move=> ?; rewrite -Rceil0 le_Rceil. Qed.
@@ -586,16 +586,16 @@ Lemma ceil_ge0 x : 0 <= x -> 0 <= ceil x.
 Proof. by move/(ge_trans (ceil_ge x)); rewrite -(ler_int R). Qed.
 
 Lemma ceil_gt0 x : 0 < x -> 0 < ceil x.
-Proof. by move=> ?; rewrite /ceil oppr_gt0 floor_lt0 // ltr_oppl oppr0. Qed.
+Proof. by move=> ?; rewrite /ceil oppr_gt0 floor_lt0 // ltrNl oppr0. Qed.
 
 Lemma ceil_le0 x : x <= 0 -> ceil x <= 0.
-Proof. by move=> x0; rewrite -ler_oppl oppr0 floor_ge0 -ler_oppr oppr0. Qed.
+Proof. by move=> x0; rewrite -lerNl oppr0 floor_ge0 -lerNr oppr0. Qed.
 
 Lemma le_ceil : {homo @ceil R : x y / x <= y}.
-Proof. by move=> x y xy; rewrite ler_oppl opprK le_floor // ler_oppl opprK. Qed.
+Proof. by move=> x y xy; rewrite lerNl opprK le_floor // lerNl opprK. Qed.
 
 Lemma ceil_ge_int x (z : int) : (x <= z%:~R) = (ceil x <= z).
-Proof. by rewrite /ceil ler_oppl -floor_ge_int// -ler_oppr mulrNz opprK. Qed.
+Proof. by rewrite /ceil lerNl -floor_ge_int// -lerNr mulrNz opprK. Qed.
 
 Lemma ceil_lt_int x (z : int) : (z%:~R < x) = (z < ceil x).
 Proof. by rewrite ltNge ceil_ge_int -ltNge. Qed.
@@ -687,7 +687,7 @@ have i0i1n : i0 - (i + 1) = n by rewrite opprD addrA i0in1 -addn1 PoszD addrK.
 have [?|/not_forallP] := pselect (lbound B (i + 1)); first exact: (ih (i + 1)).
 move=> /contrapT[x /not_implyP[Bx i1x]]; exists x; split => // k Bk.
 rewrite (le_trans _ (lbBi _ Bk)) //.
-by move/negP : i1x; rewrite -ltNge ltz_addr1.
+by move/negP : i1x; rewrite -ltNge ltzD1.
 Qed.
 
 Section rat_in_itvoo.
@@ -699,7 +699,7 @@ Let archi_bound_divP (R : archiFieldType) (x y : R) :
   0 < x -> y < x *+ bound_div x y.
 Proof.
 move=> x0; have [y0|y0] := leP 0 y; last by rewrite /bound_div y0 mulr0n.
-rewrite /bound_div (ltNge y 0) y0/= -mulr_natl -ltr_pdivr_mulr//.
+rewrite /bound_div (ltNge y 0) y0/= -mulr_natl -ltr_pdivrMr//.
 by rewrite archi_boundP// (divr_ge0 _(ltW _)).
 Qed.
 
@@ -722,31 +722,31 @@ have [m2 m2nx] : exists m2, m2.+1%:~R > - x *+ n.
   by rewrite mulrn_wge0 // oppr_ge0.
 have : exists m, -(m2.+1 : int) <= m <= m1.+1 /\ m%:~R - 1 <= x *+ n < m%:~R.
   have m2m1 : - (m2.+1 : int) < m1.+1.
-    by rewrite -(ltr_int R) (lt_trans _ m1nx)// rmorphN /= ltr_oppl // -mulNrn.
+    by rewrite -(ltr_int R) (lt_trans _ m1nx)// rmorphN /= ltrNl // -mulNrn.
   pose B := [set m : int | m%:~R > x *+ n].
   have m1B : B m1.+1 by [].
   have m2B : lbound B (- m2.+1%:~R).
-    move=> i; rewrite /B /= -(opprK (x *+ n)) -ltr_oppl -mulNrn => nxi.
-    rewrite -(mulN1r m2.+1%:~R) mulN1r -ler_oppl.
+    move=> i; rewrite /B /= -(opprK (x *+ n)) -ltrNl -mulNrn => nxi.
+    rewrite -(mulN1r m2.+1%:~R) mulN1r -lerNl.
     by have := lt_trans nxi m2nx; rewrite intz -mulrNz ltr_int => /ltW.
   have [m [Bm infB]] := int_lbound_has_minimum (ex_intro _ _ m1B) m2B.
   have mN1B : ~ B (m - 1).
-    by move=> /infB; apply/negP; rewrite -ltNge ltr_subl_addr ltz_addr1.
+    by move=> /infB; apply/negP; rewrite -ltNge ltrBlDr ltzD1.
   exists m; split; [apply/andP; split|apply/andP; split] => //.
   - by move: m2B; rewrite /lbound /= => /(_ _ Bm); rewrite intz.
   - exact: infB.
   - by rewrite leNgt; apply/negP; rewrite /B /= intrD in mN1B.
 move=> [m [/andP[m2m mm1] /andP[mnx nxm]]].
 have [/andP[a b] c] : x *+ n < m%:~R <= 1 + x *+ n /\ 1 + x *+ n < y *+ n.
-  split; [apply/andP; split|] => //; first by rewrite -ler_subl_addl.
-  by move: nyx; rewrite mulrnDl -ltr_subr_addr mulNrn.
+  split; [apply/andP; split|] => //; first by rewrite -lerBlDl.
+  by move: nyx; rewrite mulrnDl -ltrBrDr mulNrn.
 have n_gt0 : n != 0%N by apply: contraTN nyx => /eqP ->; rewrite mulr0n ltr10.
 exists (m%:Q / n%:Q); rewrite in_itv /=; apply/andP; split.
   rewrite rmorphM/= (@rmorphV _ _ _ n%:~R); first by rewrite unitfE // intr_eq0.
-  rewrite ltr_pdivl_mulr /=; first by rewrite ltr0q ltr0z ltz_nat lt0n.
+  rewrite ltr_pdivlMr /=; first by rewrite ltr0q ltr0z ltz_nat lt0n.
   by rewrite mulrC // !ratr_int mulr_natl.
 rewrite rmorphM /= (@rmorphV _ _ _ n%:~R); first by rewrite unitfE // intr_eq0.
-rewrite ltr_pdivr_mulr /=; first by rewrite ltr0q ltr0z ltz_nat lt0n.
+rewrite ltr_pdivrMr /=; first by rewrite ltr0q ltr0z ltz_nat lt0n.
 by rewrite 2!ratr_int mulr_natr (le_lt_trans _ c).
 Qed.
 

--- a/theories/sequences.v
+++ b/theories/sequences.v
@@ -137,19 +137,19 @@ Notation "'decreasing_seq' f" := ({mono f : n m / (n <= m)%nat >-> (n >= m)%O})
 
 Lemma nondecreasing_opp (T : numDomainType) (u_ : T ^nat) :
   nondecreasing_seq (- u_) = nonincreasing_seq u_.
-Proof. by rewrite propeqE; split => du x y /du; rewrite ler_opp2. Qed.
+Proof. by rewrite propeqE; split => du x y /du; rewrite lerN2. Qed.
 
 Lemma nonincreasing_opp (T : numDomainType) (u_ : T ^nat) :
   nonincreasing_seq (- u_) = nondecreasing_seq u_.
-Proof. by rewrite propeqE; split => du x y /du; rewrite ler_opp2. Qed.
+Proof. by rewrite propeqE; split => du x y /du; rewrite lerN2. Qed.
 
 Lemma decreasing_opp (T : numDomainType) (u_ : T ^nat) :
   decreasing_seq (- u_) = increasing_seq u_.
-Proof. by rewrite propeqE; split => du x y; rewrite -du ler_opp2. Qed.
+Proof. by rewrite propeqE; split => du x y; rewrite -du lerN2. Qed.
 
 Lemma increasing_opp (T : numDomainType) (u_ : T ^nat) :
   increasing_seq (- u_) = decreasing_seq u_.
-Proof. by rewrite propeqE; split => du x y; rewrite -du ler_opp2. Qed.
+Proof. by rewrite propeqE; split => du x y; rewrite -du lerN2. Qed.
 
 Lemma nondecreasing_seqP (d : unit) (T : porderType d) (u_ : T ^nat) :
   (forall n, u_ n <= u_ n.+1)%O <-> nondecreasing_seq u_.
@@ -191,7 +191,7 @@ Lemma nondecreasing_seqD T (d : unit) (R : numDomainType) (f g : (T -> R)^nat) :
   (forall x, nondecreasing_seq (f ^~ x)) ->
   (forall x, nondecreasing_seq (g ^~ x)) ->
   (forall x, nondecreasing_seq ((f \+ g) ^~ x)).
-Proof. by move=> ndf ndg t m n mn; apply: ler_add; [exact/ndf|exact/ndg]. Qed.
+Proof. by move=> ndf ndg t m n mn; apply: lerD; [exact/ndf|exact/ndg]. Qed.
 
 Local Notation eqolimn := (@eqolim _ _ _ eventually_filter).
 Local Notation eqolimPn := (@eqolimP _ _ _ eventually_filter).
@@ -466,7 +466,7 @@ near \oo => N.
 have /du uNp : (p <= N)%nat by near: N; rewrite nearE; exists p.
 have : `|limn u_ - u_ N| >= `|u_ p - limn u_|%R.
  rewrite ltr0_norm // ?subr_lt0 // opprB distrC.
- rewrite (@le_trans _ _ (limn u_ - u_ N)) // ?ler_sub //.
+ rewrite (@le_trans _ _ (limn u_ - u_ N)) // ?lerB //.
  rewrite (_ : `| _ | = `|u_ N - limn u_|%R) // ler0_norm // ?opprB //.
  by rewrite subr_le0 (le_trans _ (ltW up0)).
 rewrite leNgt => /negP; apply; by near: N.
@@ -477,7 +477,7 @@ Lemma nondecreasing_cvg_le u_ : nondecreasing_seq u_ -> cvgn u_ ->
 Proof.
 move=> iu cu n; move: (@nonincreasing_cvg_ge (- u_)).
 rewrite -nondecreasing_opp opprK => /(_ iu); rewrite is_cvgNE => /(_ cu n).
-by rewrite limN // ler_oppl opprK.
+by rewrite limN // lerNl opprK.
 Qed.
 
 Lemma cvg_has_ub u_ : cvgn u_ -> has_ubound [set `|u_ n| | n in setT].
@@ -690,7 +690,7 @@ have [p /andP[Mu_p u_pM]] : exists p, M - e%:num <= u_ p <= M.
   have [_ -[p _] <- /ltW Mu_p] := sup_adherent (gt0 e) su_.
   by exists p; rewrite Mu_p; have /ubP := sup_upper_bound su_; apply; exists p.
 near=> n; have pn : (p <= n)%N by near: n; exact: nbhs_infty_ge.
-rewrite ler_distlC (le_trans Mu_p (leu _ _ _))//= (@le_trans _ _ M) ?ler_addl//.
+rewrite ler_distlC (le_trans Mu_p (leu _ _ _))//= (@le_trans _ _ M) ?lerDl//.
 by have /ubP := sup_upper_bound su_; apply; exists n.
 Unshelve. all: by end_near. Qed.
 
@@ -739,8 +739,8 @@ Lemma near_nonincreasing_is_cvg (u_ : R ^nat) (m : R) :
 Proof.
 move=> u_ni u_m.
 rewrite -(opprK u_); apply: is_cvgN; apply/(@near_nondecreasing_is_cvg _ (- m)).
-- by apply: filterS u_ni => x u_x y xy; rewrite ler_oppl opprK u_x.
-- by apply: filterS u_m => x u_x; rewrite ler_oppl opprK.
+- by apply: filterS u_ni => x u_x y xy; rewrite lerNl opprK u_x.
+- by apply: filterS u_m => x u_x; rewrite lerNl opprK.
 Qed.
 
 Lemma adjacent (u_ v_ : R ^nat) : nondecreasing_seq u_ -> nonincreasing_seq v_ ->
@@ -750,7 +750,7 @@ Proof.
 set w_ := v_ - u_ => iu dv w0; have vu n : v_ n >= u_ n.
   suff : limn w_ <= w_ n by rewrite (cvg_lim _ w0)// subr_ge0.
   apply: (nonincreasing_cvg_ge _ (cvgP _ w0)) => m p mp.
-  by rewrite ler_sub; rewrite ?iu ?dv.
+  by rewrite lerB; rewrite ?iu ?dv.
 have cu : cvgn u_.
   apply: nondecreasing_is_cvg => //; exists (v_ 0%N) => _ [n _ <-].
   by rewrite (le_trans (vu _)) // dv.
@@ -774,7 +774,7 @@ Proof. exact/ltW/harmonic_gt0. Qed.
 Lemma cvg_harmonic {R : archiFieldType} : @harmonic R @ \oo --> 0.
 Proof.
 apply/cvgrPdist_le => _/posnumP[e]; near=> i.
-rewrite distrC subr0 ger0_norm//= -lef_pinv ?qualifE//= invrK.
+rewrite distrC subr0 ger0_norm//= -lef_pV2 ?qualifE//= invrK.
 rewrite (le_trans (ltW (archi_boundP _)))// ler_nat -add1n -leq_subLR.
 by near: i; apply: nbhs_infty_ge.
 Unshelve. all: by end_near. Qed.
@@ -786,7 +786,7 @@ have ge_half n : (0 < n)%N -> 2^-1 <= \sum_(n <= i < n.*2) harmonic i.
   rewrite (@le_trans _ _ (\sum_(n.+1 <= i < n.+1.*2) n.+1.*2%:R^-1)) //=.
     rewrite sumr_const_nat -addnn addnK addnn -mul2n natrM invfM.
     by rewrite -[_ *+ n.+1]mulr_natr divfK.
-  by apply: ler_sum_nat => i /andP[? ?]; rewrite lef_pinv ?qualifE/= ?ler_nat.
+  by apply: ler_sum_nat => i /andP[? ?]; rewrite lef_pV2 ?qualifE/= ?ler_nat.
 move/cvg_cauchy/cauchy_ballP => /(_ _ [gt0 of 2^-1 : R]); rewrite !near_map2.
 rewrite -ball_normE => /nearP_dep hcvg; near \oo => n; near \oo => m.
 have: `|series harmonic n - series harmonic m| < 2^-1 :> R by near: m; near: n.
@@ -795,7 +795,7 @@ rewrite sub_series_geq; last by near: m; apply: nbhs_infty_ge.
 rewrite -addrA sub_series_geq -addnn ?leq_addr// addnn.
 have sh_ge0 i j : 0 <= \sum_(i <= k < j) harmonic k :> R.
   by rewrite ?sumr_ge0//; move=> k _; apply: harmonic_ge0.
-by rewrite ger0_norm// ler_paddl// ge_half//; near: n.
+by rewrite ger0_norm// ler_wpDl// ge_half//; near: n.
 Unshelve. all: by end_near. Qed.
 
 Definition arithmetic_mean (R : numDomainType) (u_ : R ^nat) : R ^nat :=
@@ -817,23 +817,23 @@ Theorem cesaro (u_ : R ^nat) (l : R) : u_ @ \oo --> l ->
 Proof.
 move=> u0_cvg; have ssplit v_ m n : (m <= n)%N -> `|n%:R^-1 * series v_ n| <=
     n%:R^-1 * `|series v_ m| + n%:R^-1 * `|\sum_(m <= i < n) v_ i|.
-  move=> /subnK<-; rewrite series_addn mulrDr (le_trans (ler_norm_add _ _))//.
+  move=> /subnK<-; rewrite series_addn mulrDr (le_trans (ler_normD _ _))//.
   by rewrite !normrM ger0_norm.
 apply/cvgrPdist_lt=> _/posnumP[e]; near \oo => m; near=> n.
 have {}/ssplit -/(_ _ [sequence l - u_ n]_n) : (m.+1 <= n.+1)%nat.
   by near: n; exists m.
 rewrite !seriesEnat /= big_split/=.
 rewrite sumrN mulrBr sumr_const_nat -(mulr_natl l) mulKf//.
-move=> /le_lt_trans->//; rewrite [e%:num]splitr ltr_add//.
+move=> /le_lt_trans->//; rewrite [e%:num]splitr ltrD//.
   have [->|neq0] := eqVneq (\sum_(0 <= k < m.+1) (l - u_ k)) 0.
     by rewrite normr0 mulr0.
-  rewrite -ltr_pdivl_mulr ?normr_gt0//.
-  rewrite -ltf_pinv ?qualifE//= ?mulr_gt0 ?invr_gt0 ?normr_gt0// invrK.
+  rewrite -ltr_pdivlMr ?normr_gt0//.
+  rewrite -ltf_pV2 ?qualifE//= ?mulr_gt0 ?invr_gt0 ?normr_gt0// invrK.
   rewrite (lt_le_trans (archi_boundP _))// ler_nat leqW//.
   by near: n; apply: nbhs_infty_ge.
-rewrite ltr_pdivr_mull ?ltr0n // (le_lt_trans (ler_norm_sum _ _ _)) //.
+rewrite ltr_pdivrMl ?ltr0n // (le_lt_trans (ler_norm_sum _ _ _)) //.
 rewrite (le_lt_trans (@ler_sum_nat _ _ _ _ (fun i => e%:num / 2) _))//; last first.
-  by rewrite sumr_const_nat mulr_natl ltr_pmuln2l// ltn_subrL.
+  by rewrite sumr_const_nat mulr_natl ltr_pMn2l// ltn_subrL.
 move=> i /andP[mi _]; move: i mi; near: m.
 have : \forall x \near \oo, `|l - u_ x| < e%:num / 2.
   by move/cvgrPdist_lt : u0_cvg; apply.
@@ -857,8 +857,8 @@ have /andP[n0] : ((0 < n) && (m <= n.-1))%N.
   near: n; exists m.+1 => // k mk; rewrite (leq_trans _ mk) //=.
   by rewrite -(leq_add2r 1%N) !addn1 prednK // (leq_trans _ mk).
 move/mu => {mu}; rewrite sub0r normrN /= prednK //; apply: le_lt_trans.
-rewrite !normrM ler_wpmul2r // ger0_norm // ger0_norm //.
-by rewrite lef_pinv // ?ler_nat // posrE // ltr0n.
+rewrite !normrM ler_wpM2r // ger0_norm // ger0_norm //.
+by rewrite lef_pV2 // ?ler_nat // posrE // ltr0n.
 Unshelve. all: by end_near. Qed.
 
 Lemma cesaro_converse (u_ : R ^nat) (l : R) :
@@ -885,7 +885,7 @@ suff abel : forall n,
     rewrite a_o.
     set h := 'o_\oo (@harmonic R).
     apply/eqoP => _/posnumP[e] /=.
-    near=> n; rewrite normr1 mulr1 normrM -ler_pdivl_mull// ?normr_gt0//.
+    near=> n; rewrite normr1 mulr1 normrM -ler_pdivlMl// ?normr_gt0//.
     rewrite mulrC -normrV ?unitfE //.
     near: n.
     by case: (eqoP eventually_filterType (@harmonic R) h) => Hh _; apply Hh.
@@ -950,14 +950,14 @@ Lemma nondecreasing_series (R : numFieldType) (u_ : R ^nat) (P : pred nat) :
 Proof.
 move=> u_ge0; apply/nondecreasing_seqP => n.
 rewrite [in leRHS]big_mkcond [in leRHS]big_nat_recr//=.
-by rewrite -[in leRHS]big_mkcond/= ler_addl; case: ifPn => //; exact: u_ge0.
+by rewrite -[in leRHS]big_mkcond/= lerDl; case: ifPn => //; exact: u_ge0.
 Qed.
 
 Lemma increasing_series (R : numFieldType) (u_ : R ^nat) :
   (forall n, 0 < u_ n) -> increasing_seq (series u_).
 Proof.
 move=> u_ge0; apply/increasing_seqP => n.
-by rewrite !seriesEord/= big_ord_recr ltr_addl.
+by rewrite !seriesEord/= big_ord_recr ltrDl.
 Qed.
 
 End series_convergence.
@@ -978,7 +978,7 @@ Lemma cvg_arithmetic (R : archiFieldType) a (z : R) :
   z > 0 -> arithmetic a z @ \oo --> +oo.
 Proof.
 move=> z_gt0; apply/cvgryPge => A; near=> n => /=.
-rewrite -ler_subl_addl -mulr_natl -ler_pdivr_mulr//.
+rewrite -lerBlDl -mulr_natl -ler_pdivrMr//.
 rewrite ler_normlW// ltW// (lt_le_trans (archi_boundP _))// ler_nat.
 by near: n; apply: nbhs_infty_ge.
 Unshelve. all: by end_near. Qed.
@@ -990,10 +990,10 @@ move=> Nz_lt1; apply/norm_cvg0P; pose t := (1 - `|z|).
 apply: (@squeeze_cvgr _ _ _ _ (cst 0) _ (t^-1 *: @harmonic R)); last 2 first.
 - exact: cvg_cst.
 - by rewrite -(scaler0 _ t^-1); exact: (cvgZr cvg_harmonic).
-near=> n; rewrite normr_ge0 normrX/= ler_pdivl_mull ?subr_gt0//.
-rewrite -(@ler_pmul2l _ n.+1%:R)// mulfV// [t * _]mulrC mulr_natl.
+near=> n; rewrite normr_ge0 normrX/= ler_pdivlMl ?subr_gt0//.
+rewrite -(@ler_pM2l _ n.+1%:R)// mulfV// [t * _]mulrC mulr_natl.
 have -> : 1 = (`|z| + t) ^+ n.+1 by rewrite addrC addrNK expr1n.
-rewrite exprDn (bigD1 (inord 1)) ?inordK// subn1 expr1 bin1 ler_addl sumr_ge0//.
+rewrite exprDn (bigD1 (inord 1)) ?inordK// subn1 expr1 bin1 lerDl sumr_ge0//.
 by move=> i; rewrite ?(mulrn_wge0, mulr_ge0, exprn_ge0, subr_ge0)// ltW.
 Unshelve. all: by end_near. Qed.
 
@@ -1115,7 +1115,7 @@ move=> k0 kfK; have [K0|K0] := lerP K 0.
   + near: x; exists (k / 2); first by rewrite /mkset divr_gt0.
     move=> t /=; rewrite distrC subr0 => tk2 t0.
     by rewrite normr_gt0 t0 (lt_trans tk2) // -[in ltLHS](add0r k) midf_lt.
-  + rewrite normr1 mulr1 mulrC -ler_pdivl_mulr //.
+  + rewrite normr1 mulr1 mulrC -ler_pdivlMr //.
     near: x; exists (e%:num / K); first by rewrite /mkset divr_gt0.
     by move=> t /=; rewrite distrC subr0 => /ltW.
 Unshelve. all: by end_near. Qed.
@@ -1168,7 +1168,7 @@ Let is_cvg_S0 N : x < N%:R -> cvgn (S0 N).
 Proof.
 move=> xN; apply: is_cvgZr; rewrite is_cvg_series_restrict exprn_geometric.
 apply/is_cvg_geometric_series; rewrite normrM normfV.
-by rewrite ltr_pdivr_mulr ?mul1r !ger0_norm // 1?ltW // (lt_trans x0).
+by rewrite ltr_pdivrMr ?mul1r !ger0_norm // 1?ltW // (lt_trans x0).
 Qed.
 
 Let S0_ge0 N n : 0 <= S0 N n.
@@ -1191,7 +1191,7 @@ Lemma incr_S1 N : nondecreasing_seq (S1 N).
 Proof.
 apply/nondecreasing_seqP => n; rewrite /S1.
 have [nN|Nn] := leqP n N; first by rewrite !big_geq // (leq_trans nN).
-by rewrite big_nat_recr//= ler_addl exp_coeff_ge0 // ltW.
+by rewrite big_nat_recr//= lerDl exp_coeff_ge0 // ltW.
 Qed.
 
 Let S1_sup N : x < N%:R -> ubound (range (S1 N)) (sup (range (S0 N))).
@@ -1199,12 +1199,12 @@ Proof.
 move=> xN _ [n _ <-]; rewrite (le_trans _ (S0_sup n xN)) // /S0 big_distrr /=.
 have N_gt0 := lt_trans x0 xN; apply ler_sum => i _.
 have [Ni|iN] := ltnP N i; last first.
-  rewrite expr_div_n mulrCA ler_pmul2l ?exprn_gt0// (@le_trans _ _ 1) //.
+  rewrite expr_div_n mulrCA ler_pM2l ?exprn_gt0// (@le_trans _ _ 1) //.
     by rewrite invf_le1// ?ler1n ?ltr0n // fact_gt0.
   rewrite natrX -expfB_cond ?(negPf (lt0r_neq0 N_gt0))//.
   by rewrite exprn_ege1 // ler1n; case: (N) xN x0; case: ltrgt0P.
-rewrite /exp expr_div_n /= (fact_split Ni) mulrCA ler_pmul2l ?exprn_gt0// natrX.
-rewrite -invf_div -expfB // lef_pinv ?qualifE/= ?exprn_gt0//; last first.
+rewrite /exp expr_div_n /= (fact_split Ni) mulrCA ler_pM2l ?exprn_gt0// natrX.
+rewrite -invf_div -expfB // lef_pV2 ?qualifE/= ?exprn_gt0//; last first.
   rewrite ltr0n muln_gt0 fact_gt0/= big_seq big_mkcond/= prodn_gt0// => j.
   by case: ifPn=>//; rewrite mem_index_iota => /andP[+ _]; exact: leq_ltn_trans.
 rewrite big_nat_rev/= -natrX ler_nat -prod_nat_const_nat big_add1 /= big_ltn //.
@@ -1222,7 +1222,7 @@ rewrite /series; near \oo => N; have xN : x < N%:R; last first.
   by apply: (nondecreasing_is_cvg (incr_S1 N)); eexists; apply: S1_sup.
 near: N; exists (absz (floor x)).+1 => // m; rewrite /mkset -(@ler_nat R).
 move/lt_le_trans => -> //; rewrite (lt_le_trans (lt_succ_floor x)) // -addn1.
-by rewrite natrD ler_add2r -(@gez0_abs (floor x)) ?floor_ge0// ltW.
+by rewrite natrD lerD2r -(@gez0_abs (floor x)) ?floor_ge0// ltW.
 Unshelve. all: by end_near. Qed.
 
 End exponential_series_cvg.
@@ -1495,12 +1495,12 @@ have [{lnoo}loo|lpoo] := eqVneq l +oo.
   rewrite loo ger0_norm ?subr_ge0; last first.
     by case/ler_normlP : (contract_le1 (u_ n)).
   have [e2|e2] := lerP 2 e%:num.
-    rewrite /= ltr_subl_addr addrC -ltr_subl_addr.
-    case/ler_normlP : (contract_le1 (u_ n)); rewrite ler_oppl => un1 _.
+    rewrite /= ltrBlDr addrC -ltrBlDr.
+    case/ler_normlP : (contract_le1 (u_ n)); rewrite lerNl => un1 _.
     rewrite (@le_lt_trans _ _ (-1)) //.
-      by rewrite ler_subl_addr addrC -ler_subl_addr opprK (le_trans e2).
+      by rewrite lerBlDr addrC -lerBlDr opprK (le_trans e2).
     by move: un1; rewrite le_eqVlt eq_sym contract_eqN1 (negbTE unoo).
-  rewrite ltr_subl_addr addrC -ltr_subl_addr -lt_expandLR ?inE//=.
+  rewrite ltrBlDr addrC -ltrBlDr -lt_expandLR ?inE//=.
     near: n.
     suff [n Hn] : exists n, expand (contract +oo - e%:num)%R < u_ n.
       by exists n => // m nm; rewrite (lt_le_trans Hn) //; apply nd_u_.
@@ -1508,11 +1508,11 @@ have [{lnoo}loo|lpoo] := eqVneq l +oo.
     have : l <= expand (contract +oo - e%:num)%R.
       apply: ub_ereal_sup => x [n _ <-{x}].
       rewrite leNgt; apply/negP/abs.
-      rewrite loo leye_eq expand_eqoo ler_sub_addr addrC -ler_sub_addr subrr.
+      rewrite loo leye_eq expand_eqoo lerBDr addrC -lerBDr subrr.
       by apply/negP; rewrite -ltNge.
     have [e1|e1] := ltrP 1 e%:num.
-      by rewrite ler_subl_addr (le_trans (ltW e2)).
-    by rewrite ler_subl_addr ler_addl.
+      by rewrite lerBlDr (le_trans (ltW e2)).
+    by rewrite lerBlDr lerDl.
 have l_fin_num : l \is a fin_num by rewrite fin_numE lpoo lnoo.
 have [le1|le1] := (ltrP (`|contract l - e%:num|) 1)%R; last first.
   near=> n; rewrite /ball /= /ereal_ball /=.
@@ -1527,24 +1527,24 @@ have [le1|le1] := (ltrP (`|contract l - e%:num|) 1)%R; last first.
   have [l0|l0] := ger0P (contract l).
     have el : (e%:num > contract l)%R.
       rewrite ltNge; apply/negP => er.
-      rewrite ger0_norm ?subr_ge0// -ler_subl_addr opprK in le1.
+      rewrite ger0_norm ?subr_ge0// -lerBlDr opprK in le1.
       case/ler_normlP : (contract_le1 l) => _ /(le_trans le1); apply/negP.
-      by rewrite -ltNge ltr_addl.
+      by rewrite -ltNge ltrDl.
     rewrite ltr0_norm ?subr_lt0// opprB in le1.
-    rewrite ltr_subl_addr addrC -ltr_subl_addr -opprB ltr_oppl.
+    rewrite ltrBlDr addrC -ltrBlDr -opprB ltrNl.
     rewrite (lt_le_trans _ le1) // lt_neqAle eqr_oppLR contract_eqN1 unoo /=.
     by case/ler_normlP : (contract_le1 (u_ n)).
   rewrite ler0_norm in le1; last by rewrite subr_le0 (le_trans (ltW l0)).
-  rewrite opprB ler_subr_addr addrC -ler_subr_addr in le1.
-  rewrite ltr_subl_addr (le_lt_trans le1) // -ltr_subl_addl addrAC subrr add0r.
+  rewrite opprB lerBrDr addrC -lerBrDr in le1.
+  rewrite ltrBlDr (le_lt_trans le1) // -ltrBlDl addrAC subrr add0r.
   rewrite lt_neqAle eq_sym contract_eqN1 unoo /=.
-  by case/ler_normlP : (contract_le1 (u_ n)); rewrite ler_oppl.
+  by case/ler_normlP : (contract_le1 (u_ n)); rewrite lerNl.
 pose e' :=
   (fine l - fine (expand (contract l - e%:num)))%R.
 have e'0 : (0 < e')%R.
   rewrite /e' subr_gt0 -lte_fin fine_expand //.
-  rewrite lt_expandLR ?inE ?ltW// ltr_subl_addr fineK //.
-  by rewrite ltr_addl.
+  rewrite lt_expandLR ?inE ?ltW// ltrBlDr fineK //.
+  by rewrite ltrDl.
 have [y [m _ umx] Se'y] := ub_ereal_sup_adherent e'0 l_fin_num.
 near=> n; rewrite /ball /= /ereal_ball /=.
 rewrite ger0_norm ?subr_ge0 ?le_contract ?ereal_sup_ub//; last by exists n.
@@ -1554,7 +1554,7 @@ have leum : (contract l - e%:num < contract (u_ m))%R.
   move: le'um; rewrite /e' EFinN /= opprB EFinB.
   rewrite (fineK l_fin_num) fine_expand //.
   by rewrite addeCA subee // adde0.
-rewrite ltr_subl_addr addrC -ltr_subl_addr (lt_le_trans leum) //.
+rewrite ltrBlDr addrC -ltrBlDr (lt_le_trans leum) //.
 by rewrite le_contract nd_u_//; near: n; exists m.
 Unshelve. all: by end_near. Qed.
 
@@ -1721,7 +1721,7 @@ Proof.
 move=> ? ?; apply: nondecreasing_is_cvg.
   move=> m n mn; rewrite /series/=.
   rewrite -(subnKC mn) {2}/index_iota subn0 iotaD big_cat/=.
-  by rewrite add0n -{2}(subn0 m) -/(index_iota _ _) ler_addl sumr_ge0.
+  by rewrite add0n -{2}(subn0 m) -/(index_iota _ _) lerDl sumr_ge0.
 exists (fine (\sum_(k <oo) (u k)%:E)).
 rewrite /ubound/= => _ [n _ <-]; rewrite -lee_fin fineK//; last first.
   rewrite fin_num_abs gee0_abs//; apply: nneseries_ge0 => // i _.
@@ -2081,7 +2081,7 @@ move=> cf; have [M [Mreal Mu]] := cvg_seq_bounded cf.
 apply: nonincreasing_is_cvg.
   exact/nonincreasing_sups/bounded_fun_has_ubound/cvg_seq_bounded.
 exists (- (M + 1)) => _ [n _ <-]; rewrite (@le_trans _ _ (u n)) //.
-  by apply/lerNnormlW/Mu => //; rewrite ltr_addl.
+  by apply/lerNnormlW/Mu => //; rewrite ltrDl.
 apply: sup_ub; last by exists n => /=.
 exact/has_ubound_sdrop/bounded_fun_has_ubound/cvg_seq_bounded.
 Qed.
@@ -2226,14 +2226,14 @@ apply/andP; split.
   move/cvgrPdist_lt : (ul) => /(_ _ e0) -[k _ klu].
   near=> n; have kn : (k <= n)%N by near: n; exists k.
   apply: sup_le_ub; first by exists (u n) => /=; exists n => //=.
-  move=> _ /= [m nm] <-; apply/ltW/ltr_distl_addr; rewrite distrC.
+  move=> _ /= [m nm] <-; apply/ltW/ltr_distlDr; rewrite distrC.
   by apply: (klu m) => /=; rewrite (leq_trans kn).
-- apply/ler_addgt0Pr => e e0; rewrite -ler_subl_addr.
+- apply/ler_addgt0Pr => e e0; rewrite -lerBlDr.
   apply: limr_ge; first by apply: is_cvg_infs; apply/cvg_ex; exists l.
   move/cvgrPdist_lt : (ul) => /(_ _ e0) -[k _ klu].
   near=> n; have kn: (k <= n)%N by near: n; exists k.
   apply: lb_le_inf; first by exists (u n) => /=; exists n => //=.
-  move=> _ /= [m nm] <-; apply/ltW/ltr_distl_subl.
+  move=> _ /= [m nm] <-; apply/ltW/ltr_distlBl.
   by apply: (klu m) => /=; rewrite (leq_trans kn).
 Unshelve. all: by end_near. Qed.
 
@@ -2268,7 +2268,7 @@ Lemma le_lim_supD u v :
 Proof.
 move=> ba bb; have ab k : sups (u \+ v) k <= sups u k + sups v k.
   apply: sup_le_ub; first by exists ((u \+ v) k); exists k => /=.
-  by move=> M [n /= kn <-]; apply: ler_add; apply: sup_ub; [
+  by move=> M [n /= kn <-]; apply: lerD; apply: sup_ub; [
     exact/has_ubound_sdrop/bounded_fun_has_ubound; exact | exists n |
     exact/has_ubound_sdrop/bounded_fun_has_ubound; exact | exists n ].
 have cu : cvgn (sups u).
@@ -2290,7 +2290,7 @@ Lemma le_lim_infD u v :
 Proof.
 move=> ba bb; have ab k : infs u k + infs v k <= infs (u \+ v) k.
   apply: lb_le_inf; first by exists ((u \+ v) k); exists k => /=.
-  by move=> M [n /= kn <-]; apply: ler_add; apply: inf_lb; [
+  by move=> M [n /= kn <-]; apply: lerD; apply: inf_lb; [
     exact/has_lbound_sdrop/bounded_fun_has_lbound; exact | exists n |
     exact/has_lbound_sdrop/bounded_fun_has_lbound; exact | exists n ].
 have cu : cvgn (infs u).
@@ -2313,10 +2313,10 @@ Proof.
 move=> cu cv; have [ba bb] := (cvg_seq_bounded cu, cvg_seq_bounded cv).
 apply/eqP; rewrite eq_le le_lim_supD //=.
 have := @le_lim_supD _ _ (bounded_funD ba bb) (bounded_funN bb).
-rewrite -ler_subl_addr; apply: le_trans.
+rewrite -lerBlDr; apply: le_trans.
 rewrite -[_ \+ _]/(u + v - v) addrK -lim_infN; last exact: is_cvgN.
 rewrite /comp /=; under eq_fun do rewrite opprK.
-by rewrite ler_add// cvg_lim_infE// cvg_lim_supE.
+by rewrite lerD// cvg_lim_infE// cvg_lim_supE.
 Qed.
 
 Lemma lim_infD u v : cvgn u -> cvgn v ->
@@ -2603,22 +2603,22 @@ Proof. by rewrite ?(invr_ge0, mulr_ge0, subr_ge0, ltW q1). Qed.
 Lemma contraction_dist n m : `|y n - y (n + m)| <= C * q%:num ^+ n.
 Proof.
 have f1 k : `|y k.+1 - y k| <= q%:num ^+ k * `|f base - base|.
-  elim: k => [|k /(ler_wpmul2l (ge0 q))]; first by rewrite expr0 mul1r.
+  elim: k => [|k /(ler_wpM2l (ge0 q))]; first by rewrite expr0 mul1r.
   rewrite mulrA -exprS; apply: le_trans.
   by rewrite (@ctrfq (y k.+1, y k)); split; exact: funS.
 have /le_trans -> // : `| y n - y (n + m)| <=
     series (geometric (`|f base - base| * q%:num ^+ n) q%:num) m.
   elim: m => [|m ih].
     by rewrite geometric_seriesE ?lt_eqF//= addn0 subrr normr0 subrr mulr0 mul0r.
-  rewrite (le_trans (ler_dist_add (y (n + m)%N) _ _))//.
-  apply: (le_trans (ler_add ih _)); first by rewrite distrC addnS; exact: f1.
+  rewrite (le_trans (ler_distD (y (n + m)%N) _ _))//.
+  apply: (le_trans (lerD ih _)); first by rewrite distrC addnS; exact: f1.
   rewrite [_ * `|_|]mulrC exprD mulrA geometric_seriesE ?lt_eqF//=.
   rewrite -!/(`1-_) (onem_PosNum ctrf.1) (onemX_NngNum (ltW ctrf.1)).
-  rewrite -!mulrA -mulrDr ler_pmul// -mulrDr exprSr onemM -addrA.
+  rewrite -!mulrA -mulrDr ler_pM// -mulrDr exprSr onemM -addrA.
   rewrite -[in leRHS](mulrC _ `1-(_ ^+ m)) -onemMr onemK.
   by rewrite [in leRHS]mulrDl mulrAC mulrV ?mul1r// unitf_gt0// onem_gt0.
 rewrite geometric_seriesE ?lt_eqF//= -[leRHS]mulr1 (ACl (1*4*2*3))/= -/C.
-by rewrite ler_wpmul2l// 1?mulr_ge0// ler_subl_addr ler_addl.
+by rewrite ler_wpM2l// 1?mulr_ge0// lerBlDr lerDl.
 Qed.
 
 Lemma contraction_cvg : cvgn y.
@@ -2632,7 +2632,7 @@ case: ltrgt0P C_ge0 => // [Cpos|C0] _; last first.
   near=> n m => /=; rewrite -ball_normE.
   by apply: (le_lt_trans (lt_min _ _)); rewrite C0 mul0r.
 near=> n; rewrite -ball_normE /= (le_lt_trans (lt_min n.1 n.2)) //.
-rewrite // -ltr_pdivl_mull //.
+rewrite // -ltr_pdivlMl //.
 suff : ball 0 (C^-1 * e%:num) (q%:num ^+ minn n.1 n.2).
   by rewrite /ball /= sub0r normrN ger0_norm.
 near: n; rewrite nbhs_simpl.
@@ -2647,7 +2647,7 @@ exists ([set n | N <= n], [set n | N <= n])%N; first by split; exists N.
 move=> [n m] [Nn Nm]; rewrite /ball /= sub0r normrN ger0_norm /g //.
 apply: le_lt_trans; last by apply: (Q N) => /=.
 rewrite sub0r normrN ger0_norm /geometric //= mul1r.
-by rewrite ler_wiexpn2l // ?ltW // leq_min Nn.
+by rewrite ler_wiXn2l // ?ltW // leq_min Nn.
 Unshelve. all: end_near. Qed.
 
 Lemma contraction_cvg_fixed : closed U -> limn y = f (limn y).
@@ -2658,7 +2658,7 @@ have [q_gt0 | | q0] := ltrgt0P q%:num.
 - near=> n => /=; apply: (le_lt_trans (@ctrfq (_, _) _)) => //=.
   + split; last exact: funS.
     by apply: closed_cvg contraction_cvg => //; apply: nearW => ?; exact: funS.
-  + rewrite -ltr_pdivl_mull //; near: n; move/cvgrPdist_lt: contraction_cvg; apply.
+  + rewrite -ltr_pdivlMl //; near: n; move/cvgrPdist_lt: contraction_cvg; apply.
     by rewrite mulr_gt0 // invr_gt0.
 - by rewrite ltNge//; exact: contraNP.
 - apply: nearW => /= n; apply: (le_lt_trans (@ctrfq (_, _) _)).

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -1586,7 +1586,7 @@ Lemma small_set_sub (E : set Y) : F E ->
 Proof.
 move=> entE; exists [set E' | F E' /\ E' `<=` E]; last by move=> ? [].
 split; [by move=> E' [] | | by exists E; split].
-by move=> E1 E2 [] ? sub ? ?; split => //; exact: subset_trans sub.
+by move=> E1 E2 [] ? subE ? ?; split => //; exact: subset_trans subE.
 Qed.
 
 Lemma near_powerset_filter_fromP (P : set Y -> Prop) :
@@ -4442,12 +4442,12 @@ Section sup_uniform.
 
 Variable (T : pointedType) (Ii : Type) (Tc : Ii -> Uniform T).
 
-Let I : choiceType := [choiceType of {classic Ii}].
+Let I : choiceType := {classic Ii}.
 Let TS := fun i => Uniform.Pack (Tc i).
 Notation Tt := (sup_topology Tc).
 Let ent_of (p : I * set (T * T)) := `[< @entourage (TS p.1) p.2>].
 Let IEntType := {p : (I * set (T * T)) | ent_of p}.
-Let IEnt := [choiceType of IEntType].
+Let IEnt : choiceType := IEntType.
 
 Local Lemma IEnt_pointT (i : I) : ent_of (i, setT).
 Proof. by apply/asboolP; exact: entourageT. Qed.

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -4905,7 +4905,7 @@ exists (fun n => [set xy : T * T | ball xy.1 n.+1%:R^-1 xy.2]); last first.
   by move=> n; exact: (entourage_ball _ n.+1%:R^-1%:pos).
 move=> E; rewrite -entourage_ballE => -[e e0 subE].
 exists `|floor e^-1|%N; apply: subset_trans subE => xy; apply: le_ball.
-rewrite /= -[leRHS]invrK lef_pinv ?posrE ?invr_gt0// -natr1.
+rewrite /= -[leRHS]invrK lef_pV2 ?posrE ?invr_gt0// -natr1.
 by rewrite natr_absz ger0_norm ?floor_ge0 ?invr_ge0// 1?ltW// lt_succ_floor.
 Qed.
 
@@ -5316,7 +5316,7 @@ Lemma subset_ball_prop_in_itvcc (R : realDomainType) (x : R) e P : 0 < e ->
   {in `[(x - e), (x + e)], forall y, P y}.
 Proof.
 move=> e_gt0 PP y; rewrite in_itv/= -ler_distlC => ye; apply: PP => /=.
-by rewrite (le_lt_trans ye)// ltr_pmull// ltr1n.
+by rewrite (le_lt_trans ye)// ltr_pMl// ltr1n.
 Qed.
 
 Global Instance ball_filter (R : realFieldType) (t : R) : Filter
@@ -5341,7 +5341,7 @@ Lemma ball_norm_triangle (x y z : R) (e1 e2 : K) :
   ball_ Num.norm x e1 y -> ball_ Num.norm y e2 z -> ball_ Num.norm x (e1 + e2) z.
 Proof.
 move=> /= ? ?; rewrite -(subr0 x) -(subrr y) opprD opprK addrA -(addrA _ y).
-by rewrite (le_lt_trans (ler_norm_add _ _)) // ltr_add.
+by rewrite (le_lt_trans (ler_normD _ _)) // ltrD.
 Qed.
 
 Lemma nbhs_ball_normE :
@@ -5395,7 +5395,7 @@ apply: Build_ProperFilter => A /nbhs_ballP[_/posnumP[e] Ae].
 exists (x + e%:num / 2)%R; apply: Ae; last first.
   by rewrite eq_sym addrC -subr_eq subrr eq_sym.
 rewrite /ball /= opprD addrA subrr distrC subr0 ger0_norm //.
-by rewrite {2}(splitr e%:num) ltr_spaddl.
+by rewrite {2}(splitr e%:num) ltr_pwDl.
 Qed.
 
 Definition uniform_fun {U : Type} (A : set U) (V : Type) := U -> V.
@@ -5687,7 +5687,7 @@ apply: Build_ProperFilter => A /nbhs_ballP[_/posnumP[e] Ae].
 exists (x + e%:num / 2)%R; apply: Ae; last first.
   by rewrite eq_sym addrC -subr_eq subrr eq_sym.
 rewrite /ball /= opprD addrA subrr distrC subr0 ger0_norm //.
-by rewrite {2}(splitr e%:num) ltr_spaddl.
+by rewrite {2}(splitr e%:num) ltr_pwDl.
 Qed.
 
 Definition dense (T : topologicalType) (S : set T) :=
@@ -5704,10 +5704,10 @@ Qed.
 Lemma dense_rat (R : realType) : dense (@ratr R @` setT).
 Proof.
 move=> A [r Ar]; rewrite openE => /(_ _ Ar)/nbhs_ballP[_/posnumP[e] reA].
-have /rat_in_itvoo[q /itvP qre] : r < r + e%:num by rewrite ltr_addl.
+have /rat_in_itvoo[q /itvP qre] : r < r + e%:num by rewrite ltrDl.
 exists (ratr q) => //; split; last by exists q.
 apply: reA; rewrite /ball /= distrC ltr_distl qre andbT.
-by rewrite (@le_lt_trans _ _ r)// ?qre// ler_subl_addl ler_addr ltW.
+by rewrite (@le_lt_trans _ _ r)// ?qre// lerBlDl lerDr ltW.
 Qed.
 
 Section weak_pseudoMetric.
@@ -5890,7 +5890,7 @@ Local Lemma distN_le e1 e2 : e1 > 0 -> e1 <= e2 -> (distN e2 <= distN e1)%N.
 Proof.
 move=> e1pos e1e2; rewrite /distN; apply: lez_abs2.
   by rewrite floor_ge0 ltW// invr_gt0 (lt_le_trans _ e1e2).
-by rewrite le_floor// lef_pinv ?invrK ?invr_gt0//; exact: (lt_le_trans _ e1e2).
+by rewrite le_floor// lef_pV2 ?invrK ?invr_gt0//; exact: (lt_le_trans _ e1e2).
 Qed.
 
 Local Fixpoint n_step_ball n x e z :=
@@ -5981,7 +5981,7 @@ move: x e1 e2; elim: n.
   by apply: descendG; last (exact: gxy); exact: distN_le.
 move=> n IH x e1 e2 e1e2 z [y] [d1] [d2] [] /IH P d1pos d2pos gyz d1d2e1.
 have d1e1d2 : d1 = e1 - d2 by rewrite -d1d2e1 -addrA subrr addr0.
-have e2d2le : e1 - d2 <= e2 - d2 by exact: ler_sub.
+have e2d2le : e1 - d2 <= e2 - d2 by exact: lerB.
 exists y, (e2 - d2), d2; split => //.
 - by apply: P; apply: le_trans e2d2le; rewrite d1e1d2.
 - by apply: lt_le_trans e2d2le; rewrite -d1e1d2.
@@ -5995,7 +5995,7 @@ Proof. by move=> e1e2 ? [n P]; exists n; exact: (n_step_ball_le e1e2). Qed.
 Local Lemma distN_half (n : nat) : n.+1%:R^-1 / (2:R) <= n.+2%:R^-1.
 Proof.
 rewrite -invrM //; [|exact: unitf_gt0 |exact: unitf_gt0].
-rewrite lef_pinv ?posrE // -?natrM ?ler_nat -addn1 -addn1 -addnA mulnDr.
+rewrite lef_pV2 ?posrE // -?natrM ?ler_nat -addn1 -addn1 -addnA mulnDr.
 by rewrite muln1 leq_add2r leq_pmull.
 Qed.
 
@@ -6015,25 +6015,25 @@ move: e1 e2 x z; elim: n.
     move=> e1d1; exists x, y, 0%N, 0%N; split.
     - exact: n_step_ball_center.
     - apply: n_step_ball_le; last exact: Oxy.
-      by rewrite -deE ler_addl; apply: ltW.
+      by rewrite -deE lerDl; apply: ltW.
     - apply: (@n_step_ball_le _ _ d2); last by split.
-      rewrite -[e2]addr0 -(subrr e1) addrA -ler_subl_addr opprK addrC.
-      by rewrite [e2 + _]addrC -deE; exact: ler_add.
+      rewrite -[e2]addr0 -(subrr e1) addrA -lerBlDr opprK addrC.
+      by rewrite [e2 + _]addrC -deE; exact: lerD.
     - by rewrite addn0.
   move=> /negP; rewrite -real_ltNge ?num_real //.
   move=> e1d1; exists y, z, 0%N, 0%N; split.
   - by apply: n_step_ball_le; last (exact: Oxy); exact: ltW.
   - rewrite -deE; apply: (@n_step_ball_le _ _ d2) => //.
-    by rewrite ler_addr; apply: ltW.
+    by rewrite lerDr; apply: ltW.
   - exact: n_step_ball_center.
   - by rewrite addn0.
 move=> n IH e1 e2 x z e1pos e2pos [y] [d1] [d2] [] Od1xy d1pos d2pos gd2yz deE.
 case: (pselect (e2 <= d2)).
   move=> e2d2; exists y, z, n.+1, 0%N; split.
   - apply: (@n_step_ball_le _ _ d1); rewrite // -[e1]addr0 -(subrr e2) addrA.
-    by rewrite -deE -ler_subl_addr opprK ler_add.
+    by rewrite -deE -lerBlDr opprK lerD.
   - apply: (@n_step_ball_le _ _ d2); last by split.
-    by rewrite -deE ler_addr; exact: ltW.
+    by rewrite -deE lerDr; exact: ltW.
   - exact: n_step_ball_center.
   - by rewrite addn0.
 have d1E' : d1 = e1 + (e2 - d2).
@@ -6042,7 +6042,7 @@ move=> /negP; rewrite -?real_ltNge // ?num_real // => d2lee2.
   case: (IH e1 (e2 - d2) x y); rewrite ?subr_gt0 // -d1E' //.
   move=> t1 [t2] [c1] [c2] [] Oxy1 gt1t2 t2y <-.
   exists t1, t2, c1, c2.+1; split => //.
-  - by apply: (@n_step_ball_le _ _ d1); rewrite -?deE // ?ler_addl; exact: ltW.
+  - by apply: (@n_step_ball_le _ _ d1); rewrite -?deE // ?lerDl; exact: ltW.
   - exists y, (e2 - d2), d2; split; rewrite // ?subr_gt0//.
     by rewrite -addrA [-_ + _]addrC subrr addr0.
   - by rewrite addnS.

--- a/theories/trigo.v
+++ b/theories/trigo.v
@@ -93,14 +93,14 @@ rewrite ltNge; apply: contraPN cf => ffn /(_ _ fn0).
 have nf_ub N : \sum_(0 <= i < n.+2) f i <= \sum_(0 <= i < N.+1.*2 + n) f i.
   elim: N => // N /le_trans ->//; rewrite -(addn1 (N.+1)) doubleD addnAC.
   rewrite [in leRHS]/index_iota subn0 iotaD big_cat.
-  rewrite -[in X in _ <= X + _](subn0 (N.+1.*2 + n)%N) ler_addl /= add0n.
+  rewrite -[in X in _ <= X + _](subn0 (N.+1.*2 + n)%N) lerDl /= add0n.
   by rewrite 2!big_cons big_nil addr0 -(addnC n) ltW// -addnS fn.
-case=> N _ Nfn; have /Nfn/ltr_distlC_addr : (N.+1.*2 + n >= N)%N.
+case=> N _ Nfn; have /Nfn/ltr_distlCDr : (N.+1.*2 + n >= N)%N.
   by rewrite doubleS -addn2 -addnn -2!addnA leq_addr.
 rewrite addrA => ffnfn.
 have : lim (series f @ \oo) + f n + f n.+1 <= \sum_(0 <= i < N.+1.*2 + n) f i.
   apply: (le_trans _ (nf_ub N)).
-  by do 2 rewrite big_nat_recr //=; by rewrite -2!addrA ler_add2r.
+  by do 2 rewrite big_nat_recr //=; by rewrite -2!addrA lerD2r.
 by move/(lt_le_trans ffnfn); rewrite ltxx.
 Qed.
 
@@ -360,11 +360,11 @@ Qed.
 Lemma cos_max x : `| cos x | <= 1.
 Proof.
 rewrite -(expr_le1 (_ : 0 < 2)%nat) // -normrX ger0_norm ?exprn_even_ge0 //.
-by rewrite -(cos2Dsin2 x) ler_addl ?sqr_ge0.
+by rewrite -(cos2Dsin2 x) lerDl ?sqr_ge0.
 Qed.
 
 Lemma cos_geN1 x : -1 <= cos x.
-Proof. by rewrite ler_oppl; have /ler_normlP[] := cos_max x. Qed.
+Proof. by rewrite lerNl; have /ler_normlP[] := cos_max x. Qed.
 
 Lemma cos_le1 x : cos x <= 1.
 Proof. by have /ler_normlP[] := cos_max x. Qed.
@@ -372,11 +372,11 @@ Proof. by have /ler_normlP[] := cos_max x. Qed.
 Lemma sin_max x : `| sin x | <= 1.
 Proof.
 rewrite -(expr_le1 (_ : 0 < 2)%nat) // -normrX ger0_norm ?exprn_even_ge0 //.
-by rewrite -(cos2Dsin2 x) ler_addr ?sqr_ge0.
+by rewrite -(cos2Dsin2 x) lerDr ?sqr_ge0.
 Qed.
 
 Lemma sin_geN1 x : -1 <= sin x.
-Proof. by rewrite ler_oppl; have /ler_normlP[] := sin_max x. Qed.
+Proof. by rewrite lerNl; have /ler_normlP[] := sin_max x. Qed.
 
 Lemma sin_le1 x : sin x <= 1.
 Proof. by have /ler_normlP[] := sin_max x. Qed.
@@ -509,10 +509,10 @@ rewrite (_ : 4 = 2 * 2)%N // -(exprnP _ (2 * 2)) (exprM (-1)) sqrr_sign.
 rewrite mul1r [(-1) ^ 3](_ : _ = -1) ?mulN1r ?mulNr ?opprK; last first.
   by rewrite -exprnP 2!exprS expr1 mulrN1 opprK mulr1.
 rewrite subr_gt0.
-rewrite addnS doubleS -[X in 2 ^+ X]addn2 exprD -mulrA ltr_pmul2l//.
+rewrite addnS doubleS -[X in 2 ^+ X]addn2 exprD -mulrA ltr_pM2l//.
 rewrite factS factS 2!natrM mulrA invfM !mulrA.
-rewrite ltr_pdivr_mulr ?ltr0n ?fact_gt0// mulVf ?pnatr_eq0 ?gtn_eqF ?fact_gt0//.
-rewrite ltr_pdivr_mulr ?mul1r //.
+rewrite ltr_pdivrMr ?ltr0n ?fact_gt0// mulVf ?pnatr_eq0 ?gtn_eqF ?fact_gt0//.
+rewrite ltr_pdivrMr ?mul1r //.
 by rewrite expr2 -!natrM ltr_nat !mulSn !add2n mul0n !addnS.
 Qed.
 
@@ -537,9 +537,9 @@ rewrite -[X in _ < X - _]mul1r !mulrA -mulrBl divr_gt0 //; last first.
 rewrite subr_gt0.
 set v := _ ^_ _; rewrite -[ltRHS](divff (_ : v%:R != 0)); last first.
   by rewrite lt0r_neq0 // (ltr_nat _ 0) ffact_gt0 leq_addl.
-rewrite ltr_pmul2r; last by rewrite invr_gt0 (ltr_nat _ 0) ffact_gt0 leq_addl.
+rewrite ltr_pM2r; last by rewrite invr_gt0 (ltr_nat _ 0) ffact_gt0 leq_addl.
 rewrite {}/v !addnS addn0 !ffactnS ffactn0 muln1 /= natrM.
-by rewrite (ltr_pmul (ltW _ ) (ltW _)) // (lt_le_trans x_lt2) // ler_nat.
+by rewrite (ltr_pM (ltW _ ) (ltW _)) // (lt_le_trans x_lt2) // ler_nat.
 Qed.
 
 Lemma cos1_gt0 : cos 1 > 0 :> R.
@@ -548,12 +548,12 @@ have h := @cvg_cos_coeff' R 1; rewrite -(cvg_lim (@Rhausdorff R) h).
 apply: (@lt_trans _ _ (\sum_(0 <= i < 2) cos_coeff' 1 i)).
   rewrite big_nat_recr//= big_nat_recr//= big_nil add0r.
   rewrite /cos_coeff' expr0z expr1n fact0 !mul1r expr1n expr1z.
-  by rewrite !mulNr subr_gt0 mul1r div1r ltf_pinv ?posrE ?ltr0n// ltr_nat.
+  by rewrite !mulNr subr_gt0 mul1r div1r ltf_pV2 ?posrE ?ltr0n// ltr_nat.
 apply: lt_sum_lim_series; [by move/cvgP in h|move=> d].
 rewrite /cos_coeff' !(expr1n,mulr1).
 rewrite -muln2 -mulSn muln2 -exprnP -signr_odd odd_double expr0.
 rewrite -exprnP -signr_odd oddD/= muln2 odd_double/= expr1 add2n.
-rewrite mulNr subr_gt0 2!div1r ltf_pinv ?posrE ?ltr0n ?fact_gt0//.
+rewrite mulNr subr_gt0 2!div1r ltf_pV2 ?posrE ?ltr0n ?fact_gt0//.
 by rewrite ltr_nat ltn_pfact//ltn_double doubleS.
 Qed.
 
@@ -619,7 +619,7 @@ Lemma pihalf_lt2 : pi / 2 < 2.
 Proof. by have /andP[] := pihalf_12. Qed.
 
 Lemma pi_ge2 : 2 <= pi.
-Proof. by  have := pihalf_ge1; rewrite ler_pdivl_mulr// mul1r. Qed.
+Proof. by  have := pihalf_ge1; rewrite ler_pdivlMr// mul1r. Qed.
 
 Lemma pi_gt0 : 0 < pi. Proof. by rewrite (lt_le_trans _ pi_ge2). Qed.
 
@@ -635,7 +635,7 @@ Lemma cos_gt0_pihalf x : -(pi / 2) < x < pi / 2 -> 0 < cos x.
 Proof.
 wlog : x / 0 <= x => [Hw|x_ge0].
   case: (leP 0 x) => [/Hw//| x_lt_0].
-  rewrite -{-1}[x]opprK ltr_oppl andbC [-- _ < _]ltr_oppl cosN.
+  rewrite -{-1}[x]opprK ltrNl andbC [-- _ < _]ltrNl cosN.
   by apply: Hw => //; rewrite oppr_cp0 ltW.
 move=> /andP[x_gt0 xLpi2]; case: (ler0P (cos x)) => // cx_le0.
 have /IVT[]// : minr (cos 0) (cos x) <= 0 <= maxr (cos 0) (cos x).
@@ -713,13 +713,13 @@ Proof. by rewrite sinB cos_pihalf mulr0 add0r sin_pihalf mulr1. Qed.
 Lemma sin_ge0_pi x : 0 <= x <= pi -> 0 <= sin x.
 Proof.
 move=> xI; rewrite -cosBpihalf cos_ge0_pihalf //.
-by rewrite ler_subr_addl subrr ler_sub_addr -mulr2n -[_ *+ 2]mulr_natr divfK.
+by rewrite lerBrDl subrr lerBDr -mulr2n -[_ *+ 2]mulr_natr divfK.
 Qed.
 
 Lemma sin_gt0_pi x : 0 < x < pi -> 0 < sin x.
 Proof.
 move=> xI; rewrite -cosBpihalf cos_gt0_pihalf //.
-by rewrite ltr_subr_addl subrr ltr_sub_addr -mulr2n -[_ *+ 2]mulr_natr divfK.
+by rewrite ltrBrDl subrr ltrBDr -mulr2n -[_ *+ 2]mulr_natr divfK.
 Qed.
 
 Lemma ltr_cos : {in `[0, pi] &, {mono cos : x y /~ y < x}}.
@@ -763,10 +763,10 @@ Qed.
 
 Lemma ltr_sin : {in `[ (- (pi/2)), pi/2] &, {mono sin : x y / x < y}}.
 Proof.
-move=> x y /itvP xpi /itvP ypi; rewrite -[sin x]opprK ltr_oppl.
-rewrite -!cosDpihalf -[x < y](ltr_add2r (pi /2)) ltr_cos// !in_itv/=.
-- by rewrite -ler_subl_addr sub0r xpi/= [leRHS]splitr ler_add2r xpi.
-- by rewrite -ler_subl_addr sub0r ypi/= [leRHS]splitr ler_add2r ypi.
+move=> x y /itvP xpi /itvP ypi; rewrite -[sin x]opprK ltrNl.
+rewrite -!cosDpihalf -[x < y](ltrD2r (pi /2)) ltr_cos// !in_itv/=.
+- by rewrite -lerBlDr sub0r xpi/= [leRHS]splitr lerD2r xpi.
+- by rewrite -lerBlDr sub0r ypi/= [leRHS]splitr lerD2r ypi.
 Qed.
 
 Lemma cos_inj : {in `[0,pi] &, injective (@cos R)}.
@@ -780,8 +780,8 @@ Lemma sin_inj : {in `[(- (pi/2)), (pi/2)] &, injective sin}.
 Proof.
 move=> x y /itvP xpi /itvP ypi sinE; have : - sin x = - sin y by rewrite sinE.
 rewrite -!cosDpihalf => /cos_inj h; apply/(addIr (pi/2))/h; rewrite !in_itv/=.
-- by rewrite -ler_subl_addr sub0r xpi/= [leRHS]splitr ler_add2r xpi.
-- by rewrite -ler_subl_addr sub0r ypi/= [leRHS]splitr ler_add2r ypi.
+- by rewrite -lerBlDr sub0r xpi/= [leRHS]splitr lerD2r xpi.
+- by rewrite -lerBlDr sub0r ypi/= [leRHS]splitr lerD2r ypi.
 Qed.
 
 End Pi.
@@ -840,7 +840,7 @@ Lemma tan_piquarter : tan (pi / 4%:R) = 1.
 Proof.
 rewrite /tan -cosBpihalf (splitr (pi / 2)) opprD addrA -mulrA -invfM -natrM.
 rewrite subrr sub0r cosN divff// gt_eqF// cos_gt0_pihalf//.
-rewrite ltr_pmul2l ?pi_gt0// ltf_pinv ?qualifE//= ltr_nat andbT.
+rewrite ltr_pM2l ?pi_gt0// ltf_pV2 ?qualifE//= ltr_nat andbT.
 by rewrite (@lt_trans _ _ 0)// ?oppr_lt0 ?divr_gt0 ?pi_gt0.
 Qed.
 
@@ -909,7 +909,7 @@ Proof.
 move=> xB; rewrite /acos; case: xgetP => //= He.
 pose f y := cos y - x.
 have /(IVT (@pi_ge0 _))[] // : minr (f 0) (f pi) <= 0 <= maxr (f 0) (f pi).
-  rewrite /f cos0 cospi /minr /maxr ltr_add2r -subr_lt0 opprK (_ : 1 + 1 = 2)//.
+  rewrite /f cos0 cospi /minr /maxr ltrD2r -subr_lt0 opprK (_ : 1 + 1 = 2)//.
   by rewrite ltrn0 subr_le0 subr_ge0.
 - move=> y y0pi.
   by apply: continuousB; apply/continuous_in_subspaceT => ? ?;
@@ -960,14 +960,14 @@ Lemma acos0 : acos (0 : R) = pi / 2%:R.
 Proof.
 have := @cosK (pi / 2%:R).
 rewrite cos_pihalf => -> //; rewrite in_itv//= divr_ge0 ?ler0n ?pi_ge0//=.
-by rewrite ler_pdivr_mulr ?ltr0n// ler_pemulr ?pi_ge0// ler1n.
+by rewrite ler_pdivrMr ?ltr0n// ler_peMr ?pi_ge0// ler1n.
 Qed.
 
 Lemma acosN a : -1 <= a <= 1 -> acos (- a) = pi - acos a.
 Proof.
-move=> a1; have ? : -1 <= - a <= 1 by rewrite ler_oppl opprK ler_oppl andbC.
+move=> a1; have ? : -1 <= - a <= 1 by rewrite lerNl opprK lerNl andbC.
 apply: cos_inj; first by rewrite in_itv/= acos_ge0//= acos_lepi.
-- by rewrite in_itv/= subr_ge0 acos_lepi//= ler_subl_addl ler_addr acos_ge0.
+- by rewrite in_itv/= subr_ge0 acos_lepi//= lerBlDl lerDr acos_ge0.
 - by rewrite addrC cosDpi cosN !acosK.
 Qed.
 
@@ -976,7 +976,7 @@ Proof. by rewrite acosN ?acos1 ?subr0 ?lexx// -subr_ge0 opprK addr_ge0. Qed.
 
 Lemma cosKN a : - pi <= a <= 0 -> acos (cos a) = - a.
 Proof.
-by move=> pia0; rewrite -(cosN a) cosK// in_itv/= ler_oppr oppr0 ler_oppl andbC.
+by move=> pia0; rewrite -(cosN a) cosK// in_itv/= lerNr oppr0 lerNl andbC.
 Qed.
 
 Lemma sin_acos x : -1 <= x <= 1 -> sin (acos x) = Num.sqrt (1 - x^+2).
@@ -1035,7 +1035,7 @@ move=> xB; rewrite /asin; case: xgetP => //= He.
 pose f y := sin y - x.
 have /IVT[] // :
     minr (f (-(pi/2))) (f (pi/2)) <= 0 <= maxr (f (-(pi/2))) (f (pi/2)).
-  rewrite /f sinN sin_pihalf /minr /maxr ltr_add2r -subr_gt0 opprK.
+  rewrite /f sinN sin_pihalf /minr /maxr ltrD2r -subr_gt0 opprK.
   by rewrite (_ : 1 + 1 = 2)// ltr0n/= subr_le0 subr_ge0.
 - by rewrite -subr_ge0 opprK -splitr pi_ge0.
 - by move=> *; apply: continuousB; apply/continuous_in_subspaceT => ? ?;
@@ -1134,11 +1134,11 @@ Proof.
 rewrite /atan; case: xgetP => //= He.
 pose x1 := Num.sqrt (1 + x^+ 2) ^-1.
 have ox2_gt0 : 0 < 1 + x^2.
-  by apply: lt_le_trans (_ : 1 <= _); rewrite ?ler_addl ?sqr_ge0.
+  by apply: lt_le_trans (_ : 1 <= _); rewrite ?lerDl ?sqr_ge0.
 have ox2_ge0 : 0 <= 1 + x^2 by rewrite ltW.
 have x1B : -1 <= x1 <= 1.
   rewrite -ler_norml /x1 ger0_norm ?sqrtr_ge0 // -[leRHS]sqrtr1.
-  by rewrite ler_psqrt ?qualifE/= ?invr_gte0 //= invf_cp1 // ler_addl sqr_ge0.
+  by rewrite ler_psqrt ?qualifE/= ?invr_gte0 //= invf_cp1 // lerDl sqr_ge0.
 case: (He (Num.sg x * acos x1)); split; last first.
   case: (x =P 0) => [->|/eqP xD0]; first by rewrite /tan sgr0 mul0r sin0 mul0r.
   rewrite /tan sin_sg cos_sg // acosK ?sin_acos //.
@@ -1155,7 +1155,7 @@ case: (x =P 0) => [->|/eqP xD0]; first by rewrite sgr0 normr0 mul0r.
 rewrite normr_sg xD0 mul1r ltr_norml.
 rewrite (@lt_le_trans _ _ 0) ?acos_ge0 ?oppr_cp0 //=.
 rewrite -ltr_cos ?in_itv/= ?acos_ge0/= ?acos_lepi//; last first.
-  by rewrite divr_ge0 ?pi_ge0//= ler_pdivr_mulr// ler_pmulr ?pi_gt0// ler1n.
+  by rewrite divr_ge0 ?pi_ge0//= ler_pdivrMr// ler_pMr ?pi_gt0// ler1n.
 by rewrite cos_pihalf acosK // ?sqrtr_gt0 ?invr_gt0.
 Qed.
 
@@ -1183,14 +1183,14 @@ apply: tan_inj; first 2 last.
 rewrite in_itv/= -mulNr (lt_trans _ (_ : 0 < _ )) /=; last 2 first.
   by rewrite mulNr oppr_cp0 divr_gt0 // pi_gt0.
   by rewrite divr_gt0 ?pi_gt0 // ltr0n.
-rewrite ltr_pdivr_mulr// -mulrA ltr_pmulr// ?pi_gt0//.
+rewrite ltr_pdivrMr// -mulrA ltr_pMr// ?pi_gt0//.
 by rewrite (natrM _ 2 2) mulrA mulVf// mul1r ltr1n.
 Qed.
 
 Lemma atanN x : atan (- x) = - atan x.
 Proof.
 apply: tan_inj; first by rewrite in_itv/= atan_ltpi2 atan_gtNpi2.
-- by rewrite in_itv/= ltr_oppl opprK ltr_oppl andbC atan_ltpi2 atan_gtNpi2.
+- by rewrite in_itv/= ltrNl opprK ltrNl andbC atan_ltpi2 atan_gtNpi2.
 - by rewrite tanN !atanK.
 Qed.
 
@@ -1235,7 +1235,7 @@ apply: (@is_derive_inverse R tan).
 - by near=> z; apply: tanK; near: z.
 - by near=> z; apply/continuous_tan/lt0r_neq0/cos_gt0_pihalf; near: z.
 - by rewrite -[X in 1 + X ^+ 2]atanK -cos2_tan2 //; exact: is_derive_tan.
-by apply/lt0r_neq0/(@lt_le_trans _ _ 1) => //; rewrite ler_addl sqr_ge0.
+by apply/lt0r_neq0/(@lt_le_trans _ _ 1) => //; rewrite lerDl sqr_ge0.
 Unshelve. all: by end_near. Qed.
 
 End Atan.


### PR DESCRIPTION
##### Motivation for this change

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [ ] ~added corresponding entries in `CHANGELOG_UNRELEASED.md`~

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] ~added corresponding documentation in the headers~

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 2.0

<!-- MathComp-Analysis is compatible with MathComp < 2.0 (branch `master`) and
     MathComp 2.0 ([branch `hierarchy-builder`](https://github.com/math-comp/analysis/pull/698)).

     If this PR targets `master` and if it is merged, the merged commit will also be
     cherry-picked on the branch `hierarchy-builder`.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `hierarchy-builder` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: HB port to record divergences between `master` and `hierarchy-builder` -->

- [ ] ~I added the label `TODO: HB port` to make sure someone ports this PR to
      the `hierarchy-builder` branch **or** I already opened an issue or PR (please cross reference).~ (this is targetting HB, could be partly backported to master but only once it drops support for MC 1.16)

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
