### PR TITLE
negligible_bigcup

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -10,6 +10,9 @@
 - in `charge.v`:
   + factory `isCharge`
 
+- in `measure.v`:
+  + lemmas `negligibleI`, `negligible_bigsetU`, `negligible_bigcup`
+
 ### Changed
 
 - in `hoelder.v`:

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -3238,6 +3238,16 @@ Proof.
 by move=> BA [N [mN N0 AN]]; exists N; split => //; exact: subset_trans AN.
 Qed.
 
+Lemma negligibleI A B :
+  mu.-negligible A -> mu.-negligible B -> mu.-negligible (A `&` B).
+Proof.
+move=> [N [mN N0 AN]] [M [mM M0 BM]]; exists (N `&` M); split => //.
+- exact: measurableI.
+- apply/eqP; rewrite eq_le measure_ge0 andbT -N0 le_measure// inE//.
+  exact: measurableI.
+- exact: setISS.
+Qed.
+
 End negligible.
 Notation "mu .-negligible" := (negligible mu) : type_scope.
 
@@ -3264,7 +3274,36 @@ move=> [N [mN N0 AN]] [M [mM M0 BM]]; exists (N `|` M); split => //.
 - exact: setUSS.
 Qed.
 
+Lemma negligible_bigsetU (F : (set T)^nat) s (P : pred nat) :
+  (forall k, P k -> mu.-negligible (F k)) ->
+  mu.-negligible (\big[setU/set0]_(k <- s | P k) F k).
+Proof.
+by move=> PF; elim/big_ind : _ => //;
+  [exact: negligible_set0|exact: negligibleU].
+Qed.
+
 End negligible_ringOfSetsType.
+
+Lemma negligible_bigcup d (T : measurableType d) (R : realFieldType)
+    (mu : {measure set T -> \bar R}) (F : (set T)^nat) :
+  (forall k, mu.-negligible (F k)) -> mu.-negligible (\bigcup_k F k).
+Proof.
+move=> mF; exists (\bigcup_k sval (cid (mF k))); split.
+- by apply: bigcupT_measurable => // k; have [] := svalP (cid (mF k)).
+- rewrite seqDU_bigcup_eq measure_bigcup//; last first.
+    move=> k _; apply: measurableD; first by case: cid => //= A [].
+    by apply: bigsetU_measurable => i _; case: cid => //= A [].
+  rewrite eseries0// => k _.
+  have [mFk mFk0 ?] := svalP (cid (mF k)).
+  rewrite measureD//=.
+  + rewrite mFk0 sub0e eqe_oppLRP oppe0.
+    apply/eqP; rewrite eq_le measure_ge0 andbT.
+    rewrite -[leRHS]mFk0 le_measure//= ?inE//; apply: measurableI => //.
+    by apply: bigsetU_measurable => i _; case: cid => // A [].
+  + by apply: bigsetU_measurable => i _; case: cid => // A [].
+  + by rewrite mFk0.
+- by apply: subset_bigcup => k _; rewrite /sval/=; by case: cid => //= A [].
+Qed.
 
 Section ae.
 


### PR DESCRIPTION
lemma used in the proof of the Lebesgue differentiation theorem 

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [ ] added corresponding documentation in the headers~~

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 2.0

<!-- MathComp-Analysis is compatible with MathComp < 2.0 (branch `master`) and
     MathComp 2.0 ([branch `hierarchy-builder`](https://github.com/math-comp/analysis/pull/698)).

     If this PR targets `master` and if it is merged, the merged commit will also be
     cherry-picked on the branch `hierarchy-builder`.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `hierarchy-builder` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: HB port to record divergences between `master` and `hierarchy-builder` -->

- [x] I added the label `TODO: HB port` to make sure someone ports this PR to
      the `hierarchy-builder` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
