### PR TITLE
put all_classical in Make

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -8,6 +8,7 @@
 -arg -w -arg -redundant-canonical-projection
 -arg -w -arg -projection-no-head-constant
 
+classical/all_classical.v
 classical/boolp.v
 classical/classical_sets.v
 classical/mathcomp_extra.v

--- a/classical/Make
+++ b/classical/Make
@@ -14,3 +14,4 @@ functions.v
 cardinality.v
 fsbigop.v
 set_interval.v
+all_classical.v

--- a/classical/all_classical.v
+++ b/classical/all_classical.v
@@ -1,7 +1,7 @@
-Require Export boolp.
-Require Export classical_sets.
-Require Export mathcomp_extra.
-Require Export functions.
-Require Export cardinality.
-Require Export fsbigop.
-Require Export set_interval.
+From mathcomp.classical Require Export boolp.
+From mathcomp.classical Require Export classical_sets.
+From mathcomp.classical Require Export mathcomp_extra.
+From mathcomp.classical Require Export functions.
+From mathcomp.classical Require Export cardinality.
+From mathcomp.classical Require Export fsbigop.
+From mathcomp.classical Require Export set_interval.

--- a/classical/mathcomp_extra.v
+++ b/classical/mathcomp_extra.v
@@ -430,7 +430,7 @@ Proof. by apply: subitvP; rewrite subitvE !bound_lexx. Qed.
 (**********************************)
 
 Reserved Notation "`1- r" (format "`1- r", at level 2).
-Reserved Notation "f \^-1" (at level 3, format "f \^-1").
+Reserved Notation "f \^-1" (at level 3, format "f \^-1", left associativity).
 
 Lemma natr1 (R : ringType) (n : nat) : (n%:R + 1 = n.+1%:R :> R)%R.
 Proof. by rewrite GRing.mulrSr. Qed.


### PR DESCRIPTION
##### Motivation for this change

cherry-pick

##### Things done/to do

<!-- please fill in the following checklist -->
~~- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`~~

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [ ] added corresponding documentation in the headers~~

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 2.0

<!-- MathComp-Analysis is compatible with MathComp < 2.0 (branch `master`) and
     MathComp 2.0 ([branch `hierarchy-builder`](https://github.com/math-comp/analysis/pull/698)).

     If this PR targets `master` and if it is merged, the merged commit will also be
     cherry-picked on the branch `hierarchy-builder`.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `hierarchy-builder` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: HB port to record divergences between `master` and `hierarchy-builder` -->

- [ ] I added the label `TODO: HB port` to make sure someone ports this PR to
      the `hierarchy-builder` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
