### PR TITLE
Hardy littlewood

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -46,12 +46,18 @@
   + definition `locally_integrable`
   + lemmas `integrable_locally`, `locally_integrableN`, `locally_integrableD`,
     `locally_integrableB`
-  + definitions `HL_max`, `HL_maximal`
-  + lemmas `HL_max_ge0`, `HL_maximal_ge0`, `HL_maximalT_ge0`,
+  + definition `iavg`
+  + lemmas `iavg0`, `iavg_ge0`, `iavg_restrict`, `iavgD`
+  + definitions `HL_maximal`
+  + lemmas `HL_maximal_ge0`, `HL_maximalT_ge0`,
     `lower_semicontinuous_HL_maximal`, `measurable_HL_maximal`,
     `maximal_inequality`
 
 ### Changed
+
+- in `normedtype.v`:
+  + lemmas `vitali_lemma_finite` and `vitali_lemma_finite_cover` now returns
+    duplicate-free lists of indices
   
 ### Renamed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -29,6 +29,27 @@
 	`nondecreasing_cvge`, `nondecreasing_is_cvge`,
 	`nondecreasing_at_right_cvge`, `nondecreasing_at_right_is_cvge`,
 	`nonincreasing_at_right_cvge`, `nonincreasing_at_right_is_cvge`
+- in `ereal.v`:
+  + lemmas `ereal_sup_le`, `ereal_inf_le`
+
+- in `normedtype.v`:
+  + definition `lower_semicontinuous`
+  + lemma `lower_semicontinuousP`
+
+- in `numfun.v`:
+  + lemma `patch_indic`
+
+- in `lebesgue_measure.v`
+  + lemma `lower_semicontinuous_measurable`
+
+- in `lebesgue_integral.v`:
+  + definition `locally_integrable`
+  + lemmas `integrable_locally`, `locally_integrableN`, `locally_integrableD`,
+    `locally_integrableB`
+  + definitions `HL_max`, `HL_maximal`
+  + lemmas `HL_max_ge0`, `HL_maximal_ge0`, `HL_maximalT_ge0`,
+    `lower_semicontinuous_HL_maximal`, `measurable_HL_maximal`,
+    `maximal_inequality`
 
 ### Changed
   
@@ -38,6 +59,9 @@
   + `lnX` -> `lnXn`
 
 ### Generalized
+
+- in `lebesgue_integral.v`
+  + `ge0_integral_bigsetU` generalized from `nat` to `eqType`
 
 ### Deprecated
 

--- a/theories/charge.v
+++ b/theories/charge.v
@@ -1136,17 +1136,19 @@ Let E m j := is_max_approxRN mu nu m j.
 
 Let int_F_nu m A (mA : measurable A) : \int[mu]_(x in A) F m x <= nu A.
 Proof.
-rewrite [leLHS](_ : _ = \sum_(j < m.+1) \int[mu]_(x in (A `&` E m j)) F m x);
-    last first.
+rewrite [leLHS](_ : _ =
+    \sum_(j < m.+1) \int[mu]_(x in (A `&` E m j)) F m x); last first.
   rewrite -[in LHS](setIT A) -(bigsetU_is_max_approxRN mu nu m) big_distrr/=.
-  rewrite (@ge0_integral_bigsetU _ _ _ _ (fun n => A `&` E m n))//.
+  rewrite -(@big_mkord _ _ _ m.+1 xpredT (fun i => A `&` is_max_approxRN mu nu m i)).
+  rewrite ge0_integral_bigsetU ?big_mkord//.
   - by move=> n; apply: measurableI => //; exact: measurable_is_max_approxRN.
-  - by apply: measurable_funTS => //; exact: measurable_max_approxRN_seq.
-  - by move=> ? ?; exact: max_approxRN_seq_ge0.
+  - exact: iota_uniq.
   - apply: trivIset_setIl; apply: (@sub_trivIset _ _ _ setT (E m)) => //.
     exact: trivIset_is_max_approxRN.
-rewrite [leLHS](_ : _ = \sum_(j < m.+1) (\int[mu]_(x in (A `&` (E m j))) g j x));
-    last first.
+  - by apply: measurable_funTS => //; exact: measurable_max_approxRN_seq.
+  - by move=> ? ?; exact: max_approxRN_seq_ge0.
+rewrite [leLHS](_ : _ =
+    \sum_(j < m.+1) (\int[mu]_(x in (A `&` (E m j))) g j x)); last first.
   apply: eq_bigr => i _; apply:eq_integral => x; rewrite inE => -[?] [] Fmgi h.
   by apply/eqP; rewrite eq_le; rewrite /F Fmgi lexx.
 rewrite [leRHS](_ : _ = \sum_(j < m.+1) (nu (A `&` E m j))); last first.
@@ -1582,16 +1584,15 @@ End radon_nikodym.
 Notation "'d nu '/d mu" := (Radon_Nikodym mu nu) : charge_scope.
 
 Section radon_nikodym_lemmas.
+Context d (T : measurableType d) (R : realType).
 
-Lemma dominates_cscale d (T : measurableType d) (R : realType)
-  (mu : {sigma_finite_measure set T -> \bar R})
-  (nu : {charge set T -> \bar R})
-  (c : R) : nu `<< mu -> cscale c nu `<< mu.
+Lemma dominates_cscale (mu : {sigma_finite_measure set T -> \bar R})
+    (nu : {charge set T -> \bar R}) (c : R) :
+  nu `<< mu -> cscale c nu `<< mu.
 Proof. by move=> numu E mE /numu; rewrite /cscale => ->//; rewrite mule0. Qed.
 
-Lemma Radon_Nikodym_cscale d (T : measurableType d) (R : realType)
-  (mu : {sigma_finite_measure set T -> \bar R})
-  (nu : {charge set T -> \bar R}) (c : R) :
+Lemma Radon_Nikodym_cscale (mu : {sigma_finite_measure set T -> \bar R})
+    (nu : {charge set T -> \bar R}) (c : R) :
   nu `<< mu ->
   ae_eq mu [set: T] ('d [the charge _ _ of cscale c nu] '/d mu)
                     (fun x => c%:E * 'd nu '/d mu x).
@@ -1606,17 +1607,14 @@ move=> numu; apply: integral_ae_eq => [//| | |E mE].
   by rewrite -Radon_Nikodym_integral.
 Qed.
 
-Lemma dominates_caddl d (T : measurableType d)
-  (R : realType) (mu : {sigma_finite_measure set T -> \bar R})
-  (nu0 nu1 : {charge set T -> \bar R}) :
-  nu0 `<< mu -> nu1 `<< mu ->
-  cadd nu0 nu1 `<< mu.
+Lemma dominates_caddl (mu : {sigma_finite_measure set T -> \bar R})
+    (nu0 nu1 : {charge set T -> \bar R}) :
+  nu0 `<< mu -> nu1 `<< mu -> cadd nu0 nu1 `<< mu.
 Proof.
 by move=> nu0mu nu1mu A mA A0; rewrite /cadd nu0mu// nu1mu// adde0.
 Qed.
 
-Lemma Radon_Nikodym_cadd d (T : measurableType d) (R : realType)
-    (mu : {sigma_finite_measure set T -> \bar R})
+Lemma Radon_Nikodym_cadd (mu : {sigma_finite_measure set T -> \bar R})
     (nu0 nu1 : {charge set T -> \bar R}) :
   nu0 `<< mu -> nu1 `<< mu ->
   ae_eq mu [set: T] ('d [the charge _ _ of cadd nu0 nu1] '/d mu)

--- a/theories/ereal.v
+++ b/theories/ereal.v
@@ -506,11 +506,8 @@ case: xgetP => /=; first by move=> _ -> -[] /ubP geS _; apply geS.
 by case: (ereal_supremums_neq0 S) => /= x0 Sx0; move/(_ x0).
 Qed.
 
-Lemma ereal_sup_le S x : S !=set0 ->
-  (forall y, S y -> x <= y) -> x <= ereal_sup S.
-Proof.
-by case=> y Sy Sx; rewrite (@le_trans _ _ y)//; [exact:Sx|exact:ereal_sup_ub].
-Qed.
+Lemma ereal_sup_le S x : (exists2 y, S y & x <= y) -> x <= ereal_sup S.
+Proof. by move=> [y Sy] /le_trans; apply; exact: ereal_sup_ub. Qed.
 
 Lemma ereal_sup_ninfty S : ereal_sup S = -oo <-> S `<=` [set -oo].
 Proof.
@@ -524,11 +521,8 @@ Proof.
 by move=> x Sx; rewrite /ereal_inf lee_oppl; apply ereal_sup_ub; exists x.
 Qed.
 
-Lemma ereal_inf_le S x : S !=set0 -> (forall y, S y -> y <= x) ->
-  ereal_inf S <= x.
-Proof.
-by case=> y Sy Sx; rewrite (@le_trans _ _ y)//; [exact:ereal_inf_lb|exact:Sx].
-Qed.
+Lemma ereal_inf_le S x : (exists2 y, S y & y <= x) -> ereal_inf S <= x.
+Proof. by move=> [y Sy]; apply: le_trans; exact: ereal_inf_lb. Qed.
 
 Lemma ereal_inf_pinfty S : ereal_inf S = +oo <-> S `<=` [set +oo].
 Proof. rewrite eqe_oppLRP oppe_subset image_set1; exact: ereal_sup_ninfty. Qed.

--- a/theories/ereal.v
+++ b/theories/ereal.v
@@ -506,6 +506,12 @@ case: xgetP => /=; first by move=> _ -> -[] /ubP geS _; apply geS.
 by case: (ereal_supremums_neq0 S) => /= x0 Sx0; move/(_ x0).
 Qed.
 
+Lemma ereal_sup_le S x : S !=set0 ->
+  (forall y, S y -> x <= y) -> x <= ereal_sup S.
+Proof.
+by case=> y Sy Sx; rewrite (@le_trans _ _ y)//; [exact:Sx|exact:ereal_sup_ub].
+Qed.
+
 Lemma ereal_sup_ninfty S : ereal_sup S = -oo <-> S `<=` [set -oo].
 Proof.
 split.
@@ -518,14 +524,20 @@ Proof.
 by move=> x Sx; rewrite /ereal_inf lee_oppl; apply ereal_sup_ub; exists x.
 Qed.
 
+Lemma ereal_inf_le S x : S !=set0 -> (forall y, S y -> y <= x) ->
+  ereal_inf S <= x.
+Proof.
+by case=> y Sy Sx; rewrite (@le_trans _ _ y)//; [exact:ereal_inf_lb|exact:Sx].
+Qed.
+
 Lemma ereal_inf_pinfty S : ereal_inf S = +oo <-> S `<=` [set +oo].
 Proof. rewrite eqe_oppLRP oppe_subset image_set1; exact: ereal_sup_ninfty. Qed.
 
 Lemma le_ereal_sup : {homo @ereal_sup R : A B / A `<=` B >-> A <= B}.
-Proof. by move=> A B AB; apply ub_ereal_sup => x Ax; apply/ereal_sup_ub/AB. Qed.
+Proof. by move=> A B AB; apply: ub_ereal_sup => x Ax; apply/ereal_sup_ub/AB. Qed.
 
 Lemma le_ereal_inf : {homo @ereal_inf R : A B / A `<=` B >-> B <= A}.
-Proof. by move=> A B AB; apply lb_ereal_inf => x Bx; exact/ereal_inf_lb/AB. Qed.
+Proof. by move=> A B AB; apply: lb_ereal_inf => x Bx; exact/ereal_inf_lb/AB. Qed.
 
 Lemma hasNub_ereal_sup (A : set (\bar R)) : ~ has_ubound A ->
   A !=set0 -> ereal_sup A = +oo%E.

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -5923,30 +5923,22 @@ have KDB : K `<=` cover [set` D] B.
   by apply: (subset_trans Kcover) => /= x [r Dr] rx; exists r.
 have is_ballB i : is_ball (B i) by exact: is_ball_ball.
 have Bset0 i : B i !=set0 by exists i; exact: ballxx.
-have [E [ED tEB DE]] := @vitali_lemma_finite_cover _ _ B is_ballB Bset0 D.
-pose E' := undup E.
-have {ED}E'D : {subset E' <= D} by move=> x; rewrite mem_undup => /ED.
-have {tEB}tE'B : trivIset [set` E'] B.
-  by apply: sub_trivIset tEB => x/=; rewrite mem_undup.
-have {DE}DE' : cover [set` D] B `<=`
-               cover [set` E'] (scale_ball 3%:R \o B).
-  by move=> x /DE [r/= rE] Brx; exists r => //=; rewrite mem_undup.
-have uniqE' : uniq E' by exact: undup_uniq.
-rewrite (@le_trans _ _ (3%:R%:E * \sum_(i <- E') mu (B i)))//.
-  have {}DE' := subset_trans KDB DE'.
+have [E [uE ED tEB DE]] := @vitali_lemma_finite_cover _ _ B is_ballB Bset0 D.
+rewrite (@le_trans _ _ (3%:R%:E * \sum_(i <- E) mu (B i)))//.
+  have {}DE := subset_trans KDB DE.
   apply: (le_trans (@content_sub_additive _ _ _ [the measure _ _ of mu]
-      K (fun i => 3%:R *` B (nth 0%R E' i)) (size E') _ _ _)) => //.
+      K (fun i => 3%:R *` B (nth 0%R E i)) (size E) _ _ _)) => //.
   - by move=> k ?; rewrite scale_ballE//; exact: measurable_ball.
   - by apply: closed_measurable; apply: compact_closed => //; exact: Rhausdorff.
-  - apply: (subset_trans DE'); rewrite /cover bigcup_seq.
+  - apply: (subset_trans DE); rewrite /cover bigcup_seq.
     by rewrite (big_nth 0%R)//= big_mkord.
   - rewrite ge0_sume_distrr//= (big_nth 0%R) big_mkord; apply: lee_sum => i _.
     rewrite scale_ballE// !lebesgue_measure_ball ?mulr_ge0 ?(ltW (r_pos _))//.
     by rewrite -mulrnAr EFinM.
 rewrite !EFinM -muleA lee_wpmul2l//=.
 apply: (@le_trans _ _
-    (\sum_(i <- E') c^-1%:E * \int[mu]_(y in B i) `|(f y)|%:E)).
-  rewrite big_seq [in leRHS]big_seq; apply: lee_sum => r /E'D /Dsub /[!inE] rD.
+    (\sum_(i <- E) c^-1%:E * \int[mu]_(y in B i) `|(f y)|%:E)).
+  rewrite big_seq [in leRHS]big_seq; apply: lee_sum => r /ED /Dsub /[!inE] rD.
   by rewrite -lee_pdivr_mull ?invr_gt0// invrK /B/=; exact/ltW/cMfx_int.
 rewrite -ge0_sume_distrr//; last by move=> x _; rewrite integral_ge0.
 rewrite lee_wpmul2l//; first by rewrite lee_fin invr_ge0 ltW.

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -47,6 +47,8 @@ Require Import esum measure lebesgue_measure numfun.
 (*                           measure over T2                                  *)
 (* locally_integrable D f == the real number-valued function f is locally     *)
 (*                           integrable on D                                  *)
+(*               iavg f A := "average" of the real-valued function f over     *)
+(*                           the set A                                        *)
 (*             HL_maximal == the Hardy–Littlewood maximal operator            *)
 (*                           input: real number-valued function               *)
 (*                           output: extended real number-valued function     *)

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -1386,9 +1386,9 @@ Proof. by move/is_intervalP => ->; exact: measurable_itv. Qed.
 Section coutinuous_measurable.
 Variable R : realType.
 
-Lemma open_measurable (U : set R) : open U -> measurable U.
+Lemma open_measurable (A : set R) : open A -> measurable A.
 Proof.
-move=> /open_bigcup_rat ->; rewrite bigcup_mkcond; apply: bigcupT_measurable_rat.
+move=>/open_bigcup_rat ->; rewrite bigcup_mkcond; apply: bigcupT_measurable_rat.
 move=> q; case: ifPn => // qfab; apply: is_interval_measurable => //.
 exact: is_interval_bigcup_ointsub.
 Qed.
@@ -1400,7 +1400,7 @@ move=> mD /open_subspaceP [V [oV] VD]; rewrite setIC -VD.
 by apply: measurableI => //; exact: open_measurable.
 Qed.
 
-Lemma closed_measurable (U : set R) : closed U -> measurable U.
+Lemma closed_measurable (A : set R) : closed A -> measurable A.
 Proof. by move/closed_openC/open_measurable/measurableC; rewrite setCK. Qed.
 
 Lemma compact_measurable (A : set R) : compact A -> measurable A.
@@ -1430,6 +1430,14 @@ by move=> cf; apply: open_continuous_measurable_fun => //; exact: openT.
 Qed.
 
 End coutinuous_measurable.
+
+Lemma lower_semicontinuous_measurable {R : realType} (f : R -> \bar R) :
+  lower_semicontinuous f -> measurable_fun setT f.
+Proof.
+move=> scif; apply: (measurability (ErealGenOInfty.measurableE R)).
+move=> /= _ [_ [a ->]] <-; apply: measurableI => //; apply: open_measurable.
+by rewrite preimage_itv_o_infty; move/lower_semicontinuousP : scif; exact.
+Qed.
 
 Section standard_measurable_fun.
 Variable R : realType.

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -19,6 +19,11 @@ Require Import ereal reals signed topology prodnormedzmodule.
 (*                                   balls; the carrier type must have a      *)
 (*                                   normed Zmodule over a numDomainType.     *)
 (*                                                                            *)
+(*         lower_semicontinuous f == the extented real-valued function f is   *)
+(*                                   lower-semicontinuous. The type of f is   *)
+(*                                   X -> \bar R with X : topologicalType and *)
+(*                                   R : realType                             *)
+(*                                                                            *)
 (* * Normed modules :                                                         *)
 (*                normedModType K == interface type for a normed module       *)
 (*                                   structure over the numDomainType K.      *)
@@ -350,6 +355,27 @@ rewrite /ball /= sub0r normrN ler0_norm// (le_lt_trans (ceil_ge _))//.
 rewrite -natr1 natr_absz -abszE gez0_abs ?ceil_ge0// 1?ler_oppr ?oppr0//.
 by rewrite ltr_spaddr.
 Qed.
+
+Section lower_semicontinuous.
+Context {X : topologicalType} {R : realType}.
+Implicit Types f : X -> \bar R.
+Local Open Scope ereal_scope.
+
+Definition lower_semicontinuous f := forall x a, a%:E < f x ->
+  exists2 V, nbhs x V & forall y, V y -> a%:E < f y.
+
+Lemma lower_semicontinuousP f :
+  lower_semicontinuous f <-> forall a, open [set x | f x > a%:E].
+Proof.
+split=> [sci a|openf x a afx].
+  rewrite openE /= => x /= /sci[A + Aaf]; rewrite nbhsE /= => -[B xB BA].
+  apply: nbhs_singleton; apply: nbhs_interior.
+  by rewrite nbhsE /=; exists B => // y /BA /=; exact: Aaf.
+exists [set x | a%:E < f x] => //.
+by rewrite nbhsE/=; exists [set x | a%:E < f x].
+Qed.
+
+End lower_semicontinuous.
 
 (** neighborhoods *)
 

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -6424,7 +6424,7 @@ Hypothesis is_ballB : forall i, is_ball (B i).
 Hypothesis B_set0 : forall i, B i !=set0.
 
 Lemma vitali_lemma_finite (s : seq I) :
-  { D : seq I | [/\
+  { D : seq I | [/\ uniq D,
     {subset D <= s}, trivIset [set` D] B &
     forall i, i \in s -> exists j, [/\ j \in D,
       B i `&` B j !=set0,
@@ -6435,7 +6435,7 @@ pose LE x y := radius (B x) <= radius (B y).
 have LE_trans : transitive LE by move=> x y z; exact: le_trans.
 wlog : s / sorted LE s.
   have : sorted LE (sort LE s) by apply: sort_sorted => x y; exact: le_total.
-  move=> /[swap] /[apply] -[D [Ds trivIset_DB H]]; exists D; split => //.
+  move=> /[swap] /[apply] -[D [uD Ds trivIset_DB H]]; exists D; split => //.
   - by move=> x /Ds; rewrite mem_sort.
   - by move=> i; rewrite -(mem_sort LE) => /H.
 elim: s => [_|i [/= _ _|j t]]; first by exists nil.
@@ -6443,9 +6443,18 @@ elim: s => [_|i [/= _ _|j t]]; first by exists nil.
   move=> _ /[1!inE] /eqP ->; exists i; split => //; first by rewrite mem_head.
   - by rewrite setIid; exact: B_set0.
   - exact: sub1_scale_ball.
-rewrite /= => + /andP[ij jt] => /(_ jt)[u [ujt trivIset_uB H]].
+rewrite /= => + /andP[ij jt] => /(_ jt)[u [uu ujt trivIset_uB H]].
 have [K|] := pselect (forall j, j \in u -> B j `&` B i = set0).
+  have [iu|iu] := boolP (i \in u).
+    exists u; split => //.
+    - by move=> x /ujt xjt; rewrite inE xjt orbT.
+    - move=> k /[1!inE] /predU1P[->{k}|].
+        exists i; split; [by []| |exact: lexx|].
+          by rewrite setIid; exact: B_set0.
+        exact: sub1_scale_ball.
+      by move/H => [l [lu lk0 kl k3l]]; exists l; split => //; rewrite inE lu orbT.
   exists (i :: u); split => //.
+  - by rewrite /= iu.
   - move=> x /[1!inE] /predU1P[->|]; first by rewrite mem_head.
     by move/ujt => xjt; rewrite in_cons xjt orbT.
   - move=> k l /= /[1!inE] /predU1P[->{k}|ku].
@@ -6481,11 +6490,11 @@ move=> _ /[1!inE] /predU1P[->|/H//]; exists k; split; [exact: ku| | |].
 Qed.
 
 Lemma vitali_lemma_finite_cover (s : seq I) :
-  { D : seq I | [/\ {subset D <= s},
+  { D : seq I | [/\ uniq D, {subset D <= s},
     trivIset [set` D] B &
     cover [set` s] B `<=` cover [set` D] (scale_ball 3%:R \o B)] }.
 Proof.
-have [D [DV tD maxD]] := vitali_lemma_finite s.
+have [D [uD DV tD maxD]] := vitali_lemma_finite s.
 exists D; split => // x [i Vi] cBix/=.
 by have [j [Dj BiBj ij]] := maxD i Vi; move/(_ _ cBix) => ?; exists j.
 Qed.

--- a/theories/numfun.v
+++ b/theories/numfun.v
@@ -308,6 +308,13 @@ Qed.
 
 End indic_lemmas.
 
+Lemma patch_indic T {R : numFieldType} (f : T -> R) (D : set T) :
+  f \_ D = (f \* \1_D)%R.
+Proof.
+apply/funext => x /=; rewrite /patch /= indicE.
+by case: ifPn => _; rewrite ?(mulr1, mulr0).
+Qed.
+
 Lemma xsection_indic (R : ringType) T1 T2 (A : set (T1 * T2)) x :
   xsection A x = (fun y => (\1_A (x, y) : R)) @^-1` [set 1].
 Proof.


### PR DESCRIPTION
##### Motivation for this change

This is track C of issue #965 

~~It assumes that ` lebesgue_regularity_inner` can be proved without the boundedness hypothesis.~~

~~Based on the PR about Vitali's lemma PR #973 .~~ (merged)

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 2.0

<!-- MathComp-Analysis is compatible with MathComp < 2.0 (branch `master`) and
     MathComp 2.0 ([branch `hierarchy-builder`](https://github.com/math-comp/analysis/pull/698)).

     If this PR targets `master` and if it is merged, the merged commit will also be
     cherry-picked on the branch `hierarchy-builder`.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `hierarchy-builder` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: HB port to record divergences between `master` and `hierarchy-builder` -->

- [x] I added the label `TODO: HB port` to make sure someone ports this PR to
      the `hierarchy-builder` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
