### PR TITLE
Outer regularity for Lebesgue measure

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ### Added
+- in `measure.v`:
+  + lemma `lebesgue_regularity_outer`
 
 ### Changed
 

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -1491,6 +1491,12 @@ move=> mD /open_subspaceP [V [oV] VD]; rewrite setIC -VD.
 by apply: measurableI => //; exact: open_measurable.
 Qed.
 
+Lemma closed_measurable (U : set R) : closed U -> measurable U.
+Proof.
+move/closed_openC=> ?; rewrite -[U]setCK; apply: measurableC.
+exact: open_measurable.
+Qed.
+
 Lemma subspace_continuous_measurable_fun (D : set R) (f : subspace D -> R) :
   measurable D -> continuous f -> measurable_fun D f.
 Proof.
@@ -1888,9 +1894,87 @@ apply: (eq_measurable_fun (fun x => lim_esup (f_ ^~ x))) => //.
   by move=> x; rewrite inE => Dx; rewrite fE.
 exact: measurable_fun_lim_esup.
 Qed.
-
 End emeasurable_fun.
 Arguments emeasurable_fun_cvg {d T R D} f_.
+
+Section lebesgue_regularity.
+
+Context {d : measure_display} {R : realType}.
+Let mu := [the measure _ _ of @lebesgue_measure R].
+
+Local Open Scope ereal_scope.
+
+Lemma lebesgue_regularity_outer (D : set R) (eps : R) : 
+  measurable D -> mu D < +oo -> (0 < eps)%R -> exists (U : set R),
+  [/\ @open R U , D `<=` U & mu(U `\` D) < eps%:E].
+Proof.
+move=> mD muDpos epspos.
+have /ereal_inf_lt [z [/= M' covDM sMz zDe]] : mu D < mu D + (eps/2)%:E.
+  by rewrite lte_addl // ?fin_num_abs ?gee0_abs // lte_fin divr_gt0.
+pose e2 n := (eps/2)/(2^(n.+1))%:R; have e2pos : forall n, (0 < e2 n)%R.
+  by move=> n; rewrite divr_gt0 // ?divr_gt0 // exprz_gt0.
+pose M n := if (pselect (M' n = set0)) then set0 else 
+           (`] inf (M' n), sup (M' n) + e2 n [%classic)%R.
+have muM : forall n, mu (M n) <= mu (M' n) + (e2 n)%:E.
+  rewrite /M => n; case: (pselect _) => /= [-> |]. 
+    by rewrite measure0 add0e lee_fin; apply: ltW; exact: e2pos.
+  have /ocitvP [-> //| [[a b /= alb -> ab0]]] : ocitv (M' n). 
+    by case: covDM => /(_ n).
+  rewrite ?inf_itv ?sup_itv //.
+  have -> : (`]a, (b+e2 n)%R[ = `]a, b] `|` `]b, (b+e2 n)%R[ )%classic.
+    apply: funext=> r /=; rewrite (@itv_splitU _ _ (BSide false b)).
+      by rewrite propeqE; split=> /orP.
+    by apply/andP; split => //; rewrite /Order.le /= ?ltr_spaddr //; exact: ltW.
+  rewrite measureU.
+  - rewrite /mu /= ?lebesgue_measure_itv ?hlength_itv /=.
+    have -> : b%:E < (b+e2 n)%:E by rewrite lte_fin ltr_spaddr.
+    by rewrite -?EFinD addrAC subrr add0r.
+  - by apply: sub_sigma_algebra; exact: is_ocitv.
+  - by apply: open_measurable; apply: interval_open.
+  - rewrite eqEsubset; split => // r []/andP [_ br] /andP [rb _] /=. 
+    suff : (b < b)%O by rewrite ltxx. 
+    by apply: lt_le_trans; first exact: rb.
+pose U := \bigcup_n M n.
+exists U; have DU : D `<=` U. 
+  case: (covDM) => _ /subset_trans; apply; apply: subset_bigcup.
+  rewrite /M => n _ x; case: (pselect _); first by move => /= ->.
+  have /ocitvP [-> //| [[/= a b alb -> mn]] abx] : ocitv (M' n). 
+    by case: covDM => /(_ n).
+  rewrite inE subitvE; apply/andP; split; rewrite ?inf_itv ?sup_itv //.
+    by case/andP: abx.
+  by case/andP: abx => ? ? //; apply: ltr_spaddr => //=; rewrite e2pos. 
+have mM : forall n, measurable (M n).
+  move=> n; rewrite /M; case: pselect; first by move=> /= _; exact: measurable0.
+  by move=> /= _; apply: open_measurable; apply: interval_open.
+have muU : mu U < mu D + eps%:E.
+  apply: (@le_lt_trans _ _ (\sum_(n <oo) (mu (M n)))). 
+    by apply: measure_sigma_sub_additive => //; apply: bigcup_measurable => + _.
+  apply: (@le_lt_trans _ _ (\sum_(n <oo) (mu (M' n) + (e2 n)%:E))). 
+  rewrite ?nneseries_esum //; first by apply: le_esum => + _; exact muM.
+    by move=> n _; apply: adde_ge0; rewrite // lee_fin; apply/ltW/ e2pos.
+  apply: le_lt_trans.
+    by apply: epsilon_trick; rewrite ?divr_ge0 //; first exact: ltW.
+  rewrite {2}[eps]splitr EFinD addeA; apply: lte_le_add => //.
+  apply: (le_lt_trans _ zDe); rewrite -sMz ?nneseries_esum //. 
+  apply: le_esum => i _; rewrite -hlength_Rhull -lebesgue_measure_itv.
+  apply: le_measure => //=; rewrite ?inE.
+  - by case: covDM => /(_ i) + _; exact: sub_sigma_algebra.
+  - exact: measurable_itv.
+  - exact: sub_Rhull.
+split => //.
+  apply: bigcup_open => n _; rewrite/M; case: pselect=>/= _; first exact: open0.
+  by apply: interval_open.
+rewrite measureD => //=.
+- rewrite [U`&` D]setIidr // lte_subel_addl // ge0_fin_numE //.
+  by apply: (lt_le_trans muU); apply: leey.
+- apply: bigcup_measurable => k _; rewrite /M. 
+  case: pselect => //= _; apply: open_measurable.
+    exact: interval_open.
+- by apply: (lt_le_trans muU); apply: leey.
+Qed.
+
+End lebesgue_regularity.
+
 #[deprecated(since="mathcomp-analysis 0.6.0", note="renamed `measurable_fun_lim_esup`")]
 Notation measurable_fun_elim_sup := measurable_fun_lim_esup.
 #[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurableT_comp` instead")]


### PR DESCRIPTION
##### Motivation for this change

A standard result for the lebesgue measure, made slightly complicated by the fact we use "half" open intervals. We have to extend each half open `]a,b]` from the ocitv covering by ` ]a,b] --> ]a, b + (eps/2) / (2^n)[`. Then use the epsilon trick. Nothing too exotic, just requires a little dedication. 

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- ~[] added corresponding documentation in the headers~

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 2.0

<!-- MathComp-Analysis is compatible with MathComp < 2.0 (branch `master`) and
     MathComp 2.0 ([branch `hierarchy-builder`](https://github.com/math-comp/analysis/pull/698)).

     If this PR targets `master` and if it is merged, the merged commit will also be
     cherry-picked on the branch `hierarchy-builder`.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `hierarchy-builder` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: HB port to record divergences between `master` and `hierarchy-builder` -->

- [x] I added the label `TODO: HB port` to make sure someone ports this PR to
      the `hierarchy-builder` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
