### PR TITLE
easy lemmas

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -96,6 +96,10 @@
 
 - in `hoelder.v`:
   + lemmas `powR_Lnorm`, `minkowski`
+  + lemma `expRM`
+
+- in `measure.v`:
+  + lemma `probability_setC`
 
 ### Changed
 

--- a/theories/exp.v
+++ b/theories/exp.v
@@ -694,6 +694,9 @@ Definition powR a x := if a == 0 then (x == 0)%:R else expR (x * ln a).
 
 Local Notation "a `^ x" := (powR a x).
 
+Lemma expRM x y : expR (x * y) = (expR x) `^ y.
+Proof. by rewrite /powR gt_eqF ?expR_gt0// expRK mulrC. Qed.
+
 Lemma powR_ge0 a x : 0 <= a `^ x.
 Proof. by rewrite /powR; case: ifPn => // _; exact: expR_ge0. Qed.
 

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -2919,10 +2919,18 @@ HB.structure Definition Probability d (T : measurableType d) (R : realType) :=
 Section probability_lemmas.
 Context d (T : measurableType d) (R : realType) (P : probability T R).
 
-Lemma probability_le1 (A : set T) : measurable A -> (P A <= 1)%E.
+Lemma probability_le1 (A : set T) : measurable A -> P A <= 1.
 Proof.
 move=> mA; rewrite -(@probability_setT _ _ _ P).
 by apply: le_measure => //; rewrite ?in_setE.
+Qed.
+
+Lemma probability_setC (A : set T) : measurable A -> P (~` A) = 1 - P A.
+Proof.
+move=> mA.
+rewrite -(@probability_setT _ _ _ P) -(setvU A) measureU ?addeK ?setICl//.
+- by rewrite fin_num_measure.
+- exact: measurableC.
 Qed.
 
 End probability_lemmas.


### PR DESCRIPTION
##### Motivation for this change

@hoheinzollern spotted a few easy lemmas when experimenting with another development,
here are two of them.

@hoheinzollern FYI, `ln_div` was already here

NB: `exprM` looks a nice enough name, but then I am wondering about `exprMm`. Why did we choose the `m` suffix? 

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [ ] added corresponding documentation in the headers~~

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 2.0

<!-- MathComp-Analysis is compatible with MathComp < 2.0 (branch `master`) and
     MathComp 2.0 ([branch `hierarchy-builder`](https://github.com/math-comp/analysis/pull/698)).

     If this PR targets `master` and if it is merged, the merged commit will also be
     cherry-picked on the branch `hierarchy-builder`.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `hierarchy-builder` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: HB port to record divergences between `master` and `hierarchy-builder` -->

- [x] I added the label `TODO: HB port` to make sure someone ports this PR to
      the `hierarchy-builder` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
