### PR TITLE
Simple functions are dense in L1

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -48,6 +48,8 @@
   + lemmas `poweRD_defE`, `poweRB_defE`, `add_neq0_poweRD_def`,
     `add_neq0_poweRB_def`, `nneg_neq0_poweRD_def`, `nneg_neq0_poweRB_def`
   + lemmas `powR_eq0`, `poweR_eq0`
+- in file `lebesgue_integral.v`,
+  + new lemma `approximation_sfun_integrable`.
 
 ### Changed
 
@@ -123,6 +125,8 @@
   + lemmas `convex_expR`, `ler_power_pos` (now `ler_powR`)
 - in `exp.v`:
   + lemma `ln_power_pos` (now `ln_powR`)
+  + lemma `ln_power_pos`
+- in file `lebesgue_integral.v`, updated `le_approx`.
 
 ### Deprecated
 


### PR DESCRIPTION
##### Motivation for this change

To prove that continuous functions are dense in L1, I'm gonna go in two steps. First, simple functions are dense in L1, and continuous functions are dense in simple functions. (Tietze's extension theorem has a useful "strong" form for bounded functions, so it's way nicer to work with simple functions than measurable).

Note that we already have `approximation_sfun` which works when `f` is measurable. Here we prove that if `f` is also integrable, then all the approximators are integrable themselves, and they converge in the L1 norm (thanks to dominated convergence). An annoying amount of time is spent proving various terms are integrable, and `fin_num` results. I suppose having a proper algebra for the L1 space would automate this. But for now this is fine.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 2.0

<!-- MathComp-Analysis is compatible with MathComp < 2.0 (branch `master`) and
     MathComp 2.0 ([branch `hierarchy-builder`](https://github.com/math-comp/analysis/pull/698)).

     If this PR targets `master` and if it is merged, the merged commit will also be
     cherry-picked on the branch `hierarchy-builder`.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `hierarchy-builder` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: HB port to record divergences between `master` and `hierarchy-builder` -->

- [x] I added the label `TODO: HB port` to make sure someone ports this PR to
      the `hierarchy-builder` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
