### PR TITLE
mulr_rev out of forms.v

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -36,6 +36,9 @@
 - in `forms.v`:
   + notation ``` u ``_ _ ```
 
+- moved from `forms.v` to `matchomp_extra.v`:
+  + structure `revop`
+
 ### Renamed
 
 - in `constructive_ereal.v`:
@@ -99,8 +102,6 @@
   + definition `mulr_rev`
   + canonical `rev_mulr`
   + lemmas `mulr_is_linear`, `mulr_rev_is_linear`
-- in `forms.v`:
-  + structure `revop`
 
 ### Infrastructure
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -33,24 +33,6 @@
 
 ### Changed
 
-- in `normedtype.v`:
-  + lemmas `vitali_lemma_finite` and `vitali_lemma_finite_cover` now returns
-    duplicate-free lists of indices
-
-- moved from `lebesgue_integral.v` to `measure.v`:
-  + definition `ae_eq`
-  + lemmas
-	`ae_eq0`,
-	`ae_eq_comp`,
-	`ae_eq_funeposneg`,
-	`ae_eq_refl`,
-	`ae_eq_trans`,
-	`ae_eq_sub`,
-	`ae_eq_mul2r`,
-	`ae_eq_mul2l`,
-	`ae_eq_mul1l`,
-	`ae_eq_abse`
-
 - move from `forms.v` to `mathcomp_extra.v`:
   + structure `revop`
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -33,6 +33,31 @@
 
 ### Changed
 
+- in `normedtype.v`:
+  + lemmas `vitali_lemma_finite` and `vitali_lemma_finite_cover` now returns
+    duplicate-free lists of indices
+
+- moved from `lebesgue_integral.v` to `measure.v`:
+  + definition `ae_eq`
+  + lemmas
+	`ae_eq0`,
+	`ae_eq_comp`,
+	`ae_eq_funeposneg`,
+	`ae_eq_refl`,
+	`ae_eq_trans`,
+	`ae_eq_sub`,
+	`ae_eq_mul2r`,
+	`ae_eq_mul2l`,
+	`ae_eq_mul1l`,
+	`ae_eq_abse`
+
+- move from `forms.v` to `mathcomp_extra.v`:
+  + structure `revop`
+
+- move from `derive.v` to `mathcomp_extra.v`:
+  + definition `mulr_rev`
+  + canonical `rev_mulr`
+
 ### Renamed
 
 - in `constructive_ereal.v`:

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -36,9 +36,6 @@
 - in `forms.v`:
   + notation ``` u ``_ _ ```
 
-- moved from `forms.v` to `matchomp_extra.v`:
-  + structure `revop`
-
 ### Renamed
 
 - in `constructive_ereal.v`:
@@ -102,6 +99,10 @@
   + definition `mulr_rev`
   + canonical `rev_mulr`
   + lemmas `mulr_is_linear`, `mulr_rev_is_linear`
+
+- in `forms.v`
+  + canonical `rev_mulmx`
+  + structure `revop`
 
 ### Infrastructure
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -33,12 +33,6 @@
 
 ### Changed
 
-- move from `forms.v` to `mathcomp_extra.v`:
-  + structure `revop`
-
-- move from `derive.v` to `mathcomp_extra.v`:
-  + canonical `rev_mulr`
-
 - in `forms.v`:
   + notation ``` u ``_ _ ````
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -39,6 +39,9 @@
 - move from `derive.v` to `mathcomp_extra.v`:
   + canonical `rev_mulr`
 
+- in `forms.v`:
+  + notation ``` u ``_ _ ````
+
 ### Renamed
 
 - in `constructive_ereal.v`:
@@ -98,8 +101,12 @@
 - in `measure.v`:
   + lemmas `prod_salgebra_set0`, `prod_salgebra_setC`, `prod_salgebra_bigcup`
     (use `measurable0`, `measurableC`, `measurable_bigcup` instead)
-- in `forms.v`:
+- in `derive.v`:
   + definition `mulr_rev`
+  + canonical `rev_mulr`
+  + lemmas `mulr_is_linear`, `mulr_rev_is_linear`
+- in `forms.v`:
+  + structure `revop`
 
 ### Infrastructure
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -37,7 +37,6 @@
   + structure `revop`
 
 - move from `derive.v` to `mathcomp_extra.v`:
-  + definition `mulr_rev`
   + canonical `rev_mulr`
 
 ### Renamed
@@ -99,6 +98,8 @@
 - in `measure.v`:
   + lemmas `prod_salgebra_set0`, `prod_salgebra_setC`, `prod_salgebra_bigcup`
     (use `measurable0`, `measurableC`, `measurable_bigcup` instead)
+- in `forms.v`:
+  + definition `mulr_rev`
 
 ### Infrastructure
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -34,7 +34,7 @@
 ### Changed
 
 - in `forms.v`:
-  + notation ``` u ``_ _ ````
+  + notation ``` u ``_ _ ```
 
 ### Renamed
 

--- a/classical/mathcomp_extra.v
+++ b/classical/mathcomp_extra.v
@@ -612,10 +612,3 @@ rewrite /Order.min/=; case: ifPn => xz; case: ifPn => yz; rewrite ?ltxx//.
 Qed.
 
 End order_min.
-
-(*Structure revop X Y Z (f : Y -> X -> Z) := RevOp {
-  fun_of_revop :> X -> Y -> Z;
-  _ : forall x, f x =1 fun_of_revop^~ x }.
-
-Canonical rev_mulr {R : ringType} :=
-  @RevOp _ _ _ (@GRing.mul R^c) (@GRing.mul R) (fun _ _ => erefl).*)

--- a/classical/mathcomp_extra.v
+++ b/classical/mathcomp_extra.v
@@ -615,9 +615,8 @@ End order_min.
 
 Structure revop X Y Z (f : Y -> X -> Z) := RevOp {
   fun_of_revop :> X -> Y -> Z;
-  _ : forall x, f x =1 fun_of_revop^~ x
-}.
+  _ : forall x, f x =1 fun_of_revop^~ x }.
 
-Definition mulr_rev {R : ringType} (y x : R) := x * y.
+Definition mulr_rev {R : ringType} := @GRing.mul R^c.
 Canonical rev_mulr {R : ringType} :=
   @RevOp _ _ _ mulr_rev (@GRing.mul R) (fun _ _ => erefl).

--- a/classical/mathcomp_extra.v
+++ b/classical/mathcomp_extra.v
@@ -613,9 +613,9 @@ Qed.
 
 End order_min.
 
-Structure revop X Y Z (f : Y -> X -> Z) := RevOp {
+(*Structure revop X Y Z (f : Y -> X -> Z) := RevOp {
   fun_of_revop :> X -> Y -> Z;
   _ : forall x, f x =1 fun_of_revop^~ x }.
 
 Canonical rev_mulr {R : ringType} :=
-  @RevOp _ _ _ (@GRing.mul R^c) (@GRing.mul R) (fun _ _ => erefl).
+  @RevOp _ _ _ (@GRing.mul R^c) (@GRing.mul R) (fun _ _ => erefl).*)

--- a/classical/mathcomp_extra.v
+++ b/classical/mathcomp_extra.v
@@ -612,3 +612,7 @@ rewrite /Order.min/=; case: ifPn => xz; case: ifPn => yz; rewrite ?ltxx//.
 Qed.
 
 End order_min.
+
+Structure revop X Y Z (f : Y -> X -> Z) := RevOp {
+  fun_of_revop :> X -> Y -> Z;
+  _ : forall x, f x =1 fun_of_revop^~ x }.

--- a/classical/mathcomp_extra.v
+++ b/classical/mathcomp_extra.v
@@ -617,6 +617,5 @@ Structure revop X Y Z (f : Y -> X -> Z) := RevOp {
   fun_of_revop :> X -> Y -> Z;
   _ : forall x, f x =1 fun_of_revop^~ x }.
 
-Definition mulr_rev {R : ringType} := @GRing.mul R^c.
 Canonical rev_mulr {R : ringType} :=
-  @RevOp _ _ _ mulr_rev (@GRing.mul R) (fun _ _ => erefl).
+  @RevOp _ _ _ (@GRing.mul R^c) (@GRing.mul R) (fun _ _ => erefl).

--- a/classical/mathcomp_extra.v
+++ b/classical/mathcomp_extra.v
@@ -612,7 +612,3 @@ rewrite /Order.min/=; case: ifPn => xz; case: ifPn => yz; rewrite ?ltxx//.
 Qed.
 
 End order_min.
-
-Structure revop X Y Z (f : Y -> X -> Z) := RevOp {
-  fun_of_revop :> X -> Y -> Z;
-  _ : forall x, f x =1 fun_of_revop^~ x }.

--- a/classical/mathcomp_extra.v
+++ b/classical/mathcomp_extra.v
@@ -459,7 +459,7 @@ Inductive boxed T := Box of T.
 Reserved Notation "`1- r" (format "`1- r", at level 2).
 Reserved Notation "f \^-1" (at level 3, format "f \^-1", left associativity).
 
-(* To be backported to finmap *)
+(* TODO: To be backported to finmap *)
 
 Lemma fset_nat_maximum (X : choiceType) (A : {fset X})
     (f : X -> nat) : A != fset0 ->
@@ -612,3 +612,12 @@ rewrite /Order.min/=; case: ifPn => xz; case: ifPn => yz; rewrite ?ltxx//.
 Qed.
 
 End order_min.
+
+Structure revop X Y Z (f : Y -> X -> Z) := RevOp {
+  fun_of_revop :> X -> Y -> Z;
+  _ : forall x, f x =1 fun_of_revop^~ x
+}.
+
+Definition mulr_rev {R : ringType} (y x : R) := x * y.
+Canonical rev_mulr {R : ringType} :=
+  @RevOp _ _ _ mulr_rev (@GRing.mul R) (fun _ _ => erefl).

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -826,16 +826,6 @@ Proof.
 by move=> fc; apply/diff_locallyP; rewrite diff_bilin //; apply: dbilin p fc.
 Qed.
 
-Lemma mulr_is_linear x : linear (@GRing.mul R x : R -> R).
-Proof. by move=> ? ? ?; rewrite mulrDr scalerAr. Qed.
-HB.instance Definition _ x := GRing.isLinear.Build R R R _ ( *%R x)
-  (mulr_is_linear x).
-
-Lemma mulr_rev_is_linear y : linear (@GRing.mul R^c y : R -> R).
-Proof. by move=> ? ? ?; rewrite mulrDr scalerAl. Qed.
-HB.instance Definition _ y := GRing.isLinear.Build R R R _ (@GRing.mul R^c y)
-  (mulr_rev_is_linear y).
-
 Lemma mulr_is_bilinear :
   bilinear_for
     (GRing.Scale.Law.clone _ _ *:%R _) (GRing.Scale.Law.clone _ _ *:%R _)

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -831,9 +831,9 @@ Proof. by move=> ? ? ?; rewrite mulrDr scalerAr. Qed.
 HB.instance Definition _ x := GRing.isLinear.Build R R R _ ( *%R x)
   (mulr_is_linear x).
 
-Lemma mulr_rev_is_linear y : linear (mulr_rev y : R -> R).
-Proof. by move=> ? ? ?; rewrite /mulr_rev mulrDr scalerAl. Qed.
-HB.instance Definition _ y := GRing.isLinear.Build R R R _ (mulr_rev y)
+Lemma mulr_rev_is_linear y : linear (@GRing.mul R^c y : R -> R).
+Proof. by move=> ? ? ?; rewrite mulrDr scalerAl. Qed.
+HB.instance Definition _ y := GRing.isLinear.Build R R R _ (@GRing.mul R^c y)
   (mulr_rev_is_linear y).
 
 Lemma mulr_is_bilinear :

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -832,7 +832,7 @@ HB.instance Definition _ x := GRing.isLinear.Build R R R _ ( *%R x)
   (mulr_is_linear x).
 
 Lemma mulr_rev_is_linear y : linear (mulr_rev y : R -> R).
-Proof. by move=> ? ? ?; rewrite /mulr_rev mulrDl scalerAl. Qed.
+Proof. by move=> ? ? ?; rewrite /mulr_rev mulrDr scalerAl. Qed.
 HB.instance Definition _ y := GRing.isLinear.Build R R R _ (mulr_rev y)
   (mulr_rev_is_linear y).
 

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -826,16 +826,13 @@ Proof.
 by move=> fc; apply/diff_locallyP; rewrite diff_bilin //; apply: dbilin p fc.
 Qed.
 
-Definition mulr_rev (y x : R) := x * y.
-Canonical rev_mulr := @RevOp _ _ _ mulr_rev (@GRing.mul R) (fun _ _ => erefl).
-
 Lemma mulr_is_linear x : linear (@GRing.mul R x : R -> R).
-Proof. by move=> ???; rewrite mulrDr scalerAr. Qed.
+Proof. by move=> ? ? ?; rewrite mulrDr scalerAr. Qed.
 HB.instance Definition _ x := GRing.isLinear.Build R R R _ ( *%R x)
   (mulr_is_linear x).
 
 Lemma mulr_rev_is_linear y : linear (mulr_rev y : R -> R).
-Proof. by move=> ???; rewrite /mulr_rev mulrDl scalerAl. Qed.
+Proof. by move=> ? ? ?; rewrite /mulr_rev mulrDl scalerAl. Qed.
 HB.instance Definition _ y := GRing.isLinear.Build R R R _ (mulr_rev y)
   (mulr_rev_is_linear y).
 

--- a/theories/forms.v
+++ b/theories/forms.v
@@ -27,7 +27,7 @@ Reserved Notation "A ^_|_"    (at level 8, format "A ^_|_").
 Reserved Notation "A _|_ B" (at level 69, format "A  _|_  B").
 Reserved Notation "eps_theta .-sesqui" (at level 2, format "eps_theta .-sesqui").
 
-Notation "u '``_' i" := (u (GRing.zero [the zmodType of 'I_1]) i) : ring_scope.
+Notation "u '``_' i" := (u (0 : 'I_1) i) : ring_scope.
 Notation "''e_' i" := (delta_mx 0 i)
  (format "''e_' i", at level 3) : ring_scope.
 

--- a/theories/forms.v
+++ b/theories/forms.v
@@ -1,11 +1,7 @@
 From HB Require Import structures.
-From mathcomp
-Require Import all_ssreflect ssralg fingroup zmodp poly ssrnum.
-From mathcomp
-Require Import matrix mxalgebra vector falgebra ssrnum algC algnum.
-From mathcomp
-Require Import fieldext.
-From mathcomp Require Import vector.
+From mathcomp Require Import all_ssreflect ssralg fingroup zmodp poly ssrnum.
+From mathcomp Require Import matrix mxalgebra vector falgebra ssrnum fieldext.
+From mathcomp Require Import vector mathcomp_extra.
 
 (**md**************************************************************************)
 (* # Bilinear forms                                                           *)
@@ -37,11 +33,6 @@ Notation "''e_' i" := (delta_mx 0 i)
 
 Local Notation "M ^ phi" := (map_mx phi M).
 Local Notation "M ^t phi" := (map_mx phi (M ^T)) (phi at level 30, at level 30).
-
-Structure revop X Y Z (f : Y -> X -> Z) := RevOp {
-  fun_of_revop :> X -> Y -> Z;
-  _ : forall x, f x =1 fun_of_revop^~ x
-}.
 
 Lemma eq_map_mx_id (R : ringType) m n (M : 'M[R]_(m,n)) (f : R -> R) :
   f =1 id -> M ^ f = M.

--- a/theories/forms.v
+++ b/theories/forms.v
@@ -188,9 +188,6 @@ End BidirectionalLinearZ.
 
 End BilinearTheory.
 
-Canonical rev_mulmx (R : ringType) m n p := @RevOp _ _ _ (@mulmxr R m n p)
-  (@mulmx R m n p) (fun _ _ => erefl).
-
 Lemma mulmx_is_bilinear (R : comRingType) m n p :
   bilinear_for
     (GRing.Scale.Law.clone _ _ *:%R _) (GRing.Scale.Law.clone _ _ *:%R _)


### PR DESCRIPTION
##### Motivation for this change

fixes #1092 

`mulr_rev` had nothing to do in `derive.v`

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [] added corresponding documentation in the headers~~

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 2.0

<!-- MathComp-Analysis is compatible with MathComp < 2.0 (branch `master`) and
     MathComp 2.0 ([branch `hierarchy-builder`](https://github.com/math-comp/analysis/pull/698)).

     If this PR targets `master` and if it is merged, the merged commit will also be
     cherry-picked on the branch `hierarchy-builder`.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `hierarchy-builder` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: HB port to record divergences between `master` and `hierarchy-builder` -->

- [x] I added the label `TODO: HB port` to make sure someone ports this PR to
      the `hierarchy-builder` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
