### PR TITLE
fixes #979 (my_ball_le from local lemme to `Let`)

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -162,6 +162,9 @@
 
 ### Removed
 
+- in `topology.v`:
+  + lemma `my_ball_le` (use `ball_le` instead)
+
 ### Infrastructure
 
 ### Misc

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -4902,13 +4902,12 @@ Export PseudoMetric.Exports.
 
 Section PseudoMetricUniformity.
 
-Lemma my_ball_le (R : numDomainType) (M : Type) (ent : set (set (M * M)))
+Let ball_le (R : numDomainType) (M : Type) (ent : set (set (M * M)))
     (m : PseudoMetric.mixin_of R ent) :
   forall (x : M), {homo PseudoMetric.ball m x : e1 e2 / e1 <= e2 >-> e1 `<=` e2}.
 Proof.
-move=> x e1 e2 le12 y xe1_y.
-move: le12; rewrite le_eqVlt => /orP [/eqP <- //|].
-rewrite -subr_gt0 => lt12.
+move=> x e1 e2 + y xe1_y.
+rewrite le_eqVlt => /predU1P[<- //|]; rewrite -subr_gt0 => lt12.
 rewrite -[e2](subrK e1); apply: PseudoMetric.ball_triangle xe1_y.
 suff : PseudoMetric.ball m x (PosNum lt12)%:num x by [].
 exact: PseudoMetric.ball_center.
@@ -4922,7 +4921,7 @@ Next Obligation.
 move=> R T ent nbhs nbhsE m; rewrite (PseudoMetric.entourageE m).
 apply: filter_from_filter; first by exists 1 => /=.
 move=> _ _ /posnumP[e1] /posnumP[e2]; exists (Num.min e1 e2)%:num => //=.
-by rewrite subsetI; split=> ?; apply: my_ball_le;
+by rewrite subsetI; split=> ?; apply: ball_le;
    rewrite -leEsub// le_minl lexx ?orbT.
 Qed.
 Next Obligation.


### PR DESCRIPTION
##### Motivation for this change

fixes #979 

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 2.0

<!-- MathComp-Analysis is compatible with MathComp < 2.0 (branch `master`) and
     MathComp 2.0 ([branch `hierarchy-builder`](https://github.com/math-comp/analysis/pull/698)).

     If this PR targets `master` and if it is merged, the merged commit will also be
     cherry-picked on the branch `hierarchy-builder`.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `hierarchy-builder` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: HB port to record divergences between `master` and `hierarchy-builder` -->

- [x] I added the label `TODO: HB port` to make sure someone ports this PR to
      the `hierarchy-builder` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
