### PR TITLE
fixes #1049

### DIFF
--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -5582,7 +5582,6 @@ have ritv r : 0 < r -> mu `[x - r, x + r]%classic = (r *+ 2)%:E.
 move=> oA intf ctsfx Ax.
 apply: (@cvg_zero rT [normedModType R of rT^o]).
 apply/cvgrPdist_le => eps epos; apply: filter_app (@nbhs_right_gt rT 0).
-have ? : Filter (nbhs (0 : R)^'+) := at_right_proper_filter 0.
 move/cvgrPdist_le/(_ eps epos)/at_right_in_segment : ctsfx; apply: filter_app.
 apply: filter_app (open_itvcc_subset oA Ax).
 have mA : measurable A := open_measurable oA.

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -2255,7 +2255,6 @@ Arguments cvgr_neq0 {R V T F FF f}.
 #[global] Hint Extern 0 (ProperFilter _^'+) =>
   (apply: at_right_proper_filter) : typeclass_instances.
 
-
 Section at_left_rightR.
 Variable (R : numFieldType).
 

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -2255,6 +2255,11 @@ Arguments cvgr_neq0 {R V T F FF f}.
 #[global] Hint Extern 0 (ProperFilter _^'+) =>
   (apply: at_right_proper_filter) : typeclass_instances.
 
+#[global] Hint Extern 0 (Filter (nbhs _^'+)) =>
+  (apply: at_right_proper_filter) : typeclass_instances.
+#[global] Hint Extern 0 (Filter (nbhs _^'-)) =>
+  (apply: at_left_proper_filter) : typeclass_instances.
+
 Section at_left_rightR.
 Variable (R : numFieldType).
 

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -2255,10 +2255,6 @@ Arguments cvgr_neq0 {R V T F FF f}.
 #[global] Hint Extern 0 (ProperFilter _^'+) =>
   (apply: at_right_proper_filter) : typeclass_instances.
 
-#[global] Hint Extern 0 (Filter (nbhs _^'+)) =>
-  (apply: at_right_proper_filter) : typeclass_instances.
-#[global] Hint Extern 0 (Filter (nbhs _^'-)) =>
-  (apply: at_left_proper_filter) : typeclass_instances.
 
 Section at_left_rightR.
 Variable (R : numFieldType).


### PR DESCRIPTION
##### Motivation for this change

~~ incidentally, the addition of these instances makes the `near=>` tactic usable with goals of the form `\forall x \near a^'+` (tested in a forthcoming PR) ~~

in fact no instance is needed, the unnamed hypothesis was actually not used, it suffices to remove it,
I'll commit the instances later with their use-case

##### Things done/to do

<!-- please fill in the following checklist -->
~~- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`~~

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [ ] added corresponding documentation in the headers~~

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 2.0

<!-- MathComp-Analysis is compatible with MathComp < 2.0 (branch `master`) and
     MathComp 2.0 ([branch `hierarchy-builder`](https://github.com/math-comp/analysis/pull/698)).

     If this PR targets `master` and if it is merged, the merged commit will also be
     cherry-picked on the branch `hierarchy-builder`.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `hierarchy-builder` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: HB port to record divergences between `master` and `hierarchy-builder` -->

- [x] I added the label `TODO: HB port` to make sure someone ports this PR to
      the `hierarchy-builder` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
