### PR TITLE
ae_eq lemmas

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -52,6 +52,8 @@
   + lemmas `HL_maximal_ge0`, `HL_maximalT_ge0`,
     `lower_semicontinuous_HL_maximal`, `measurable_HL_maximal`,
     `maximal_inequality`
+- in file `lebesgue_integral.v`
+  + add lemmas `ae_eqS`, `measure_dominates_ae_eq`.
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -52,15 +52,30 @@
   + lemmas `HL_maximal_ge0`, `HL_maximalT_ge0`,
     `lower_semicontinuous_HL_maximal`, `measurable_HL_maximal`,
     `maximal_inequality`
-- in file `lebesgue_integral.v`
-  + add lemmas `ae_eqS`, `measure_dominates_ae_eq`.
+
+- in file `measure.v`
+  + add lemmas `ae_eq_subset`, `measure_dominates_ae_eq`.
 
 ### Changed
 
 - in `normedtype.v`:
   + lemmas `vitali_lemma_finite` and `vitali_lemma_finite_cover` now returns
     duplicate-free lists of indices
-  
+
+- moved from `lebesgue_integral.v` to `measure.v`:
+  + definition `ae_eq`
+  + lemmas
+	`ae_eq0`,
+	`ae_eq_comp`,
+	`ae_eq_funeposneg`,
+	`ae_eq_refl`,
+	`ae_eq_trans`,
+	`ae_eq_sub`,
+	`ae_eq_mul2r`,
+	`ae_eq_mul2l`,
+	`ae_eq_mul1l`,
+	`ae_eq_abse`
+
 ### Renamed
 
 - in `exp.v`:

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -3488,6 +3488,25 @@ Proof. by apply: filterS => x /[apply] /= ->. Qed.
 
 End ae_eq.
 
+Section ae_eq_lemmas.
+Context d (T : measurableType d) (R : realType).
+
+Lemma ae_eqS (mu : {measure set T -> \bar R}) A B f g :
+  B `<=` A -> ae_eq mu A f g ->  ae_eq mu B f g.
+Proof.
+move=> BA.
+case => N [mN N0 fg]; exists N; split => //.
+by apply: subset_trans fg; apply: subsetC => z /= /[swap] /BA ? ->//.
+Qed.
+
+Lemma measure_dominates_ae_eq
+  (mu : {measure set T -> \bar R}) (nu : {measure set T -> \bar R})
+  (f g : T -> \bar R) E : measurable E ->
+    nu `<< mu -> ae_eq mu E f g -> ae_eq nu E f g.
+Proof. by move=> mE munu [A [mA A0 EA]]; exists A; split => //; exact: munu. Qed.
+
+End ae_eq_lemmas.
+
 Section ae_eq_integral.
 Local Open Scope ereal_scope.
 Context d (T : measurableType d) (R : realType)

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -38,7 +38,6 @@ Require Import esum measure lebesgue_measure numfun.
 (*       Rintegral mu D f := fine (\int[mu]_(x in D) f x).                    *)
 (*     mu.-integrable D f == f is measurable over D and the integral of f     *)
 (*                           w.r.t. D is < +oo                                *)
-(*            ae_eq D f g == f is equal to g almost everywhere                *)
 (*               m1 \x m2 == product measure over T1 * T2, m1 is a measure    *)
 (*                           measure over T1, and m2 is a sigma finite        *)
 (*                           measure over T2                                  *)
@@ -3440,73 +3439,6 @@ Proof. by rewrite -integral_setI_indic// setIid. Qed.
 
 End integral_indic.
 
-Section ae_eq.
-Local Open Scope ereal_scope.
-Context d (T : measurableType d) (R : realType).
-Variables (mu : {measure set T -> \bar R}) (D : set T).
-Implicit Types f g h i : T -> \bar R.
-
-Definition ae_eq f g := {ae mu, forall x, D x -> f x = g x}.
-
-Lemma ae_eq0 f g : measurable D -> mu D = 0 -> ae_eq f g.
-Proof. by move=> mD D0; exists D; split => // t/= /not_implyP[]. Qed.
-
-Lemma ae_eq_comp (j : \bar R -> \bar R) f g :
-  ae_eq f g -> ae_eq (j \o f) (j \o g).
-Proof. by apply: filterS => x /[apply] /= ->. Qed.
-
-Lemma ae_eq_funeposneg f g : ae_eq f g <-> ae_eq f^\+ g^\+ /\ ae_eq f^\- g^\-.
-Proof.
-split=> [fg|[]].
-  by rewrite /funepos /funeneg; split; apply: filterS fg => x /[apply] ->.
-apply: filterS2 => x + + Dx => /(_ Dx) fg /(_ Dx) gf.
-by rewrite (funeposneg f) (funeposneg g) fg gf.
-Qed.
-
-Lemma ae_eq_refl f : ae_eq f f. Proof. exact/aeW. Qed.
-
-Lemma ae_eq_sym f g : ae_eq f g -> ae_eq g f.
-Proof. by apply: filterS => x + Dx => /(_ Dx). Qed.
-
-Lemma ae_eq_trans f g h : ae_eq f g -> ae_eq g h -> ae_eq f h.
-Proof. by apply: filterS2 => x + + Dx => /(_ Dx) ->; exact. Qed.
-
-Lemma ae_eq_sub f g h i : ae_eq f g -> ae_eq h i -> ae_eq (f \- h) (g \- i).
-Proof. by apply: filterS2 => x + + Dx => /(_ Dx) -> /(_ Dx) ->. Qed.
-
-Lemma ae_eq_mul2r f g h : ae_eq f g -> ae_eq (f \* h) (g \* h).
-Proof. by apply: filterS => x /[apply] ->. Qed.
-
-Lemma ae_eq_mul2l f g h : ae_eq f g -> ae_eq (h \* f) (h \* g).
-Proof. by apply: filterS => x /[apply] ->. Qed.
-
-Lemma ae_eq_mul1l f g : ae_eq f (cst 1) -> ae_eq g (g \* f).
-Proof. by apply: filterS => x /[apply] ->; rewrite mule1. Qed.
-
-Lemma ae_eq_abse f g : ae_eq f g -> ae_eq (abse \o f) (abse \o g).
-Proof. by apply: filterS => x /[apply] /= ->. Qed.
-
-End ae_eq.
-
-Section ae_eq_lemmas.
-Context d (T : measurableType d) (R : realType).
-
-Lemma ae_eqS (mu : {measure set T -> \bar R}) A B f g :
-  B `<=` A -> ae_eq mu A f g ->  ae_eq mu B f g.
-Proof.
-move=> BA.
-case => N [mN N0 fg]; exists N; split => //.
-by apply: subset_trans fg; apply: subsetC => z /= /[swap] /BA ? ->//.
-Qed.
-
-Lemma measure_dominates_ae_eq
-  (mu : {measure set T -> \bar R}) (nu : {measure set T -> \bar R})
-  (f g : T -> \bar R) E : measurable E ->
-    nu `<< mu -> ae_eq mu E f g -> ae_eq nu E f g.
-Proof. by move=> mE munu [A [mA A0 EA]]; exists A; split => //; exact: munu. Qed.
-
-End ae_eq_lemmas.
-
 Section ae_eq_integral.
 Local Open Scope ereal_scope.
 Context d (T : measurableType d) (R : realType)
@@ -3729,7 +3661,7 @@ Qed.
 Lemma ge0_ae_eq_integral (D : set T) (f g : T -> \bar R) :
   measurable D -> measurable_fun D f -> measurable_fun D g ->
   (forall x, D x -> 0 <= f x) -> (forall x, D x -> 0 <= g x) ->
-  ae_eq D f g -> \int[mu]_(x in D) (f x)  = \int[mu]_(x in D) (g x).
+  ae_eq D f g -> \int[mu]_(x in D) (f x) = \int[mu]_(x in D) (g x).
 Proof.
 move=> mD mf mg f0 g0 [N [mN N0 subN]].
 rewrite integralEindic// [RHS]integralEindic//.


### PR DESCRIPTION
##### Motivation for this change

Lemmas `ae_eqS` and `measure_dominates_ae_eq` in PR #1083 does not depends on charge,
so I think they should be moved to `lebesgue_integral.v`.

fixes #1096 

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 2.0

<!-- MathComp-Analysis is compatible with MathComp < 2.0 (branch `master`) and
     MathComp 2.0 ([branch `hierarchy-builder`](https://github.com/math-comp/analysis/pull/698)).

     If this PR targets `master` and if it is merged, the merged commit will also be
     cherry-picked on the branch `hierarchy-builder`.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `hierarchy-builder` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: HB port to record divergences between `master` and `hierarchy-builder` -->

- [x] I added the label `TODO: HB port` to make sure someone ports this PR to
      the `hierarchy-builder` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
