### PR TITLE
Continuous functions are dense in L1

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -45,6 +45,12 @@
     `compact_finite_measure`, `approximation_continuous_integrable`, and
     `cvge_harmonic`.
 
+- in `mathcomp_extra.v`:
+  + lemmas `le_bigmax_seq`, `bigmax_sup_seq`
+
+- in `constructive_ereal.v`:
+  + lemma `bigmaxe_fin_num`
+
 ### Changed
 
 - `mnormalize` moved from `kernel.v` to `measure.v` and generalized
@@ -57,6 +63,9 @@
 
 - removed dependency in `Rstruct.v` on `normedtype.v`:
 - added dependency in `normedtype.v` on `Rstruct.v`:
+
+- in `cardinality.f`:
+  + implicits of `fimfunP`
 
 ### Renamed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -42,7 +42,8 @@
 
 - in file `lebesgue_integral.v`,
   + new lemmas `simple_bounded`, `measurable_bounded_integrable`, 
-    `compact_finite_measure`, and `cvge_harmonic`.
+    `compact_finite_measure`, `approximation_continuous_integrable`, and
+    `cvge_harmonic`.
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -42,8 +42,10 @@
 
 - in file `lebesgue_integral.v`,
   + new lemmas `simple_bounded`, `measurable_bounded_integrable`, 
-    `compact_finite_measure`, `approximation_continuous_integrable`, and
-    `cvge_harmonic`.
+    `compact_finite_measure`, `approximation_continuous_integrable`
+
+- in `sequences.v`:
+  + lemma `cvge_harmonic`
 
 - in `mathcomp_extra.v`:
   + lemmas `le_bigmax_seq`, `bigmax_sup_seq`
@@ -64,8 +66,11 @@
 - removed dependency in `Rstruct.v` on `normedtype.v`:
 - added dependency in `normedtype.v` on `Rstruct.v`:
 
-- in `cardinality.f`:
+- in `cardinality.v`:
   + implicits of `fimfunP`
+
+- in `lebesgue_integral.v`:
+  + implicits of `integral_le_bound`
 
 ### Renamed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -40,6 +40,10 @@
   + new definition `regular_space`.
   + new lemma `ent_closure`.
 
+- in file `lebesgue_integral.v`,
+  + new lemmas `simple_bounded`, `measurable_bounded_integrable`, 
+    `compact_finite_measure`, and `cvge_harmonic`.
+
 ### Changed
 
 - `mnormalize` moved from `kernel.v` to `measure.v` and generalized

--- a/classical/cardinality.v
+++ b/classical/cardinality.v
@@ -1235,13 +1235,15 @@ HB.mixin Record FiniteImage aT rT (f : aT -> rT) := {
 }.
 HB.structure Definition FImFun aT rT := {f of @FiniteImage aT rT f}.
 
+Arguments fimfunP {aT rT} _.
+#[global] Hint Resolve fimfunP : core.
+
 Reserved Notation "{ 'fimfun' aT >-> T }"
   (at level 0, format "{ 'fimfun'  aT  >->  T }").
 Reserved Notation "[ 'fimfun' 'of' f ]"
   (at level 0, format "[ 'fimfun'  'of'  f ]").
 Notation "{ 'fimfun' aT >-> T }" := (@FImFun.type aT T) : form_scope.
 Notation "[ 'fimfun' 'of' f ]" := [the {fimfun _ >-> _} of f] : form_scope.
-#[global] Hint Resolve fimfunP : core.
 
 Lemma fimfun_inP {aT rT} (f : {fimfun aT >-> rT}) (D : set aT) :
   finite_set (f @` D).

--- a/classical/mathcomp_extra.v
+++ b/classical/mathcomp_extra.v
@@ -1416,3 +1416,25 @@ Qed.
 End max_min.
 
 Notation trivial := (ltac:(done)).
+
+Section bigmax_seq.
+Context d {T : orderType d} {x : T} {I : eqType}.
+Variables (r : seq I) (i0 : I) (P : pred I).
+
+(* NB: as of [2023-08-28], bigop.leq_bigmax_seq already exists for nat *)
+Lemma le_bigmax_seq F :
+  i0 \in r -> P i0 -> (F i0 <= \big[Order.max/x]_(i <- r | P i) F i)%O.
+Proof.
+move=> + Pi0; elim: r => // h t ih; rewrite inE big_cons.
+move=> /predU1P[<-|i0t]; first by rewrite Pi0 le_maxr// lexx.
+by case: ifPn => Ph; [rewrite le_maxr ih// orbT|rewrite ih].
+Qed.
+
+(* NB: as of [2023-08-28], bigop.bigmax_sup_seq already exists for nat *)
+Lemma bigmax_sup_seq (m : T) (F : I -> T) :
+  i0 \in r -> P i0 -> (m <= F i0)%O ->
+  (m <= \big[Order.max/x]_(i <- r | P i) F i)%O.
+Proof. by move=> i0r Pi0 ?; apply: le_trans (le_bigmax_seq _ _ _). Qed.
+
+End bigmax_seq.
+Arguments le_bigmax_seq {d T} x {I r} i0 P.

--- a/theories/constructive_ereal.v
+++ b/theories/constructive_ereal.v
@@ -2413,6 +2413,16 @@ Lemma mineMl z x y : z \is a fin_num -> 0 < z ->
   mine x y * z = mine (x * z) (y * z).
 Proof. by move=> zfin z0; rewrite muleC mineMr// !(muleC z). Qed.
 
+Lemma bigmaxe_fin_num (s : seq R) r : r \in s ->
+  \big[maxe/-oo%E]_(i <- s) i%:E \is a fin_num.
+Proof.
+move=> rs; have {rs} : s != [::].
+  by rewrite -size_eq0 -lt0n -has_predT; apply/hasP; exists r.
+elim: s => [[]//|a l]; have [-> _ _|_ /(_ isT) ih _] := eqVneq l [::].
+  by rewrite big_seq1.
+by rewrite big_cons {1}/maxe;  case: (_ < _)%E.
+Qed.
+
 Lemma lee_pemull x y : 0 <= y -> 1 <= x -> y <= x * y.
 Proof.
 move: x y => [x| |] [y| |] //; last by rewrite mulyy.

--- a/theories/kernel.v
+++ b/theories/kernel.v
@@ -1006,7 +1006,7 @@ HB.instance Definition _ n := @isMeasurableFun.Build _ _ _ _ (mk_2 n).
 
 Let fk_2 n : finite_set (range (k_2 n)).
 Proof.
-have := @fimfunP _ _ (k_ n).
+have := fimfunP (k_ n).
 suff : range (k_ n) = range (k_2 n) by move=> <-.
 by apply/seteqP; split => r [y ?] <-; [exists (point, y)|exists y.2].
 Qed.

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -4877,7 +4877,7 @@ move=> cptA ctsfA; apply: measurable_bounded_integrable.
   by exists M; split; rewrite ?num_real // => ? ? ? ?; exact: mrt.
 Qed.
 
-Local Lemma approximation_continuous_integrable (E : set R) (f : R -> R^o):
+Lemma approximation_continuous_integrable (E : set R) (f : R -> R^o):
   measurable E -> mu E < +oo -> mu.-integrable E (EFin \o f) ->
   exists g_ : (rT -> rT)^nat,
     [/\ forall n, continuous (g_ n),

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -400,6 +400,27 @@ rewrite /preimage /= => [fxfy gzf].
 by rewrite gzf -fxfy addrC subrK.
 Qed.
 
+Section simple_bounded.
+Context d (T : measurableType d) (R : realType).
+
+Lemma simple_bounded {f : {sfun T >-> R}} : 
+  bounded_fun (f : T -> [normedModType R of R^o]).
+Proof.
+case/finite_seqP:(@fimfunP _ _ f) => r fr.
+exists (fine (\big[maxe/-oo%E]_(i <- r) (`|i|)%:E)). 
+split; rewrite ?num_real // => x mx z _; apply: ltW; apply: (le_lt_trans _ mx).
+rewrite (_ : normr (f z) = fine (EFin (normr (f z)))) // fine_le //; first last.
+have fzr : (f z \in r) by (have : (range f) (f z) by exists z); rewrite fr.
+  by rewrite (big_rem _ fzr) /= le_maxr; apply/orP; left.
+have fpr : (exists p, p \in r). 
+  by exists (f point); (have : (range f) (f point) by exists point); rewrite fr.
+elim: r fpr {fr mx}; first by case => ?.
+move=> a l IH _; case: (pselect (exists p, p \in l)).
+  by move/IH => bfin; rewrite big_cons /maxe; case: (_ < _)%E; rewrite ?bfin.
+move=> npl; suff : l == [::] by move/eqP ->; rewrite big_seq1.
+rewrite -set_seq_eq0; apply/eqP; rewrite -subset0; move/forallNP: npl; apply.
+Qed.
+
 Section nnsfun_functions.
 Context d (T : measurableType d) (R : realType).
 
@@ -4819,8 +4840,32 @@ rewrite !ger0_norm ?fine_ge0 ?integral_ge0 ?fine_le//.
   + by apply: emeasurable_funD; [move: mfp | move: mfn]; case/integrableP.
   + by move=> ? ?; rewrite fpn; exact: lee_abs_sub.
 Unshelve. all: by end_near. Qed.
-
 End simple_density_L1.
+
+Section continuous_density_L1.
+Local Open Scope ereal_scope.
+Context (rT : realType).
+Let mu := [the measure _ _ of @lebesgue_measure rT].
+Let R  := [the measurableType _ of measurableTypeR rT].
+Lemma approximation_continuous_sfun (E : set R) (f : {sfun R >-> rT}):
+  measurable E -> mu E < +oo -> exists g_ : (rT -> rT)^nat,
+    [/\ forall n, continuous (g_ n : R -> R),
+        forall n, mu.-integrable E (EFin \o g_ n) &
+        (fun n => \int[mu]_(z in E) `|(f z - g_ n z)%:E|) --> 0].
+Proof.
+move=> mE Efin.
+have : (exists M, 0 < M /\ forall x, `|f x| <= M)%R.
+  
+ 
+  Search FImFun.type.
+have : forall n, exists (g : rT -> rT), 
+    continuous g /\ \int[mu]_(z in E) `|(f z - g z)%:E| < ((1/n)%R%:E).
+  move=> n.
+Search (exists (_ : (_  -> _)), _) "choice".
+
+
+
+
 
 Section fubini_functions.
 Local Open Scope ereal_scope.

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -4889,7 +4889,7 @@ Lemma cvge_harmonic : (EFin \o (@harmonic rT)) @ \oo --> 0%E.
 Proof. by apply: cvg_EFin; [exact: nearW | exact: cvg_harmonic]. Qed.
 
 Local Open Scope ereal_scope.
-Local Lemma approximation_continuous_bounded (E : set R) (f : R -> R^o):
+Local Lemma approximation_continuous_integrable (E : set R) (f : R -> R^o):
   measurable E -> mu E < +oo -> mu.-integrable E (EFin \o f) ->
   exists g_ : (rT -> rT)^nat,
     [/\ forall n, continuous (g_ n : R -> R),

--- a/theories/sequences.v
+++ b/theories/sequences.v
@@ -771,6 +771,9 @@ rewrite (le_trans (ltW (archi_boundP _)))// ler_nat -add1n -leq_subLR.
 by near: i; apply: nbhs_infty_ge.
 Unshelve. all: by end_near. Qed.
 
+Lemma cvge_harmonic {R : archiFieldType} : (EFin \o @harmonic R) @ \oo --> 0%E.
+Proof. by apply: cvg_EFin; [exact: nearW | exact: cvg_harmonic]. Qed.
+
 Lemma dvg_harmonic (R : numFieldType) : ~ cvg (series (@harmonic R)).
 Proof.
 have ge_half n : (0 < n)%N -> 2^-1 <= \sum_(n <= i < n.*2) harmonic i.


### PR DESCRIPTION
##### Motivation for this change
The last piece of track B for #965. 
The proof starts with an integrable function `f`
1. Approximate that with a simple function `g` via `approximation_sfun_integrable` 
2. Use lusin's to get a compact region on which `g` is continuous.
3. Use tietzes (and simple -> bounded) to extend g over to a continuous approximation, `h`. 
4. Chain these approximations together.

The proof could be factored out into more reusable components. However, having the topology for L1 is pretty important to make that work. Then we can circumvent most of the the boiler plate with
-  A filter convergences in a metric spaces <-> a corresponding sequence converges
- Dense is transitive
But without the Lp spaces defined, there's no great way to do this. I'm happy with things as they are now, mostly because I want to keep pushing towards FTC. 

@affeldt-aist Is this phrasing of density ok? It's pretty easy to convert to one about `(forall eps, exists N, ...)` by applying `cvg_ballP` and `fine_fcvg` if that's easier for you. 

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 2.0

<!-- MathComp-Analysis is compatible with MathComp < 2.0 (branch `master`) and
     MathComp 2.0 ([branch `hierarchy-builder`](https://github.com/math-comp/analysis/pull/698)).

     If this PR targets `master` and if it is merged, the merged commit will also be
     cherry-picked on the branch `hierarchy-builder`.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `hierarchy-builder` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: HB port to record divergences between `master` and `hierarchy-builder` -->

- [x] I added the label `TODO: HB port` to make sure someone ports this PR to
      the `hierarchy-builder` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
