### PR TITLE
Zorn lemma for inclusion

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -54,6 +54,9 @@
 - in `classical_sets.v`:
   + lemmas `properW`, `properxx`
 
+- in `classical_sets.v`:
+  + lemma `Zorn_bigcup`
+
 ### Changed
 
 - moved from `lebesgue_measure.v` to `real_interval.v`:

--- a/classical/classical_sets.v
+++ b/classical/classical_sets.v
@@ -2677,12 +2677,12 @@ Lemma Zorn T (R : T -> T -> Prop) :
   exists t, forall s, R t s -> s = t.
 Proof.
 move=> Rrefl Rtrans Rantisym Rtot_max.
-set totR := ({A : set T | total_on A R}).
+pose totR := {A : set T | total_on A R}.
 set R' := fun A B : totR => sval A `<=` sval B.
 have R'refl A : R' A A by [].
 have R'trans A B C : R' A B -> R' B C -> R' A C by apply: subset_trans.
 have R'antisym A B : R' A B -> R' B A -> A = B.
-  rewrite /R'; case: A; case: B => /= B totB A totA sAB sBA.
+  rewrite /R'; move: A B => [/= A totA] [/= B totB] sAB sBA.
   by apply: eq_exist; rewrite predeqE=> ?; split=> [/sAB|/sBA].
 have R'tot_lub A : total_on A R' -> exists t, (forall s, A s -> R' s t) /\
     forall r, (forall s, A s -> R' s r) -> R' t r.
@@ -2693,7 +2693,7 @@ have R'tot_lub A : total_on A R' -> exists t, (forall s, A s -> R' s t) /\
       by have /(_ _ _ Cs Ct) := svalP C.
     by have /(_ _ _ Bs Bt) := svalP B.
   exists (exist _ (\bigcup_(B in A) sval B) AUtot); split.
-    by move=> B ???; exists B.
+    by move=> B ? ? ?; exists B.
   by move=> B Bub ? /= [? /Bub]; apply.
 apply: contrapT => nomax.
 have {}nomax t : exists s, R t s /\ s <> t.
@@ -2708,9 +2708,9 @@ have Astot : total_on (sval A `|` [set s]) R.
     by move=> [/tub Rvt|->]; right=> //; apply: Rtrans Rts.
   move=> [Av|->]; [apply: (svalP A)|left] => //.
   by apply: Rtrans Rts; apply: tub.
-exists (exist _ (sval A `|` [set s]) Astot); split; first by move=> ??; left.
+exists (exist _ (sval A `|` [set s]) Astot); split; first by move=> ? ?; left.
 split=> [AeAs|[B Btot] sAB sBAs].
-  have [/tub Rst|] := (pselect (sval A s)); first exact/snet/Rantisym.
+  have [/tub Rst|] := pselect (sval A s); first exact/snet/Rantisym.
   by rewrite AeAs /=; apply; right.
 have [Bs|nBs] := pselect (B s).
   by right; apply: eq_exist; rewrite predeqE => r; split=> [/sBAs|[/sAB|->]].
@@ -2718,6 +2718,29 @@ left; case: A tub Astot sBAs sAB => A Atot /= tub Astot sBAs sAB.
 apply: eq_exist; rewrite predeqE => r; split=> [Br|/sAB] //.
 by have /sBAs [|ser] // := Br; rewrite ser in Br.
 Qed.
+
+Section Zorn_subset.
+Variables (T : Type) (P : set T -> Prop).
+Let sigP := {x | P x}.
+Let R (sA sB : sigP) := sval sA `<=` sval sB.
+
+Lemma Zorn_bigcup :
+    (forall F, total_on F R -> P (\bigcup_(x in F) sval x)) ->
+  exists A, P A /\ forall B, A `<` B -> ~ P B.
+Proof.
+move=> totR.
+have {}totR F : total_on F R -> exists sB, forall sA, F sA -> R sA sB.
+  by move=> FR; exists (exist _ _ (totR _ FR)) => sA FsA; exact: bigcup_sup.
+have [| | |sA sAmax] := Zorn _ _ _ totR.
+- by move=> ?; exact: subset_refl.
+- by move=> ? ? ?; exact: subset_trans.
+- by move=> [A PA] [B PB]; rewrite /R /= => AB BA; exact/eq_exist/seteqP.
+- exists (sval sA); case: sA => A PA in sAmax *; split => //= B AB PB.
+  have [BA] := sAmax (exist _ B PB) (properW AB).
+  by move: AB; rewrite BA; exact: properxx.
+Qed.
+
+End Zorn_subset.
 
 Definition premaximal T (R : T -> T -> Prop) (t : T) :=
   forall s, R t s -> R s t.


### PR DESCRIPTION
##### Motivation for this change

Corollary of Zorn's lemma.
It has a new on its own (https://fr.wikipedia.org/wiki/Lemme_de_Zorn#Principes_de_maximalit%C3%A9_pour_l'inclusion) and happens to be exactly what we need for Vitali's lemma (PR #973 )

@t6s 

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 2.0

<!-- MathComp-Analysis is compatible with MathComp < 2.0 (branch `master`) and
     MathComp 2.0 ([branch `hierarchy-builder`](https://github.com/math-comp/analysis/pull/698)).

     If this PR targets `master` and if it is merged, the merged commit will also be
     cherry-picked on the branch `hierarchy-builder`.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `hierarchy-builder` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: HB port to record divergences between `master` and `hierarchy-builder` -->

- [x] I added the label `TODO: HB port` to make sure someone ports this PR to
      the `hierarchy-builder` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
