### PR TITLE
Adds measurable_expR and measurable function composition

### DIFF
--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -158,11 +158,11 @@ HB.instance Definition _ := @isMeasurableFun.Build _ _ rT
 HB.instance Definition _ := isMeasurableFun.Build _ _ rT
   (@expR rT) (@measurable_expR rT).
 
-Let measurableT_comp_subproof (f : {mfun rT >-> rT}) (g : {mfun aT >-> rT}) :
+Let measurableT_comp_subproof {rT' : realType} (f : {mfun rT >-> rT'}) (g : {mfun aT >-> rT}) :
   measurable_fun setT (f \o g).
 Proof. by apply: measurableT_comp; last apply: @measurable_funP _ _ _ g. Qed.
 
-HB.instance Definition _ (f : {mfun rT >-> rT}) (g : {mfun aT >-> rT}) := isMeasurableFun.Build _ _ _ (f \o g) (@measurableT_comp_subproof _ _).
+HB.instance Definition _ {rT' : realType} (f : {mfun rT >-> rT'}) (g : {mfun aT >-> rT}) := isMeasurableFun.Build _ _ _ (f \o g) (@measurableT_comp_subproof _ _ _).
 
 End mfun.
 

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -155,6 +155,15 @@ Lemma mfun_cst x : @cst_mfun x =1 cst x. Proof. by []. Qed.
 HB.instance Definition _ := @isMeasurableFun.Build _ _ rT
   (@normr rT rT) (@measurable_normr rT setT).
 
+HB.instance Definition _ := isMeasurableFun.Build _ _ rT
+  (@expR rT) (@measurable_expR rT).
+
+Let measurableT_comp_subproof (f : {mfun rT >-> rT}) (g : {mfun aT >-> rT}) :
+  measurable_fun setT (f \o g).
+Proof. by apply: measurableT_comp; last apply: @measurable_funP _ _ _ g. Qed.
+
+HB.instance Definition _ (f : {mfun rT >-> rT}) (g : {mfun aT >-> rT}) := isMeasurableFun.Build _ _ _ (f \o g) (@measurableT_comp_subproof _ _).
+
 End mfun.
 
 Section ring.


### PR DESCRIPTION
Measurable function composition only works in the specific case where `f` and `g` are maps to reals

##### Motivation for this change

Required lemmas for #1053 

##### Things done/to do

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 2.0

<!-- MathComp-Analysis is compatible with MathComp < 2.0 (branch `master`) and
     MathComp 2.0 ([branch `hierarchy-builder`](https://github.com/math-comp/analysis/pull/698)).

     If this PR targets `master` and if it is merged, the merged commit will also be
     cherry-picked on the branch `hierarchy-builder`.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `hierarchy-builder` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: HB port to record divergences between `master` and `hierarchy-builder` -->

- [ ] I added the label `TODO: HB port` to make sure someone ports this PR to
      the `hierarchy-builder` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
