### PR TITLE
Adapt to math-comp/math-comp#1133 (replace fun_scope with function_scope)

### DIFF
--- a/classical/functions.v
+++ b/classical/functions.v
@@ -260,11 +260,12 @@ Notation "{ 'inv' aT >->  rT }" := (@Inversible.type aT rT) : type_scope.
 Notation "[ 'inv'  'of'  f ]" := [the {inv _ >-> _} of f : _ -> _] : form_scope.
 Definition phant_inv aT rT (f : {inv aT >-> rT}) of phantom (_ -> _) f :=
   @inv _ _ f.
-Notation "f ^-1" := (@inv _ _ f%FUN) (only printing) : fun_scope.
 Notation "f ^-1" := (@inv _ _ f%function) (only printing) : function_scope.
-Notation "f ^-1" := (@phant_inv _ _ _ (Phantom (_ -> _) f%FUN)) : fun_scope.
 Notation "f ^-1" :=
   (@phant_inv _ _ _ (Phantom (_ -> _) f%function)) : function_scope.
+(* TODO: remove the following notations in fun_scope *)
+Notation "f ^-1" := (@inv _ _ f%FUN) (only printing) : fun_scope.
+Notation "f ^-1" := (@phant_inv _ _ _ (Phantom (_ -> _) f%FUN)) : fun_scope.
 
 HB.structure Definition InvFun aT rT A B :=
   {f of Inv aT rT f & isFun aT rT A B f}.
@@ -1903,7 +1904,7 @@ End inj.
 
 End patch.
 Notation restrict := (patch (fun=> point)).
-Notation "f \_ D" := (restrict D f) : fun_scope.
+Notation "f \_ D" := (restrict D f) : function_scope.
 
 Lemma patchE aT (rT : pointedType) (f : aT -> rT) (B : set aT) x :
   (f \_ B) x = if x \in B then f x else point.

--- a/theories/constructive_ereal.v
+++ b/theories/constructive_ereal.v
@@ -1234,11 +1234,11 @@ Notation "x *? y" := (mule_def x y) : ereal_scope.
 
 Notation maxe := (@Order.max ereal_display _).
 Notation "@ 'maxe' R" := (@Order.max ereal_display R)
-  (at level 10, R at level 8, only parsing) : fun_scope.
+  (at level 10, R at level 8, only parsing) : function_scope.
 
 Notation mine := (@Order.min ereal_display _).
 Notation "@ 'mine' R" := (@Order.min ereal_display R)
-  (at level 10, R at level 8, only parsing) : fun_scope.
+  (at level 10, R at level 8, only parsing) : function_scope.
 
 Module DualAddTheoryNumDomain.
 

--- a/theories/reals.v
+++ b/theories/reals.v
@@ -132,7 +132,7 @@ Bind Scope ring_scope with Real.sort.
 (* -------------------------------------------------------------------- *)
 Definition sup {R : realType} := @supremum _ R 0.
 (*Local Notation "-` E" := [pred x | - x \in E]
-  (at level 35, right associativity) : fun_scope.*)
+  (at level 35, right associativity) : function_scope.*)
 Definition inf {R : realType} (E : set R) := - sup (-%R @` E).
 
 (* -------------------------------------------------------------------- *)


### PR DESCRIPTION
##### Motivation for this change

See https://github.com/math-comp/math-comp/pull/1133.

##### Things done/to do

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- ~[ ] added corresponding documentation in the headers~

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 2.0

<!-- MathComp-Analysis is compatible with MathComp < 2.0 (branch `master`) and
     MathComp 2.0 ([branch `hierarchy-builder`](https://github.com/math-comp/analysis/pull/698)).

     If this PR targets `master` and if it is merged, the merged commit will also be
     cherry-picked on the branch `hierarchy-builder`.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `hierarchy-builder` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: HB port to record divergences between `master` and `hierarchy-builder` -->

- [ ] I added the label `TODO: HB port` to make sure someone ports this PR to
      the `hierarchy-builder` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
