### PR TITLE
Monotonicity lemmas for norms

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -33,7 +33,7 @@
     `wlength_sigma_sub_additive`, `wlength_sigma_finite`
   + measure instance of `hlength`
   + definition `lebesgue_stieltjes_measure`
-- in `mathcomp_extras.v`
+- in `mathcomp_extra.v`
   + lemmas `ge0_ler_normr`, `gt0_ler_normr`, `le0_ger_normr` and `lt0_ger_normr`
 
 ### Changed

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -34,7 +34,7 @@
   + measure instance of `hlength`
   + definition `lebesgue_stieltjes_measure`
 - in `mathcomp_extras.v`
-  + lemmas `ge0_ler_normr` and `lt0_ger_normr`
+  + lemmas `ge0_ler_normr`, `gt0_ler_normr`, `le0_ger_normr` and `lt0_ger_normr`
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -33,6 +33,8 @@
     `wlength_sigma_sub_additive`, `wlength_sigma_finite`
   + measure instance of `hlength`
   + definition `lebesgue_stieltjes_measure`
+- in `mathcomp_extras.v`
+  + lemmas `ge0_ler_normr` and `lt0_ger_normr`
 
 ### Changed
 

--- a/classical/mathcomp_extra.v
+++ b/classical/mathcomp_extra.v
@@ -1442,3 +1442,17 @@ Arguments le_bigmax_seq {d T} x {I r} i0 P.
 (* NB: PR 1079 to MathComp in progress *)
 Lemma gerBl {R : numDomainType} (x y : R) : 0 <= y -> x - y <= x.
 Proof. by move=> y0; rewrite ler_subl_addl ler_addr. Qed.
+
+
+Section normr.
+Variable R : realDomainType.
+
+Lemma ge0_ler_normr :
+  {in Num.nneg &, {mono (@Num.Def.normr _ R) : x y / x <= y}}.
+Proof. by move=> x y; rewrite !nnegrE => x0 y0; rewrite !ger0_norm. Qed.
+
+Lemma lt0_ger_normr :
+  {in Num.neg &, {mono (@Num.Def.normr _ R) : x y / x <= y >-> x >= y}}.
+Proof. by move=> x y; rewrite !negrE => x0 y0; rewrite !ler0_norm ?lter_oppE// ?ltW. Qed.
+
+End normr.

--- a/classical/mathcomp_extra.v
+++ b/classical/mathcomp_extra.v
@@ -1447,12 +1447,15 @@ Proof. by move=> y0; rewrite ler_subl_addl ler_addr. Qed.
 Section normr.
 Variable R : realDomainType.
 
+Definition Rnpos : qualifier 0 R := [qualify x : R | x <= 0].
+Lemma nposrE x : (x \is Rnpos) = (x <= 0). Proof. by []. Qed.
+
 Lemma ge0_ler_normr :
   {in Num.nneg &, {mono (@Num.Def.normr _ R) : x y / x <= y}}.
 Proof. by move=> x y; rewrite !nnegrE => x0 y0; rewrite !ger0_norm. Qed.
 
-Lemma lt0_ger_normr :
-  {in Num.neg &, {mono (@Num.Def.normr _ R) : x y / x <= y >-> x >= y}}.
-Proof. by move=> x y; rewrite !negrE => x0 y0; rewrite !ler0_norm ?lter_oppE// ?ltW. Qed.
+Lemma le0_ger_normr :
+  {in Rnpos &, {mono (@Num.Def.normr _ R) : x y / x <= y >-> x >= y}}.
+Proof. by move=> x y; rewrite !nposrE => x0 y0; rewrite !ler0_norm ?lter_oppE// ?ltW. Qed.
 
 End normr.

--- a/classical/mathcomp_extra.v
+++ b/classical/mathcomp_extra.v
@@ -1454,8 +1454,16 @@ Lemma ge0_ler_normr :
   {in Num.nneg &, {mono (@Num.Def.normr _ R) : x y / x <= y}}.
 Proof. by move=> x y; rewrite !nnegrE => x0 y0; rewrite !ger0_norm. Qed.
 
+Lemma gt0_ler_normr :
+  {in Num.pos &, {mono (@Num.Def.normr _ R) : x y / x <= y}}.
+Proof. by move=> x y; rewrite !posrE => x0 y0; rewrite !gtr0_norm. Qed.
+
 Lemma le0_ger_normr :
   {in Rnpos &, {mono (@Num.Def.normr _ R) : x y / x <= y >-> x >= y}}.
-Proof. by move=> x y; rewrite !nposrE => x0 y0; rewrite !ler0_norm ?lter_oppE// ?ltW. Qed.
+Proof. by move=> x y; rewrite !nposrE => x0 y0; rewrite !ler0_norm ?lter_oppE. Qed.
+
+Lemma lt0_ger_normr :
+  {in Num.neg &, {mono (@Num.Def.normr _ R) : x y / x <= y >-> x >= y}}.
+Proof. by move=> x y; rewrite !negrE => x0 y0; rewrite !ler0_norm ?lter_oppE// ?ltW. Qed.
 
 End normr.

--- a/classical/mathcomp_extra.v
+++ b/classical/mathcomp_extra.v
@@ -1443,27 +1443,30 @@ Arguments le_bigmax_seq {d T} x {I r} i0 P.
 Lemma gerBl {R : numDomainType} (x y : R) : 0 <= y -> x - y <= x.
 Proof. by move=> y0; rewrite ler_subl_addl ler_addr. Qed.
 
-
+(* the following appears in MathComp 2.1.0 and MathComp 1.18.0 *)
 Section normr.
 Variable R : realDomainType.
 
 Definition Rnpos : qualifier 0 R := [qualify x : R | x <= 0].
 Lemma nposrE x : (x \is Rnpos) = (x <= 0). Proof. by []. Qed.
 
-Lemma ge0_ler_normr :
+Lemma ger0_le_norm :
   {in Num.nneg &, {mono (@Num.Def.normr _ R) : x y / x <= y}}.
 Proof. by move=> x y; rewrite !nnegrE => x0 y0; rewrite !ger0_norm. Qed.
 
-Lemma gt0_ler_normr :
+Lemma gtr0_le_norm :
   {in Num.pos &, {mono (@Num.Def.normr _ R) : x y / x <= y}}.
-Proof. by move=> x y; rewrite !posrE => x0 y0; rewrite !gtr0_norm. Qed.
+Proof. by move=> x y; rewrite !posrE => /ltW x0 /ltW y0; exact: ger0_le_norm. Qed.
 
-Lemma le0_ger_normr :
+Lemma ler0_ge_norm :
   {in Rnpos &, {mono (@Num.Def.normr _ R) : x y / x <= y >-> x >= y}}.
-Proof. by move=> x y; rewrite !nposrE => x0 y0; rewrite !ler0_norm ?lter_oppE. Qed.
+Proof.
+move=> x y; rewrite !nposrE => x0 y0.
+by rewrite !ler0_norm// -subr_ge0 opprK addrC subr_ge0.
+Qed.
 
-Lemma lt0_ger_normr :
+Lemma ltr0_ge_norm :
   {in Num.neg &, {mono (@Num.Def.normr _ R) : x y / x <= y >-> x >= y}}.
-Proof. by move=> x y; rewrite !negrE => x0 y0; rewrite !ler0_norm ?lter_oppE// ?ltW. Qed.
+Proof. by move=> x y; rewrite !negrE => /ltW x0 /ltW y0; exact: ler0_ge_norm. Qed.
 
 End normr.


### PR DESCRIPTION
##### Motivation for this change

Adds lemmas on monotonicity and antimonotonicity for norms, needed by #1053 

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 2.0

<!-- MathComp-Analysis is compatible with MathComp < 2.0 (branch `master`) and
     MathComp 2.0 ([branch `hierarchy-builder`](https://github.com/math-comp/analysis/pull/698)).

     If this PR targets `master` and if it is merged, the merged commit will also be
     cherry-picked on the branch `hierarchy-builder`.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `hierarchy-builder` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: HB port to record divergences between `master` and `hierarchy-builder` -->

- [ ] I added the label `TODO: HB port` to make sure someone ports this PR to
      the `hierarchy-builder` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
