### PR TITLE
Int signed instances

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -168,6 +168,11 @@
 - in `topology.v`:
   + lemma `my_ball_le` (use `ball_le` instead)
 
+- in `signed.v`:
+  + lemma `nat_snum_subproof`
+  + canonical instance `nat_snum` (useless, there is already a default instance
+    pointing to the typ_snum mechanism (then identifying nats as >= 0))
+
 ### Infrastructure
 
 ### Misc

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -64,6 +64,10 @@
 - in `classical_sets.v`:
   + lemma `Zorn_bigcup`
 
+- in `signed.v`:
+  + lemmas `Posz_snum_subproof` and `Negz_snum_subproof`
+  + canonical instances `Posz_snum` and `Negz_snum`
+
 ### Changed
 
 - moved from `lebesgue_measure.v` to `real_interval.v`:

--- a/theories/signed.v
+++ b/theories/signed.v
@@ -925,11 +925,6 @@ Section NatStability.
 Local Open Scope nat_scope.
 Implicit Type (n : nat).
 
-Lemma nat_snum_subproof n : Signed.spec 0 ?=0 >=0 n.
-Proof. by []. Qed.
-
-Canonical nat_snum n := Signed.mk (nat_snum_subproof n).
-
 Lemma zeron_snum_subproof : Signed.spec 0 ?=0 =0 0.
 Proof. by []. Qed.
 

--- a/theories/signed.v
+++ b/theories/signed.v
@@ -1020,6 +1020,26 @@ Canonical maxn_snum (xnz ynz : nullity) (xr yr : reality)
 
 End NatStability.
 
+Section IntStability.
+
+Lemma Posz_snum_subproof (xnz : nullity) (xr : reality)
+    (x : {compare 0%N & xnz & xr}) :
+  Signed.spec 0%Z xnz xr (Posz x%:num).
+Proof.
+by apply/andP; split; move: xr xnz x => [[[]|]|] []//=; move=> [[|x]//= _].
+Qed.
+
+Canonical Posz_snum (xnz : nullity) (xr : reality)
+    (x : {compare 0%N & xnz & xr}) :=
+  Signed.mk (Posz_snum_subproof x).
+
+Lemma Negz_snum_subproof (n : nat) : Signed.spec 0%Z !=0 <=0 (Negz n).
+Proof. by []. Qed.
+
+Canonical Negz_snum n := Signed.mk (Negz_snum_subproof n).
+
+End IntStability.
+
 Section Morph0.
 Context {R : numDomainType} {cond : reality}.
 Local Notation nR := {num R & ?=0 & cond}.


### PR DESCRIPTION
##### Motivation for this change

Makes positive constants posnum (for instance 1 / 3 is now a posnum, following yesterday's meeting discussion: https://github.com/math-comp/analysis/wiki/2023-07-27-Meeting )

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] ~added corresponding documentation in the headers~

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 2.0

<!-- MathComp-Analysis is compatible with MathComp < 2.0 (branch `master`) and
     MathComp 2.0 ([branch `hierarchy-builder`](https://github.com/math-comp/analysis/pull/698)).

     If this PR targets `master` and if it is merged, the merged commit will also be
     cherry-picked on the branch `hierarchy-builder`.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `hierarchy-builder` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: HB port to record divergences between `master` and `hierarchy-builder` -->

- [x] I added the label `TODO: HB port` to make sure someone ports this PR to
      the `hierarchy-builder` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
