### PR TITLE
expeR

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -82,6 +82,12 @@
 - in `topology.v`:
   + lemmas `closure_eq0`, `separated_open_countable`
 
+- in `exp.v`:
+  + definition `expeR`
+  + lemmas `expeR0`, `expeR_ge0`, `expeR_gt0`
+  + lemmas `expeR_eq0`, `expeRD`, `expeR_ge1Dx`
+  + lemmas `ltr_expeR`, `ler_expeR`, `expeR_inj`, `expeR_total`
+
 ### Changed
 
 - in `hoelder.v`:

--- a/classical/functions.v
+++ b/classical/functions.v
@@ -1625,7 +1625,7 @@ Context {V : zmodType} (x : V).
 
 HB.instance Definition _ := Inv.Build V V (-%R) (-%R).
 
-Lemma inv_oppr : (-%R)^-1 = (-%R). by []. Qed.
+Lemma inv_oppr : (-%R)^-1 = (-%R). Proof. by []. Qed.
 
 Lemma oppr_can2_subproof : Inv_Can2 V V setT setT (-%R).
 Proof. by split => // y _; rewrite inv_oppr ?GRing.opprK. Qed.

--- a/theories/exp.v
+++ b/theories/exp.v
@@ -540,6 +540,41 @@ Qed.
 Lemma expeR_ge1Dx x : 0 <= x -> 1 + x <= expeR x.
 Proof. case: x => //= r; rewrite -EFinD !lee_fin; exact: expR_ge1Dx. Qed.
 
+Lemma ltr_expeR : {mono expeR : x y / x < y}.
+Proof.
+move=> x y.
+case: x => /= [r||].
+- by case: y => /= [s||]; rewrite ?lte_fin ?ltr_expR// ?ltry ?le_gtF ?leNye ?expR_ge0.
+- by rewrite !le_gtF ?lteey.
+- by case: y => //= [s|]; rewrite ?lte_fin ?expR_gt0 ?ltNyr ?ltry ?ltNye. 
+Qed.
+
+Lemma ler_expeR : {mono expeR : x y / x <= y}.
+Proof.
+move=> x y.
+case: x => [r||].
+- by case: y => [s||]; rewrite ?lee_fin ?ler_expR ?leey// le_eqVlt expR_eq0 le_gtF ?expR_ge0.
+- by case: y.
+- by case: y => /= [s||]; rewrite ?lee_fin ?leNye ?expR_ge0 ?leey ?le_refl.
+Qed.
+
+Lemma expeR_inj : injective expeR.
+Proof.
+case => [r||]; case => //=.
+- by move=> s; case=> ?; apply: congr1; exact: expR_inj.
+- by move/eqP; rewrite eqe expR_eq0.
+- by move=> r /eqP; rewrite eqe eq_sym expR_eq0.
+Qed.
+
+Lemma expeR_total x : 0 <= x -> exists y, expeR y = x.
+Proof.
+case: x => // [r|_].
+  rewrite le_eqVlt => /orP [/eqP <-|r0].
+  - by exists -oo.
+  - by have := expR_total r0; case=> s <-; exists s%:E.
+by exists +oo.
+Qed.
+
 End expeR.
 
 Section Ln.

--- a/theories/exp.v
+++ b/theories/exp.v
@@ -321,7 +321,7 @@ have -> : 1 + x = lim (series (f x)).
   by apply/esym/lim_near_cst => //; near=> n; apply: F; near: n.
 apply: ler_lim; first by apply: is_cvg_near_cst; near=> n; apply: F; near: n.
   exact: is_cvg_series_exp_coeff.
-by near=> n; apply: ler_sum => [] [|[|i]] _;
+by near=> n; apply: ler_sum => -[|[|i]] _;
   rewrite /f /exp_coeff /= !(mulr0n, mulr1n, expr0, expr1, divr1, addr0, add0r)
           // exp_coeff_ge0.
 Unshelve. all: by end_near. Qed.

--- a/theories/exp.v
+++ b/theories/exp.v
@@ -19,6 +19,7 @@ Require Import itv convex.
 (*         pseries f x == [series f n * x ^ n]_n                              *)
 (*   pseries_diffs f i == (i + 1) * f (i + 1)                                 *)
 (*                                                                            *)
+(*             expeR x == extended real number-valued exponential function    *)
 (*                ln x == the natural logarithm                               *)
 (*              s `^ r == power function, in ring_scope (assumes s >= 0)      *)
 (*              e `^ r == power function, in ereal_scope (assumes e >= 0)     *)

--- a/theories/exp.v
+++ b/theories/exp.v
@@ -496,6 +496,52 @@ Local Close Scope convex_scope.
 
 End expR.
 
+Section expeR.
+
+Variable R : realType.
+Implicit Types x y : \bar R.
+Implicit Types r s : R.
+
+Local Open Scope ereal_scope.
+
+Definition expeR x :=
+  match x with
+  | r%:E => (expR r)%:E
+  | +oo => +oo
+  | -oo => 0
+  end.
+
+Lemma expeR0 : expeR 0 = 1.
+Proof. by rewrite /= expR0. Qed.
+
+Lemma expeR_ge0 x : 0 <= expeR x.
+Proof. by case: x => //= r; rewrite ltW// lte_fin expR_gt0. Qed.
+
+Lemma expeR_gt0 x : -oo < x -> 0 < expeR x.
+Proof. by case: x => //= r; rewrite lte_fin expR_gt0. Qed.
+
+Lemma expeR_eq0 x : (expeR x == 0) = (x == -oo).
+Proof. case: x => //= [r|]; rewrite ?eq_refl// eqe expR_eq0 gt_eqF// ltNyr//. Qed.
+
+Lemma expeRD x y : expeR (x + y) = expeR x * expeR y.
+Proof. 
+case: x => /= [r||].
+- case: y => /= [s||].
+  by rewrite -?EFinM ?expRD. 
+  by rewrite ?mule0// mulry /Num.sg expR_eq0 le_gtF ?mul1e ?expR_ge0// mule0.
+  by rewrite mule0.
+- case: y => //= [s||].
+  by rewrite mulyr /Num.sg expR_eq0 le_gtF ?mul1e ?expR_ge0.
+  by rewrite mulyy.
+by rewrite mule0.
+by rewrite mul0e.
+Qed.
+
+Lemma expeR_ge1Dx x : 0 <= x -> 1 + x <= expeR x.
+Proof. case: x => //= r; rewrite -EFinD !lee_fin; exact: expR_ge1Dx. Qed.
+
+End expeR.
+
 Section Ln.
 Variable R : realType.
 Implicit Types x : R.

--- a/theories/exp.v
+++ b/theories/exp.v
@@ -497,82 +497,68 @@ Local Close Scope convex_scope.
 End expR.
 
 Section expeR.
-
-Variable R : realType.
-Implicit Types x y : \bar R.
-Implicit Types r s : R.
+Context {R : realType}.
+Implicit Types (x y : \bar R) (r s : R).
 
 Local Open Scope ereal_scope.
 
 Definition expeR x :=
-  match x with
-  | r%:E => (expR r)%:E
-  | +oo => +oo
-  | -oo => 0
-  end.
+  match x with | r%:E => (expR r)%:E | +oo => +oo | -oo => 0 end.
 
-Lemma expeR0 : expeR 0 = 1.
-Proof. by rewrite /= expR0. Qed.
+Lemma expeR0 : expeR 0 = 1. Proof. by rewrite /= expR0. Qed.
 
 Lemma expeR_ge0 x : 0 <= expeR x.
-Proof. by case: x => //= r; rewrite ltW// lte_fin expR_gt0. Qed.
+Proof. by case: x => //= r; rewrite lee_fin expR_ge0. Qed.
 
 Lemma expeR_gt0 x : -oo < x -> 0 < expeR x.
 Proof. by case: x => //= r; rewrite lte_fin expR_gt0. Qed.
 
 Lemma expeR_eq0 x : (expeR x == 0) = (x == -oo).
-Proof. case: x => //= [r|]; rewrite ?eq_refl// eqe expR_eq0 gt_eqF// ltNyr//. Qed.
+Proof. by case: x => //= [r|]; rewrite ?eqxx// eqe expR_eq0. Qed.
 
 Lemma expeRD x y : expeR (x + y) = expeR x * expeR y.
-Proof. 
-case: x => /= [r||].
-- case: y => /= [s||].
-  by rewrite -?EFinM ?expRD. 
-  by rewrite ?mule0// mulry /Num.sg expR_eq0 le_gtF ?mul1e ?expR_ge0// mule0.
-  by rewrite mule0.
-- case: y => //= [s||].
-  by rewrite mulyr /Num.sg expR_eq0 le_gtF ?mul1e ?expR_ge0.
-  by rewrite mulyy.
-by rewrite mule0.
-by rewrite mul0e.
+Proof.
+case: x => /= [r| |]; last by rewrite mul0e.
+- case: y => /= [s| |]; last by rewrite mule0.
+  + by rewrite expRD EFinM.
+  + by rewrite mulry gtr0_sg ?mul1e// expR_gt0.
+- case: y => /= [s| |]; last by rewrite mule0.
+  + by rewrite mulyr gtr0_sg ?mul1e// expR_gt0.
+  + by rewrite mulyy.
 Qed.
 
 Lemma expeR_ge1Dx x : 0 <= x -> 1 + x <= expeR x.
-Proof. case: x => //= r; rewrite -EFinD !lee_fin; exact: expR_ge1Dx. Qed.
+Proof. by case: x => //= r; rewrite -EFinD !lee_fin; exact: expR_ge1Dx. Qed.
 
 Lemma ltr_expeR : {mono expeR : x y / x < y}.
 Proof.
-move=> x y.
-case: x => /= [r||].
-- by case: y => /= [s||]; rewrite ?lte_fin ?ltr_expR// ?ltry ?le_gtF ?leNye ?expR_ge0.
-- by rewrite !le_gtF ?lteey.
-- by case: y => //= [s|]; rewrite ?lte_fin ?expR_gt0 ?ltNyr ?ltry ?ltNye. 
+move=> [r| |] [s| |]//=; rewrite ?ltry//.
+- by rewrite !lte_fin ltr_expR.
+- by rewrite !ltNge lee_fin expR_ge0 leNye.
+- by rewrite lte_fin expR_gt0 ltNye.
 Qed.
 
 Lemma ler_expeR : {mono expeR : x y / x <= y}.
 Proof.
-move=> x y.
-case: x => [r||].
-- by case: y => [s||]; rewrite ?lee_fin ?ler_expR ?leey// le_eqVlt expR_eq0 le_gtF ?expR_ge0.
-- by case: y.
-- by case: y => /= [s||]; rewrite ?lee_fin ?leNye ?expR_ge0 ?leey ?le_refl.
+move=> [r| |] [s| |]//=; rewrite ?leey ?lexx//.
+- by rewrite !lee_fin ler_expR.
+- by rewrite !leNgt lte_fin expR_gt0 ltNye.
+- by rewrite lee_fin expR_ge0 leNye.
 Qed.
 
 Lemma expeR_inj : injective expeR.
 Proof.
-case => [r||]; case => //=.
-- by move=> s; case=> ?; apply: congr1; exact: expR_inj.
-- by move/eqP; rewrite eqe expR_eq0.
-- by move=> r /eqP; rewrite eqe eq_sym expR_eq0.
+move=> [r| |] [s| |] => //=.
+- by move=> [] /expR_inj ->.
+- by case => /eqP; rewrite expR_eq0.
+- by case => /esym/eqP; rewrite expR_eq0.
 Qed.
 
 Lemma expeR_total x : 0 <= x -> exists y, expeR y = x.
 Proof.
-case: x => // [r|_].
-  rewrite le_eqVlt => /orP [/eqP <-|r0].
-  - by exists -oo.
-  - by have := expR_total r0; case=> s <-; exists s%:E.
-by exists +oo.
+move: x => [r|_|//]; last by exists +oo.
+rewrite le_eqVlt => /predU1P[<-|]; first by exists -oo.
+by rewrite lte_fin => /expR_total[y <-]; exists y%:E.
 Qed.
 
 End expeR.


### PR DESCRIPTION
##### Motivation for this change

Introduces `expeR` and related lemmas

Co-authored-by: @ndslusarz
Co-authored-by: @affeldt-aist 

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 2.0

<!-- MathComp-Analysis is compatible with MathComp < 2.0 (branch `master`) and
     MathComp 2.0 ([branch `hierarchy-builder`](https://github.com/math-comp/analysis/pull/698)).

     If this PR targets `master` and if it is merged, the merged commit will also be
     cherry-picked on the branch `hierarchy-builder`.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `hierarchy-builder` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: HB port to record divergences between `master` and `hierarchy-builder` -->

- [x] I added the label `TODO: HB port` to make sure someone ports this PR to
      the `hierarchy-builder` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
