### PR TITLE
fixes #1123 (unusable lemma)

### DIFF
--- a/theories/ereal.v
+++ b/theories/ereal.v
@@ -533,15 +533,21 @@ Proof. by move=> A B AB; apply: ub_ereal_sup => x Ax; apply/ereal_sup_ub/AB. Qed
 Lemma le_ereal_inf : {homo @ereal_inf R : A B / A `<=` B >-> B <= A}.
 Proof. by move=> A B AB; apply: lb_ereal_inf => x Bx; exact/ereal_inf_lb/AB. Qed.
 
-Lemma hasNub_ereal_sup (A : set (\bar R)) : ~ has_ubound A ->
-  A !=set0 -> ereal_sup A = +oo%E.
+Lemma hasNub_ereal_sup (A : set R) : ~ has_ubound A ->
+  A !=set0 -> ereal_sup (EFin @` A) = +oo%E.
 Proof.
 move=> hasNubA A0.
 apply/eqP; rewrite eq_le leey /= leNgt; apply: contra_notN hasNubA => Aoo.
-by exists (ereal_sup A); exact: ereal_sup_ub.
+exists (fine (ereal_sup (EFin @` A))) => x Ax.
+rewrite -lee_fin -(@fineK _ x%:E)// lee_fin fine_le//; last first.
+  by apply: ereal_sup_ub => /=; exists x.
+rewrite fin_numE// -ltey Aoo andbT.
+apply/negP => /eqP/ereal_sup_ninfty/(_ x%:E).
+have : (EFin @` A) x%:E by exists x.
+by move=> /[swap] /[apply].
 Qed.
 
-Lemma ereal_sup_EFin  (A : set R) :
+Lemma ereal_sup_EFin (A : set R) :
   has_ubound A -> A !=set0 -> ereal_sup (EFin @` A) = (sup A)%:E.
 Proof.
 move=> has_ubA A0; apply/eqP; rewrite eq_le; apply/andP; split.

--- a/theories/ereal.v
+++ b/theories/ereal.v
@@ -536,15 +536,13 @@ Proof. by move=> A B AB; apply: lb_ereal_inf => x Bx; exact/ereal_inf_lb/AB. Qed
 Lemma hasNub_ereal_sup (A : set R) : ~ has_ubound A ->
   A !=set0 -> ereal_sup (EFin @` A) = +oo%E.
 Proof.
-move=> hasNubA A0.
-apply/eqP; rewrite eq_le leey /= leNgt; apply: contra_notN hasNubA => Aoo.
+move=> + A0; apply: contra_notP => /eqP; rewrite -ltey => Aoo.
 exists (fine (ereal_sup (EFin @` A))) => x Ax.
 rewrite -lee_fin -(@fineK _ x%:E)// lee_fin fine_le//; last first.
   by apply: ereal_sup_ub => /=; exists x.
 rewrite fin_numE// -ltey Aoo andbT.
-apply/negP => /eqP/ereal_sup_ninfty/(_ x%:E).
-have : (EFin @` A) x%:E by exists x.
-by move=> /[swap] /[apply].
+apply/eqP => /ereal_sup_ninfty/(_ x%:E).
+by have /[swap] /[apply]: (EFin @` A) x%:E by exists x.
 Qed.
 
 Lemma ereal_sup_EFin (A : set R) :
@@ -565,7 +563,7 @@ by rewrite -lee_fin fineK//; apply: ereal_sup_ub; exists r.
 Qed.
 
 Lemma ereal_inf_EFin (A : set R) : has_lbound A -> A !=set0 ->
-   ereal_inf (EFin @` A) = (inf A)%:E.
+  ereal_inf (EFin @` A) = (inf A)%:E.
 Proof.
 move=> has_lbA A0; rewrite /ereal_inf /inf EFinN; congr (- _)%E.
 rewrite -ereal_sup_EFin; [|exact/has_lb_ubN|exact/nonemptyN].


### PR DESCRIPTION
##### Motivation for this change

fixes #1123 

@t6s 

@zstone1 I noticed after the fact that you also fix this lemma in you PR on total variation so that I put you as co-author of this commit

##### Things done/to do

<!-- please fill in the following checklist -->
~~- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`~~

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [ ] added corresponding documentation in the headers~~

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 2.0

<!-- MathComp-Analysis is compatible with MathComp < 2.0 (branch `master`) and
     MathComp 2.0 ([branch `hierarchy-builder`](https://github.com/math-comp/analysis/pull/698)).

     If this PR targets `master` and if it is merged, the merged commit will also be
     cherry-picked on the branch `hierarchy-builder`.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `hierarchy-builder` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: HB port to record divergences between `master` and `hierarchy-builder` -->

- [x] I added the label `TODO: HB port` to make sure someone ports this PR to
      the `hierarchy-builder` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
