### PR TITLE
restrain the scope of measurable args

### DIFF
--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -492,24 +492,24 @@ Qed.
 
 Lemma measurable_itv (i : interval R) : measurable [set` i].
 Proof.
-have moc (a b : R) : measurable `]a, b]%classic.
+have moc (a b : R) : measurable `]a, b].
   by apply: sub_sigma_algebra; apply: is_ocitv.
-have mopoo (x : R) : measurable `]x, +oo[%classic.
+have mopoo (x : R) : measurable `]x, +oo[.
   by rewrite itv_bnd_infty_bigcup; exact: bigcup_measurable.
-have mnooc (x : R) : measurable `]-oo, x]%classic.
+have mnooc (x : R) : measurable `]-oo, x].
   by rewrite -setCitvr; exact/measurableC.
-have ooE (a b : R) : `]a, b[%classic = `]a, b]%classic `\ b.
+have ooE (a b : R) : `]a, b[%classic = `]a, b] `\ b.
   case: (boolP (a < b)) => ab; last by rewrite !set_itv_ge ?set0D.
   by rewrite -setUitv1// setUDK// => x [->]; rewrite /= in_itv/= ltxx andbF.
-have moo (a b : R) : measurable `]a, b[%classic.
+have moo (a b : R) : measurable `]a, b[.
   by rewrite ooE; exact: measurableD.
-have mcc (a b : R) : measurable `[a, b]%classic.
+have mcc (a b : R) : measurable `[a, b].
   case: (boolP (a <= b)) => ab; last by rewrite set_itv_ge.
   by rewrite -setU1itv//; apply/measurableU.
-have mco (a b : R) : measurable `[a, b[%classic.
+have mco (a b : R) : measurable `[a, b[.
   case: (boolP (a < b)) => ab; last by rewrite set_itv_ge.
   by rewrite -setU1itv//; apply/measurableU.
-have oooE (b : R) : `]-oo, b[%classic = `]-oo, b]%classic `\ b.
+have oooE (b : R) : `]-oo, b[%classic = `]-oo, b] `\ b.
   by rewrite -setUitv1// setUDK// => x [->]; rewrite /= in_itv/= ltxx.
 case: i => [[[] a|[]] [[] b|[]]] => //; do ?by rewrite set_itv_ge.
 - by rewrite -setU1itv//; exact/measurableU.

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -721,6 +721,8 @@ HB.mixin Record isSemiRingOfSets (d : measure_display) T := {
 #[short(type=semiRingOfSetsType)]
 HB.structure Definition SemiRingOfSets d := {T of isSemiRingOfSets d T}.
 
+Arguments measurable {d}%measure_display_scope {s} _%classical_set_scope.
+
 Canonical semiRingOfSets_eqType d (T : semiRingOfSetsType d) := EqType T ptclass.
 Canonical semiRingOfSets_choiceType d (T : semiRingOfSetsType d) :=
   ChoiceType T ptclass.


### PR DESCRIPTION
##### Motivation for this change

@pi8027 noticed that we are not doing a good usage of scope restrictions with the `Arguments` command.
This is one miss that he found out.
There is certainly more to learn from https://coq.inria.fr/refman/user-extensions/syntax-extensions.html#notation-scopes

##### Things done/to do

<!-- please fill in the following checklist -->
~~- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`~~

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [ ] added corresponding documentation in the headers~~

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 2.0

<!-- MathComp-Analysis is compatible with MathComp < 2.0 (branch `master`) and
     MathComp 2.0 ([branch `hierarchy-builder`](https://github.com/math-comp/analysis/pull/698)).

     If this PR targets `master` and if it is merged, the merged commit will also be
     cherry-picked on the branch `hierarchy-builder`.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `hierarchy-builder` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: HB port to record divergences between `master` and `hierarchy-builder` -->

- [x] I added the label `TODO: HB port` to make sure someone ports this PR to
      the `hierarchy-builder` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
