### PR TITLE
fixes #1051 (rename `lim_sup` -> `limn_sup`)

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -69,6 +69,35 @@
 - in `ereal.v`:
   + `le_er_map` -> `le_er_map_in`
 
+- in `sequences.v`:
+  + `lim_sup` -> `limn_sup`
+  + `lim_inf` -> `limn_inf`
+  + `lim_infN` -> `limn_infN`
+  + `lim_supE` -> `limn_supE`
+  + `lim_infE` -> `limn_infE`
+  + `lim_inf_le_lim_sup` -> `limn_inf_sup`
+  + `cvg_lim_inf_sup` -> `cvg_limn_inf_sup`
+  + `cvg_lim_supE` -> `cvg_limn_supE`
+  + `le_lim_supD` -> `le_limn_supD`
+  + `le_lim_infD` -> `le_limn_infD`
+  + `lim_supD` -> `limn_supD`
+  + `lim_infD` -> `limn_infD`
+  + `LimSup.lim_esup` -> `limn_esup`
+  + `LimSup.lim_einf` -> `limn_einf`
+  + `lim_einf_shift` -> `limn_einf_shift`
+  + `lim_esup_le_cvg` -> `limn_esup_le_cvg`
+  + `lim_einfN` -> `limn_einfN`
+  + `lim_esupN` -> `limn_esupN`
+  + `lim_einf_sup` -> `limn_einf_sup`
+  + `cvgNy_lim_einf_sup` -> `cvgNy_limn_einf_sup`
+  + `cvg_lim_einf_sup` -> `cvg_limn_einf_sup`
+  + `is_cvg_lim_einfE` -> `is_cvg_limn_einfE`
+  + `is_cvg_lim_esupE` -> `is_cvg_limn_esupE`
+
+- in `lebesgue_measure.v`:
+  + `measurable_fun_lim_sup` -> `measurable_fun_limn_sup`
+  + `measurable_fun_lim_esup` -> `measurable_fun_limn_esup`
+
 ### Generalized
 
 - in `topology.v`:
@@ -79,6 +108,26 @@
 ### Removed
 
 - `lebesgue_measure_unique` (generalized to `lebesgue_stieltjes_measure_unique`)
+
+- in `sequences.v`:
+  + notations `elim_sup`, `elim_inf`
+  + `LimSup.lim_esup`, `LimSup.lim_einf`
+  + `elim_inf_shift`
+  + `elim_sup_le_cvg`
+  + `elim_infN`
+  + `elim_supN`
+  + `elim_inf_sup`
+  + `cvg_ninfty_elim_inf_sup`
+  + `cvg_ninfty_einfs`
+  + `cvg_ninfty_esups`
+  + `cvg_pinfty_einfs`
+  + `cvg_pinfty_esups`
+  + `cvg_elim_inf_sup`
+  + `is_cvg_elim_infE`
+  + `is_cvg_elim_supE`
+
+- in `lebesgue_measure.v`:
+  + `measurable_fun_elim_sup`
 
 ### Infrastructure
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,24 @@ Landau notations can be written in four shapes:
 
 The outcome is an expression with the normal Leibniz equality `=` and term `'o_F` which is not parsable. See [this paper](https://doi.org/10.6092/issn.1972-5787/8124) for more explanation and the header of the file [landau.v](https://github.com/math-comp/analysis/blob/master/theories/landau.v).
 
+## Deprecation
+
+Deprecations are introduced for breaking changes. For a simple renaming, the pattern is:
+```
+#[deprecated(since="analysis X.Y.Z", note="Use new_definition instead.")]
+Notation old_definition := new_definition (only parsing).
+```
+Note that this needs to be at the top-level (i.e., not inside a section).
+
+When a lemma `lem` is scheduled for deletion, it ought better be renamed `__deprecated__lem`
+(so that it can be blacklisted). The deprecation command then becomes:
+```
+#[deprecated(since="analysis X.Y.Z", note="Use another_lemma instead.")]
+Notation lem := __deprecated__lem (only parsing).
+```
+The `(only parsing)` format is needed so that Coq does not print back the deprecated name
+(for example when displaying error messages, that would be confusing).
+
 ## Naming convention
 
 ### homo and mono notations

--- a/classical/cardinality.v
+++ b/classical/cardinality.v
@@ -909,7 +909,7 @@ Lemma __deprecated__bigcup_fset_set T (I : choiceType) (A : set I) (F : I -> set
   finite_set A -> \bigcup_(i in A) F i = \big[setU/set0]_(i <- fset_set A) F i.
 Proof. by move=> /bigsetU_fset_set->. Qed.
 #[deprecated(note="Use -bigsetU_fset_set instead")]
-Notation bigcup_fset_set := __deprecated__bigcup_fset_set.
+Notation bigcup_fset_set := __deprecated__bigcup_fset_set (only parsing).
 
 Lemma bigsetU_fset_set_cond T (I : choiceType) (A : set I) (F : I -> set T)
     (P : pred I) : finite_set A ->
@@ -923,7 +923,7 @@ Lemma __deprecated__bigcup_fset_set_cond T (I : choiceType) (A : set I) (F : I -
   \bigcup_(i in A `&` P) F i = \big[setU/set0]_(i <- fset_set A | P i) F i.
 Proof. by move=> /bigsetU_fset_set_cond->. Qed.
 #[deprecated(note="Use -bigsetU_fset_set_cond instead")]
-Notation bigcup_fset_set_cond := __deprecated__bigcup_fset_set_cond.
+Notation bigcup_fset_set_cond := __deprecated__bigcup_fset_set_cond (only parsing).
 
 Lemma bigsetI_fset_set T (I : choiceType) (A : set I) (F : I -> set T) :
   finite_set A -> \big[setI/setT]_(i <- fset_set A) F i =\bigcap_(i in A) F i.
@@ -935,7 +935,7 @@ Lemma __deprecated__bigcap_fset_set T (I : choiceType) (A : set I) (F : I -> set
   finite_set A -> \bigcap_(i in A) F i = \big[setI/setT]_(i <- fset_set A) F i.
 Proof. by move=> /bigsetI_fset_set->. Qed.
 #[deprecated(note="Use -bigsetI_fset_set instead")]
-Notation bigcap_fset_set := __deprecated__bigcap_fset_set.
+Notation bigcap_fset_set := __deprecated__bigcap_fset_set (only parsing).
 
 Lemma bigsetI_fset_set_cond T (I : choiceType) (A : set I) (F : I -> set T)
     (P : pred I) : finite_set A ->
@@ -1064,7 +1064,7 @@ by under eq_imagel do rewrite /= gE ?inE//; rewrite image_eq.
 Qed.
 
 #[deprecated(note="use countable0 instead")]
-Notation countable_set0 := countable0.
+Notation countable_set0 := countable0 (only parsing).
 
 Lemma countable1 T (x : T) : countable [set x].
 Proof. exact: finite_set_countable. Qed.

--- a/classical/classical_sets.v
+++ b/classical/classical_sets.v
@@ -466,7 +466,7 @@ apply: contra_notP => /forallNP h.
 by apply/eqP; rewrite predeqE => t; split => // _; apply: contrapT.
 Qed.
 #[deprecated(note="Use setTPn instead")]
-Notation setTP := setTPn.
+Notation setTP := setTPn (only parsing).
 
 Lemma in_set0 (x : T) : (x \in set0) = false. Proof. by rewrite memNset. Qed.
 Lemma in_setT (x : T) : x \in setT. Proof. by rewrite mem_set. Qed.
@@ -1033,9 +1033,9 @@ End basic_lemmas.
 #[global]
 Hint Resolve subsetUl subsetUr subIsetl subIsetr subDsetl subDsetr : core.
 #[deprecated(since="mathcomp-analysis 0.6", note="Use setICl instead.")]
-Notation setvI := setICl.
+Notation setvI := setICl (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6", note="Use setICr instead.")]
-Notation setIv := setICr.
+Notation setIv := setICr (only parsing).
 Arguments setU_id2r {T} C {A B}.
 
 Section set_order.
@@ -1981,13 +1981,13 @@ Proof. by apply: setC_inj; rewrite setC_bigcap setC_bigsetI bigcup_seq. Qed.
 
 End bigcup_seq.
 #[deprecated(since="mathcomp-analysis 0.6.4",note="Use bigcup_seq instead")]
-Notation bigcup_set := bigcup_seq.
+Notation bigcup_set := bigcup_seq (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.4",note="Use bigcup_seq_cond instead")]
-Notation bigcup_set_cond := bigcup_seq_cond.
+Notation bigcup_set_cond := bigcup_seq_cond (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.4",note="Use bigcap_seq instead")]
-Notation bigcap_set := bigcap_seq.
+Notation bigcap_set := bigcap_seq (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.4",note="Use bigcap_seq_cond instead")]
-Notation bigcap_set_cond := bigcap_seq_cond.
+Notation bigcap_set_cond := bigcap_seq_cond (only parsing).
 
 Lemma bigcup_pred [T : finType] [U : Type] (P : {pred T}) (f : T -> set U) :
   \bigcup_(t in [set` P]) f t = \big[setU/set0]_(t in P) f t.
@@ -2628,7 +2628,7 @@ Qed.
 End partitions.
 
 #[deprecated(note="Use trivIset_setIl instead")]
-Notation trivIset_setI := trivIset_setIl.
+Notation trivIset_setI := trivIset_setIl (only parsing).
 
 Definition total_on T (A : set T) (R : T -> T -> Prop) :=
   forall s t, A s -> A t -> R s t \/ R t s.

--- a/classical/fsbigop.v
+++ b/classical/fsbigop.v
@@ -276,7 +276,7 @@ Proof. by move=> Afin; apply: __deprecated__full_fsbigID; apply: finite_setIl. Q
 Arguments fsbigID {R idx op I} B.
 
 #[deprecated(note="Use fsbigID instead")]
-Notation full_fsbigID := __deprecated__full_fsbigID.
+Notation full_fsbigID := __deprecated__full_fsbigID (only parsing).
 
 Lemma fsbigU (R : Type) (idx : R) (op : Monoid.com_law idx)
     (I : choiceType) (A B : set I) (F : I -> R) :
@@ -422,9 +422,9 @@ Arguments fsbig_image {R idx op I J} _ _.
 Arguments __deprecated__reindex_inside {R idx op I J} _ _.
 Arguments reindex_fsbigT {R idx op I J} _ _.
 #[deprecated(note="use reindex_fsbig, fsbig_image or reindex_fsbigT instead")]
-Notation reindex_inside := __deprecated__reindex_inside.
+Notation reindex_inside := __deprecated__reindex_inside (only parsing).
 #[deprecated(note="use reindex_fsbigT instead")]
-Notation reindex_inside_setT := reindex_fsbigT.
+Notation reindex_inside_setT := reindex_fsbigT (only parsing).
 
 Lemma fsbigN1 (R : eqType) (idx : R) (op : Monoid.com_law idx)
     (T1 T2 : choiceType) (Q : set T2) (f : T1 -> T2 -> R) (x : T1) :

--- a/theories/charge.v
+++ b/theories/charge.v
@@ -1078,9 +1078,11 @@ Definition fRN := fun x => lim (F ^~ x).
 
 Lemma measurable_fun_fRN : measurable_fun [set: T] fRN.
 Proof.
-rewrite (_ : fRN = fun x => lim_esup (F ^~ x)).
-  by apply: measurable_fun_lim_esup => // n; exact: measurable_max_approxRN_seq.
-by apply/funext=> n; rewrite is_cvg_lim_esupE//; exact: is_cvg_max_approxRN_seq.
+rewrite (_ : fRN = fun x => limn_esup (F ^~ x)).
+  apply: measurable_fun_limn_esup => // n.
+  exact: measurable_max_approxRN_seq.
+apply/funext=> n; rewrite is_cvg_limn_esupE//.
+exact: is_cvg_max_approxRN_seq.
 Qed.
 
 Lemma fRN_ge0 x : 0 <= fRN x.

--- a/theories/constructive_ereal.v
+++ b/theories/constructive_ereal.v
@@ -1020,13 +1020,13 @@ by apply/eqP/esum_eqyP => //; exists i.
 Qed.
 
 #[deprecated(since="mathcomp-analysis 0.6.0", note="renamed `esum_eqNyP`")]
-Notation esum_ninftyP := esum_eqNyP.
+Notation esum_ninftyP := esum_eqNyP (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.0", note="renamed `esum_eqNy`")]
-Notation esum_ninfty := esum_eqNy.
+Notation esum_ninfty := esum_eqNy (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.0", note="renamed `esum_eqyP`")]
-Notation esum_pinftyP := esum_eqyP.
+Notation esum_pinftyP := esum_eqyP (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.0", note="renamed `esum_eqy`")]
-Notation esum_pinfty := esum_eqy.
+Notation esum_pinfty := esum_eqy (only parsing).
 
 Lemma adde_ge0 x y : 0 <= x -> 0 <= y -> 0 <= x + y.
 Proof. by move: x y => [r0| |] [r1| |] // ? ?; rewrite !lee_fin addr_ge0. Qed.
@@ -1398,13 +1398,13 @@ by under eq_existsb => i do rewrite eqe_oppLR.
 Qed.
 
 #[deprecated(since="mathcomp-analysis 0.6.0", note="renamed `desum_eqNyP`")]
-Notation desum_ninftyP := desum_eqNyP.
+Notation desum_ninftyP := desum_eqNyP (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.0", note="renamed `desum_eqNy`")]
-Notation desum_ninfty := desum_eqNy.
+Notation desum_ninfty := desum_eqNy (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.0", note="renamed `desum_eqyP`")]
-Notation desum_pinftyP := desum_eqyP.
+Notation desum_pinftyP := desum_eqyP (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.0", note="renamed `desum_eqy`")]
-Notation desum_pinfty := desum_eqy.
+Notation desum_pinfty := desum_eqy (only parsing).
 
 Lemma dadde_ge0 x y : 0 <= x -> 0 <= y -> 0 <= x + y.
 Proof. rewrite dual_addeE oppe_ge0 -!oppe_le0; exact: adde_le0. Qed.
@@ -1498,7 +1498,7 @@ by apply/negP; rewrite -leNgt; apply/Ax/ltr_spaddr; rewrite // le_maxr lexx.
 Qed.
 
 #[deprecated(since="mathcomp-analysis 0.6.0", note="renamed `eqyP`")]
-Notation eq_pinftyP := eqyP.
+Notation eq_pinftyP := eqyP (only parsing).
 
 Lemma seq_psume_eq0 (I : choiceType) (r : seq I)
     (P : pred I) (F : I -> \bar R) : (forall i, P i -> 0 <= F i)%E ->
@@ -2597,11 +2597,11 @@ Arguments lee_sum_npos_natl {R}.
 #[global] Hint Extern 0 (is_true (0 <= `| _ |)%E) => solve [apply: abse_ge0] : core.
 
 #[deprecated(since="mathcomp-analysis 0.6", note="Use lte_spaddre instead.")]
-Notation lte_spaddr := lte_spaddre.
+Notation lte_spaddr := lte_spaddre (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.5", note="Use leeN2 instead.")]
-Notation lee_opp := leeN2.
+Notation lee_opp := leeN2 (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.5", note="Use lteN2 instead.")]
-Notation lte_opp := lteN2.
+Notation lte_opp := lteN2 (only parsing).
 
 Module DualAddTheoryRealDomain.
 

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -1376,7 +1376,7 @@ Lemma __deprecated__le0r_cvg_map (R : realFieldType) (T : topologicalType) (F : 
 Proof. by move=> ? ?; rewrite limr_ge. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="generalized by `limr_ge`")]
-Notation le0r_cvg_map := __deprecated__le0r_cvg_map.
+Notation le0r_cvg_map := __deprecated__le0r_cvg_map (only parsing).
 
 Lemma __deprecated__ler0_cvg_map (R : realFieldType) (T : topologicalType) (F : set (set T))
   (FF : ProperFilter F) (f : T -> R) :
@@ -1384,7 +1384,7 @@ Lemma __deprecated__ler0_cvg_map (R : realFieldType) (T : topologicalType) (F : 
 Proof. by move=> ? ?; rewrite limr_le. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="generalized by `limr_le`")]
-Notation ler0_cvg_map := __deprecated__ler0_cvg_map.
+Notation ler0_cvg_map := __deprecated__ler0_cvg_map (only parsing).
 
 Lemma __deprecated__ler_cvg_map (R : realFieldType) (T : topologicalType) (F : set (set T))
     (FF : ProperFilter F) (f g : T -> R) :
@@ -1393,7 +1393,7 @@ Lemma __deprecated__ler_cvg_map (R : realFieldType) (T : topologicalType) (F : s
 Proof. by move=> ? ? ?; rewrite ler_lim. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="subsumed by `ler_lim`")]
-Notation ler_cvg_map := __deprecated__ler_cvg_map.
+Notation ler_cvg_map := __deprecated__ler_cvg_map (only parsing).
 
 Lemma derive1_at_max (R : realFieldType) (f : R -> R) (a b c : R) :
   a <= b -> (forall t, t \in `]a, b[%R -> derivable f t 1) -> c \in `]a, b[%R ->

--- a/theories/kernel.v
+++ b/theories/kernel.v
@@ -516,10 +516,10 @@ Lemma measurable_fun_xsection_integral
 Proof.
 move=> h.
 rewrite (_ : (fun x => _) =
-    (fun x => lim_esup (fun n => \int[l x]_y (k_ n (x, y))%:E))); last first.
+    (fun x => limn_esup (fun n => \int[l x]_y (k_ n (x, y))%:E))); last first.
   apply/funext => x.
   transitivity (lim (fun n => \int[l x]_y (k_ n (x, y))%:E)); last first.
-    rewrite is_cvg_lim_esupE//.
+    rewrite is_cvg_limn_esupE//.
     apply: ereal_nondecreasing_is_cvg => m n mn.
     apply: ge0_le_integral => //.
     - by move=> y _; rewrite lee_fin.
@@ -532,7 +532,7 @@ rewrite (_ : (fun x => _) =
   - by move=> n; exact/EFin_measurable_fun/measurableT_comp.
   - by move=> n y _; rewrite lee_fin.
   - by move=> y _ m n mn; rewrite lee_fin; exact/lefP/ndk_.
-apply: measurable_fun_lim_esup => n.
+apply: measurable_fun_limn_esup => n.
 rewrite [X in measurable_fun _ X](_ : _ = (fun x => \int[l x]_y
     (\sum_(r \in range (k_ n))
       r * \1_(k_ n @^-1` [set r]) (x, y))%:E)); last first.

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -1832,10 +1832,10 @@ Lemma ge0_emeasurable_fun_sum D (h : nat -> (T -> \bar R)) :
   measurable_fun D (fun x => \sum_(i <oo) h i x).
 Proof.
 move=> h0 mh; rewrite [X in measurable_fun _ X](_ : _ =
-    (fun x => lim_esup (fun n => \sum_(0 <= i < n) h i x))); last first.
-  apply/funext=> x; rewrite is_cvg_lim_esupE//.
+    (fun x => limn_esup (fun n => \sum_(0 <= i < n) h i x))); last first.
+  apply/funext=> x; rewrite is_cvg_limn_esupE//.
   exact: is_cvg_ereal_nneg_natsum.
-by apply: measurable_fun_lim_esup => k; exact: emeasurable_fun_sum.
+by apply: measurable_fun_limn_esup => k; exact: emeasurable_fun_sum.
 Qed.
 
 Lemma emeasurable_funB D f g :
@@ -2345,8 +2345,8 @@ Variable (f : (T -> \bar R)^nat).
 Hypothesis mf : forall n, measurable_fun D (f n).
 Hypothesis f0 : forall n x, D x -> 0 <= f n x.
 
-Lemma fatou : \int[mu]_(x in D) lim_einf (f^~ x) <=
-              lim_einf (fun n => \int[mu]_(x in D) f n x).
+Lemma fatou : \int[mu]_(x in D) limn_einf (f^~ x) <=
+              limn_einf (fun n => \int[mu]_(x in D) f n x).
 Proof.
 pose g n := fun x => einfs (f ^~ x) n.
 have mg := measurable_fun_einfs mf.
@@ -4111,8 +4111,8 @@ Proof.
 have := fatou mu mD mgg gg_ge0.
 rewrite [X in X <= _ -> _](_ : _ = \int[mu]_(x in D) (2%:E * g x) ); last first.
   apply: eq_integral => t; rewrite inE => Dt.
-  rewrite lim_einf_shift//; last by rewrite fin_numM// fing.
-  rewrite is_cvg_lim_einfE//; last first.
+  rewrite limn_einf_shift//; last by rewrite fin_numM// fing.
+  rewrite is_cvg_limn_einfE//; last first.
     by apply: is_cvgeN; apply/cvg_ex; eexists; exact: cvg_g_.
   rewrite [X in _ + X](_ : _ = 0) ?adde0//; apply/cvg_lim => //.
   by rewrite -(oppe0); apply: cvgeN; exact: cvg_g_.
@@ -4123,7 +4123,7 @@ rewrite integralZl// lte_mul_pinfty// ?lee_fin//; case: (integrableP _ _ _ ig) =
 have ? : \int[mu]_(x in D) (2%:E * g x)  \is a fin_num.
   by rewrite ge0_fin_numE// integral_ge0// => ? ?; rewrite mule_ge0 ?lee_fin ?g0.
 rewrite [X in _ <= X -> _](_ : _ = \int[mu]_(x in D) (2%:E * g x)  + -
-    lim_esup (fun n => \int[mu]_(x in D) g_ n x)); last first.
+    limn_esup (fun n => \int[mu]_(x in D) g_ n x)); last first.
   rewrite (_ : (fun _ => _) = (fun n => \int[mu]_(x in D) (2%:E * g x)  +
       \int[mu]_(x in D) - g_ n x)); last first.
     rewrite funeqE => n; rewrite integralB//.
@@ -4141,10 +4141,10 @@ rewrite [X in _ <= X -> _](_ : _ = \int[mu]_(x in D) (2%:E * g x)  + -
       apply: le_integrable dominated_integrable => //.
       - exact: measurableT_comp.
       - by move=> x Dx; rewrite /= abse_id.
-  rewrite lim_einf_shift // -lim_einfN; congr (_ + lim_einf _).
+  rewrite limn_einf_shift // -limn_einfN; congr (_ + limn_einf _).
   by rewrite funeqE => n /=; rewrite -integral_ge0N// => x Dx; rewrite /g_.
 rewrite addeC -lee_subl_addr// subee// lee_oppr oppe0 => lim_ge0.
-by apply/lim_esup_le_cvg => // n; rewrite integral_ge0// => x _; rewrite /g_.
+by apply/limn_esup_le_cvg => // n; rewrite integral_ge0// => x _; rewrite /g_.
 Qed.
 
 Local Lemma dominated_cvg :

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -241,7 +241,7 @@ Qed.
 #[global] Hint Extern 0  (measurable_fun _ (\1__ : _ -> _)) =>
   (exact: measurable_indic ) : core.
 #[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_indic` instead")]
-Notation measurable_fun_indic := measurable_indic.
+Notation measurable_fun_indic := measurable_indic (only parsing).
 
 Section sfun_pred.
 Context {d} {aT : measurableType d} {rT : realType}.
@@ -1536,7 +1536,7 @@ Qed.
 
 End semi_linearity0.
 #[deprecated(since="mathcomp-analysis 0.6.4", note="use `ge0_integralZl_EFin` instead")]
-Notation ge0_integralM_EFin := ge0_integralZl_EFin.
+Notation ge0_integralM_EFin := ge0_integralZl_EFin (only parsing).
 
 Section semi_linearity.
 Local Open Scope ereal_scope.
@@ -2224,7 +2224,7 @@ Unshelve. all: by end_near. Qed.
 
 End ge0_integralZl.
 #[deprecated(since="mathcomp-analysis 0.6.4", note="use `ge0_integralZl` instead")]
-Notation ge0_integralM := ge0_integralZl.
+Notation ge0_integralM := ge0_integralZl (only parsing).
 
 Section integral_indic.
 Local Open Scope ereal_scope.
@@ -2269,9 +2269,9 @@ Qed.
 End integralZl_indic.
 Arguments integralZl_indic {d T R m D} mD f.
 #[deprecated(since="mathcomp-analysis 0.6.4", note="use `integralZl_indic` instead")]
-Notation integralM_indic := integralZl_indic.
+Notation integralM_indic := integralZl_indic (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.4", note="use `integralZl_indic_nnsfun` instead")]
-Notation integralM_indic_nnsfun := integralZl_indic_nnsfun.
+Notation integralM_indic_nnsfun := integralZl_indic_nnsfun (only parsing).
 
 Section integral_mscale.
 Local Open Scope ereal_scope.
@@ -3022,9 +3022,9 @@ End integrable_theory.
 Notation "mu .-integrable" := (integrable mu) : type_scope.
 Arguments eq_integrable {d T R mu D} mD f.
 #[deprecated(since="mathcomp-analysis 0.6.4", note="use `integrableZl` instead")]
-Notation integrablerM := integrableZl.
+Notation integrablerM := integrableZl (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.4", note="use `integrableZr` instead")]
-Notation integrableMr := integrableZr.
+Notation integrableMr := integrableZr (only parsing).
 
 Section sequence_measure.
 Local Open Scope ereal_scope.
@@ -3272,7 +3272,7 @@ Qed.
 
 End linearity.
 #[deprecated(since="mathcomp-analysis 0.6.4", note="use `integralZl` instead")]
-Notation integralM := integralZl.
+Notation integralM := integralZl (only parsing).
 
 Section linearity.
 Local Open Scope ereal_scope.

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -1562,15 +1562,15 @@ move=> _ [_ [x ->] <-]; rewrite infs_preimage // setI_bigcupr.
 by apply: bigcup_measurable => k /= nk; apply: mf => //; exact: measurable_itv.
 Qed.
 
-Lemma measurable_fun_lim_sup D (h : (T -> R)^nat) :
+Lemma measurable_fun_limn_sup D (h : (T -> R)^nat) :
   (forall t, D t -> has_ubound (range (h ^~ t))) ->
   (forall t, D t -> has_lbound (range (h ^~ t))) ->
   (forall n, measurable_fun D (h n)) ->
-  measurable_fun D (fun x => lim_sup (h ^~ x)).
+  measurable_fun D (fun x => limn_sup (h ^~ x)).
 Proof.
 move=> f_ub f_lb mf.
 have : {in D, (fun x => inf [set sups (h ^~ x) n | n in [set n | 0 <= n]%N])
-              =1 (fun x => lim_sup (h^~ x))}.
+              =1 (fun x => limn_sup (h^~ x))}.
   move=> t; rewrite inE => Dt; apply/esym/cvg_lim; first exact: Rhausdorff.
   rewrite [X in _ --> X](_ : _ = inf (range (sups (h^~t)))).
     by apply: cvg_sups_inf; [exact: f_ub|exact: f_lb].
@@ -1586,12 +1586,12 @@ Lemma measurable_fun_cvg D (h : (T -> R)^nat) f :
   (forall m, measurable_fun D (h m)) -> (forall x, D x -> h ^~ x --> f x) ->
   measurable_fun D f.
 Proof.
-move=> mf_ f_f; have fE x : D x -> f x = lim_sup (h ^~ x).
+move=> mf_ f_f; have fE x : D x -> f x = limn_sup (h ^~ x).
   move=> Dx; have /cvg_lim  <-// := @cvg_sups _ (h ^~ x) (f x) (f_f _ Dx).
   exact: Rhausdorff.
-apply: (@eq_measurable_fun _ _ _ _ D (fun x => lim_sup (h ^~ x))).
+apply: (@eq_measurable_fun _ _ _ _ D (fun x => limn_sup (h ^~ x))).
   by move=> x; rewrite inE => Dx; rewrite -fE.
-apply: (@measurable_fun_lim_sup _ h) => // t Dt.
+apply: (@measurable_fun_limn_sup _ h) => // t Dt.
 - apply/bounded_fun_has_ubound/(@cvg_seq_bounded _ [normedModType R of R^o]).
   by apply/cvg_ex; eexists; exact: f_f.
 - apply/bounded_fun_has_lbound/(@cvg_seq_bounded _ [normedModType R of R^o]).
@@ -1599,6 +1599,8 @@ apply: (@measurable_fun_lim_sup _ h) => // t Dt.
 Qed.
 
 End measurable_fun_realType.
+#[deprecated(since="mathcomp-analysis 0.6.6", note="renamed `measurable_fun_limn_sup`")]
+Notation measurable_fun_lim_sup := measurable_fun_limn_sup.
 
 Lemma measurable_ln (R : realType) : measurable_fun [set~ (0:R)] (@ln R).
 Proof.
@@ -1777,9 +1779,9 @@ move=> mf mg; rewrite (_ : (fun _ => _) = (fun x => - maxe (- f x) (- g x))).
 by rewrite funeqE => x; rewrite oppe_max !oppeK.
 Qed.
 
-Lemma measurable_fun_lim_esup D (f : (T -> \bar R)^nat) :
+Lemma measurable_fun_limn_esup D (f : (T -> \bar R)^nat) :
   (forall n, measurable_fun D (f n)) ->
-  measurable_fun D (fun x => lim_esup (f ^~ x)).
+  measurable_fun D (fun x => limn_esup (f ^~ x)).
 Proof.
 move=> mf mD; rewrite (_ :  (fun _ => _) =
     (fun x => ereal_inf [set esups (f^~ x) n | n in [set n | n >= 0]%N])).
@@ -1794,17 +1796,15 @@ Lemma emeasurable_fun_cvg D (f_ : (T -> \bar R)^nat) (f : T -> \bar R) :
   (forall m, measurable_fun D (f_ m)) ->
   (forall x, D x -> f_ ^~ x --> f x) -> measurable_fun D f.
 Proof.
-move=> mf_ f_f; have fE x : D x -> f x = lim_esup (f_^~ x).
+move=> mf_ f_f; have fE x : D x -> f x = limn_esup (f_^~ x).
   by move=> Dx; have /cvg_lim  <-// := @cvg_esups _ (f_^~x) (f x) (f_f x Dx).
-apply: (eq_measurable_fun (fun x => lim_esup (f_ ^~ x))) => //.
+apply: (eq_measurable_fun (fun x => limn_esup (f_ ^~ x))) => //.
   by move=> x; rewrite inE => Dx; rewrite fE.
-exact: measurable_fun_lim_esup.
+exact: measurable_fun_limn_esup.
 Qed.
 End emeasurable_fun.
 Arguments emeasurable_fun_cvg {d T R D} f_.
 
-#[deprecated(since="mathcomp-analysis 0.6.0", note="renamed `measurable_fun_lim_esup`")]
-Notation measurable_fun_elim_sup := measurable_fun_lim_esup.
 #[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurableT_comp` instead")]
 Notation emeasurable_funN := measurableT_comp.
 #[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_maxe` instead")]
@@ -1815,6 +1815,8 @@ Notation emeasurable_fun_min := measurable_mine.
 Notation emeasurable_fun_funepos := measurable_funepos.
 #[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_funeneg` instead")]
 Notation emeasurable_fun_funeneg := measurable_funeneg.
+#[deprecated(since="mathcomp-analysis 0.6.6", note="renamed `measurable_fun_limn_esup`")]
+Notation measurable_fun_lim_esup := measurable_fun_limn_esup.
 
 Section lebesgue_regularity.
 Context {d : measure_display} {R : realType}.

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -548,23 +548,23 @@ Qed.
 Lemma __deprecated__itv_cpinfty_pinfty : `[+oo%E, +oo[%classic = [set +oo%E] :> set (\bar R).
 Proof. by rewrite itv_cyy. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0", note="renamed `itv_cyy`")]
-Notation itv_cpinfty_pinfty := __deprecated__itv_cpinfty_pinfty.
+Notation itv_cpinfty_pinfty := __deprecated__itv_cpinfty_pinfty (only parsing).
 
 Lemma __deprecated__itv_opinfty_pinfty : `]+oo%E, +oo[%classic = set0 :> set (\bar R).
 Proof. by rewrite itv_oyy. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0", note="renamed `itv_oyy`")]
-Notation itv_opinfty_pinfty := __deprecated__itv_opinfty_pinfty.
+Notation itv_opinfty_pinfty := __deprecated__itv_opinfty_pinfty (only parsing).
 
 Lemma __deprecated__itv_cninfty_pinfty : `[-oo%E, +oo[%classic = setT :> set (\bar R).
 Proof. by rewrite itv_cNyy. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0", note="renamed `itv_cNyy`")]
-Notation itv_cninfty_pinfty := __deprecated__itv_cninfty_pinfty.
+Notation itv_cninfty_pinfty := __deprecated__itv_cninfty_pinfty (only parsing).
 
 Lemma __deprecated__itv_oninfty_pinfty :
   `]-oo%E, +oo[%classic = ~` [set -oo]%E :> set (\bar R).
 Proof. by rewrite itv_oNyy. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0", note="renamed `itv_oNyy`")]
-Notation itv_oninfty_pinfty := __deprecated__itv_oninfty_pinfty.
+Notation itv_oninfty_pinfty := __deprecated__itv_oninfty_pinfty (only parsing).
 
 Let emeasurable_itv_bndy b (y : \bar R) :
   measurable [set` Interval (BSide b y) +oo%O].
@@ -695,9 +695,9 @@ Hint Extern 0 (measurable [set _]) => solve [apply: measurable_set1|
 #[global]
 Hint Extern 0 (measurable [set` _] ) => exact: measurable_itv : core.
 #[deprecated(since="mathcomp-analysis 0.6.2", note="use `emeasurable_itv` instead")]
-Notation emeasurable_itv_bnd_pinfty := emeasurable_itv.
+Notation emeasurable_itv_bnd_pinfty := emeasurable_itv (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.2", note="use `emeasurable_itv` instead")]
-Notation emeasurable_itv_ninfty_bnd := emeasurable_itv.
+Notation emeasurable_itv_ninfty_bnd := emeasurable_itv (only parsing).
 
 Lemma measurable_fine (R : realType) (D : set (\bar R)) : measurable D ->
   measurable_fun D fine.
@@ -717,7 +717,7 @@ Qed.
 #[global] Hint Extern 0 (measurable_fun _ fine) =>
   solve [exact: measurable_fine] : core.
 #[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_fine` instead")]
-Notation measurable_fun_fine := measurable_fine.
+Notation measurable_fun_fine := measurable_fine (only parsing).
 
 Section lebesgue_measure_itv.
 Variable R : realType.
@@ -1459,17 +1459,17 @@ End standard_measurable_fun.
 #[global] Hint Extern 0 (measurable_fun _ (fun x => x ^+ _)) =>
   solve [exact: measurable_exprn] : core.
 #[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_exprn` instead")]
-Notation measurable_fun_sqr := measurable_exprn.
+Notation measurable_fun_sqr := measurable_exprn (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_oppr` instead")]
-Notation measurable_fun_opp := measurable_oppr.
+Notation measurable_fun_opp := measurable_oppr (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_oppr` instead")]
-Notation measurable_funN := measurable_oppr.
+Notation measurable_funN := measurable_oppr (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_normr` instead")]
-Notation measurable_fun_normr := measurable_normr.
+Notation measurable_fun_normr := measurable_normr (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_exprn` instead")]
-Notation measurable_fun_exprn := measurable_exprn.
+Notation measurable_fun_exprn := measurable_exprn (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_mulrl` instead")]
-Notation measurable_funrM := measurable_mulrl.
+Notation measurable_funrM := measurable_mulrl (only parsing).
 
 Section measurable_fun_realType.
 Context d (T : measurableType d) (R : realType).
@@ -1600,7 +1600,7 @@ Qed.
 
 End measurable_fun_realType.
 #[deprecated(since="mathcomp-analysis 0.6.6", note="renamed `measurable_fun_limn_sup`")]
-Notation measurable_fun_lim_sup := measurable_fun_limn_sup.
+Notation measurable_fun_lim_sup := measurable_fun_limn_sup (only parsing).
 
 Lemma measurable_ln (R : realType) : measurable_fun [set~ (0:R)] (@ln R).
 Proof.
@@ -1619,7 +1619,7 @@ Qed.
 #[global] Hint Extern 0 (measurable_fun _ (@ln _)) =>
   solve [apply: measurable_ln] : core.
 #[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_ln` instead")]
-Notation measurable_fun_ln := measurable_ln.
+Notation measurable_fun_ln := measurable_ln (only parsing).
 
 Lemma measurable_expR (R : realType) : measurable_fun [set: R] expR.
 Proof. by apply: continuous_measurable_fun; exact: continuous_expR. Qed.
@@ -1639,11 +1639,11 @@ Qed.
 #[global] Hint Extern 0 (measurable_fun _ (@powR _ ^~ _)) =>
   solve [apply: measurable_powR] : core.
 #[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_powR` instead")]
-Notation measurable_fun_power_pos := measurable_powR.
+Notation measurable_fun_power_pos := measurable_powR (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.4", note="use `measurable_powR` instead")]
-Notation measurable_power_pos := measurable_powR.
+Notation measurable_power_pos := measurable_powR (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_maxr` instead")]
-Notation measurable_fun_max := measurable_maxr.
+Notation measurable_fun_max := measurable_maxr (only parsing).
 
 Section standard_emeasurable_fun.
 Variable R : realType.
@@ -1689,11 +1689,11 @@ End standard_emeasurable_fun.
 #[global] Hint Extern 0 (measurable_fun _ (-%E)) =>
   solve [exact: measurable_oppe] : core.
 #[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_oppe` instead")]
-Notation emeasurable_fun_minus := measurable_oppe.
+Notation emeasurable_fun_minus := measurable_oppe (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_abse` instead")]
-Notation measurable_fun_abse := measurable_abse.
+Notation measurable_fun_abse := measurable_abse (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_EFin` instead")]
-Notation measurable_fun_EFin := measurable_EFin.
+Notation measurable_fun_EFin := measurable_EFin (only parsing).
 
 (* NB: real-valued function *)
 Lemma EFin_measurable_fun d (T : measurableType d) (R : realType) (D : set T)
@@ -1720,7 +1720,7 @@ apply: measurable_fun_ifT => //=.
 + exact/EFin_measurable_fun/measurableT_comp.
 Qed.
 #[deprecated(since="mathcomp-analysis 0.6.3", note="renamed `measurable_er_map`")]
-Notation measurable_fun_er_map := measurable_er_map.
+Notation measurable_fun_er_map := measurable_er_map (only parsing).
 
 Section emeasurable_fun.
 Local Open Scope ereal_scope.
@@ -1806,17 +1806,17 @@ End emeasurable_fun.
 Arguments emeasurable_fun_cvg {d T R D} f_.
 
 #[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurableT_comp` instead")]
-Notation emeasurable_funN := measurableT_comp.
+Notation emeasurable_funN := measurableT_comp (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_maxe` instead")]
-Notation emeasurable_fun_max := measurable_maxe.
+Notation emeasurable_fun_max := measurable_maxe (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_mine` instead")]
-Notation emeasurable_fun_min := measurable_mine.
+Notation emeasurable_fun_min := measurable_mine (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_funepos` instead")]
-Notation emeasurable_fun_funepos := measurable_funepos.
+Notation emeasurable_fun_funepos := measurable_funepos (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_funeneg` instead")]
-Notation emeasurable_fun_funeneg := measurable_funeneg.
+Notation emeasurable_fun_funeneg := measurable_funeneg (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.6", note="renamed `measurable_fun_limn_esup`")]
-Notation measurable_fun_lim_esup := measurable_fun_limn_esup.
+Notation measurable_fun_lim_esup := measurable_fun_limn_esup (only parsing).
 
 Section lebesgue_regularity.
 Context {d : measure_display} {R : realType}.

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -1182,15 +1182,15 @@ End measurable_fun.
 Arguments eq_measurable_fun {d1 d2 T1 T2 D} f {g}.
 Arguments measurable_fun_bool {d1 T1 D f} b.
 #[deprecated(since="mathcomp-analysis 0.6.2", note="renamed `eq_measurable_fun`")]
-Notation measurable_fun_ext := eq_measurable_fun.
+Notation measurable_fun_ext := eq_measurable_fun (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.3", note="renamed `measurable_id`")]
-Notation measurable_fun_id := measurable_id.
+Notation measurable_fun_id := measurable_id (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.3", note="renamed `measurable_cst`")]
-Notation measurable_fun_cst := measurable_cst.
+Notation measurable_fun_cst := measurable_cst (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.3", note="renamed `measurable_comp`")]
-Notation measurable_fun_comp := measurable_comp.
+Notation measurable_fun_comp := measurable_comp (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.3", note="renamed `measurableT_comp`")]
-Notation measurable_funT_comp := measurableT_comp.
+Notation measurable_funT_comp := measurableT_comp (only parsing).
 
 Section measurability.
 
@@ -3605,7 +3605,7 @@ by rewrite caratheodory_additive.
 Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
       note="renamed `caratheodory_lime_le`")]
-Notation caratheodory_lim_lee := caratheodory_lime_le.
+Notation caratheodory_lim_lee := caratheodory_lime_le (only parsing).
 
 Lemma caratheodory_measurable_trivIset_bigcup (A : (set T) ^nat) :
   (forall n, M (A n)) -> trivIset setT A -> M (\bigcup_k (A k)).
@@ -4329,7 +4329,7 @@ Proof. by move=> mf mg; exact/prod_measurable_funP. Qed.
 
 End prod_measurable_fun.
 #[deprecated(since="mathcomp-analysis 0.6.3", note="renamed `measurable_fun_prod`")]
-Notation measurable_fun_pair := measurable_fun_prod.
+Notation measurable_fun_pair := measurable_fun_prod (only parsing).
 
 Section prod_measurable_proj.
 Context d1 d2 (T1 : measurableType d1) (T2 : measurableType d2).
@@ -4355,11 +4355,11 @@ End prod_measurable_proj.
 Arguments measurable_fst {d1 d2 T1 T2}.
 Arguments measurable_snd {d1 d2 T1 T2}.
 #[deprecated(since="mathcomp-analysis 0.6.3", note="renamed `measurable_fst`")]
-Notation measurable_fun_fst := measurable_fst.
+Notation measurable_fun_fst := measurable_fst (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.3", note="renamed `measurable_snd`")]
-Notation measurable_fun_snd := measurable_snd.
+Notation measurable_fun_snd := measurable_snd (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.3", note="renamed `measurable_swap`")]
-Notation measurable_fun_swap := measurable_swap.
+Notation measurable_fun_swap := measurable_swap (only parsing).
 #[global] Hint Extern 0 (measurable_fun _ fst) =>
   solve [apply: measurable_fst] : core.
 #[global] Hint Extern 0 (measurable_fun _ snd) =>

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -1593,7 +1593,7 @@ Proof. by move=> nxu; rewrite normrZ normrV// normr_id mulVr. Qed.
 End NormedModule_numDomainType.
 
 #[deprecated(since="mathcomp-analysis 0.6.0", note="renamed `normrZ`")]
-Notation normmZ := normrZ.
+Notation normmZ := normrZ (only parsing).
 
 Section NormedModule_numFieldType.
 Variables (R : numFieldType) (V : normedModType R).
@@ -1686,7 +1686,7 @@ Lemma __deprecated__cvg_dist {F : set (set V)} {FF : Filter F} (y : V) :
 Proof. exact: cvgr_dist_lt. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="use `cvgr_dist_lt` or a variation instead")]
-Notation cvg_dist := __deprecated__cvg_dist.
+Notation cvg_dist := __deprecated__cvg_dist (only parsing).
 
 Lemma cvgr_distC_lt {T} {F : set (set T)} {FF : Filter F} (f : T -> V) (y : V) :
   f @ F --> y -> forall eps, eps > 0 -> \forall t \near F, `|f t - y| < eps.
@@ -1782,7 +1782,7 @@ Arguments cvgr0_norm_le {_ _ _ F FF}.
 
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="use `cvgrPdist_lt` or a variation instead")]
-Notation cvg_distP := fcvgrPdist_lt.
+Notation cvg_distP := fcvgrPdist_lt (only parsing).
 
 (* NB: the following section used to be in Rstruct.v *)
 Require Rstruct.
@@ -2659,10 +2659,10 @@ Proof. by move=> /cvgrPdist_le. Qed.
 End PseudoNormedZMod_numFieldType.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="use `cvgrPdist_le` or a variation instead")]
-Notation cvg_distW := __deprecated__cvg_distW.
+Notation cvg_distW := __deprecated__cvg_distW (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to `norm_cvgi_lim`")]
-Notation norm_cvgi_map_lim := norm_cvgi_lim.
+Notation norm_cvgi_map_lim := norm_cvgi_lim (only parsing).
 
 Section NormedModule_numFieldType.
 Variables (R : numFieldType) (V : normedModType R).
@@ -2713,7 +2713,7 @@ Arguments cvg_bounded {R V I F FF}.
 Hint Extern 0 (hausdorff_space _) => solve[apply: norm_hausdorff] : core.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="use `cvgr_norm_lty` or a variation instead")]
-Notation cvg_bounded_real := __deprecated__cvg_bounded_real.
+Notation cvg_bounded_real := __deprecated__cvg_bounded_real (only parsing).
 
 Module Export NbhsNorm.
 Definition nbhs_simpl := (nbhs_simpl,@nbhs_nbhs_norm,@filter_from_norm_nbhs).
@@ -2751,7 +2751,7 @@ Lemma __deprecated__continuous_cvg_dist {R : numFieldType}
 Proof. by move=> cf /cvg_eq->// e; rewrite subrr normr0. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="simply use the fact that `(x --> l) -> (x = l)`")]
-Notation continuous_cvg_dist := __deprecated__continuous_cvg_dist.
+Notation continuous_cvg_dist := __deprecated__continuous_cvg_dist (only parsing).
 
 (** ** Matrices *)
 
@@ -2956,7 +2956,7 @@ Lemma __deprecated__cvg_dist2 {F : set (set U)} {G : set (set V)}
 Proof. exact: cvgr2dist_lt. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
 note="use `cvgr2dist_lt` or a variant instead")]
-Notation cvg_dist2 := __deprecated__cvg_dist2.
+Notation cvg_dist2 := __deprecated__cvg_dist2 (only parsing).
 
 End prod_NormedModule_lemmas.
 Arguments cvgr2dist_ltP {_ _ _ _ _ F G FF FG}.
@@ -2964,7 +2964,7 @@ Arguments cvgr2dist_lt {_ _ _ _ _ F G FF FG}.
 
 #[deprecated(since="mathcomp-analysis 0.6.0",
 note="use `fcvgr2dist_ltP` or a variant instead")]
-Notation cvg_dist2P := fcvgr2dist_ltP.
+Notation cvg_dist2P := fcvgr2dist_ltP (only parsing).
 
 (** Normed vector spaces have some continuous functions *)
 (** that are in fact continuous on pseudoMetricNormedZmodType *)
@@ -3134,7 +3134,7 @@ Lemma __deprecated__cvg_dist0 {U} {K : numFieldType} {V : normedModType K}
 Proof. exact: norm_cvg0. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
  note="renamed to `norm_cvg0` and generalized to `pseudoMetricNormedZmodType`")]
-Notation cvg_dist0 := __deprecated__cvg_dist0.
+Notation cvg_dist0 := __deprecated__cvg_dist0 (only parsing).
 
 Section cvg_composition_normed.
 Context {K : numFieldType} {V : normedModType K} {T : Type}.
@@ -3319,10 +3319,10 @@ Proof. by move=> ?; apply: cvgr_le. Qed.
 End ProperFilterRealType.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to `cvgr_ge` and generalized to a `Filter`")]
-Notation cvg_gt_ge := __deprecated__cvg_gt_ge.
+Notation cvg_gt_ge := __deprecated__cvg_gt_ge (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to `cvgr_le` and generalized to a `Filter`")]
-Notation cvg_lt_le_:= __deprecated__cvg_lt_le.
+Notation cvg_lt_le_:= __deprecated__cvg_lt_le (only parsing).
 
 Section local_continuity.
 
@@ -3706,25 +3706,25 @@ End max_cts.
 
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to cvgeN, and generalized to filter in Type")]
-Notation ereal_cvgN := cvgeN.
+Notation ereal_cvgN := cvgeN (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to is_cvgeN, and generalized to filter in Type")]
-Notation ereal_is_cvgN := is_cvgeN.
+Notation ereal_is_cvgN := is_cvgeN (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to cvgeMl, and generalized to filter in Type")]
-Notation ereal_cvgrM := cvgeMl.
+Notation ereal_cvgrM := cvgeMl (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to is_cvgeMl, and generalized to filter in Type")]
-Notation ereal_is_cvgrM := is_cvgeMl.
+Notation ereal_is_cvgrM := is_cvgeMl (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to cvgeMr, and generalized to filter in Type")]
-Notation ereal_cvgMr := cvgeMr.
+Notation ereal_cvgMr := cvgeMr (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to is_cvgeMr, and generalized to filter in Type")]
-Notation ereal_is_cvgMr := is_cvgeMr.
+Notation ereal_is_cvgMr := is_cvgeMr (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to cvgeM, and generalized to a realFieldType")]
-Notation ereal_cvgM := cvgeM.
+Notation ereal_cvgM := cvgeM (only parsing).
 
 Section pseudoMetricDist.
 Context {R : realType} {X : pseudoMetricType R}.
@@ -4865,7 +4865,7 @@ Hint Extern 0 (hausdorff_space _) => solve[apply: ereal_hausdorff] : core.
 
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to `nbhs_image_EFin`")]
-Notation nbhs_image_ERFin := nbhs_image_EFin.
+Notation nbhs_image_ERFin := nbhs_image_EFin (only parsing).
 
 Lemma EFin_lim (R : realFieldType) (f : nat -> R) : cvg f ->
   lim (EFin \o f) = (lim f)%:E.
@@ -4962,11 +4962,11 @@ Proof. by move=> ? ?; apply/cvg_lim => //; apply: cvg_nnesum. Qed.
 End ecvg_realFieldType_proper.
 
 #[deprecated(since="mathcomp-analysis 0.6.0", note="generalized to `limeMl`")]
-Notation ereal_limrM := limeMl.
+Notation ereal_limrM := limeMl (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.0", note="generalized to `limeMr`")]
-Notation ereal_limMr := limeMr.
+Notation ereal_limMr := limeMr (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.0", note="generalized to `limeN`")]
-Notation ereal_limN := limeN.
+Notation ereal_limN := limeN (only parsing).
 
 Section cvg_0_pinfty.
 Context {R : realFieldType} {I : Type} {a : set (set I)} {FF : Filter a}.
@@ -5444,7 +5444,7 @@ Lemma __deprecated__ler0_addgt0P (R : numFieldType) (x : R) :
 Proof. exact: ler_gtP. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="use `ler_gtP` instead which generalizes it to any upper bound.")]
-Notation ler0_addgt0P := __deprecated__ler0_addgt0P.
+Notation ler0_addgt0P := __deprecated__ler0_addgt0P (only parsing).
 
 Lemma IVT (R : realType) (f : R -> R) (a b v : R) :
   a <= b -> {within `[a, b], continuous f} ->
@@ -6080,7 +6080,7 @@ Unshelve. all: by end_near. Qed.
 End LinearContinuousBounded.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="generalized to `continuous_linear_bounded`")]
-Notation linear_continuous0 := __deprecated__linear_continuous0.
+Notation linear_continuous0 := __deprecated__linear_continuous0 (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="generalized to `bounded_linear_continuous`")]
-Notation linear_bounded0 := __deprecated__linear_bounded0.
+Notation linear_bounded0 := __deprecated__linear_bounded0 (only parsing).

--- a/theories/sequences.v
+++ b/theories/sequences.v
@@ -68,10 +68,10 @@ Require Import reals ereal signed topology normedtype landau.
 (*             sdrop u n := {u_k | k >= n}                                    *)
 (*                sups u := [sequence sup (sdrop u n)]_n                      *)
 (*                infs u := [sequence inf (sdrop u n)]_n                      *)
-(*         lim_{inf,sup} == limit inferior/superior for realType              *)
+(*         limn_{inf,sup} == limit inferior/superior for realType             *)
 (*               esups u := [sequence ereal_sup (sdrop u n)]_n                *)
 (*               einfs u := [sequence ereal_inf (sdrop u n)]_n                *)
-(*        lim_e{inf,sup} == limit inferior/superior for \bar R                *)
+(*        limn_e{inf,sup} == limit inferior/superior for \bar R               *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -2145,48 +2145,48 @@ Qed.
 
 End sups_infs.
 
-Section lim_sup_lim_inf.
+Section limn_sup_limn_inf.
 Variable R : realType.
 Implicit Types (r : R) (u v : R^o^nat).
 
-Definition lim_sup u := lim (sups u).
+Definition limn_sup u := lim (sups u).
 
-Definition lim_inf u := lim (infs u).
+Definition limn_inf u := lim (infs u).
 
-Lemma lim_infN u : cvg u -> lim_inf (-%R \o u) = - lim_sup u.
+Lemma limn_infN u : cvg u -> limn_inf (-%R \o u) = - limn_sup u.
 Proof.
-move=> cu_; rewrite /lim_inf infsN.
+move=> cu_; rewrite /limn_inf infsN.
 rewrite (@limN _ [normedModType R of R^o] _ _ _ (sups u)) //.
 exact: is_cvg_sups.
 Qed.
 
-Lemma lim_supE u : bounded_fun u -> lim_sup u = inf (range (sups u)).
+Lemma limn_supE u : bounded_fun u -> limn_sup u = inf (range (sups u)).
 Proof.
 move=> ba; apply/cvg_lim; first exact: Rhausdorff.
 by apply/cvg_sups_inf; [exact/bounded_fun_has_ubound|
                         exact/bounded_fun_has_lbound].
 Qed.
 
-Lemma lim_infE u : bounded_fun u -> lim_inf u = sup (range (infs u)).
+Lemma limn_infE u : bounded_fun u -> limn_inf u = sup (range (infs u)).
 Proof.
 move=> ba; apply/cvg_lim; first exact: Rhausdorff.
-apply/cvg_infs_sup; [exact/bounded_fun_has_ubound|
-                     exact/bounded_fun_has_lbound].
+by apply/cvg_infs_sup; [exact/bounded_fun_has_ubound|
+                        exact/bounded_fun_has_lbound].
 Qed.
 
-Lemma lim_inf_le_lim_sup u : cvg u -> lim_inf u <= lim_sup u.
+Lemma limn_inf_sup u : cvg u -> limn_inf u <= limn_sup u.
 Proof.
 move=> cf_; apply: ler_lim; [exact: is_cvg_infs|exact: is_cvg_sups|].
 by apply: nearW => n; apply: infs_le_sups.
 Qed.
 
-Lemma cvg_lim_inf_sup u l : u --> l -> (lim_inf u = l) * (lim_sup u = l).
+Lemma cvg_limn_inf_sup u l : u --> l -> (limn_inf u = l) * (limn_sup u = l).
 Proof.
 move=> ul.
 have /cvg_seq_bounded [M [Mr Mu]] : cvg u by apply/cvg_ex; eexists; exact: ul.
-suff: lim_sup u <= l <= lim_inf u.
+suff: limn_sup u <= l <= limn_inf u.
   move=> /andP[sul liu].
-  have /lim_inf_le_lim_sup iusu : cvg u by apply/cvg_ex; eexists; exact: ul.
+  have /limn_inf_sup iusu : cvg u by apply/cvg_ex; eexists; exact: ul.
   split; first by apply/eqP; rewrite eq_le liu andbT (le_trans iusu).
   by apply/eqP; rewrite eq_le sul /= (le_trans _ iusu).
 apply/andP; split.
@@ -2206,34 +2206,34 @@ apply/andP; split.
   by apply: (klu m) => /=; rewrite (leq_trans kn).
 Unshelve. all: by end_near. Qed.
 
-Lemma cvg_lim_infE u : cvg u -> lim_inf u = lim u.
+Lemma cvg_limn_infE u : cvg u -> limn_inf u = lim u.
 Proof.
-move=> /cvg_ex[l ul]; have [-> _] := cvg_lim_inf_sup ul.
+move=> /cvg_ex[l ul]; have [-> _] := cvg_limn_inf_sup ul.
 by move/cvg_lim : ul => ->.
 Qed.
 
-Lemma cvg_lim_supE u : cvg u -> lim_sup u = lim u.
+Lemma cvg_limn_supE u : cvg u -> limn_sup u = lim u.
 Proof.
-move=> /cvg_ex[l ul]; have [_ ->] := cvg_lim_inf_sup ul.
+move=> /cvg_ex[l ul]; have [_ ->] := cvg_limn_inf_sup ul.
 by move/cvg_lim : ul => ->.
 Qed.
 
-Lemma cvg_sups u l : u --> l -> (sups u) --> (l : R^o).
+Lemma cvg_sups u l : u --> l -> sups u --> (l : R^o).
 Proof.
-move=> ul; have [iul <-] := cvg_lim_inf_sup ul.
+move=> ul; have [iul <-] := cvg_limn_inf_sup ul.
 apply/cvg_closeP; split => //; apply: is_cvg_sups.
 by apply/cvg_ex; eexists; apply: ul.
 Qed.
 
-Lemma cvg_infs u l : u --> l -> (infs u) --> (l : R^o).
+Lemma cvg_infs u l : u --> l -> infs u --> (l : R^o).
 Proof.
-move=> ul; have [<- iul] := cvg_lim_inf_sup ul.
+move=> ul; have [<- iul] := cvg_limn_inf_sup ul.
 apply/cvg_closeP; split => //; apply: is_cvg_infs.
 by apply/cvg_ex; eexists; apply: ul.
 Qed.
 
-Lemma le_lim_supD u v :
-  bounded_fun u -> bounded_fun v -> lim_sup (u \+ v) <= lim_sup u + lim_sup v.
+Lemma le_limn_supD u v : bounded_fun u -> bounded_fun v ->
+  limn_sup (u \+ v) <= limn_sup u + limn_sup v.
 Proof.
 move=> ba bb; have ab k : sups (u \+ v) k <= sups u k + sups v k.
   apply: sup_le_ub; first by exists ((u \+ v) k); exists k => /=.
@@ -2254,8 +2254,8 @@ rewrite -(@limD _ [normedModType R of R^o] _ _ _ _ _ cu cv); apply: ler_lim.
 - exact: nearW.
 Qed.
 
-Lemma le_lim_infD u v :
-  bounded_fun u -> bounded_fun v -> lim_inf u + lim_inf v <= lim_inf (u \+ v).
+Lemma le_limn_infD u v : bounded_fun u -> bounded_fun v ->
+  limn_inf u + limn_inf v <= limn_inf (u \+ v).
 Proof.
 move=> ba bb; have ab k : infs u k + infs v k <= infs (u \+ v) k.
   apply: lb_le_inf; first by exists ((u \+ v) k); exists k => /=.
@@ -2276,26 +2276,53 @@ rewrite -(@limD _ [normedModType R of R^o] _ _ _ _ _ cu cv); apply: ler_lim.
 - exact: nearW.
 Qed.
 
-Lemma lim_supD u v : cvg u -> cvg v -> lim_sup (u \+ v) = lim_sup u + lim_sup v.
+Lemma limn_supD u v : cvg u -> cvg v ->
+  limn_sup (u \+ v) = limn_sup u + limn_sup v.
 Proof.
 move=> cu cv; have [ba bb] := (cvg_seq_bounded cu, cvg_seq_bounded cv).
-apply/eqP; rewrite eq_le le_lim_supD //=.
-have := @le_lim_supD _ _ (bounded_funD ba bb) (bounded_funN bb).
+apply/eqP; rewrite eq_le le_limn_supD //=.
+have := @le_limn_supD _ _ (bounded_funD ba bb) (bounded_funN bb).
 rewrite -ler_subl_addr; apply: le_trans.
-rewrite -[_ \+ _]/(u + v - v) addrK -lim_infN; last exact: is_cvgN.
+rewrite -[_ \+ _]/(u + v - v) addrK -limn_infN; last exact: is_cvgN.
 rewrite /comp /=; under eq_fun do rewrite opprK.
-by rewrite ler_add// cvg_lim_infE// cvg_lim_supE.
+by rewrite ler_add// cvg_limn_infE// cvg_limn_supE.
 Qed.
 
-Lemma lim_infD u v : cvg u -> cvg v -> lim_inf (u \+ v) = lim_inf u + lim_inf v.
+Lemma limn_infD u v : cvg u -> cvg v ->
+  limn_inf (u \+ v) = limn_inf u + limn_inf v.
 Proof.
-move=> cu cv; rewrite (cvg_lim_infE cu) -(cvg_lim_supE cu).
-rewrite (cvg_lim_infE cv) -(cvg_lim_supE cv) -lim_supD//.
-rewrite cvg_lim_supE; last exact: (@is_cvgD _ _ _ _ _ _ _ cu cv).
-by rewrite cvg_lim_infE //; exact: (@is_cvgD _ _ _ _ _ _ _ cu cv).
+move=> cu cv; rewrite (cvg_limn_infE cu) -(cvg_limn_supE cu).
+rewrite (cvg_limn_infE cv) -(cvg_limn_supE cv) -limn_supD//.
+rewrite cvg_limn_supE; last exact: (@is_cvgD _ _ _ _ _ _ _ cu cv).
+by rewrite cvg_limn_infE //; exact: (@is_cvgD _ _ _ _ _ _ _ cu cv).
 Qed.
 
-End lim_sup_lim_inf.
+End limn_sup_limn_inf.
+
+#[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `limn_sup`")]
+Notation lim_sup := limn_sup.
+#[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `limn_inf`")]
+Notation lim_inf := limn_sup.
+#[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `limn_infN`")]
+Notation lim_infN := limn_infN.
+#[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `limn_supE`")]
+Notation lim_supE := limn_supE.
+#[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `limn_infE`")]
+Notation lim_infE := limn_infE.
+#[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `limn_inf_sup`")]
+Notation lim_inf_le_lim_sup := limn_inf_sup.
+#[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `cvg_limn_infE`")]
+Notation cvg_lim_infE := cvg_limn_infE.
+#[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `cvg_limn_supE`")]
+Notation cvg_lim_supE := cvg_limn_supE.
+#[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `le_limn_supD`")]
+Notation le_lim_supD := le_limn_supD.
+#[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `le_limn_infD`")]
+Notation le_lim_infD := le_limn_infD.
+#[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `limn_supD`")]
+Notation lim_supD := limn_supD.
+#[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `limn_infD`")]
+Notation lim_infD := limn_infD.
 
 Section esups_einfs.
 Variable R : realType.
@@ -2375,26 +2402,16 @@ Qed.
 
 End esups_einfs.
 
-Module LimSup.
-Definition lim_esup (R : realType) (u : (\bar R)^nat) := lim (esups u).
-Definition lim_einf (R : realType) (u : (\bar R)^nat) := lim (einfs u).
-End LimSup.
-
-#[deprecated(since="mathcomp-analysis 0.6.0", note="renamed to `lim_esup`")]
-Notation elim_sup := LimSup.lim_esup.
-#[deprecated(since="mathcomp-analysis 0.6.0", note="renamed to `lim_einf`")]
-Notation elim_inf := LimSup.lim_einf.
-
-Notation lim_esup := LimSup.lim_esup.
-Notation lim_einf := LimSup.lim_einf.
+Definition limn_esup (R : realType) (u : (\bar R)^nat) := lim (esups u).
+Definition limn_einf (R : realType) (u : (\bar R)^nat) := lim (einfs u).
 
 Section lim_esup_inf.
 Local Open Scope ereal_scope.
 Variable R : realType.
 Implicit Types (u v : (\bar R)^nat) (l : \bar R).
 
-Lemma lim_einf_shift u l : l \is a fin_num ->
-  lim_einf (fun x => l + u x) = l + lim_einf u.
+Lemma limn_einf_shift u l : l \is a fin_num ->
+  limn_einf (fun x => l + u x) = l + limn_einf u.
 Proof.
 move=> lfin; apply/cvg_lim => //; apply: cvg_trans; last first.
   by apply: (@cvgeD _ \oo _ _ (cst l) (einfs u) _ (lim (einfs u)));
@@ -2409,7 +2426,8 @@ apply/eqP; rewrite eq_le; apply/andP; split.
   by rewrite lee_add2l//; apply: ereal_inf_lb; exists m => /=.
 Qed.
 
-Lemma lim_esup_le_cvg u l : lim_esup u <= l -> (forall n, l <= u n) -> u --> l.
+Lemma limn_esup_le_cvg u l :
+  limn_esup u <= l -> (forall n, l <= u n) -> u --> l.
 Proof.
 move=> supul ul; have usupu n : l <= u n <= esups u n.
   by rewrite ul /=; apply/ereal_sup_ub; exists n => /=.
@@ -2422,28 +2440,28 @@ have /le_trans : l <= einfs u m by apply: lb_ereal_inf => _ [p /= pm] <-.
 by apply; exact: einfs_le_esups.
 Qed.
 
-Lemma lim_einfN u : lim_einf (-%E \o u) = - lim_esup u.
+Lemma limn_einfN u : limn_einf (-%E \o u) = - limn_esup u.
 Proof.
-by rewrite /lim_einf einfsN /lim_esup limeN //; exact/is_cvg_esups.
+by rewrite /limn_einf einfsN /limn_esup limeN //; exact/is_cvg_esups.
 Qed.
 
-Lemma lim_esupN u : lim_esup (-%E \o u) = - lim_einf u.
+Lemma limn_esupN u : limn_esup (-%E \o u) = - limn_einf u.
 Proof.
-apply/eqP; rewrite -eqe_oppLR -lim_einfN /=.
+apply/eqP; rewrite -eqe_oppLR -limn_einfN /=.
 by rewrite (_ : _ \o _ = u) // funeqE => n /=; rewrite oppeK.
 Qed.
 
-Lemma lim_einf_sup u : lim_einf u <= lim_esup u.
+Lemma limn_einf_sup u : limn_einf u <= limn_esup u.
 Proof.
 apply: lee_lim; [exact/is_cvg_einfs|exact/is_cvg_esups|].
 by apply: nearW; exact: einfs_le_esups.
 Qed.
 
-Lemma cvgNy_lim_einf_sup u : u --> -oo ->
-  (lim_einf u = -oo) * (lim_esup u = -oo).
+Lemma cvgNy_limn_einf_sup u : u --> -oo ->
+  (limn_einf u = -oo) * (limn_esup u = -oo).
 Proof.
-move=> uoo; suff: lim_esup u = -oo.
-  by move=> {}uoo; split => //; apply/eqP; rewrite -leeNy_eq -uoo lim_einf_sup.
+move=> uoo; suff: limn_esup u = -oo.
+  by move=> {}uoo; split => //; apply/eqP; rewrite -leeNy_eq -uoo limn_einf_sup.
 apply: cvg_lim => //=. apply/cvgeNyPle => M.
 have /cvgeNyPle/(_ M)[m _ uM] := uoo.
 near=> n; apply: ub_ereal_sup => _ [k /= nk <-].
@@ -2452,13 +2470,13 @@ Unshelve. all: by end_near. Qed.
 
 Lemma cvgNy_einfs u : u --> -oo -> einfs u --> -oo.
 Proof.
-move=> /cvgNy_lim_einf_sup[uoo _].
+move=> /cvgNy_limn_einf_sup[uoo _].
 by apply/cvg_closeP; split; [exact: is_cvg_einfs|rewrite closeE].
 Qed.
 
 Lemma cvgNy_esups u : u --> -oo -> esups u --> -oo.
 Proof.
-move=> /cvgNy_lim_einf_sup[_ uoo].
+move=> /cvgNy_limn_einf_sup[_ uoo].
 by apply/cvg_closeP; split; [exact: is_cvg_esups|rewrite closeE].
 Qed.
 
@@ -2503,51 +2521,42 @@ move=> /cvgeN/cvg_esups/cvgeN; rewrite oppeK esupsN.
 by under eq_cvg do rewrite /= oppeK.
 Qed.
 
-Lemma cvg_lim_einf_sup u l : u --> l -> (lim_einf u = l) * (lim_esup u = l).
+Lemma cvg_limn_einf_sup u l : u --> l -> (limn_einf u = l) * (limn_esup u = l).
 Proof.
 by move=> ul; split; apply/cvg_lim => //; [apply/cvg_einfs|apply/cvg_esups].
 Qed.
 
-Lemma is_cvg_lim_einfE u : cvg u -> lim_einf u = lim u.
+Lemma is_cvg_limn_einfE u : cvg u -> limn_einf u = lim u.
 Proof.
-move=> /cvg_ex[l ul]; have [-> _] := cvg_lim_einf_sup ul.
+move=> /cvg_ex[l ul]; have [-> _] := cvg_limn_einf_sup ul.
 by move/cvg_lim : ul => ->.
 Qed.
 
-Lemma is_cvg_lim_esupE u : cvg u -> lim_esup u = lim u.
+Lemma is_cvg_limn_esupE u : cvg u -> limn_esup u = lim u.
 Proof.
-move=> /cvg_ex[l ul]; have [_ ->] := cvg_lim_einf_sup ul.
+move=> /cvg_ex[l ul]; have [_ ->] := cvg_limn_einf_sup ul.
 by move/cvg_lim : ul => ->.
 Qed.
 
 End lim_esup_inf.
-
-#[deprecated(since="mathcomp-analysis 0.6.0", note="renamed to `lim_einf_shift`")]
-Notation elim_inf_shift := lim_einf_shift.
-#[deprecated(since="mathcomp-analysis 0.6.0", note="renamed to `lim_esup_le_cvg`")]
-Notation elim_sup_le_cvg := lim_esup_le_cvg.
-#[deprecated(since="mathcomp-analysis 0.6.0", note="renamed to `lim_einfN`")]
-Notation elim_infN := lim_einfN.
-#[deprecated(since="mathcomp-analysis 0.6.0", note="renamed to `lim_esupN`")]
-Notation elim_supN := lim_esupN.
-#[deprecated(since="mathcomp-analysis 0.6.0", note="renamed to `lim_einf_sup`")]
-Notation elim_inf_sup := lim_einf_sup.
-#[deprecated(since="mathcomp-analysis 0.6.0", note="renamed to `cvgNy_lim_einf_sup`")]
-Notation cvg_ninfty_elim_inf_sup := cvgNy_lim_einf_sup.
-#[deprecated(since="mathcomp-analysis 0.6.0", note="renamed to `cvgNy_einfs`")]
-Notation cvg_ninfty_einfs := cvgNy_einfs.
-#[deprecated(since="mathcomp-analysis 0.6.0", note="renamed to `cvgNy_esups`")]
-Notation cvg_ninfty_esups := cvgNy_esups.
-#[deprecated(since="mathcomp-analysis 0.6.0", note="renamed to `cvgy_einfs`")]
-Notation cvg_pinfty_einfs := cvgy_einfs.
-#[deprecated(since="mathcomp-analysis 0.6.0", note="renamed to `cvgy_esups`")]
-Notation cvg_pinfty_esups := cvgy_esups.
-#[deprecated(since="mathcomp-analysis 0.6.0", note="renamed to `cvg_lim_einf_sup`")]
-Notation cvg_elim_inf_sup := cvg_lim_einf_sup.
-#[deprecated(since="mathcomp-analysis 0.6.0", note="renamed to `is_cvg_lim_einfE`")]
-Notation is_cvg_elim_infE := is_cvg_lim_einfE.
-#[deprecated(since="mathcomp-analysis 0.6.0", note="renamed to `is_cvg_lim_esupE`")]
-Notation is_cvg_elim_supE := is_cvg_lim_esupE.
+#[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `limn_einf_shift`")]
+Notation lim_einf_shift := limn_einf_shift.
+#[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `limn_esup_le_cvg`")]
+Notation lim_esup_le_cvg := limn_esup_le_cvg.
+#[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `limn_einfN`")]
+Notation lim_einfN := limn_einfN.
+#[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `limn_esupN`")]
+Notation lim_esupN := limn_esupN.
+#[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `limn_einf_sup`")]
+Notation lim_einf_sup := limn_einf_sup.
+#[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `cvgNy_limn_einf_sup`")]
+Notation cvgNy_lim_einf_sup := cvgNy_limn_einf_sup.
+#[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `cvg_limn_einf_sup`")]
+Notation cvg_lim_einf_sup := cvg_limn_einf_sup.
+#[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `is_cvg_limn_einfE`")]
+Notation is_cvg_lim_einfE := is_cvg_limn_einfE.
+#[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `is_cvg_limn_esupE`")]
+Notation is_cvg_lim_esupE := is_cvg_limn_esupE.
 
 Lemma geometric_le_lim {R : realType} (n : nat) (a x : R) :
   0 <= a -> 0 < x -> `|x| < 1 -> series (geometric a x) n <= a * (1 - x)^-1.

--- a/theories/sequences.v
+++ b/theories/sequences.v
@@ -387,59 +387,59 @@ Lemma __deprecated__squeeze T (f g h : T -> R) (a : filter_on T) :
 Proof. exact: squeeze_cvgr. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to `squeeze_cvgr`")]
-Notation squeeze := __deprecated__squeeze.
+Notation squeeze := __deprecated__squeeze (only parsing).
 
 Lemma __deprecated__cvgPpinfty (u_ : R ^nat) :
   u_ --> +oo <-> forall A, \forall n \near \oo, A <= u_ n.
 Proof. exact: cvgryPge. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to `cvgryPge`, and generalized to any filter")]
-Notation cvgPpinfty := __deprecated__cvgPpinfty.
+Notation cvgPpinfty := __deprecated__cvgPpinfty (only parsing).
 
 Lemma __deprecated__cvgNpinfty u_ : (- u_ --> +oo) = (u_ --> -oo).
 Proof. exact/propeqP/cvgNry. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="use `cvgNry` instead")]
-Notation cvgNpinfty := __deprecated__cvgNpinfty.
+Notation cvgNpinfty := __deprecated__cvgNpinfty (only parsing).
 
 Lemma __deprecated__cvgNninfty u_ : (- u_ --> -oo) = (u_ --> +oo).
 Proof. exact/propeqP/cvgNrNy. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="use `cvgNrNy` instead")]
-Notation cvgNninfty := __deprecated__cvgNninfty.
+Notation cvgNninfty := __deprecated__cvgNninfty (only parsing).
 
 Lemma __deprecated__cvgPninfty (u_ : R ^nat) :
   u_ --> -oo <-> forall A, \forall n \near \oo, A >= u_ n.
 Proof. exact: cvgrNyPle. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to `cvgrNyPle`, and generalized to any filter")]
-Notation cvgPninfty := __deprecated__cvgPninfty.
+Notation cvgPninfty := __deprecated__cvgPninfty (only parsing).
 
 Lemma __deprecated__ger_cvg_pinfty u_ v_ : (\forall n \near \oo, u_ n <= v_ n) ->
   u_ --> +oo -> v_ --> +oo.
 Proof. exact: ger_cvgy. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to `ger_cvgy`, and generalized to any filter")]
-Notation ger_cvg_pinfty := __deprecated__ger_cvg_pinfty.
+Notation ger_cvg_pinfty := __deprecated__ger_cvg_pinfty (only parsing).
 
 Lemma __deprecated__ler_cvg_ninfty v_ u_ : (\forall n \near \oo, u_ n <= v_ n) ->
   v_ --> -oo -> u_ --> -oo.
 Proof. exact: ler_cvgNy. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to `ler_cvgNy`, and generalized to any filter")]
-Notation ler_cvg_ninfty := __deprecated__ler_cvg_ninfty.
+Notation ler_cvg_ninfty := __deprecated__ler_cvg_ninfty (only parsing).
 
 Lemma __deprecated__lim_ge x u : cvg u -> (\forall n \near \oo, x <= u n) -> x <= lim u.
 Proof. exact: limr_ge. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to `limr_ge`, and generalized to any proper filter")]
-Notation lim_ge := __deprecated__lim_ge.
+Notation lim_ge := __deprecated__lim_ge (only parsing).
 
 Lemma __deprecated__lim_le x u : cvg u -> (\forall n \near \oo, x >= u n) -> x >= lim u.
 Proof. exact: limr_le. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to `limr_le`, and generalized to any proper filter")]
-Notation lim_le := __deprecated__lim_le.
+Notation lim_le := __deprecated__lim_le (only parsing).
 
 Lemma lt_lim u (M : R) : nondecreasing_seq u -> cvg u -> M < lim u ->
   \forall n \near \oo, M <= u n.
@@ -496,42 +496,42 @@ Lemma __deprecated__cvgPpinfty_lt (u_ : R ^nat) :
 Proof. exact: cvgryPgt. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to `cvgryPgt`, and generalized to any proper filter")]
-Notation cvgPpinfty_lt := __deprecated__cvgPpinfty_lt.
+Notation cvgPpinfty_lt := __deprecated__cvgPpinfty_lt (only parsing).
 
 Lemma __deprecated__cvgPninfty_lt (u_ : R ^nat) :
   u_ --> -oo%R <-> forall A, \forall n \near \oo, (A > u_ n)%R.
 Proof. exact: cvgrNyPlt. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to `cvgrNyPlt`, and generalized to any proper filter")]
-Notation cvgPninfty_lt := __deprecated__cvgPninfty_lt.
+Notation cvgPninfty_lt := __deprecated__cvgPninfty_lt (only parsing).
 
 Lemma __deprecated__cvgPpinfty_near (u_ : R ^nat) :
   u_ --> +oo%R <-> \forall A \near +oo, \forall n \near \oo, (A <= u_ n)%R.
 Proof. exact: cvgryPgey. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to `cvgryPgey`, and generalized to any proper filter")]
-Notation cvgPpinfty_near := __deprecated__cvgPpinfty_near.
+Notation cvgPpinfty_near := __deprecated__cvgPpinfty_near (only parsing).
 
 Lemma __deprecated__cvgPninfty_near (u_ : R ^nat) :
   u_ --> -oo%R <-> \forall A \near -oo, \forall n \near \oo, (A >= u_ n)%R.
 Proof. exact: cvgrNyPleNy. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to `cvgrNyPleNy`, and generalized to any proper filter")]
-Notation cvgPninfty_near := __deprecated__cvgPninfty_near.
+Notation cvgPninfty_near := __deprecated__cvgPninfty_near (only parsing).
 
 Lemma __deprecated__cvgPpinfty_lt_near (u_ : R ^nat) :
   u_ --> +oo%R <-> \forall A \near +oo, \forall n \near \oo, (A < u_ n)%R.
 Proof. exact: cvgryPgty. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to `cvgryPgty`, and generalized to any proper filter")]
-Notation cvgPpinfty_lt_near := __deprecated__cvgPpinfty_lt_near.
+Notation cvgPpinfty_lt_near := __deprecated__cvgPpinfty_lt_near (only parsing).
 
 Lemma __deprecated__cvgPninfty_lt_near (u_ : R ^nat) :
   u_ --> -oo%R <-> \forall A \near -oo, \forall n \near \oo, (A > u_ n)%R.
 Proof. exact: cvgrNyPltNy. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to `cvgrNyPltNy`, and generalized to any proper filter")]
-Notation cvgPninfty_lt_near := __deprecated__cvgPninfty_lt_near.
+Notation cvgPninfty_lt_near := __deprecated__cvgPninfty_lt_near (only parsing).
 
 End sequences_R_lemmas_realFieldType.
 
@@ -540,14 +540,14 @@ Lemma __deprecated__invr_cvg0 (R : realFieldType) (u : R^nat) :
 Proof. by move=> ?; rewrite gtr0_cvgV0//; apply: nearW. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to `gtr0_cvgV0` and generalized")]
-Notation invr_cvg0 := __deprecated__invr_cvg0.
+Notation invr_cvg0 := __deprecated__invr_cvg0 (only parsing).
 
 Lemma __deprecated__invr_cvg_pinfty (R : realFieldType) (u : R^nat) :
   (forall i, 0 < u i) -> ((u i)^-1 @[i --> \oo] --> +oo) <-> (u --> 0).
 Proof. by move=> ?; rewrite cvgrVy//; apply: nearW. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to `cvgrVy` and generalized")]
-Notation invr_cvg_pinfty := __deprecated__invr_cvg_pinfty.
+Notation invr_cvg_pinfty := __deprecated__invr_cvg_pinfty (only parsing).
 
 Section partial_sum.
 Variables (V : zmodType) (u_ : V ^nat).
@@ -1258,14 +1258,14 @@ Lemma __deprecated__nat_dvg_real (R : realType) (u_ : nat ^nat) : u_ --> \oo ->
 Proof. by move=> ?; apply/cvgrnyP. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to `cvgrnyP` and generalized")]
-Notation nat_dvg_real := __deprecated__nat_dvg_real.
+Notation nat_dvg_real := __deprecated__nat_dvg_real (only parsing).
 
 Lemma __deprecated__nat_cvgPpinfty (u : nat^nat) :
   u --> \oo <-> forall A, \forall n \near \oo, (A <= u n)%N.
 Proof. exact: cvgnyPge. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
       note="renamed to `cvgnyPge` and generalized")]
-Notation nat_cvgPpinfty:= __deprecated__nat_cvgPpinfty.
+Notation nat_cvgPpinfty:= __deprecated__nat_cvgPpinfty (only parsing).
 
 Lemma nat_nondecreasing_is_cvg (u_ : nat^nat) :
   nondecreasing_seq u_ -> has_ubound (range u_) -> cvg u_.
@@ -1422,34 +1422,34 @@ Lemma __deprecated__ereal_cvg_abs0 (R : realFieldType) (f : (\bar R)^nat) :
 Proof. by move/cvg_abse0P. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to `cvg_abse0P` and generalized")]
-Notation ereal_cvg_abs0 := __deprecated__ereal_cvg_abs0.
+Notation ereal_cvg_abs0 := __deprecated__ereal_cvg_abs0 (only parsing).
 
 Lemma __deprecated__ereal_cvg_ge0 (R : realFieldType) (f : (\bar R)^nat) (a : \bar R) :
   (forall n, 0 <= f n) -> f --> a -> 0 <= a.
 Proof. by move=> f_ge0; apply: cvge_ge; apply: nearW. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0", note="use `cvge_ge` instead")]
-Notation ereal_cvg_ge0 := __deprecated__ereal_cvg_ge0.
+Notation ereal_cvg_ge0 := __deprecated__ereal_cvg_ge0 (only parsing).
 
 Lemma __deprecated__ereal_lim_ge (R : realFieldType) x (u_ : (\bar R)^nat) : cvg u_ ->
   (\forall n \near \oo, x <= u_ n) -> x <= lim u_.
 Proof. exact: lime_ge. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to `lime_ge` and generalized")]
-Notation ereal_lim_ge := __deprecated__ereal_lim_ge.
+Notation ereal_lim_ge := __deprecated__ereal_lim_ge (only parsing).
 
 Lemma __deprecated__ereal_lim_le (R : realFieldType) x (u_ : (\bar R)^nat) : cvg u_ ->
   (\forall n \near \oo, u_ n <= x) -> lim u_ <= x.
 Proof. exact: lime_le. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to `lime_le` and generalized")]
-Notation ereal_lim_le := __deprecated__ereal_lim_le.
+Notation ereal_lim_le := __deprecated__ereal_lim_le (only parsing).
 
 Lemma __deprecated__dvg_ereal_cvg (R : realFieldType) (u_ : R ^nat) :
   u_ --> +oo%R -> [sequence (u_ n)%:E]_n --> +oo.
 Proof. by rewrite cvgeryP. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to `cvgeryP` and generalized")]
-Notation dvg_ereal_cvg := __deprecated__dvg_ereal_cvg.
+Notation dvg_ereal_cvg := __deprecated__dvg_ereal_cvg (only parsing).
 
 Lemma __deprecated__ereal_cvg_real (R : realFieldType) (f : (\bar R)^nat) a :
   {near \oo, forall x, f x \is a fin_num} /\
@@ -1457,7 +1457,7 @@ Lemma __deprecated__ereal_cvg_real (R : realFieldType) (f : (\bar R)^nat) a :
 Proof. by rewrite fine_cvgP. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to `fine_cvgP` and generalized")]
-Notation ereal_cvg_real := __deprecated__ereal_cvg_real.
+Notation ereal_cvg_real := __deprecated__ereal_cvg_real (only parsing).
 
 Lemma ereal_nondecreasing_cvg (R : realType) (u_ : (\bar R)^nat) :
   nondecreasing_seq u_ -> u_ --> ereal_sup (range u_).
@@ -1713,7 +1713,7 @@ by split=> [/cvgeyPge//|u_ge]; apply/cvgeyPgey; near=> x; apply: u_ge.
 Unshelve. all: by end_near. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="use `cvgeyPge` or a variant instead")]
-Notation ereal_cvgPpinfty := __deprecated__ereal_cvgPpinfty.
+Notation ereal_cvgPpinfty := __deprecated__ereal_cvgPpinfty (only parsing).
 
 Lemma __deprecated__ereal_cvgPninfty (R : realFieldType) (u_ : (\bar R)^nat) :
   u_ --> -oo <-> (forall A, (A < 0)%R -> \forall n \near \oo, u_ n <= A%:E).
@@ -1722,7 +1722,7 @@ by split=> [/cvgeNyPle//|u_ge]; apply/cvgeNyPleNy; near=> x; apply: u_ge.
 Unshelve. all: by end_near. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="use `cvgeNyPle` or a variant instead")]
-Notation ereal_cvgPninfty := __deprecated__ereal_cvgPninfty.
+Notation ereal_cvgPninfty := __deprecated__ereal_cvgPninfty (only parsing).
 
 Lemma __deprecated__ereal_squeeze (R : realType) (f g h : (\bar R)^nat) :
   (\forall x \near \oo, f x <= g x <= h x) -> forall (l : \bar R),
@@ -1730,7 +1730,7 @@ Lemma __deprecated__ereal_squeeze (R : realType) (f g h : (\bar R)^nat) :
 Proof. by move=> ? ?; apply: squeeze_cvge. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to `squeeze_cvge` and generalized")]
-Notation ereal_squeeze := __deprecated__ereal_squeeze.
+Notation ereal_squeeze := __deprecated__ereal_squeeze (only parsing).
 
 Lemma nneseries_pinfty (R : realType) (u_ : (\bar R)^nat)
   (P : pred nat) k : (forall n, P n -> 0 <= u_ n) -> P k ->
@@ -1767,32 +1767,32 @@ Lemma __deprecated__ereal_cvgD_pinfty_fin (R : realFieldType) (f g : (\bar R)^na
   f --> +oo -> g --> b%:E -> f \+ g --> +oo.
 Proof. exact: cvgeD. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0", note="use `cvgeD` instead")]
-Notation ereal_cvgD_pinfty_fin := __deprecated__ereal_cvgD_pinfty_fin.
+Notation ereal_cvgD_pinfty_fin := __deprecated__ereal_cvgD_pinfty_fin (only parsing).
 
 Lemma __deprecated__ereal_cvgD_ninfty_fin (R : realFieldType) (f g : (\bar R)^nat) b :
   f --> -oo -> g --> b%:E -> f \+ g --> -oo.
 Proof. exact: cvgeD. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0", note="use `cvgeD` instead")]
-Notation ereal_cvgD_ninfty_fin := __deprecated__ereal_cvgD_ninfty_fin.
+Notation ereal_cvgD_ninfty_fin := __deprecated__ereal_cvgD_ninfty_fin (only parsing).
 
 Lemma __deprecated__ereal_cvgD_pinfty_pinfty (R : realFieldType) (f g : (\bar R)^nat) :
   f --> +oo -> g --> +oo -> f \+ g --> +oo.
 Proof. exact: cvgeD. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0", note="use `cvgeD` instead")]
-Notation ereal_cvgD_pinfty_pinfty := __deprecated__ereal_cvgD_pinfty_pinfty.
+Notation ereal_cvgD_pinfty_pinfty := __deprecated__ereal_cvgD_pinfty_pinfty (only parsing).
 
 Lemma __deprecated__ereal_cvgD_ninfty_ninfty (R : realFieldType) (f g : (\bar R)^nat) :
   f --> -oo -> g --> -oo -> f \+ g --> -oo.
 Proof. exact: cvgeD. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0", note="use `cvgeD` instead")]
-Notation ereal_cvgD_ninfty_ninfty := __deprecated__ereal_cvgD_ninfty_ninfty.
+Notation ereal_cvgD_ninfty_ninfty := __deprecated__ereal_cvgD_ninfty_ninfty (only parsing).
 
 Lemma __deprecated__ereal_cvgD (R : realFieldType) (f g : (\bar R)^nat) a b :
   a +? b -> f --> a -> g --> b -> f \+ g --> a + b.
 Proof. exact: cvgeD. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to `cvgeD` and generalized")]
-Notation ereal_cvgD := __deprecated__ereal_cvgD.
+Notation ereal_cvgD := __deprecated__ereal_cvgD (only parsing).
 
 Section nneseries_split.
 
@@ -1801,21 +1801,21 @@ Lemma __deprecated__ereal_cvgB (R : realFieldType) (f g : (\bar R)^nat) a b :
 Proof. exact: cvgeB. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to `cvgeB` and generalized")]
-Notation ereal_cvgB := __deprecated__ereal_cvgB.
+Notation ereal_cvgB := __deprecated__ereal_cvgB (only parsing).
 
 Lemma __deprecated__ereal_is_cvgD (R : realFieldType) (u v : (\bar R)^nat) :
   lim u +? lim v -> cvg u -> cvg v -> cvg (u \+ v).
 Proof. exact: is_cvgeD. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to `is_cvgeD` and generalized")]
-Notation ereal_is_cvgD := __deprecated__ereal_is_cvgD.
+Notation ereal_is_cvgD := __deprecated__ereal_is_cvgD (only parsing).
 
 Lemma __deprecated__ereal_cvg_sub0 (R : realFieldType) (f : (\bar R)^nat) (k : \bar R) :
   k \is a fin_num -> (fun x => f x - k) --> 0 <-> f --> k.
 Proof. exact: cvge_sub0. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to `cvge_sub0` and generalized")]
-Notation ereal_cvg_sub0 := __deprecated__ereal_cvg_sub0.
+Notation ereal_cvg_sub0 := __deprecated__ereal_cvg_sub0 (only parsing).
 
 Lemma __deprecated__ereal_limD (R : realFieldType) (f g : (\bar R)^nat) :
   cvg f -> cvg g -> lim f +? lim g ->
@@ -1823,7 +1823,7 @@ Lemma __deprecated__ereal_limD (R : realFieldType) (f g : (\bar R)^nat) :
 Proof. exact: limeD. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to `limeD` and generalized")]
-Notation ereal_limD := __deprecated__ereal_limD.
+Notation ereal_limD := __deprecated__ereal_limD (only parsing).
 
 Lemma __deprecated__ereal_cvgM_gt0_pinfty (R : realFieldType) (f g : (\bar R)^nat) b :
   (0 < b)%R -> f --> +oo -> g --> b%:E -> f \* g --> +oo.
@@ -1832,7 +1832,7 @@ move=> b_lt0 fl gl; have /= := cvgeM _ fl gl; rewrite gt0_mulye//; apply.
 by rewrite mule_def_infty_neq0// gt_eqF.
 Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0", note="use `cvgeM` instead")]
-Notation ereal_cvgM_gt0_pinfty := __deprecated__ereal_cvgM_gt0_pinfty.
+Notation ereal_cvgM_gt0_pinfty := __deprecated__ereal_cvgM_gt0_pinfty (only parsing).
 
 Lemma __deprecated__ereal_cvgM_lt0_pinfty (R : realFieldType) (f g : (\bar R)^nat) b :
   (b < 0)%R -> f --> +oo -> g --> b%:E -> f \* g --> -oo.
@@ -1841,7 +1841,7 @@ move=> b_lt0 fl gl; have /= := cvgeM _ fl gl; rewrite lt0_mulye//; apply.
 by rewrite mule_def_infty_neq0// lt_eqF.
 Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0", note="use `cvgeM` instead")]
-Notation ereal_cvgM_lt0_pinfty := __deprecated__ereal_cvgM_lt0_pinfty.
+Notation ereal_cvgM_lt0_pinfty := __deprecated__ereal_cvgM_lt0_pinfty (only parsing).
 
 Lemma __deprecated__ereal_cvgM_gt0_ninfty (R : realFieldType) (f g : (\bar R)^nat) b :
   (0 < b)%R -> f --> -oo -> g --> b%:E -> f \* g --> -oo.
@@ -1850,7 +1850,7 @@ move=> b_lt0 fl gl; have /= := cvgeM _ fl gl; rewrite gt0_mulNye//; apply.
 by rewrite mule_def_infty_neq0// gt_eqF.
 Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0", note="use `cvgeM` instead")]
-Notation ereal_cvgM_gt0_ninfty := __deprecated__ereal_cvgM_gt0_ninfty.
+Notation ereal_cvgM_gt0_ninfty := __deprecated__ereal_cvgM_gt0_ninfty (only parsing).
 
 Lemma __deprecated__ereal_cvgM_lt0_ninfty (R : realFieldType) (f g : (\bar R)^nat) b :
   (b < 0)%R -> f --> -oo -> g --> b%:E -> f \* g --> +oo.
@@ -1859,14 +1859,14 @@ move=> b_lt0 fl gl; have /= := cvgeM _ fl gl; rewrite lt0_mulNye//; apply.
 by rewrite mule_def_infty_neq0// lt_eqF.
 Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0", note="use `cvgeM` instead")]
-Notation ereal_cvgM_lt0_ninfty := __deprecated__ereal_cvgM_lt0_ninfty.
+Notation ereal_cvgM_lt0_ninfty := __deprecated__ereal_cvgM_lt0_ninfty (only parsing).
 
 Lemma __deprecated__ereal_cvgM (R : realType) (f g : (\bar R) ^nat) (a b : \bar R) :
  a *? b -> f --> a -> g --> b -> f \* g --> a * b.
 Proof. exact: cvgeM. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to `cvgeM` and generalized")]
-Notation ereal_cvgM := __deprecated__ereal_cvgM.
+Notation ereal_cvgM := __deprecated__ereal_cvgM (only parsing).
 
 Lemma __deprecated__ereal_lim_sum (R : realFieldType) (I : Type) (r : seq I)
     (f : I -> (\bar R)^nat) (l : I -> \bar R) (P : pred I) :
@@ -1878,7 +1878,7 @@ by move=> f0 ?; apply: cvg_nnesum => // ? ?; apply: nearW => ?; apply: f0.
 Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="renamed to `cvg_nnesum` and generalized")]
-Notation ereal_lim_sum := __deprecated__ereal_lim_sum.
+Notation ereal_lim_sum := __deprecated__ereal_lim_sum (only parsing).
 
 Let lim_shift_cst (R : realFieldType) (u : (\bar R) ^nat) (l : \bar R) :
   cvg u -> (forall n, 0 <= u n) -> -oo < l -> lim (fun x => l + u x) = l + lim u.
@@ -1977,13 +1977,13 @@ Proof. by congr (lim _); apply: eq_fun => n /=; apply: big_mkcond. Qed.
 
 End sequences_ereal.
 #[deprecated(since="analysis 0.6.0", note="Use eseries0 instead.")]
-Notation nneseries0 := eseries0.
+Notation nneseries0 := eseries0 (only parsing).
 #[deprecated(since="analysis 0.6.0", note="Use eq_eseriesr instead.")]
-Notation eq_nneseries := eq_eseriesr.
+Notation eq_nneseries := eq_eseriesr (only parsing).
 #[deprecated(since="analysis 0.6.0", note="Use eseries_pred0 instead.")]
-Notation nneseries_pred0 := eseries_pred0.
+Notation nneseries_pred0 := eseries_pred0 (only parsing).
 #[deprecated(since="analysis 0.6.0", note="Use eseries_mkcond instead.")]
-Notation nneseries_mkcond := eseries_mkcond.
+Notation nneseries_mkcond := eseries_mkcond (only parsing).
 
 Definition sdrop T (u : T^nat) n := [set u k | k in [set k | k >= n]]%N.
 
@@ -2300,29 +2300,29 @@ Qed.
 End limn_sup_limn_inf.
 
 #[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `limn_sup`")]
-Notation lim_sup := limn_sup.
+Notation lim_sup := limn_sup (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `limn_inf`")]
-Notation lim_inf := limn_sup.
+Notation lim_inf := limn_sup (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `limn_infN`")]
-Notation lim_infN := limn_infN.
+Notation lim_infN := limn_infN (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `limn_supE`")]
-Notation lim_supE := limn_supE.
+Notation lim_supE := limn_supE (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `limn_infE`")]
-Notation lim_infE := limn_infE.
+Notation lim_infE := limn_infE (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `limn_inf_sup`")]
-Notation lim_inf_le_lim_sup := limn_inf_sup.
+Notation lim_inf_le_lim_sup := limn_inf_sup (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `cvg_limn_infE`")]
-Notation cvg_lim_infE := cvg_limn_infE.
+Notation cvg_lim_infE := cvg_limn_infE (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `cvg_limn_supE`")]
-Notation cvg_lim_supE := cvg_limn_supE.
+Notation cvg_lim_supE := cvg_limn_supE (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `le_limn_supD`")]
-Notation le_lim_supD := le_limn_supD.
+Notation le_lim_supD := le_limn_supD (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `le_limn_infD`")]
-Notation le_lim_infD := le_limn_infD.
+Notation le_lim_infD := le_limn_infD (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `limn_supD`")]
-Notation lim_supD := limn_supD.
+Notation lim_supD := limn_supD (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `limn_infD`")]
-Notation lim_infD := limn_infD.
+Notation lim_infD := limn_infD (only parsing).
 
 Section esups_einfs.
 Variable R : realType.
@@ -2540,23 +2540,23 @@ Qed.
 
 End lim_esup_inf.
 #[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `limn_einf_shift`")]
-Notation lim_einf_shift := limn_einf_shift.
+Notation lim_einf_shift := limn_einf_shift (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `limn_esup_le_cvg`")]
-Notation lim_esup_le_cvg := limn_esup_le_cvg.
+Notation lim_esup_le_cvg := limn_esup_le_cvg (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `limn_einfN`")]
-Notation lim_einfN := limn_einfN.
+Notation lim_einfN := limn_einfN (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `limn_esupN`")]
-Notation lim_esupN := limn_esupN.
+Notation lim_esupN := limn_esupN (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `limn_einf_sup`")]
-Notation lim_einf_sup := limn_einf_sup.
+Notation lim_einf_sup := limn_einf_sup (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `cvgNy_limn_einf_sup`")]
-Notation cvgNy_lim_einf_sup := cvgNy_limn_einf_sup.
+Notation cvgNy_lim_einf_sup := cvgNy_limn_einf_sup (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `cvg_limn_einf_sup`")]
-Notation cvg_lim_einf_sup := cvg_limn_einf_sup.
+Notation cvg_lim_einf_sup := cvg_limn_einf_sup (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `is_cvg_limn_einfE`")]
-Notation is_cvg_lim_einfE := is_cvg_limn_einfE.
+Notation is_cvg_lim_einfE := is_cvg_limn_einfE (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.6", note="renamed to `is_cvg_limn_esupE`")]
-Notation is_cvg_lim_esupE := is_cvg_limn_esupE.
+Notation is_cvg_lim_esupE := is_cvg_limn_esupE (only parsing).
 
 Lemma geometric_le_lim {R : realType} (n : nat) (a x : R) :
   0 <= a -> 0 < x -> `|x| < 1 -> series (geometric a x) n <= a * (1 - x)^-1.

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -3616,9 +3616,9 @@ Qed.
 End separated_topologicalType.
 
 #[deprecated(since="mathcomp-analysis 0.6.0", note="renamed to `cvg_lim`")]
-Notation cvg_map_lim := cvg_lim.
+Notation cvg_map_lim := cvg_lim (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.0", note="renamed to `cvgi_lim`")]
-Notation cvgi_map_lim := cvgi_lim.
+Notation cvgi_map_lim := cvgi_lim (only parsing).
 
 Section connected_sets.
 Variable T : topologicalType.
@@ -5076,7 +5076,7 @@ by apply/fcvg_ballP=> _/posnumP[eps] //.
 Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
   note="use a combination of `cvg_ballP` and `posnumP`")]
-Notation cvg_ballPpos := __deprecated__cvg_ballPpos.
+Notation cvg_ballPpos := __deprecated__cvg_ballPpos (only parsing).
 
 Lemma fcvg_ball {F} {FF : Filter F} (y : M) :
   F --> y -> forall eps : R, 0 < eps -> \forall y' \near F, ball y eps y'.
@@ -5113,7 +5113,7 @@ End pseudoMetricType_numDomainType.
 Arguments close_cvg {T} F1 F2 {FF2} _.
 
 #[deprecated(since="mathcomp-analysis 0.6.0", note="renamed `cvg_ball`")]
-Notation app_cvg_locally := cvg_ball.
+Notation app_cvg_locally := cvg_ball (only parsing).
 
 Section pseudoMetricType_numFieldType.
 Context {R : numFieldType} {M : pseudoMetricType R}.


### PR DESCRIPTION
##### Motivation for this change

fixes #1051

as (briefly) discussed during the last meeting https://github.com/math-comp/analysis/wiki/2023-10-16-Meeting

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 2.0

<!-- MathComp-Analysis is compatible with MathComp < 2.0 (branch `master`) and
     MathComp 2.0 ([branch `hierarchy-builder`](https://github.com/math-comp/analysis/pull/698)).

     If this PR targets `master` and if it is merged, the merged commit will also be
     cherry-picked on the branch `hierarchy-builder`.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `hierarchy-builder` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: HB port to record divergences between `master` and `hierarchy-builder` -->

- [x] I added the label `TODO: HB port` to make sure someone ports this PR to
      the `hierarchy-builder` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
