### PR TITLE
Cherry-pick queue for the MathComp 2 port

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -51,6 +51,9 @@
 - in file `lebesgue_integral.v`,
   + new lemma `approximation_sfun_integrable`.
 
+- in `classical_sets.v`:
+  + lemmas `properW`, `properxx`
+
 ### Changed
 
 - moved from `lebesgue_measure.v` to `real_interval.v`:
@@ -119,6 +122,15 @@
   + `powere_posM` -> `poweRM`
   + `powere12_sqrt` -> `poweR12_sqrt`
 
+- in `lebesgue_integral.v`:
+  + `ge0_integralM_EFin` -> `ge0_integralZl_EFin`
+  + `ge0_integralM` -> `ge0_integralZl`
+  + `integralM_indic` -> `integralZl_indic`
+  + `integralM_indic_nnsfun` -> `integralZl_indic_nnsfun`
+  + `integrablerM` -> `integrableZl`
+  + `integrableMr` -> `integrableZr`
+  + `integralM` -> `integralZl`
+
 ### Generalized
 
 - in `exp.v`:
@@ -127,6 +139,11 @@
   + lemma `ln_power_pos` (now `ln_powR`)
   + lemma `ln_power_pos`
 - in file `lebesgue_integral.v`, updated `le_approx`.
+
+- in `sequences.v`:
+  + lemmas `is_cvg_nneseries_cond`, `is_cvg_npeseries_cond`
+  + lemmas `is_cvg_nneseries`, `is_cvg_npeseries`
+  + lemmas `nneseries_ge0`, `npeseries_le0`
 
 ### Deprecated
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -40,6 +40,13 @@
   + lemmas `set_predC`, `preimage_true`, `preimage_false`
 - in `lebesgue_measure.v`:
   + lemmas `measurable_fun_ltr`, `measurable_minr`
+- in file `lebesgue_integral.v`,
+  + new lemmas `lusin_simple`, and `measurable_almost_continuous`.
+- in file `measure.v`,
+  + new lemmas `finite_card_sum`, and `measureU2`.
+
+- in `topology.v`:
+  + lemma `bigsetU_compact`
 
 - in `exp.v`:
   + notation `` e `^?(r +? s) ``

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -61,6 +61,9 @@
 - in `classical_sets.v`:
   + lemmas `properW`, `properxx`
 
+- in `classical_sets.v`:
+  + lemma `Zorn_bigcup`
+
 ### Changed
 
 - moved from `lebesgue_measure.v` to `real_interval.v`:

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -162,6 +162,9 @@
 
 ### Removed
 
+- in `topology.v`:
+  + lemma `my_ball_le` (use `ball_le` instead)
+
 ### Infrastructure
 
 ### Misc

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -48,6 +48,8 @@
   + lemmas `poweRD_defE`, `poweRB_defE`, `add_neq0_poweRD_def`,
     `add_neq0_poweRB_def`, `nneg_neq0_poweRD_def`, `nneg_neq0_poweRB_def`
   + lemmas `powR_eq0`, `poweR_eq0`
+- in file `lebesgue_integral.v`,
+  + new lemma `approximation_sfun_integrable`.
 
 ### Changed
 
@@ -123,6 +125,8 @@
   + lemmas `convex_expR`, `ler_power_pos` (now `ler_powR`)
 - in `exp.v`:
   + lemma `ln_power_pos` (now `ln_powR`)
+  + lemma `ln_power_pos`
+- in file `lebesgue_integral.v`, updated `le_approx`.
 
 ### Deprecated
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -152,6 +152,12 @@
   + lemmas `is_cvg_nneseries`, `is_cvg_npeseries`
   + lemmas `nneseries_ge0`, `npeseries_le0`
 
+- in `measure.v`:
+  + lemmas `measureDI`, `measureD`, `measureUfinl`, `measureUfinr`,
+    `null_set_setU`, `measureU0`
+    (from measure to content)
+  + lemma `subset_measure0` (from `realType` to `realFieldType`)
+
 ### Deprecated
 
 ### Removed

--- a/classical/classical_sets.v
+++ b/classical/classical_sets.v
@@ -60,6 +60,7 @@ From mathcomp Require Import mathcomp_extra boolp.
 (*                 \bigcap_i F == same as before with T left implicit.        *)
 (*                smallest C G := \bigcap_(A in [set M | C M /\ G `<=` M]) A  *)
 (*                   A `<=` B <-> A is included in B.                         *)
+(*                    A `<` B := A `<=` B /\ ~ (B `<=` A)                     *)
 (*                  A `<=>` B <-> double inclusion A `<=` B and B `<=` A.     *)
 (*                   f @^-1` A == preimage of A by f.                         *)
 (*                      f @` A == image of A by f. Notation for `image A f`.  *)
@@ -530,6 +531,10 @@ Lemma subset_trans B A C : A `<=` B -> B `<=` C -> A `<=` C.
 Proof. by move=> sAB sBC ? ?; apply/sBC/sAB. Qed.
 
 Lemma sub0set A : set0 `<=` A. Proof. by []. Qed.
+
+Lemma properW A B : A `<` B -> A `<=` B. Proof. by case. Qed.
+
+Lemma properxx A : ~ A `<` A. Proof. by move=> [?]; apply. Qed.
 
 Lemma setC0 : ~` set0 = setT :> set T.
 Proof. by rewrite predeqE; split => ?. Qed.

--- a/classical/mathcomp_extra.v
+++ b/classical/mathcomp_extra.v
@@ -830,3 +830,18 @@ Reserved Notation "f \min g" (at level 50, left associativity).
 Definition min_fun T (R : numDomainType) (f g : T -> R) x := Num.min (f x) (g x).
 Notation "f \min g" := (min_fun f g) : ring_scope.
 Arguments min_fun {T R} _ _ _ /.
+
+(* NB: Coq 8.17.0 generalizes dependent_choice from Set to Type
+   making the following lemma redundant *)
+Section dependent_choice_Type.
+Context X (R : X -> X -> Prop).
+
+Lemma dependent_choice_Type : (forall x, {y | R x y}) ->
+  forall x0, {f | f 0%N = x0 /\ forall n, R (f n) (f n.+1)}.
+Proof.
+move=> h x0.
+set (f := fix f n := if n is n'.+1 then proj1_sig (h (f n')) else x0).
+exists f; split => //.
+intro n; induction n; simpl; apply: proj2_sig.
+Qed.
+End dependent_choice_Type.

--- a/theories/charge.v
+++ b/theories/charge.v
@@ -69,21 +69,6 @@ Unset Printing Implicit Defensive.
 Import Order.TTheory GRing.Theory Num.Def Num.Theory.
 Import numFieldTopology.Exports.
 
-(* NB: in the next releases of Coq, dependent_choice will be
-   generalized from Set to Type making the following lemma redundant *)
-Section dependent_choice_Type.
-Context X (R : X -> X -> Prop).
-
-Lemma dependent_choice_Type : (forall x, {y | R x y}) ->
-  forall x0, {f | f 0 = x0 /\ forall n, R (f n) (f n.+1)}.
-Proof.
-move=> h x0.
-set (f := fix f n := if n is n'.+1 then proj1_sig (h (f n')) else x0).
-exists f; split => //.
-intro n; induction n; simpl; apply: proj2_sig.
-Qed.
-End dependent_choice_Type.
-
 Local Open Scope ring_scope.
 Local Open Scope classical_set_scope.
 Local Open Scope ereal_scope.
@@ -723,7 +708,7 @@ move=> /cvg_ex[[l| |]]; first last.
     have : nu N <= -oo by rewrite -limNoo// nuN.
     by rewrite leNgt => /negP; apply; rewrite ltNye_eq fin_num_measure.
   - move/cvg_lim => limoo.
-    have := @npeseries_le0 _ (fun n => maxe (z_ (v n) * 2^-1%:E) (- 1%E)) xpredT.
+    have := @npeseries_le0 _ (fun n => maxe (z_ (v n) * 2^-1%:E) (- 1%E)) xpredT 0.
     by rewrite limoo// leNgt => /(_ (fun n _ => max_le0 n))/negP; apply.
 move/fine_cvgP => [Hfin cvgl].
 have : cvg (series (fun n => fine (maxe (z_ (v n) * 2^-1%:E) (- 1%E))) n @[n --> \oo]).

--- a/theories/kernel.v
+++ b/theories/kernel.v
@@ -509,7 +509,7 @@ rewrite [X in measurable_fun _ X](_ : _ = (fun x => r%:E *
     \int[l x]_y (\1_(k_ n @^-1` [set r]) (x, y))%:E)); last first.
   apply/funext => x; under eq_integral do rewrite EFinM.
   have [r0|r0] := leP 0%R r.
-    rewrite ge0_integralM//; last by move=> y _; rewrite lee_fin.
+    rewrite ge0_integralZl//; last by move=> y _; rewrite lee_fin.
     exact/EFin_measurable_fun/measurableT_comp.
   rewrite integral0_eq; last first.
     by move=> y _; rewrite preimage_nnfun0// indic0 mule0.
@@ -1083,7 +1083,7 @@ under [in RHS]eq_integral.
     - by move=> r z _; rewrite EFinM nnfun_muleindic_ge0.
   under eq_fsbigr.
     move=> r _.
-    rewrite (integralM_indic _ (fun r => f @^-1` [set r]))//; last first.
+    rewrite (integralZl_indic _ (fun r => f @^-1` [set r]))//; last first.
       by move=> r0; rewrite preimage_nnfun0.
     rewrite integral_indic// setIT.
     over.
@@ -1095,11 +1095,11 @@ rewrite /= ge0_integral_fsum//; last 2 first.
     have := mulemu_ge0 (fun n => f @^-1` [set n]).
     by apply; exact: preimage_nnfun0.
 apply: eq_fsbigr => r _.
-rewrite (integralM_indic _ (fun r => f @^-1` [set r]))//; last first.
+rewrite (integralZl_indic _ (fun r => f @^-1` [set r]))//; last first.
   exact: preimage_nnfun0.
 rewrite /= integral_kcomp_indic; last exact/measurable_sfunP.
 have [r0|r0] := leP 0%R r.
-  rewrite ge0_integralM//; last first.
+  rewrite ge0_integralZl//; last first.
     exact: measurableT_comp (measurable_kernel k (f @^-1` [set r]) _) _.
   by congr (_ * _); apply: eq_integral => y _; rewrite integral_indic// setIT.
 rewrite integral0_eq ?mule0; last first.

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -1588,7 +1588,7 @@ Variables f1 f2 : T -> \bar R.
 Hypothesis f10 : forall x, D x -> 0 <= f1 x.
 Hypothesis mf1 : measurable_fun D f1.
 
-Lemma ge0_integralM_EFin k : (0 <= k)%R ->
+Lemma ge0_integralZl_EFin k : (0 <= k)%R ->
   \int[mu]_(x in D) (k%:E * f1 x) = k%:E * \int[mu]_(x in D) f1 x.
 Proof.
 rewrite integral_mkcond erestrict_scale [in RHS]integral_mkcond => k0.
@@ -1613,6 +1613,8 @@ rewrite (@nd_ge0_integral_lim _ _ _ mu (fun x => k%:E * h1 x) kg).
 Qed.
 
 End semi_linearity0.
+#[deprecated(since="mathcomp-analysis 0.6.4", note="use `ge0_integralZl_EFin` instead")]
+Notation ge0_integralM_EFin := ge0_integralZl_EFin.
 
 Section semi_linearity.
 Local Open Scope ereal_scope.
@@ -2108,19 +2110,19 @@ Qed.
 
 End integral_nneseries.
 
-(* generalization of ge0_integralM_EFin to a constant potentially +oo
+(* generalization of ge0_integralZl_EFin to a constant potentially +oo
    using the monotone convergence theorem *)
-Section ge0_integralM.
+Section ge0_integralZl.
 Local Open Scope ereal_scope.
 Context d (T : measurableType d) (R : realType).
 Variable mu : {measure set T -> \bar R}.
 Variables (D : set T) (mD : measurable D) (f : T -> \bar R).
 Hypothesis mf : measurable_fun D f.
 
-Lemma ge0_integralM (k : \bar R) : (forall x, D x -> 0 <= f x) ->
+Lemma ge0_integralZl (k : \bar R) : (forall x, D x -> 0 <= f x) ->
   0 <= k -> \int[mu]_(x in D) (k * f x)%E = k * \int[mu]_(x in D) (f x).
 Proof.
-move=> f0; move: k => [k|_|//]; first exact: ge0_integralM_EFin.
+move=> f0; move: k => [k|_|//]; first exact: ge0_integralZl_EFin.
 pose g : (T -> \bar R)^nat := fun n x => n%:R%:E * f x.
 have mg n : measurable_fun D (g n) by apply: measurable_funeM.
 have g0 n x : D x -> 0 <= g n x.
@@ -2154,7 +2156,7 @@ transitivity (\int[mu]_(x in D) limn (g^~ x)).
       exact: cvg_cst.
     by rewrite funeqE => n /=; rewrite mule0.
 rewrite (monotone_convergence mu mD mg g0 nd_g).
-under eq_fun do  rewrite /g ge0_integralM_EFin//.
+under eq_fun do  rewrite /g ge0_integralZl_EFin//.
 have : 0 <= \int[mu]_(x in D) (f x) by exact: integral_ge0.
 rewrite le_eqVlt => /predU1P[<-|if_gt0].
   by rewrite mule0; under eq_fun do rewrite mule0; rewrite lim_cst.
@@ -2174,7 +2176,9 @@ rewrite lee_fin natr_absz ger0_norm ?ceil_ge// ceil_ge0//.
 by rewrite mulr_ge0// ?invr_ge0//; apply/fine_ge0/integral_ge0.
 Unshelve. all: by end_near. Qed.
 
-End ge0_integralM.
+End ge0_integralZl.
+#[deprecated(since="mathcomp-analysis 0.6.4", note="use `ge0_integralZl` instead")]
+Notation ge0_integralM := ge0_integralZl.
 
 Section integral_indic.
 Local Open Scope ereal_scope.
@@ -2190,12 +2194,12 @@ Qed.
 
 End integral_indic.
 
-Section integralM_indic.
+Section integralZl_indic.
 Local Open Scope ereal_scope.
 Context d (T : measurableType d) (R : realType).
 Variables (m : {measure set T -> \bar R}) (D : set T) (mD : measurable D).
 
-Lemma integralM_indic (f : R -> set T) (k : R) :
+Lemma integralZl_indic (f : R -> set T) (k : R) :
     ((k < 0)%R -> f k = set0) -> measurable (f k) ->
   \int[m]_(x in D) (k * \1_(f k) x)%:E =
   k%:E * \int[m]_(x in D) (\1_(f k) x)%:E.
@@ -2204,20 +2208,24 @@ move=> fk0 mfk; have [k0|k0] := ltP k 0%R.
   rewrite integral0_eq//; last by move=> x _; rewrite fk0// indic0 mulr0.
   by rewrite integral0_eq ?mule0// => x _; rewrite fk0// indic0.
 under eq_integral do rewrite EFinM.
-rewrite ge0_integralM//; first exact/EFin_measurable_fun.
+rewrite ge0_integralZl//; first exact/EFin_measurable_fun.
 by move=> y _; rewrite lee_fin.
 Qed.
 
-Lemma integralM_indic_nnsfun (f : {nnsfun T >-> R}) (k : R) :
+Lemma integralZl_indic_nnsfun (f : {nnsfun T >-> R}) (k : R) :
   \int[m]_(x in D) (k * \1_(f @^-1` [set k]) x)%:E =
   k%:E * \int[m]_(x in D) (\1_(f @^-1` [set k]) x)%:E.
 Proof.
-rewrite (@integralM_indic (fun k => f @^-1` [set k]))// => k0.
+rewrite (@integralZl_indic (fun k => f @^-1` [set k]))// => k0.
 by rewrite preimage_nnfun0.
 Qed.
 
-End integralM_indic.
-Arguments integralM_indic {d T R m D} mD f.
+End integralZl_indic.
+Arguments integralZl_indic {d T R m D} mD f.
+#[deprecated(since="mathcomp-analysis 0.6.4", note="use `integralZl_indic` instead")]
+Notation integralM_indic := integralZl_indic.
+#[deprecated(since="mathcomp-analysis 0.6.4", note="use `integralZl_indic_nnsfun` instead")]
+Notation integralM_indic_nnsfun := integralZl_indic_nnsfun.
 
 Section integral_mscale.
 Local Open Scope ereal_scope.
@@ -2237,7 +2245,7 @@ under [LHS]eq_integral do rewrite fimfunE -fsumEFin//.
 rewrite [LHS]ge0_integral_fsum//; last 2 first.
   - by move=> r; exact/EFin_measurable_fun/measurableT_comp.
   - by move=> n x _; rewrite EFinM nnfun_muleindic_ge0.
-rewrite -[RHS]ge0_integralM//; last 2 first.
+rewrite -[RHS]ge0_integralZl//; last 2 first.
   - exact/EFin_measurable_fun/measurable_funTS.
   - by move=> x _; rewrite lee_fin.
 under [RHS]eq_integral.
@@ -2247,8 +2255,8 @@ under [RHS]eq_integral.
 rewrite [RHS]ge0_integral_fsum//; last 2 first.
   - by move=> r; apply/EFin_measurable_fun; do 2 apply/measurableT_comp => //.
   - by move=> n x _; rewrite EFinM mule_ge0// nnfun_muleindic_ge0.
-apply: eq_fsbigr => r _; rewrite ge0_integralM//.
-- by rewrite !integralM_indic_nnsfun//= integral_mscale_indic// muleCA.
+apply: eq_fsbigr => r _; rewrite ge0_integralZl//.
+- by rewrite !integralZl_indic_nnsfun//= integral_mscale_indic// muleCA.
 - exact/EFin_measurable_fun/measurableT_comp.
 - by move=> t _; rewrite nnfun_muleindic_ge0.
 Qed.
@@ -2446,8 +2454,8 @@ transitivity (\sum_(k \in range (f_ n))
   rewrite ge0_integral_fsum//; last 2 first.
     - by move=> y; apply/EFin_measurable_fun; exact: measurable_funM.
     - by move=> y x _; rewrite nnfun_muleindic_ge0.
-  apply: eq_fsbigr => r _; rewrite integralM_indic_nnsfun// integral_indic//=.
-  rewrite (integralM_indic _ (fun r => f_ n @^-1` [set r] \o phi))//.
+  apply: eq_fsbigr => r _; rewrite integralZl_indic_nnsfun// integral_indic//=.
+  rewrite (integralZl_indic _ (fun r => f_ n @^-1` [set r] \o phi))//.
     by congr (_ * _); rewrite [RHS](@integral_indic).
   by move=> r0; rewrite preimage_nnfun0.
 rewrite -ge0_integral_fsum//; last 2 first.
@@ -2480,7 +2488,7 @@ rewrite (_ : (fun _ => _) = (fun n => (f_ n a)%:E)).
 apply/funext => n.
 under eq_integral do rewrite fimfunE// -fsumEFin//.
 rewrite ge0_integral_fsum//.
-- under eq_fsbigr do rewrite integralM_indic_nnsfun//.
+- under eq_fsbigr do rewrite integralZl_indic_nnsfun//.
   rewrite /= (fsbigD1 (f_ n a))//=; last by exists a.
   rewrite integral_indic//= diracE mem_set// mule1.
   rewrite fsbig1 ?adde0// => r /= [_ rfna].
@@ -2528,7 +2536,7 @@ rewrite ge0_integral_fsum//; last 2 first.
 transitivity (\sum_(i \in range f)
     (\sum_(n < N) i%:E * \int[m_ n]_x (\1_(f @^-1` [set i]) x)%:E)).
   apply: eq_fsbigr => r _.
-  rewrite integralM_indic_nnsfun// integral_measure_sum_indic//.
+  rewrite integralZl_indic_nnsfun// integral_measure_sum_indic//.
   by rewrite ge0_sume_distrr// => n _; apply: integral_ge0 => t _; rewrite lee_fin.
 rewrite fsbig_finite//= exchange_big/=; apply: eq_bigr => i _.
 rewrite integralT_nnsfun sintegralE fsbig_finite//=; apply: eq_bigr => r _.
@@ -2638,7 +2646,7 @@ rewrite ge0_integral_fsum//; last 2 first.
 transitivity (\sum_(i \in range f)
     (\sum_(n <oo) i%:E * \int[m_ n]_x (\1_(f @^-1` [set i]) x)%:E)).
   apply: eq_fsbigr => r _.
-  rewrite integralM_indic_nnsfun// integral_measure_series_indic// nneseriesrM//.
+  rewrite integralZl_indic_nnsfun// integral_measure_series_indic// nneseriesrM//.
   by move=> n _; apply: integral_ge0 => t _; rewrite lee_fin.
 rewrite fsbig_finite//= -nneseries_sum; last first.
   move=> r j _.
@@ -2847,17 +2855,17 @@ move=> /integrableP[mf foo]; apply/integrableP; split; last first.
 by rewrite /comp; apply: measurableT_comp =>//; exact: measurable_oppe.
 Qed.
 
-Lemma integrablerM (k : R) f : mu_int f -> mu_int (fun x => k%:E * f x).
+Lemma integrableZl (k : R) f : mu_int f -> mu_int (fun x => k%:E * f x).
 Proof.
 move=> /integrableP[mf foo]; apply/integrableP; split.
   exact: measurable_funeM.
 under eq_fun do rewrite abseM.
-by rewrite ge0_integralM// ?lte_mul_pinfty//; exact: measurableT_comp.
+by rewrite ge0_integralZl// ?lte_mul_pinfty//; exact: measurableT_comp.
 Qed.
 
-Lemma integrableMr (k : R) f : mu_int f -> mu_int (f \* cst k%:E).
+Lemma integrableZr (k : R) f : mu_int f -> mu_int (f \* cst k%:E).
 Proof.
-by move=> mf; apply: eq_integrable (integrablerM k mf) => // x; rewrite muleC.
+by move=> mf; apply: eq_integrable (integrableZl k mf) => // x; rewrite muleC.
 Qed.
 
 Lemma integrableD f g : mu_int f -> mu_int g -> mu_int (f \+ g).
@@ -2971,6 +2979,10 @@ Qed.
 End integrable_theory.
 Notation "mu .-integrable" := (integrable mu) : type_scope.
 Arguments eq_integrable {d T R mu D} mD f.
+#[deprecated(since="mathcomp-analysis 0.6.4", note="use `integrableZl` instead")]
+Notation integrablerM := integrableZl.
+#[deprecated(since="mathcomp-analysis 0.6.4", note="use `integrableZr` instead")]
+Notation integrableMr := integrableZr.
 
 Section sequence_measure.
 Local Open Scope ereal_scope.
@@ -3149,7 +3161,7 @@ have [->|/set0P E0] := eqVneq E set0; first by rewrite measure0.
 have [M M0 muM] : exists2 M, (0 <= M)%R &
     forall n, n%:R%:E * mu (E `&` D) <= M%:E.
   exists (fine (\int[mu]_(x in D) `|f x|)); first exact/fine_ge0/integral_ge0.
-  move=> n; rewrite -integral_indic// -ge0_integralM//; last 2 first.
+  move=> n; rewrite -integral_indic// -ge0_integralZl//; last 2 first.
     - exact: measurableT_comp.
     - by move=> *; rewrite lee_fin.
   rewrite fineK//; last first.
@@ -3182,7 +3194,7 @@ Qed.
 
 End integrable_ae.
 
-Section linearityM.
+Section linearity.
 Local Open Scope ereal_scope.
 Context d (T : measurableType d) (R : realType).
 Variables (mu : {measure set T -> \bar R}) (D : set T) (mD : measurable D).
@@ -3191,20 +3203,20 @@ Hypothesis intf : mu.-integrable D f.
 
 Let mesf : measurable_fun D f. Proof. exact: measurable_int intf. Qed.
 
-Lemma integralM r :
+Lemma integralZl r :
   \int[mu]_(x in D) (r%:E * f x) = r%:E * \int[mu]_(x in D) f x.
 Proof.
 have [r0|r0|->] := ltgtP r 0%R; last first.
   by under eq_fun do rewrite mul0e; rewrite mul0e integral0.
 - rewrite [in LHS]integralE// gt0_funeposM// gt0_funenegM//.
-  rewrite (ge0_integralM_EFin _ _ _ _ (ltW r0)) //; last first.
+  rewrite (ge0_integralZl_EFin _ _ _ _ (ltW r0)) //; last first.
     exact: measurable_funepos.
-  rewrite (ge0_integralM_EFin _ _ _ _ (ltW r0)) //; last first.
+  rewrite (ge0_integralZl_EFin _ _ _ _ (ltW r0)) //; last first.
     exact: measurable_funeneg.
   rewrite -muleBr 1?[in RHS]integralE//.
   exact: integrable_add_def.
 - rewrite [in LHS]integralE// lt0_funeposM// lt0_funenegM//.
-  rewrite ge0_integralM_EFin //; last 2 first.
+  rewrite ge0_integralZl_EFin //; last 2 first.
     + exact: measurable_funeneg.
     + by rewrite -lerNr oppr0 ltW.
   rewrite ge0_integralM_EFin //; last 2 first.
@@ -3215,7 +3227,9 @@ have [r0|r0|->] := ltgtP r 0%R; last first.
   by rewrite [in RHS]integralE.
 Qed.
 
-End linearityM.
+End linearity.
+#[deprecated(since="mathcomp-analysis 0.6.4", note="use `integralZl` instead")]
+Notation integralM := integralZl.
 
 Section linearity.
 Local Open Scope ereal_scope.
@@ -3416,7 +3430,7 @@ have le_f_M t : D t -> `|f t| <= M%:E * (f' t)%:E.
   by rewrite notin_set=> /not_andP[//|/negP/negPn/eqP ->]; rewrite abse0 mule0.
 have : 0 <= \int[mu]_(x in D) `|f x|  <= `|M|%:E * mu Df_neq0.
   rewrite integral_ge0//= /Df_neq0 -{2}(setIid D) setIAC -integral_indic//.
-  rewrite -/Df_neq0 -ge0_integralM//; last 2 first.
+  rewrite -/Df_neq0 -ge0_integralZl//; last 2 first.
     - exact: measurableT_comp.
     - by move=> x ?; rewrite lee_fin.
   apply: ge0_le_integral => //.
@@ -4024,7 +4038,7 @@ rewrite [X in X <= _ -> _](_ : _ = \int[mu]_(x in D) (2%:E * g x) ); last first.
   rewrite [X in _ + X](_ : _ = 0) ?adde0//; apply/cvg_lim => //.
   by rewrite -(oppe0); apply: cvgeN; exact: cvg_g_.
 have i2g : \int[mu]_(x in D) (2%:E * g x)  < +oo.
-rewrite integralM// lte_mul_pinfty// ?lee_fin//; case: (integrableP _ _ _ ig) => _.
+rewrite integralZl// lte_mul_pinfty// ?lee_fin//; case: (integrableP _ _ _ ig) => _.
   apply: le_lt_trans; rewrite le_eqVlt; apply/orP; left; apply/eqP.
   by apply: eq_integral => t Dt; rewrite gee0_abs// g0//; rewrite inE in Dt.
 have ? : \int[mu]_(x in D) (2%:E * g x)  \is a fin_num.
@@ -4035,7 +4049,7 @@ rewrite [X in _ <= X -> _](_ : _ = \int[mu]_(x in D) (2%:E * g x)  + -
       \int[mu]_(x in D) - g_ n x)); last first.
     rewrite funeqE => n; rewrite integralB//.
     - by rewrite -integral_ge0N// => x Dx//; rewrite /g_.
-    - exact: integrablerM.
+    - exact: integrableZl.
     - have integrable_normfn : mu.-integrable D (abse \o f_ n).
         apply: le_integrable ig => //; first exact: measurableT_comp.
         by move=> x Dx /=; rewrite abse_id (le_trans (absfg _ Dx))// lee_abs.
@@ -4544,7 +4558,7 @@ move=> mA1 mA2 /=; rewrite /product_measure1 /=.
 rewrite (eq_integral (fun x => m2 A2 * (\1_A1 x)%:E)); last first.
   by move=> x _; rewrite indicE; have [xA1|xA1] /= := boolP (x \in A1);
     [rewrite in_xsectionM// mule1|rewrite mule0 notin_xsectionM].
-rewrite ge0_integralM//; last by move=> x _; rewrite lee_fin.
+rewrite ge0_integralZl//; last by move=> x _; rewrite lee_fin.
 - by rewrite muleC integral_indic// setIT.
 - exact: measurableT_comp.
 Qed.
@@ -4645,7 +4659,7 @@ Proof.
 have mA1A2 : measurable (A1 `*` A2) by apply: measurableM.
 transitivity (\int[m2]_y (m1 \o ysection (A1 `*` A2)) y) => //.
 rewrite (_ : _ \o _ = fun y => m1 A1 * (\1_A2 y)%:E).
-  rewrite ge0_integralM//; last 2 first.
+  rewrite ge0_integralZl//; last 2 first.
     - exact: measurableT_comp.
     - by move=> y _; rewrite lee_fin.
   by rewrite integral_indic ?setIT ?mul1e.
@@ -4834,7 +4848,7 @@ rewrite ge0_integral_fsum //; last 2 first.
   - by move=> r y _; rewrite EFinM nnfun_muleindic_ge0.
 apply: eq_fsbigr => i; rewrite inE => -[/= t _ <-{i}].
 under eq_fun do rewrite EFinM.
-rewrite ge0_integralM//; last by rewrite lee_fin.
+rewrite ge0_integralZl//; last by rewrite lee_fin.
 - by rewrite -/((m2 \o xsection _) x) -indic_fubini_tonelli_FE.
 - exact/EFin_measurable_fun/measurableT_comp.
 - by move=> y _; rewrite lee_fin.
@@ -4857,7 +4871,7 @@ rewrite ge0_integral_fsum //; last 2 first.
   - by move=> r x _; rewrite EFinM nnfun_muleindic_ge0.
 apply: eq_fsbigr => i; rewrite inE => -[/= t _ <-{i}].
 under eq_fun do rewrite EFinM.
-rewrite ge0_integralM//; last by rewrite lee_fin.
+rewrite ge0_integralZl//; last by rewrite lee_fin.
 - by rewrite -/((m1 \o ysection _) y) -indic_fubini_tonelli_GE.
 - exact/EFin_measurable_fun/measurableT_comp.
 - by move=> x _; rewrite lee_fin.
@@ -4883,11 +4897,11 @@ under [LHS]eq_integral
 transitivity (\sum_(k \in range f)
   \int[m1]_x (k%:E * (fubini_F m2 (EFin \o \1_(f @^-1` [set k])) x))).
   apply: eq_fsbigr => i; rewrite inE => -[z _ <-{i}].
-  rewrite ge0_integralM//; last 3 first.
+  rewrite ge0_integralZl//; last 3 first.
     - exact/EFin_measurable_fun.
     - by move=> /= x _; rewrite lee_fin.
     - by rewrite lee_fin.
-  rewrite indic_fubini_tonelli1// -ge0_integralM//; last by rewrite lee_fin.
+  rewrite indic_fubini_tonelli1// -ge0_integralZl//; last by rewrite lee_fin.
   - exact: indic_measurable_fun_fubini_tonelli_F.
   - by move=> /= x _; exact: indic_fubini_tonelli_F_ge0.
 rewrite -ge0_integral_fsum //; last 2 first.
@@ -4911,11 +4925,11 @@ under [LHS]eq_integral
 transitivity (\sum_(k \in range f)
   \int[m2]_x (k%:E * (fubini_G m1 (EFin \o \1_(f @^-1` [set k])) x))).
   apply: eq_fsbigr => i; rewrite inE => -[z _ <-{i}].
-  rewrite ge0_integralM//; last 3 first.
+  rewrite ge0_integralZl//; last 3 first.
     - exact/EFin_measurable_fun.
     - by move=> /= x _; rewrite lee_fin.
     - by rewrite lee_fin.
-  rewrite indic_fubini_tonelli2// -ge0_integralM//; last by rewrite lee_fin.
+  rewrite indic_fubini_tonelli2// -ge0_integralZl//; last by rewrite lee_fin.
   - exact: indic_measurable_fun_fubini_tonelli_G.
   - by move=> /= x _; exact: indic_fubini_tonelli_G_ge0.
 rewrite -ge0_integral_fsum //; last 2 first.

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -1580,6 +1580,7 @@ Qed.
 
 End approximation.
 
+
 Section semi_linearity0.
 Local Open Scope ereal_scope.
 Context d (T : measurableType d) (R : realType).
@@ -1713,6 +1714,128 @@ by move=> Dx; rewrite (funeposneg f); apply: cvgeD;
 Qed.
 
 End approximation_sfun.
+
+Section lusin.
+Hint Extern 0  (hausdorff_space _) => (exact: Rhausdorff ) : core.
+Local Open Scope ereal_scope.
+Context (rT : realType) (A : set rT).
+Let mu := [the measure _ _ of @lebesgue_measure rT].
+Let R  := [the measurableType _ of measurableTypeR rT].
+Hypothesis mA : measurable A.
+Hypothesis finA : mu A < +oo.
+
+Let lusin_simple (f : {sfun R >-> rT}) (eps : rT) : (0 < eps)%R ->
+  exists K, [/\ compact K, K `<=` A, mu (A `\` K) < eps%:E &
+  {within K, continuous f}].
+Proof.
+move: eps=> _/posnumP[eps]; have [N /card_fset_set rfN] := @fimfunP _ _ f.
+pose Af x : set R := A `&` f @^-1` [set x].
+have mAf x : measurable (Af x) by exact: measurableI.
+have finAf x : mu (Af x) < +oo.
+  by rewrite (le_lt_trans _ finA)// le_measure// ?inE//; exact: subIsetl.
+have eNpos : (0 < eps%:num/N.+1%:R)%R by [].
+have dK' x := lebesgue_regularity_inner (mAf x) (finAf x) eNpos.
+pose dK x : set R := projT1 (cid (dK' x)); pose J i : set R := Af i `\` dK i.
+have dkP x := projT2 (cid (dK' x)).
+have mdK i : measurable (dK i).
+  by apply: closed_measurable; apply: compact_closed => //; case: (dkP i).
+have mJ i : measurable (J i) by apply: measurableD => //; exact: measurableI.
+have dKsub z : dK z `<=` f @^-1` [set z].
+  by case: (dkP z) => _ /subset_trans + _; apply => ? [].
+exists (\bigcup_(i in range f) dK i); split.
+- by rewrite -bigsetU_fset_set//; apply: bigsetU_compact=>// i _; case: (dkP i).
+- by move=> z [y _ dy]; have [_ /(_ _ dy) []] := dkP y.
+- have -> : A `\` \bigcup_(i in range f) dK i = \bigcup_(i in range f) J i.
+    rewrite -bigcupDr /= ?eqEsubset; last by exists (f point), point.
+    split => z; first by move=> /(_ (f z)) [//| ? ?]; exists (f z).
+    case => ? [? _ <-] [[zab /= <- nfz]] ? [r _ <-]; split => //.
+    by move: nfz; apply: contra_not => /[dup] /dKsub ->.
+  apply: (@le_lt_trans _ _ (\sum_(i \in range f) mu (J i))).
+    by apply: content_sub_fsum => //; exact: fin_bigcup_measurable.
+  apply: le_lt_trans.
+    apply: (@lee_fsum _ _ _ _ (fun=> (eps%:num / N.+1%:R)%:E * 1%:E)) => //.
+    by move=> i ?; rewrite mule1; apply: ltW; have [_ _] := dkP i.
+  rewrite /=-ge0_mule_fsumr // -esum_fset // finite_card_sum // -EFinM lte_fin.
+  by rewrite rfN -mulrA gtr_pmulr // mulrC ltr_pdivr_mulr // mul1r ltr_nat.
+- suff : closed (\bigcup_(i in range f) dK i) /\
+    {within \bigcup_(i in range f) dK i, continuous f} by case.
+  rewrite -bigsetU_fset_set //.
+  apply: (@big_ind _ (fun U => closed U /\ {within U, continuous f})).
+  + by split; [exact: closed0 | exact: continuous_subspace0].
+  + by move=> ? ? [? ?][? ?]; split; [exact: closedU|exact: withinU_continuous].
+  + move=> i _; split; first by apply: compact_closed; have [] := dkP i.
+    apply: (continuous_subspaceW (dKsub i)).
+    apply: (@subspace_eq_continuous _ _ _ (fun=> i)).
+      by move=> ? /set_mem ->.
+    by apply: continuous_subspaceT => ?; exact: cvg_cst.
+Qed.
+
+Let measurable_almost_continuous' (f : R -> R) (eps : rT) :
+  (0 < eps)%R -> measurable_fun A f -> exists K,
+  [/\ measurable K, K `<=` A, mu (A `\` K) < eps%:E &
+  {within K, continuous f}].
+Proof.
+move: eps=> _/posnumP[eps] mf; pose f' := EFin \o f.
+have mf' : measurable_fun A f' by exact/EFin_measurable_fun.
+have [/= g_ gf'] := @approximation_sfun _ R rT _ _ mA mf'.
+pose e2n n := (eps%:num / 2) / (2 ^ n.+1)%:R.
+have e2npos n : (0 < e2n n)%R by rewrite divr_gt0.
+have gK' n := @lusin_simple (g_ n) (e2n n) (e2npos n).
+pose gK n := projT1 (cid (gK' n)); have gKP n := projT2 (cid (gK' n)).
+pose K := \bigcap_i gK i; have mgK n : measurable (gK n).
+  by apply: closed_measurable; apply: compact_closed => //; have [] := gKP n.
+have mK : measurable K by exact: bigcap_measurable.
+have Kab : K `<=` A by move=> z /(_ O I); have [_ + _ _] := gKP O; apply.
+have []// := @pointwise_almost_uniform _ rT R mu g_ f K (eps%:num / 2).
+- by move=> n; exact: measurable_funTS.
+- exact: (measurable_funS _ Kab).
+- by rewrite (@le_lt_trans _ _ (mu A))// le_measure// ?inE.
+- by move=> z Kz; have /fine_fcvg := gf' z (Kab _ Kz); rewrite -fmap_comp compA.
+move=> D [/= mD Deps KDf]; exists (K `\` D); split => //.
+- exact: measurableD.
+- exact: subset_trans Kab.
+- rewrite setDDr; apply: le_lt_trans => /=.
+    by apply: measureU2 => //; apply: measurableI => //; apply: measurableC.
+  rewrite [_%:num]splitr EFinD; apply: lee_lt_add => //=; first 2 last.
+  + by rewrite (@le_lt_trans _ _ (mu D)) ?le_measure ?inE//; exact: measurableI.
+  + rewrite ge0_fin_numE// (@le_lt_trans _ _ (mu A))// le_measure// ?inE//.
+    exact: measurableD.
+  rewrite setDE setC_bigcap setI_bigcupr.
+  apply: (@le_trans _ _(\sum_(k <oo) mu (A `\` gK k))).
+    apply: measure_sigma_sub_additive => //; [|apply: bigcup_measurable => + _].
+      by move=> k /=; apply: measurableD => //; apply: mgK.
+    by move=> k /=; apply: measurableD => //; apply: mgK.
+  apply: (@le_trans _ _(\sum_(k <oo) (e2n k)%:E)); last exact: epsilon_trick0.
+  by apply: lee_nneseries => // k _; apply: ltW; have [] := gKP k.
+apply: (@uniform_limit_continuous_subspace _ _ _ (g_ @ \oo)) => //.
+near_simpl; apply: nearW => // n; apply: (@continuous_subspaceW _ _ _ (gK n)).
+  by move=> z [+ _]; apply.
+by have [] := projT2 (cid (gK' n)).
+Qed.
+
+Lemma measurable_almost_continuous (f : R -> R) (eps : rT) :
+  (0 < eps)%R -> measurable_fun A f -> exists K,
+  [/\ compact K, K `<=` A, mu (A `\` K) < eps%:E &
+  {within K, continuous f}].
+Proof.
+move: eps=> _/posnumP[eps] mf; have e2pos : (0 < eps%:num/2)%R by [].
+have [K [mK KA ? ?]] := measurable_almost_continuous' e2pos mf.
+have Kfin : mu K < +oo by rewrite (le_lt_trans _ finA)// le_measure ?inE.
+have [D /= [cD DK KDe]] := lebesgue_regularity_inner mK Kfin e2pos.
+exists D; split => //; last exact: (continuous_subspaceW DK).
+  exact: (subset_trans DK).
+have -> : A `\` D = (A `\` K) `|` (K `\` D).
+  rewrite eqEsubset; split => z.
+    by case: (pselect (K z)) => // ? [? ?]; [right | left].
+  case; case=> az nz; split => //; [by move: z nz {az}; apply/subsetC|].
+  exact: KA.
+apply: le_lt_trans.
+  apply: measureU2; apply: measurableD => //; apply: closed_measurable.
+  by apply: compact_closed; first exact: Rhausdorff.
+by rewrite [_ eps]splitr EFinD lte_add.
+Qed.
+
+End lusin.
 
 Section emeasurable_fun.
 Local Open Scope ereal_scope.

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -1487,7 +1487,7 @@ rewrite (@le_lt_trans _ _ (1 / 2 ^+ n)) //.
 by near: n; exact: near_infty_natSinv_expn_lt.
 Unshelve. all: by end_near. Qed.
 
-Lemma le_approx k x (f0 : forall x, (0 <= f x)%E) : D x ->
+Lemma le_approx k x (f0 : forall x, D x -> (0 <= f x)%E) : D x ->
   ((approx k x)%:E <= f x)%E.
 Proof.
 move=> Dx; have [fixoo|] := ltP (f x) (+oo%E); last first.
@@ -1499,7 +1499,7 @@ have cvg_af := cvg_approx fi0 Dx fixoo.
 have is_cvg_af : cvgn (approx ^~ x) by apply/cvg_ex; eexists; exact: cvg_af.
 have {is_cvg_af} := nondecreasing_cvg_le nd_ag is_cvg_af k.
 rewrite -lee_fin => /le_trans; apply.
-rewrite -(@fineK _ (f x)); last by rewrite ge0_fin_numE.
+rewrite -(@fineK _ (f x)); last by rewrite ge0_fin_numE //; apply: f0.
 by move/(cvg_lim (@Rhausdorff R)) : cvg_af => ->.
 Qed.
 
@@ -4655,6 +4655,93 @@ by rewrite mule0 /= notin_ysectionM.
 Qed.
 
 End product_measure2E.
+
+Section simple_density_L1.
+Context d (T : measurableType d) (R : realType).
+Variables (mu : {measure set T -> \bar R}) (E : set T) (mE : measurable E).
+
+Local Open Scope ereal_scope.
+
+Let sfun_dense_L1_pos (f : T -> \bar R) :
+  mu.-integrable E f -> (forall x, E x -> 0 <= f x) ->
+  exists g_ : {sfun T >-> R}^nat,
+    [/\ forall n, mu.-integrable E (EFin \o g_ n),
+        forall x, E x -> EFin \o g_^~ x @ \oo --> f x &
+        (fun n => \int[mu]_(z in E) `|f z - (g_ n z)%:E|) @ \oo --> 0].
+Proof.
+move=> intf fpos; case/integrableP: (intf) => mfE _.
+pose g_ n := nnsfun_approx mE mfE n.
+have [] // := @dominated_convergence _ _ _ mu _ mE (fun n => EFin \o g_ n) f f.
+- by move=> ?; apply/EFin_measurable_fun/measurable_funTS.
+- apply: aeW => ? ?; under eq_fun => ? do rewrite /g_ nnsfun_approxE.
+  exact: ecvg_approx.
+- apply: aeW => /= ? ? ?; rewrite ger0_norm // /g_ nnsfun_approxE.
+  exact: le_approx.
+move=> _ /= fg0 gfcvg; exists g_; split.
+- move=> n; apply: (le_integrable mE _ _ intf).
+    exact/EFin_measurable_fun/measurable_funTS.
+  move=> ? ?; rewrite /g_ !gee0_abs ?lee_fin//; last exact: fpos.
+  by rewrite /= nnsfun_approxE le_approx.
+- exact: cvg_nnsfun_approx.
+- by apply: cvg_trans fg0; under eq_fun => ? do under eq_fun => t do
+     rewrite EFinN -[_ - _]oppeK fin_num_oppeB // abseN addeC.
+Qed.
+
+Lemma approximation_sfun_integrable (f : T -> \bar R):
+  mu.-integrable E f ->
+  exists g_ : {sfun T >-> R}^nat,
+    [/\ forall n, mu.-integrable E (EFin \o g_ n),
+        forall x, E x -> EFin \o g_^~ x @ \oo --> f x &
+        (fun n => \int[mu]_(z in E) `|f z - (g_ n z)%:E|) @ \oo --> 0].
+Proof.
+move=> intf.
+have [//|p_ [intp pf pl1]] := sfun_dense_L1_pos (integrable_funepos mE intf).
+have [//|n_ [intn nf nl1]] := sfun_dense_L1_pos (integrable_funeneg mE intf).
+exists (fun n => p_ n - n_ n)%R; split.
+- move=> n; rewrite /comp; under eq_fun => ? do rewrite sfunB /= EFinB.
+  by apply: integrableB => //; [exact: intp | exact: intn].
+- move=> ? ?; rewrite /comp; under eq_fun => ? do rewrite sfunB /= EFinB.
+  rewrite [f]funeposneg; apply: cvgeB => //;[|exact: pf|exact:nf].
+  exact: add_def_funeposneg.
+have fpn z n : f z - ((p_ n - n_ n) z)%:E =
+    (f^\+ z - (p_ n z)%:E) - (f^\- z - (n_ n z)%:E).
+  rewrite sfunB EFinB fin_num_oppeB // {1}[f]funeposneg -addeACA.
+  by congr (_ _); rewrite fin_num_oppeB.
+case/integrableP: (intf) => mf _.
+have mfpn n : mu.-integrable E (fun z => f z - ((p_ n - n_ n) z)%:E).
+  under eq_fun => ? do rewrite fpn; apply: integrableB => //.
+    by apply: integrableB => //; [exact: integrable_funepos | exact: intp].
+  by apply: integrableB => //; [exact: integrable_funeneg | exact: intn].
+apply/fine_cvgP; split => //.
+  near=> N; case/integrableP: (mfpn N) => _; rewrite ge0_fin_numE //.
+  exact: integral_ge0.
+apply/cvg_ballP=> _/posnumP[eps]; have e2p : (0 < eps%:num/2)%R by [].
+case/fine_cvgP: pl1 => + /cvg_ballP/(_ _ e2p); apply: filter_app2.
+case/fine_cvgP: nl1 => + /cvg_ballP/(_ _ e2p); apply: filter_app2.
+near=> n; rewrite /ball /=; do 3 rewrite distrC subr0.
+move=> finfn ne2 finfp pe2; rewrite [_%:num]splitr.
+rewrite (le_lt_trans _ (ltr_add pe2 ne2))// (le_trans _ (ler_norm_add _ _))//.
+under [fun z => _ (f^\+ z + _)]eq_fun => ? do rewrite EFinN.
+under [fun z => _ (f^\- z + _)]eq_fun => ? do rewrite EFinN.
+have mfp : mu.-integrable E (fun z => `|f^\+ z - (p_ n z)%:E|).
+  apply/integrable_abse/integrableB => //; first exact: integrable_funepos.
+  exact: intp.
+have mfn : mu.-integrable E (fun z => `|f^\- z - (n_ n z)%:E|).
+  apply/integrable_abse/integrableB => //; first exact: integrable_funeneg.
+  exact: intn.
+rewrite -[x in (_ <= `|x|)%R]fineD // -integralD //.
+rewrite !ger0_norm ?fine_ge0 ?integral_ge0 ?fine_le//.
+- by apply: integral_fune_fin_num => //; exact/integrable_abse/mfpn.
+- by apply: integral_fune_fin_num => //; exact: integrableD.
+- apply: ge0_le_integral => //.
+  + by apply: measurableT_comp => //; case/integrableP: (mfpn n).
+  + by move=> x Ex; rewrite adde_ge0.
+  + by apply: emeasurable_funD; [move: mfp | move: mfn]; case/integrableP.
+  + by move=> ? ?; rewrite fpn; exact: lee_abs_sub.
+  + by move=> x Ex; rewrite adde_ge0.
+Unshelve. all: by end_near. Qed.
+
+End simple_density_L1.
 
 Section fubini_functions.
 Local Open Scope ereal_scope.

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -3515,7 +3515,7 @@ suff : forall X, mu X = \sum_(k <oo) mu (X `&` A k) + mu (X `&` ~` B).
     rewrite funeqE => n; rewrite big_mkord; apply: eq_bigr => i _; congr (mu _).
     by rewrite setIC; apply/setIidPl; exact: bigcup_sup.
   move=> ->; have := fun n (_ : xpredT n) => outer_measure_ge0 mu (A n).
-  move/is_cvg_nneseries => /cvg_ex[l] hl.
+  move/(@is_cvg_nneseries _ _ _ 0) => /cvg_ex[l] hl.
   under [in X in _ --> X]eq_fun do rewrite -(big_mkord xpredT (mu \o A)).
   by move/cvg_lim : (hl) => ->.
 move=> X.

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -2933,28 +2933,28 @@ Qed.
 HB.instance Definition _ R :=
   @isSigmaFinite.Build _ _ _ (@counting _ R) (sigma_finite_counting R).
 
-Lemma measureIl d (R : realFieldType) (T : semiRingOfSetsType d)
-    (mu : {content set T -> \bar R}) (A B : set T) :
-  measurable A -> measurable B -> (mu (A `&` B) <= mu A)%E.
-Proof. by move=> mA mB; rewrite le_measure ?inE//; apply: measurableI. Qed.
+Section content_semiRingOfSetsType.
+Context d (T : semiRingOfSetsType d) (R : realFieldType).
+Variables (mu : {content set T -> \bar R}) (A B : set T).
+Hypotheses (mA : measurable A) (mB : measurable B).
 
-Lemma measureIr d (R : realFieldType) (T : semiRingOfSetsType d)
-    (mu : {content set T -> \bar R}) (A B : set T) :
-  measurable A -> measurable B -> (mu (A `&` B) <= mu B)%E.
-Proof. by move=> mA mB; rewrite le_measure ?inE//; apply: measurableI. Qed.
+Lemma measureIl : mu (A `&` B) <= mu A.
+Proof. by rewrite le_measure ?inE//; apply: measurableI. Qed.
 
-Lemma subset_measure0 d (T : semiRingOfSetsType d) (R : realType)
-  (mu : {content set T -> \bar R}) (A B : set T) :
-  measurable A -> measurable B -> A `<=` B ->
-  mu B = 0%E -> mu A = 0%E.
+Lemma measureIr : mu (A `&` B) <= mu B.
+Proof. by rewrite le_measure ?inE//; apply: measurableI. Qed.
+
+Lemma subset_measure0 : A `<=` B -> mu B = 0 -> mu A = 0.
 Proof.
-move=> mA mB AB B0; apply/eqP; rewrite eq_le measure_ge0// ?andbT -?B0.
-by apply: le_measure; rewrite ?inE.
+by move=> AB B0; apply/eqP; rewrite eq_le measure_ge0// -B0 le_measure// inE.
 Qed.
 
-Section measureD.
+End content_semiRingOfSetsType.
+
+Section content_ringOfSetsType.
 Context d (T : ringOfSetsType d) (R : realFieldType).
 Variable mu : {content set T -> \bar R}.
+Implicit Types A B : set T.
 
 Lemma measureDI A B : measurable A -> measurable B ->
   mu A = mu (A `\` B) + mu (A `&` B).
@@ -2976,12 +2976,6 @@ rewrite (measureDI mA mB) addeK// fin_numE 1?gt_eqF 1?lt_eqF//.
 - by rewrite (lt_le_trans _ (measure_ge0 _ _)).
 Qed.
 
-End measureD.
-
-Section measureU2.
-Context d (T : ringOfSetsType d) (R : realFieldType).
-Variable mu : {content set T -> \bar R}.
-
 Lemma measureU2 A B : measurable A -> measurable B ->
   mu (A `|` B) <= mu A + mu B.
 Proof.
@@ -2992,7 +2986,7 @@ by apply: bigsetU_measurable => -[] [//|[//|[|]]].
 by rewrite big_ord_recr/= big_ord_recr/= big_ord0 add0e.
 Qed.
 
-End measureU2.
+End content_ringOfSetsType.
 
 Section measureU.
 Context d (T : ringOfSetsType d) (R : realFieldType).
@@ -3012,6 +3006,20 @@ Lemma measureUfinl A B : measurable A -> measurable B -> mu A < +oo ->
   mu (A `|` B) = mu A + mu B - mu (A `&` B).
 Proof. by move=> *; rewrite setUC measureUfinr// setIC [mu B + _]addeC. Qed.
 
+Lemma null_set_setU A B : measurable A -> measurable B ->
+  mu A = 0 -> mu B = 0 -> mu (A `|` B) = 0.
+Proof.
+move=> mA mB A0 B0; rewrite measureUfinl/= ?A0//= ?B0 ?add0e.
+by apply/eqP; rewrite oppe_eq0 -measure_le0/= -A0 measureIl.
+Qed.
+
+Lemma measureU0 A B : measurable A -> measurable B -> mu B = 0 ->
+  mu (A `|` B) = mu A.
+Proof.
+move=> mA mB B0; rewrite measureUfinr/= ?B0// adde0.
+by rewrite (@subset_measure0 _ _ _ _ (A `&` B) B) ?sube0//; exact: measurableI.
+Qed.
+
 End measureU.
 
 Lemma eq_measureU d (T : ringOfSetsType d) (R : realFieldType) (A B : set T)
@@ -3021,27 +3029,10 @@ Lemma eq_measureU d (T : ringOfSetsType d) (R : realFieldType) (A B : set T)
   mu (A `|` B) = mu' (A `|` B).
 Proof.
 move=> mA mB muA muB muAB; have [mu'ANoo|] := ltP (mu' A) +oo.
-  by rewrite !measureUfinl ?muA ?muB ?muAB.
+  by rewrite !measureUfinl/= ?muA ?muB ?muAB.
 rewrite leye_eq => /eqP mu'A; transitivity (+oo : \bar R); apply/eqP.
   by rewrite -leye_eq -mu'A -muA le_measure ?inE//=; apply: measurableU.
 by rewrite eq_sym -leye_eq -mu'A le_measure ?inE//=; apply: measurableU.
-Qed.
-
-Lemma null_set_setU d (R : realFieldType) (T : ringOfSetsType d)
-  (mu : {measure set T -> \bar R}) (A B : set T) :
-  measurable A -> measurable B -> mu A = 0%E -> mu B = 0%E -> mu (A `|` B) = 0%E.
-Proof.
-move=> mA mB A0 B0; rewrite measureUfinl ?A0//= ?B0 ?add0e.
-apply/eqP; rewrite oppe_eq0 -measure_le0/=; do ?exact: measurableI.
-by rewrite -A0 measureIl.
-Qed.
-
-Lemma measureU0 d (R : realType) (T : ringOfSetsType d)
-  (mu : {measure set T -> \bar R}) (A B : set T) :
-  measurable A -> measurable B -> mu B = 0 -> mu (A `|` B) = mu A.
-Proof.
-move=> mA mB B0; rewrite measureUfinr ?B0// adde0.
-by rewrite (@subset_measure0 _ _ _ _ (A `&` B) B) ?sube0//; exact: measurableI.
 Qed.
 
 Section measure_continuity.
@@ -4256,8 +4247,8 @@ Qed.
 
 Lemma measurable_pair2 (y : T2) : measurable_fun [set: T1] (pair^~ y).
 Proof.
-have m1pairy : measurable_fun [set: T1] (fst \o pair^~ y) by exact/measurable_id.
-have m2pairy: measurable_fun [set: T1] (snd \o pair^~ y) by exact/measurable_cst.
+have m1pairy : measurable_fun [set: T1] (fst \o pair^~y) by exact/measurable_id.
+have m2pairy : measurable_fun [set: T1] (snd \o pair^~y) by exact/measurable_cst.
 exact/(prod_measurable_funP _).
 Qed.
 

--- a/theories/probability.v
+++ b/theories/probability.v
@@ -138,7 +138,7 @@ Lemma expectationM (X : {RV P >-> R}) (iX : P.-integrable [set: T] (EFin \o X))
   (k : R) : 'E_P[k \o* X] = k%:E * 'E_P [X].
 Proof.
 rewrite unlock; under eq_integral do rewrite EFinM.
-by rewrite -integralM//; under eq_integral do rewrite muleC.
+by rewrite -integralZl//; under eq_integral do rewrite muleC.
 Qed.
 
 Lemma expectation_ge0 (X : {RV P >-> R}) :
@@ -212,11 +212,11 @@ rewrite unlock [X in 'E_P[X]](_ : _ = (X \* Y \- fine 'E_P[X] \o* Y
   apply/funeqP => x /=; rewrite mulrDr !mulrDl/= mul1r fineM// mulrNN addrA.
   by rewrite mulrN mulNr [Z in (X x * Y x - Z)%R]mulrC.
 have ? : P.-integrable [set: T] (EFin \o (X \* Y \- fine 'E_P[X] \o* Y)%R).
-  by rewrite compreBr ?integrableB// compre_scale ?integrablerM.
+  by rewrite compreBr ?integrableB// compre_scale ?integrableZl.
 rewrite expectationD/=; last 2 first.
-  - by rewrite compreBr// integrableB// compre_scale ?integrablerM.
-  - by rewrite compre_scale// integrablerM// finite_measure_integrable_cst.
-rewrite 2?expectationB//= ?compre_scale// ?integrablerM//.
+  - by rewrite compreBr// integrableB// compre_scale ?integrableZl.
+  - by rewrite compre_scale// integrableZl// finite_measure_integrable_cst.
+rewrite 2?expectationB//= ?compre_scale// ?integrableZl//.
 rewrite 3?expectationM//= ?finite_measure_integrable_cst//.
 by rewrite expectation_cst mule1 fineM// EFinM !fineK// muleC subeK ?fin_numM.
 Qed.
@@ -255,8 +255,8 @@ move=> X1 Y1 XY1.
 have aXY : (a \o* X * Y = a \o* (X * Y))%R.
   by apply/funeqP => x; rewrite mulrAC.
 rewrite [LHS]covarianceE => [||//|] /=; last 2 first.
-- by rewrite compre_scale ?integrablerM.
-- by rewrite aXY compre_scale ?integrablerM.
+- by rewrite compre_scale ?integrableZl.
+- by rewrite aXY compre_scale ?integrableZl.
 rewrite covarianceE// aXY !expectationM//.
 by rewrite -muleA -muleBr// fin_num_adde_defr// expectation_fin_num.
 Qed.
@@ -392,10 +392,10 @@ Lemma varianceZ a (X : {RV P >-> R}) :
 Proof.
 move=> X1 X2; rewrite /variance covarianceZl//=.
 - by rewrite covarianceZr// muleA.
-- by rewrite compre_scale// integrablerM.
+- by rewrite compre_scale// integrableZl.
 - rewrite [X in EFin \o X](_ : _ = (a \o* X ^+ 2)%R); last first.
     by apply/funeqP => x; rewrite mulrA.
-  by rewrite compre_scale// integrablerM.
+  by rewrite compre_scale// integrableZl.
 Qed.
 
 Lemma varianceN (X : {RV P >-> R}) :
@@ -416,7 +416,7 @@ have XY : P.-integrable [set: T] (EFin \o (X \+ Y)%R).
 rewrite covarianceDl//=; last 3 first.
 - rewrite -expr2 sqrrD compreDr ?integrableD// compreDr// integrableD//.
   rewrite -mulr_natr -[(_ * 2)%R]/(2 \o* (X * Y))%R compre_scale//.
-  exact: integrablerM.
+  exact: integrableZl.
 - by rewrite mulrDr compreDr ?integrableD.
 - by rewrite mulrDr mulrC compreDr ?integrableD.
 rewrite covarianceDr// covarianceDr; [|by []..|by rewrite mulrC |exact: Y2].
@@ -445,8 +445,8 @@ Proof.
 move=> X1 X2.
 rewrite varianceD//=; last 3 first.
 - exact: finite_measure_integrable_cst.
-- by rewrite compre_scale// integrablerM// finite_measure_integrable_cst.
-- by rewrite mulrC compre_scale ?integrablerM.
+- by rewrite compre_scale// integrableZl// finite_measure_integrable_cst.
+- by rewrite mulrC compre_scale ?integrableZl.
 by rewrite variance_cst add0e covariance_cst_l mule0 adde0.
 Qed.
 
@@ -494,10 +494,10 @@ apply: deg_le2_ge0 => r; rewrite -lee_fin !EFinD.
 rewrite EFinM fineK ?variance_fin_num// muleC -varianceZ//.
 rewrite -mulrA EFinM mulrC EFinM ?fineK ?covariance_fin_num// -covarianceZl//.
 rewrite addeAC -varianceD ?variance_ge0//=.
-- by rewrite compre_scale ?integrablerM.
+- by rewrite compre_scale ?integrableZl.
 - rewrite [X in EFin \o X](_ : _ = r ^+2 \o* X ^+ 2)%R 1?mulrACA//.
-  by rewrite compre_scale ?integrablerM.
-- by rewrite -mulrAC compre_scale// integrablerM.
+  by rewrite compre_scale ?integrableZl.
+- by rewrite -mulrAC compre_scale// integrableZl.
 Qed.
 
 End variance.
@@ -569,7 +569,7 @@ have Y2 : P.-integrable [set: T] (EFin \o (Y ^+ 2)%R).
   rewrite compreDr => [|//]; apply: integrableD X2 _ => [//|].
   rewrite [X in EFin \o X](_ : _ = (- fine 'E_P[X] * 2) \o* X)%R; last first.
     by apply/funeqP => x /=; rewrite -mulr_natl mulrC mulrA.
-  by rewrite compre_scale => [|//]; apply: integrablerM X1.
+  by rewrite compre_scale => [|//]; apply: integrableZl X1.
 have EY : 'E_P[Y] = 0.
   rewrite expectationB/= ?finite_measure_integrable_cst//.
   rewrite expectation_cst finEK subee//.
@@ -590,7 +590,7 @@ have le (u : R) : (0 <= u)%R ->
     rewrite compreDr => [|//]; apply: integrableD Y2 _ => [//|].
     rewrite [X in EFin \o X](_ : _ = (2 * u) \o* Y)%R; last first.
       by apply/funeqP => x /=; rewrite -mulr_natl mulrCA.
-    by rewrite compre_scale => [|//]; apply: integrablerM Y1.
+    by rewrite compre_scale => [|//]; apply: integrableZl Y1.
   have -> : (fine 'V_P[X] + u^2)%:E = 'E_P[(Y \+ cst u)^+2]%R.
     rewrite -VY -[RHS](@subeK _ _ (('E_P[(Y \+ cst u)%R])^+2)); last first.
       by rewrite fin_numX ?unlock ?integral_fune_fin_num.
@@ -773,7 +773,7 @@ transitivity (\sum_(i <oo)
 transitivity (\sum_(i <oo) (dRV_enum X i)%:E *
   \int[P]_(x in (if i \in dRV_dom X then X @^-1` [set dRV_enum X i] else set0))
     1).
-  apply: eq_eseriesr => i _; rewrite -integralM//; last 2 first.
+  apply: eq_eseriesr => i _; rewrite -integralZl//; last 2 first.
     - by case: ifPn.
     - apply/integrableP; split => //.
       rewrite (eq_integral (cst 1%E)); last by move=> x _; rewrite abse1.

--- a/theories/sequences.v
+++ b/theories/sequences.v
@@ -1673,24 +1673,31 @@ Lemma is_cvg_ereal_npos_natsum m : (forall n, (m <= n)%N -> u_ n <= 0) ->
   cvgn (fun n => \sum_(m <= i < n) u_ i).
 Proof. by move=> u_le0; apply: is_cvg_ereal_npos_natsum_cond => n /u_le0. Qed.
 
-Lemma is_cvg_nneseries_cond P : (forall n, P n -> 0 <= u_ n) ->
-  cvgn (fun n => \sum_(0 <= i < n | P i) u_ i).
+Lemma is_cvg_nneseries_cond P N : (forall n, P n -> 0 <= u_ n) ->
+  cvgn (fun n => \sum_(N <= i < n | P i) u_ i).
 Proof. by move=> u_ge0; apply: is_cvg_ereal_nneg_natsum_cond => n _ /u_ge0. Qed.
 
-Lemma is_cvg_npeseries_cond P : (forall n, P n -> u_ n <= 0) ->
-  cvgn (fun n => \sum_(0 <= i < n | P i) u_ i).
+Lemma is_cvg_npeseries_cond P N : (forall n, P n -> u_ n <= 0) ->
+  cvgn (fun n => \sum_(N <= i < n | P i) u_ i).
 Proof. by move=> u_le0; apply: is_cvg_ereal_npos_natsum_cond => n _ /u_le0. Qed.
 
-Lemma is_cvg_nneseries P : (forall n, P n -> 0 <= u_ n) ->
-  cvgn (fun n => \sum_(0 <= i < n | P i) u_ i).
+Lemma is_cvg_nneseries P N : (forall n, P n -> 0 <= u_ n) ->
+  cvgn (fun n => \sum_(N <= i < n | P i) u_ i).
 Proof. by move=> ?; exact: is_cvg_nneseries_cond. Qed.
 
-Lemma is_cvg_npeseries P : (forall n, P n -> u_ n <= 0) ->
-  cvgn (fun n => \sum_(0 <= i < n | P i) u_ i).
+Lemma is_cvg_npeseries P N : (forall n, P n -> u_ n <= 0) ->
+  cvgn (fun n => \sum_(N <= i < n | P i) u_ i).
 Proof. by move=> ?; exact: is_cvg_npeseries_cond. Qed.
 
-Lemma npeseries_le0 P : (forall n : nat, P n -> u_ n <= 0) ->
-  \sum_(i <oo | P i) u_ i <= 0.
+Lemma nneseries_ge0 P N : (forall n, P n -> 0 <= u_ n) ->
+  0 <= \sum_(N <= i <oo | P i) u_ i.
+Proof.
+move=> u0; apply: (lime_ge (is_cvg_nneseries u0)).
+by apply: nearW => k; rewrite sume_ge0.
+Qed.
+
+Lemma npeseries_le0 P N : (forall n : nat, P n -> u_ n <= 0) ->
+  \sum_(N <= i <oo | P i) u_ i <= 0.
 Proof.
 move=> u0; apply: (lime_le (is_cvg_npeseries u0)).
 by apply: nearW => k; rewrite sume_le0.
@@ -1706,13 +1713,6 @@ Proof.
 move=> f0; rewrite -limeMl//; last exact: is_cvg_nneseries.
 by apply/congr_lim/funext => /= n; rewrite ge0_sume_distrr.
 Qed.
-
-Lemma nneseries_ge0 (R : realType) (u_ : (\bar R)^nat) (P : pred nat) :
-  (forall n, P n -> 0 <= u_ n) -> 0 <= \sum_(i <oo | P i) u_ i.
-Proof.
-move=> u0; apply: (lime_ge (is_cvg_nneseries _ _ u0)).
-by near=> k; rewrite sume_ge0 // => i; apply: u0.
-Unshelve. all: by end_near. Qed.
 
 Lemma nnseries_is_cvg {R : realType} (u : nat -> R) :
     (forall i, 0 <= u i)%R -> \sum_(k <oo) (u k)%:E < +oo ->
@@ -1735,8 +1735,8 @@ Lemma adde_def_nneseries (R : realType) (f g : (\bar R)^nat)
   (\sum_(i <oo | P i) f i) +? (\sum_(i <oo | Q i) g i).
 Proof.
 move=> f0 g0; rewrite /adde_def !negb_and; apply/andP; split; apply/orP.
-- by right; apply/eqP => Qg; have := nneseries_ge0 g0; rewrite Qg.
-- by left; apply/eqP => Pf; have := nneseries_ge0 f0; rewrite Pf.
+- by right; apply/eqP => Qg; have := nneseries_ge0 0 g0; rewrite Qg.
+- by left; apply/eqP => Pf; have := nneseries_ge0 0 f0; rewrite Pf.
 Qed.
 
 Lemma __deprecated__ereal_cvgPpinfty (R : realFieldType) (u_ : (\bar R)^nat) :

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -4778,7 +4778,7 @@ HB.factory Record Nbhs_isPseudoMetric (R : numFieldType) M of Nbhs M := {
 
 HB.builders Context R M of Nbhs_isPseudoMetric R M.
 
-Lemma my_ball_le x : {homo ball x : e1 e2 / e1 <= e2 >-> e1 `<=` e2}.
+Lemma ball_le x : {homo ball x : e1 e2 / e1 <= e2 >-> e1 `<=` e2}.
 Proof.
 move=> e1 e2 le12 y xe1_y.
 move: le12; rewrite le_eqVlt => /orP [/eqP <- //|].
@@ -4792,7 +4792,7 @@ Lemma entourage_filter_subproof : Filter ent.
 Proof.
 rewrite entourageE; apply: filter_from_filter; first by exists 1 => /=.
 move=> _ _ /posnumP[e1] /posnumP[e2]; exists (Num.min e1 e2)%:num => //=.
-by rewrite subsetI; split=> ?; apply: my_ball_le;
+by rewrite subsetI; split=> ?; apply: ball_le;
    rewrite num_le// le_minl lexx ?orbT.
 Qed.
 

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -3151,6 +3151,11 @@ have /cptB[x BFx] : F B by apply: filterS FBA; exact: subIsetr.
 by exists x; right.
 Qed.
 
+Lemma bigsetU_compact I (F : I -> set X) (s : seq I) (P : pred I) :
+    (forall i, P i -> compact (F i)) ->
+  compact (\big[setU/set0]_(i <- s | P i) F i).
+Proof. by move=> ?; elim/big_ind : _ =>//; [exact:compact0|exact:compactU]. Qed.
+
 (* The closed condition here is neccessary to make this definition work in a  *)
 (* non-hausdorff setting.                                                     *)
 Definition compact_near (F : set_system X) :=


### PR DESCRIPTION
##### Motivation for this change

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 2.0

<!-- MathComp-Analysis is compatible with MathComp < 2.0 (branch `master`) and
     MathComp 2.0 ([branch `hierarchy-builder`](https://github.com/math-comp/analysis/pull/698)).

     If this PR targets `master` and if it is merged, the merged commit will also be
     cherry-picked on the branch `hierarchy-builder`.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `hierarchy-builder` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: HB port to record divergences between `master` and `hierarchy-builder` -->

- [ ] I added the label `TODO: HB port` to make sure someone ports this PR to
      the `hierarchy-builder` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
