### PR TITLE
add measurable_minr

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -27,6 +27,13 @@
   + new lemmas `pointwise_almost_uniform`, and 
     `ae_pointwise_almost_uniform`.
 
+- in `mathcomp_extra.v`:
+  + definition `min_fun`, notation `\min`
+- in `classical_sets.v`:
+  + lemmas `set_predC`, `preimage_true`, `preimage_false`
+- in `lebesgue_measure.v`:
+  + lemmas `measurable_fun_ltr`, `measurable_minr`
+
 ### Changed
 
 - moved from `lebesgue_measure.v` to `real_interval.v`:

--- a/classical/classical_sets.v
+++ b/classical/classical_sets.v
@@ -502,6 +502,9 @@ Proof. by apply/seteqP; split. Qed.
 Lemma set_false : [set` pred0] = set0 :> set T.
 Proof. by apply/seteqP; split. Qed.
 
+Lemma set_predC (P : {pred T}) : [set` predC P] = ~` [set` P].
+Proof. by apply/seteqP; split => t /negP. Qed.
+
 Lemma set_andb (P Q : {pred T}) : [set` predI P Q] = [set` P] `&` [set` Q].
 Proof. by apply/predeqP => x; split; rewrite /= inE => /andP. Qed.
 
@@ -1391,14 +1394,17 @@ Qed.
 Lemma preimage10 {T R} {f : T -> R} {x} : ~ range f x -> f @^-1` [set x] = set0.
 Proof. by move/preimage10P. Qed.
 
+Lemma preimage_true {T} (P : {pred T}) : P @^-1` [set true] = [set` P].
+Proof. by apply/seteqP; split => [x/=//|x]. Qed.
+
+Lemma preimage_false {T} (P : {pred T}) : P @^-1` [set false] = ~` [set` P].
+Proof. by apply/seteqP; split => [t/= /negbT/negP|t /= /negP/negbTE]. Qed.
+
 Lemma preimage_mem_true {T} (A : set T) : mem A @^-1` [set true] = A.
-Proof. by apply/seteqP; split => [x/= /set_mem//|x /mem_set]. Qed.
+Proof. by rewrite preimage_true; under eq_fun do rewrite inE. Qed.
 
 Lemma preimage_mem_false {T} (A : set T) : mem A @^-1` [set false] = ~` A.
-Proof.
-apply/seteqP; split => [x/=|x/=]; last exact: memNset.
-by apply: contraFnot; exact/mem_set.
-Qed.
+Proof. by rewrite preimage_false; under eq_fun do rewrite inE. Qed.
 
 End image_lemmas.
 Arguments sub_image_setI {aT rT f A B} t _.

--- a/classical/mathcomp_extra.v
+++ b/classical/mathcomp_extra.v
@@ -17,6 +17,7 @@ From mathcomp Require Import finset interval.
 (* This files contains lemmas and definitions missing from MathComp.          *)
 (*                                                                            *)
 (*               f \max g := fun x => Num.max (f x) (g x)                     *)
+(*               f \min g := fun x => Num.min (f x) (g x)                     *)
 (*                oflit f := Some \o f                                        *)
 (*          pred_oapp T D := [pred x | oapp (mem D) false x]                  *)
 (*                 f \* g := fun x => f x * g x                               *)
@@ -1370,3 +1371,9 @@ have := @deg_le2_poly_ge0 _ p (size_poly _ _); rewrite !coef_poly/=; apply=> r.
 rewrite horner_poly !big_ord_recr !big_ord0/= !Monoid.simpm/= expr1.
 by rewrite -mulrA -expr2 addrC addrA addrAC.
 Qed.
+
+Reserved Notation "f \min g" (at level 50, left associativity).
+
+Definition min_fun T (R : numDomainType) (f g : T -> R) x := Num.min (f x) (g x).
+Notation "f \min g" := (min_fun f g) : ring_scope.
+Arguments min_fun {T R} _ _ _ /.

--- a/theories/charge.v
+++ b/theories/charge.v
@@ -1346,7 +1346,7 @@ pose AP := A `&` P.
 have mAP : measurable AP by exact: measurableI.
 have muAP_gt0 : 0 < mu AP.
   rewrite lt_neqAle measure_ge0// andbT eq_sym.
-  apply/eqP/(@contra_not _ _ (nu_mu _ mAP))/eqP; rewrite gt_eqF //.
+  apply/eqP/(@contra_not _ _ (nu_mu _ mAP))/eqP; rewrite gt_eqF//.
   rewrite (@lt_le_trans _ _ (sigma AP))//.
     rewrite (@lt_le_trans _ _ (sigma A))//; last first.
       rewrite (charge_partition _ _ mP mN)// gee_addl//.

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -1558,16 +1558,32 @@ rewrite -(addrA (f x * g x *+ 2)) -opprB opprK (addrC (g x ^+ 2)) addrK.
 by rewrite -(mulr_natr (f x * g x)) -(mulrC 2) mulrA mulVr ?mul1r// unitfE.
 Qed.
 
+Lemma measurable_fun_ltr D f g : measurable_fun D f -> measurable_fun D g ->
+  measurable_fun D (fun x => f x < g x).
+Proof.
+move=> mf mg mD Y mY; have [| | |] := set_bool Y => /eqP ->.
+- under eq_fun do rewrite -subr_gt0.
+  rewrite preimage_true -preimage_itv_o_infty.
+  by apply: (measurable_funB mg mf) => //; exact: measurable_itv.
+- under eq_fun do rewrite ltNge -subr_ge0.
+  rewrite preimage_false set_predC setCK -preimage_itv_c_infty.
+  by apply: (measurable_funB mf mg) => //; exact: measurable_itv.
+- by rewrite preimage_set0 setI0.
+- by rewrite preimage_setT setIT.
+Qed.
+
 Lemma measurable_maxr D f g :
   measurable_fun D f -> measurable_fun D g -> measurable_fun D (f \max g).
 Proof.
-move=> mf mg mD; apply (measurability (RGenCInfty.measurableE R)) => //.
-move=> _ [_ [x ->] <-]; rewrite [X in measurable X](_ : _ =
-    (D `&` f @^-1` `[x, +oo[) `|` (D `&` g @^-1` `[x, +oo[)); last first.
-  rewrite predeqE => t /=; split.
-    by rewrite /= !in_itv /= !andbT le_maxr => -[Dx /orP[|]]; tauto.
-  by move=> [|]; rewrite !in_itv/= !andbT le_maxr => -[Dx ->]//; rewrite orbT.
-by apply: measurableU; [apply: mf|apply: mg] =>//; apply: measurable_itv.
+by move=> mf mg mD; move: (mD); apply: measurable_fun_if => //;
+  [exact: measurable_fun_ltr|exact: measurable_funS mg|exact: measurable_funS mf].
+Qed.
+
+Lemma measurable_minr D f g :
+  measurable_fun D f -> measurable_fun D g -> measurable_fun D (f \min g).
+Proof.
+by move=> mf mg mD; move: (mD); apply: measurable_fun_if => //;
+ [exact: measurable_fun_ltr|exact: measurable_funS mf|exact: measurable_funS mg].
 Qed.
 
 Lemma measurable_fun_sups D (h : (T -> R)^nat) n :


### PR DESCRIPTION
##### Motivation for this change

add the lemma `measurable_minr` using a new lemma `measurable_fun_ltr` that can
also be used to prove `measurable_maxr` following an observation by @marcomole00 

@hoheinzollern 

note the same approach cannot be used right away for extended real numbers-values
functions because `emeasurable_funB` is in `lebesgue_integral.v` (it uses the approximation theorem)

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [ ] added corresponding documentation in the headers~~

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 2.0

<!-- MathComp-Analysis is compatible with MathComp < 2.0 (branch `master`) and
     MathComp 2.0 ([branch `hierarchy-builder`](https://github.com/math-comp/analysis/pull/698)).

     If this PR targets `master` and if it is merged, the merged commit will also be
     cherry-picked on the branch `hierarchy-builder`.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `hierarchy-builder` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: HB port to record divergences between `master` and `hierarchy-builder` -->

- [x] I added the label `TODO: HB port` to make sure someone ports this PR to
      the `hierarchy-builder` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
