### PR TITLE
naming conventions

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -8,6 +8,23 @@
 
 ### Renamed
 
+- in `constructive_ereal.v`:
+  + `lee_addl` -> `leeDl`
+  + `lee_addr` -> `leeDr`
+  + `lee_add2l` -> `leeD2l`
+  + `lee_add2r` -> `leeD2r`
+  + `lee_add` -> `leeD`
+  + `lee_sub` -> `leeB`
+  + `lee_add2lE` -> `leeD2lE`
+  + `lte_add2lE` -> `lteD2lE`
+  + `lee_oppl` -> `leeNl`
+  + `lee_oppr` -> `leeNr`
+  + `lte_oppr` -> `lteNr`
+  + `lte_oppl` -> `lteNl`
+  + `lte_add` -> `lteD`
+  + `lte_addl` -> `lteDl`
+  + `lte_addr` -> `lteDr`
+
 ### Generalized
 
 ### Deprecated

--- a/theories/constructive_ereal.v
+++ b/theories/constructive_ereal.v
@@ -1594,22 +1594,22 @@ Lemma sube_ge0 x y : (x \is a fin_num) || (y \is a fin_num) ->
   (0 <= y - x) = (x <= y).
 Proof. by move=> /orP[?|?]; [rewrite suber_ge0|rewrite subre_ge0]. Qed.
 
-Lemma lte_oppl x y : (- x < y) = (- y < x).
+Lemma lteNl x y : (- x < y) = (- y < x).
 Proof.
 by move: x y => [r| |] [r'| |] //=; rewrite ?(ltry, ltNyr)// !lte_fin ltrNl.
 Qed.
 
-Lemma lte_oppr x y : (x < - y) = (y < - x).
+Lemma lteNr x y : (x < - y) = (y < - x).
 Proof.
 by move: x y => [r| |] [r'| |] //=; rewrite ?(ltry, ltNyr)// !lte_fin ltrNr.
 Qed.
 
-Lemma lee_oppr x y : (x <= - y) = (y <= - x).
+Lemma leeNr x y : (x <= - y) = (y <= - x).
 Proof.
 by move: x y => [r0| |] [r1| |] //=; rewrite ?(leey, leNye)// !lee_fin lerNr.
 Qed.
 
-Lemma lee_oppl x y : (- x <= y) = (- y <= x).
+Lemma leeNl x y : (- x <= y) = (- y <= x).
 Proof.
 by move: x y => [r0| |] [r1| |] //=; rewrite ?(leey, leNye)// !lee_fin lerNl.
 Qed.
@@ -1621,9 +1621,9 @@ move: x y => [x| |] [y| |] //=; rewrite /mule/=; try by rewrite ltry.
 - by rewrite !eqe !lte_fin; case: ltrgtP => //; rewrite oppe0.
 - by rewrite !eqe !lte_fin; case: ltrgtP => //; rewrite oppe0.
 - rewrite !eqe oppr_eq0 eq_sym; case: ifP; rewrite ?oppe0// => y0.
-  by rewrite [RHS]fun_if ltNge if_neg EFinN lee_oppl oppe0 le_eqVlt eqe y0.
+  by rewrite [RHS]fun_if ltNge if_neg EFinN leeNl oppe0 le_eqVlt eqe y0.
 - rewrite !eqe oppr_eq0 eq_sym; case: ifP; rewrite ?oppe0// => y0.
-  by rewrite [RHS]fun_if ltNge if_neg EFinN lee_oppl oppe0 le_eqVlt eqe y0.
+  by rewrite [RHS]fun_if ltNge if_neg EFinN leeNl oppe0 le_eqVlt eqe y0.
 Qed.
 
 Lemma mulNe x y : - x * y = - (x * y). Proof. by rewrite muleC muleN muleC. Qed.
@@ -1724,26 +1724,25 @@ Lemma mule_eq_ninfty x y : (x * y == -oo) =
      (x == -oo) && (y > 0) | (x == +oo) && (y < 0)].
 Proof.
 have := mule_eq_pinfty x (- y); rewrite muleN eqe_oppLR => ->.
-by rewrite !eqe_oppLR lte_oppr lte_oppl oppe0 (orbC _ ((x == -oo) && _)).
+by rewrite !eqe_oppLR lteNr lteNl oppe0 (orbC _ ((x == -oo) && _)).
 Qed.
 
-Lemma lteN2 x y : (- x < - y) = (y < x).
-Proof. by rewrite lte_oppl oppeK. Qed.
+Lemma lteN2 x y : (- x < - y) = (y < x). Proof. by rewrite lteNl oppeK. Qed.
 
-Lemma lte_add a b x y : a < b -> x < y -> a + x < b + y.
+Lemma lteD a b x y : a < b -> x < y -> a + x < b + y.
 Proof.
 move: a b x y=> [a| |] [b| |] [x| |] [y| |]; rewrite ?(ltry,ltNyr)//.
 by rewrite !lte_fin; exact: ltrD.
 Qed.
 
-Lemma lee_addl x y : 0 <= y -> x <= x + y.
+Lemma leeDl x y : 0 <= y -> x <= x + y.
 Proof.
 move: x y => -[ x [y| |]//= | [| |]// | [| | ]//];
   by [rewrite !lee_fin lerDl | move=> _; exact: leey].
 Qed.
 
-Lemma lee_addr x y : 0 <= y -> x <= y + x.
-Proof. by rewrite addeC; exact: lee_addl. Qed.
+Lemma leeDr x y : 0 <= y -> x <= y + x.
+Proof. by rewrite addeC; exact: leeDl. Qed.
 
 Lemma gee_addl x y : y <= 0 -> x + y <= x.
 Proof.
@@ -1754,13 +1753,13 @@ Qed.
 Lemma gee_addr x y : y <= 0 -> y + x <= x.
 Proof. rewrite addeC; exact: gee_addl. Qed.
 
-Lemma lte_addl y x : y \is a fin_num -> (y < y + x) = (0 < x).
+Lemma lteDl y x : y \is a fin_num -> (y < y + x) = (0 < x).
 Proof.
 by move: x y => [x| |] [y| |] _ //; rewrite ?ltry ?ltNyr // !lte_fin ltrDl.
 Qed.
 
-Lemma lte_addr y x : y \is a fin_num -> (y < x + y) = (0 < x).
-Proof. rewrite addeC; exact: lte_addl. Qed.
+Lemma lteDr y x : y \is a fin_num -> (y < x + y) = (0 < x).
+Proof. rewrite addeC; exact: lteDl. Qed.
 
 Lemma gte_subl y x : y \is a fin_num -> (y - x < y) = (0 < x).
 Proof.
@@ -1779,13 +1778,13 @@ Qed.
 Lemma gte_addr x y : x \is a fin_num -> (y + x < x) = (y < 0).
 Proof. by rewrite addeC; exact: gte_addl. Qed.
 
-Lemma lte_add2lE x a b : x \is a fin_num -> (x + a < x + b) = (a < b).
+Lemma lteD2lE x a b : x \is a fin_num -> (x + a < x + b) = (a < b).
 Proof.
 move: a b x => [a| |] [b| |] [x| |] _ //; rewrite ?(ltry, ltNyr)//.
 by rewrite !lte_fin ltrD2l.
 Qed.
 
-Lemma lee_add2l x a b : a <= b -> x + a <= x + b.
+Lemma leeD2l x a b : a <= b -> x + a <= x + b.
 Proof.
 move: a b x => -[a [b [x /=|//|//] | []// |//] | []// | ].
 - by rewrite !lee_fin lerD2l.
@@ -1793,16 +1792,16 @@ move: a b x => -[a [b [x /=|//|//] | []// |//] | []// | ].
 - by move=> -[b [|  |]// | []// | //] r oob; exact: leNye.
 Qed.
 
-Lemma lee_add2lE x a b : x \is a fin_num -> (x + a <= x + b) = (a <= b).
+Lemma leeD2lE x a b : x \is a fin_num -> (x + a <= x + b) = (a <= b).
 Proof.
 move: a b x => [a| |] [b| |] [x| |] _ //; rewrite ?(leey, leNye)//.
 by rewrite !lee_fin lerD2l.
 Qed.
 
-Lemma lee_add2r x a b : a <= b -> a + x <= b + x.
-Proof. rewrite addeC (addeC b); exact: lee_add2l. Qed.
+Lemma leeD2r x a b : a <= b -> a + x <= b + x.
+Proof. rewrite addeC (addeC b); exact: leeD2l. Qed.
 
-Lemma lee_add a b x y : a <= b -> x <= y -> a + x <= b + y.
+Lemma leeD a b x y : a <= b -> x <= y -> a + x <= b + y.
 Proof.
 move: a b x y => [a| |] [b| |] [x| |] [y| |]; rewrite ?(leey, leNye)//.
 by rewrite !lee_fin; exact: lerD.
@@ -1817,7 +1816,7 @@ Qed.
 Lemma lee_lt_add a b x y : a \is a fin_num -> a <= x -> b < y -> a + b < x + y.
 Proof. by move=> afin xa yb; rewrite (addeC a) (addeC x) lte_le_add. Qed.
 
-Lemma lee_sub x y z u : x <= y -> u <= z -> x - z <= y - u.
+Lemma leeB x y z u : x <= y -> u <= z -> x - z <= y - u.
 Proof.
 move: x y z u => -[x| |] -[y| |] -[z| |] -[u| |] //=; rewrite ?(leey,leNye)//.
 by rewrite !lee_fin; exact: lerB.
@@ -1847,8 +1846,8 @@ Proof. by move=> zfin z0 x y; rewrite 2!(muleC z) lte_pmul2r. Qed.
 
 Lemma lte_nmul2l z : z \is a fin_num -> z < 0 -> {mono *%E z : x y /~ x < y}.
 Proof.
-rewrite -oppe0 lte_oppr => zfin z0 x y.
-by rewrite -(oppeK z) !mulNe lte_oppl oppeK -2!mulNe lte_pmul2l ?fin_numN.
+rewrite -oppe0 lteNr => zfin z0 x y.
+by rewrite -(oppeK z) !mulNe lteNl oppeK -2!mulNe lte_pmul2l ?fin_numN.
 Qed.
 
 Lemma lte_nmul2r z : z \is a fin_num -> z < 0 -> {mono *%E^~ z : x y /~ x < y}.
@@ -1869,7 +1868,7 @@ Proof. by move=> yfin y0; rewrite muleC lte_nmulr. Qed.
 Lemma lee_sum I (f g : I -> \bar R) s (P : pred I) :
   (forall i, P i -> f i <= g i) ->
   \sum_(i <- s | P i) f i <= \sum_(i <- s | P i) g i.
-Proof. by move=> Pfg; elim/big_ind2 : _ => // *; apply lee_add. Qed.
+Proof. by move=> Pfg; elim/big_ind2 : _ => // *; exact: leeD. Qed.
 
 Lemma lee_sum_nneg_subset I (s : seq I) (P Q : {pred I}) (f : I -> \bar R) :
   {subset Q <= P} -> {in [predD P & Q], forall i, 0 <= f i} ->
@@ -1891,7 +1890,7 @@ Lemma lee_sum_nneg (I : eqType) (s : seq I) (P Q : pred I)
   (f : I -> \bar R) : (forall i, P i -> ~~ Q i -> 0 <= f i) ->
   \sum_(i <- s | P i && Q i) f i <= \sum_(i <- s | P i) f i.
 Proof.
-move=> PQf; rewrite [leRHS](bigID Q) /= -[leLHS]adde0 lee_add //.
+move=> PQf; rewrite [leRHS](bigID Q) /= -[leLHS]adde0 leeD //.
 by rewrite sume_ge0// => i /andP[]; exact: PQf.
 Qed.
 
@@ -1899,7 +1898,7 @@ Lemma lee_sum_npos (I : eqType) (s : seq I) (P Q : pred I)
   (f : I -> \bar R) : (forall i, P i -> ~~ Q i -> f i <= 0) ->
   \sum_(i <- s | P i) f i <= \sum_(i <- s | P i && Q i) f i.
 Proof.
-move=> PQf; rewrite [leLHS](bigID Q) /= -[leRHS]adde0 lee_add //.
+move=> PQf; rewrite [leLHS](bigID Q) /= -[leRHS]adde0 leeD //.
 by rewrite sume_le0// => i /andP[]; exact: PQf.
 Qed.
 
@@ -1961,7 +1960,7 @@ Lemma lee_sum_nneg_subfset (T : choiceType) (A B : {fset T}%fset) (P : pred T)
   \sum_(t <- A | P t) f t <= \sum_(t <- B | P t) f t.
 Proof.
 move=> AB f0; rewrite [leRHS]big_mkcond (big_fsetID _ (mem A) B) /=.
-rewrite -[leLHS]adde0 lee_add //.
+rewrite -[leLHS]adde0 leeD //.
   rewrite -big_mkcond /= {1}(_ : A = [fset x in B | x \in A]%fset) //.
   by apply/fsetP=> t; rewrite !inE /= andbC; case: (boolP (_ \in _)) => // /AB.
 rewrite big_fset /= big_seq_cond sume_ge0 // => t /andP[tB tA].
@@ -1974,7 +1973,7 @@ Lemma lee_sum_npos_subfset (T : choiceType) (A B : {fset T}%fset) (P : pred T)
   \sum_(t <- B | P t) f t <= \sum_(t <- A | P t) f t.
 Proof.
 move=> AB f0; rewrite big_mkcond (big_fsetID _ (mem A) B) /=.
-rewrite -[leRHS]adde0 lee_add //.
+rewrite -[leRHS]adde0 leeD //.
   rewrite -big_mkcond /= {3}(_ : A = [fset x in B | x \in A]%fset) //.
   by apply/fsetP=> t; rewrite !inE /= andbC; case: (boolP (_ \in _)) => // /AB.
 rewrite big_fset /= big_seq_cond sume_le0 // => t /andP[tB tA].
@@ -2307,11 +2306,10 @@ Qed.
 Lemma eq_ninfty x : (forall r, x <= r%:E) -> x = -oo.
 Proof.
 move=> *; apply: (can_inj oppeK); apply: eq_infty => r.
-by rewrite lee_oppr -EFinN.
+by rewrite leeNr -EFinN.
 Qed.
 
-Lemma leeN2 x y : (- x <= - y) = (y <= x).
-Proof. by rewrite lee_oppl oppeK. Qed.
+Lemma leeN2 x y : (- x <= - y) = (y <= x). Proof. by rewrite leeNl oppeK. Qed.
 
 Lemma lee_abs x : x <= `|x|.
 Proof. by move: x => [x| |]//=; rewrite lee_fin ler_norm. Qed.
@@ -2338,7 +2336,7 @@ Lemma lee_abs_sum (I : Type) (s : seq I) (F : I -> \bar R) (P : pred I) :
   `|\sum_(i <- s | P i) F i| <= \sum_(i <- s | P i) `|F i|.
 Proof.
 elim/big_ind2 : _ => //; first by rewrite abse0.
-by move=> *; exact/(le_trans (lee_abs_add _ _) (lee_add _ _)).
+by move=> *; exact/(le_trans (lee_abs_add _ _) (leeD _ _)).
 Qed.
 
 Lemma lee_abs_sub x y : `|x - y| <= `|x| + `|y|.
@@ -2386,15 +2384,15 @@ Proof. by move=> a b /=; rewrite -fine_min. Qed.
 Lemma adde_maxl : left_distributive (@GRing.add (\bar R)) maxe.
 Proof.
 move=> x y z; have [xy|yx] := leP x y.
-by apply/esym/max_idPr; rewrite lee_add2r.
-by apply/esym/max_idPl; rewrite lee_add2r// ltW.
+  by apply/esym/max_idPr; rewrite leeD2r.
+by apply/esym/max_idPl; rewrite leeD2r// ltW.
 Qed.
 
 Lemma adde_maxr : right_distributive (@GRing.add (\bar R)) maxe.
 Proof.
 move=> x y z; have [yz|zy] := leP y z.
-by apply/esym/max_idPr; rewrite lee_add2l.
-by apply/esym/max_idPl; rewrite lee_add2l// ltW.
+  by apply/esym/max_idPr; rewrite leeD2l.
+by apply/esym/max_idPl; rewrite leeD2l// ltW.
 Qed.
 
 Lemma maxye : left_zero (+oo : \bar R) maxe.
@@ -2596,7 +2594,7 @@ by case: x => [x||]; rewrite /= ?mulyy ?mulNyNy ?le0y//; apply: sqr_ge0.
 Qed.
 
 Lemma lee_paddl y x z : 0 <= x -> y <= z -> y <= x + z.
-Proof. by move=> *; rewrite -[y]add0e lee_add. Qed.
+Proof. by move=> *; rewrite -[y]add0e leeD. Qed.
 
 Lemma lte_paddl y x z : 0 <= x -> y < z -> y < x + z.
 Proof. by move=> x0 /lt_le_trans; apply; rewrite lee_paddl. Qed.
@@ -2634,6 +2632,36 @@ Notation lte_spaddr := lte_spaddre (only parsing).
 Notation lee_opp := leeN2 (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.5", note="Use lteN2 instead.")]
 Notation lte_opp := lteN2 (only parsing).
+#[deprecated(since="mathcomp-analysis 1.0.1", note="Use leeDl instead.")]
+Notation lee_addl := leeDl (only parsing).
+#[deprecated(since="mathcomp-analysis 1.0.1", note="Use leeDr instead.")]
+Notation lee_addr := leeDr (only parsing).
+#[deprecated(since="mathcomp-analysis 1.0.1", note="Use leeD2l instead.")]
+Notation lee_add2l := leeD2l (only parsing).
+#[deprecated(since="mathcomp-analysis 1.0.1", note="Use leeD2r instead.")]
+Notation lee_add2r := leeD2r (only parsing).
+#[deprecated(since="mathcomp-analysis 1.0.1", note="Use leeD instead.")]
+Notation lee_add := leeD (only parsing).
+#[deprecated(since="mathcomp-analysis 1.0.1", note="Use leeB instead.")]
+Notation lee_sub := leeB (only parsing).
+#[deprecated(since="mathcomp-analysis 1.0.1", note="Use leeD2lE instead.")]
+Notation lee_add2lE := leeD2lE (only parsing).
+#[deprecated(since="mathcomp-analysis 1.0.1", note="Use leeNl instead.")]
+Notation lee_oppl := leeNl (only parsing).
+#[deprecated(since="mathcomp-analysis 1.0.1", note="Use leeNr instead.")]
+Notation lee_oppr := leeNr (only parsing).
+#[deprecated(since="mathcomp-analysis 1.0.1", note="Use lteNl instead.")]
+Notation lte_oppl := lteNl (only parsing).
+#[deprecated(since="mathcomp-analysis 1.0.1", note="Use lteNr instead.")]
+Notation lte_oppr := lteNr (only parsing).
+#[deprecated(since="mathcomp-analysis 1.0.1", note="Use lteD instead.")]
+Notation lte_add := lteD (only parsing).
+#[deprecated(since="mathcomp-analysis 1.0.1", note="Use lteD2lE instead.")]
+Notation lte_add2lE := lteD2lE (only parsing).
+#[deprecated(since="mathcomp-analysis 1.0.1", note="Use lteDl instead.")]
+Notation lte_addl := lteDl (only parsing).
+#[deprecated(since="mathcomp-analysis 1.0.1", note="Use lteDr instead.")]
+Notation lte_addr := lteDr (only parsing).
 
 Module DualAddTheoryRealDomain.
 
@@ -2667,54 +2695,54 @@ Lemma dsube_le0 x y : (x \is a fin_num) || (y \is a fin_num) ->
 Proof. by move=> /orP[?|?]; [rewrite dsuber_le0|rewrite dsubre_le0]. Qed.
 
 Lemma lte_dadd a b x y : a < b -> x < y -> a + x < b + y.
-Proof. rewrite !dual_addeE lteN2 -lteN2 -(lteN2 y); exact: lte_add. Qed.
+Proof. rewrite !dual_addeE lteN2 -lteN2 -(lteN2 y); exact: lteD. Qed.
 
 Lemma lee_daddl x y : 0 <= y -> x <= x + y.
-Proof. rewrite dual_addeE lee_oppr -oppe_le0; exact: gee_addl. Qed.
+Proof. rewrite dual_addeE leeNr -oppe_le0; exact: gee_addl. Qed.
 
 Lemma lee_daddr x y : 0 <= y -> x <= y + x.
-Proof. rewrite dual_addeE lee_oppr -oppe_le0; exact: gee_addr. Qed.
+Proof. rewrite dual_addeE leeNr -oppe_le0; exact: gee_addr. Qed.
 
 Lemma gee_daddl x y : y <= 0 -> x + y <= x.
-Proof. rewrite dual_addeE lee_oppl -oppe_ge0; exact: lee_addl. Qed.
+Proof. rewrite dual_addeE leeNl -oppe_ge0; exact: leeDl. Qed.
 
 Lemma gee_daddr x y : y <= 0 -> y + x <= x.
-Proof. rewrite dual_addeE lee_oppl -oppe_ge0; exact: lee_addr. Qed.
+Proof. rewrite dual_addeE leeNl -oppe_ge0; exact: leeDr. Qed.
 
 Lemma lte_daddl y x : y \is a fin_num -> (y < y + x) = (0 < x).
-Proof. by rewrite -fin_numN dual_addeE lte_oppr; exact: gte_subl. Qed.
+Proof. by rewrite -fin_numN dual_addeE lteNr; exact: gte_subl. Qed.
 
 Lemma lte_daddr y x : y \is a fin_num -> (y < x + y) = (0 < x).
-Proof. by rewrite -fin_numN dual_addeE lte_oppr addeC; exact: gte_subl. Qed.
+Proof. by rewrite -fin_numN dual_addeE lteNr addeC; exact: gte_subl. Qed.
 
 Lemma gte_dsubl y x : y \is a fin_num -> (y - x < y) = (0 < x).
-Proof. by rewrite -fin_numN dual_addeE lte_oppl oppeK; exact: lte_addl. Qed.
+Proof. by rewrite -fin_numN dual_addeE lteNl oppeK; exact: lteDl. Qed.
 
 Lemma gte_dsubr y x : y \is a fin_num -> (- x + y < y) = (0 < x).
-Proof. by rewrite -fin_numN dual_addeE lte_oppl oppeK; exact: lte_addr. Qed.
+Proof. by rewrite -fin_numN dual_addeE lteNl oppeK; exact: lteDr. Qed.
 
 Lemma gte_daddl x y : x \is a fin_num -> (x + y < x) = (y < 0).
 Proof.
-by rewrite -fin_numN dual_addeE lte_oppl -[0]oppe0 lte_oppr; exact: lte_addl.
+by rewrite -fin_numN dual_addeE lteNl -[0]oppe0 lteNr; exact: lteDl.
 Qed.
 
 Lemma gte_daddr x y : x \is a fin_num -> (y + x < x) = (y < 0).
 Proof. by rewrite daddeC; exact: gte_daddl. Qed.
 
 Lemma lte_dadd2lE x a b : x \is a fin_num -> (x + a < x + b) = (a < b).
-Proof. by move=> ?; rewrite !dual_addeE lteN2 lte_add2lE ?fin_numN// lteN2. Qed.
+Proof. by move=> ?; rewrite !dual_addeE lteN2 lteD2lE ?fin_numN// lteN2. Qed.
 
 Lemma lee_dadd2l x a b : a <= b -> x + a <= x + b.
-Proof. rewrite !dual_addeE leeN2 -leeN2; exact: lee_add2l. Qed.
+Proof. rewrite !dual_addeE leeN2 -leeN2; exact: leeD2l. Qed.
 
 Lemma lee_dadd2lE x a b : x \is a fin_num -> (x + a <= x + b) = (a <= b).
-Proof. by move=> ?; rewrite !dual_addeE leeN2 lee_add2lE ?fin_numN// leeN2. Qed.
+Proof. by move=> ?; rewrite !dual_addeE leeN2 leeD2lE ?fin_numN// leeN2. Qed.
 
 Lemma lee_dadd2r x a b : a <= b -> a + x <= b + x.
-Proof. rewrite !dual_addeE leeN2 -leeN2; exact: lee_add2r. Qed.
+Proof. rewrite !dual_addeE leeN2 -leeN2; exact: leeD2r. Qed.
 
 Lemma lee_dadd a b x y : a <= b -> x <= y -> a + x <= b + y.
-Proof. rewrite !dual_addeE leeN2 -leeN2 -(leeN2 y); exact: lee_add. Qed.
+Proof. rewrite !dual_addeE leeN2 -leeN2 -(leeN2 y); exact: leeD. Qed.
 
 Lemma lte_le_dadd a b x y : b \is a fin_num -> a < x -> b <= y -> a + b < x + y.
 Proof. rewrite !dual_addeE lteN2 -lteN2; exact: lte_le_sub. Qed.
@@ -2723,7 +2751,7 @@ Lemma lee_lt_dadd a b x y : a \is a fin_num -> a <= x -> b < y -> a + b < x + y.
 Proof. by move=> afin xa yb; rewrite (daddeC a) (daddeC x) lte_le_dadd. Qed.
 
 Lemma lee_dsub x y z t : x <= y -> t <= z -> x - z <= y - t.
-Proof. rewrite !dual_addeE lee_oppl oppeK -leeN2 !oppeK; exact: lee_add. Qed.
+Proof. rewrite !dual_addeE leeNl oppeK -leeN2 !oppeK; exact: leeD. Qed.
 
 Lemma lte_le_dsub z u x y : u \is a fin_num -> x < z -> u <= y -> x - y < z - u.
 Proof. by rewrite !dual_addeE lteN2 !oppeK -lteN2; exact: lte_le_add. Qed.
@@ -2838,82 +2866,82 @@ Qed.
 
 Lemma lte_dsubl_addr x y z : y \is a fin_num -> (x - y < z) = (x < z + y).
 Proof.
-by move=> ?; rewrite !dual_addeE lte_oppl lte_oppr oppeK lte_subl_addr.
+by move=> ?; rewrite !dual_addeE lteNl lteNr oppeK lte_subl_addr.
 Qed.
 
 Lemma lte_dsubl_addl x y z : y \is a fin_num -> (x - y < z) = (x < y + z).
 Proof.
-by move=> ?; rewrite !dual_addeE lte_oppl lte_oppr lte_subr_addl ?fin_numN.
+by move=> ?; rewrite !dual_addeE lteNl lteNr lte_subr_addl ?fin_numN.
 Qed.
 
 Lemma lte_dsubr_addr x y z : z \is a fin_num -> (x < y - z) = (x + z < y).
 Proof.
-by move=> ?; rewrite !dual_addeE lte_oppl lte_oppr lte_subl_addr ?fin_numN.
+by move=> ?; rewrite !dual_addeE lteNl lteNr lte_subl_addr ?fin_numN.
 Qed.
 
 Lemma lte_dsubr_addl x y z : z \is a fin_num -> (x < y - z) = (z + x < y).
 Proof.
-by move=> ?; rewrite !dual_addeE lte_oppl lte_oppr lte_subl_addl ?fin_numN.
+by move=> ?; rewrite !dual_addeE lteNl lteNr lte_subl_addl ?fin_numN.
 Qed.
 
 Lemma lte_dsuber_addr x y z : y \is a fin_num -> (x < y - z) = (x + z < y).
 Proof.
-by move=> ?; rewrite !dual_addeE lte_oppl lte_oppr lte_subel_addr ?fin_numN.
+by move=> ?; rewrite !dual_addeE lteNl lteNr lte_subel_addr ?fin_numN.
 Qed.
 
 Lemma lte_dsuber_addl x y z : y \is a fin_num -> (x < y - z) = (z + x < y).
 Proof.
-by move=> ?; rewrite !dual_addeE lte_oppl lte_oppr lte_subel_addl ?fin_numN.
+by move=> ?; rewrite !dual_addeE lteNl lteNr lte_subel_addl ?fin_numN.
 Qed.
 
 Lemma lte_dsubel_addr x y z : z \is a fin_num -> (x - y < z) = (x < z + y).
 Proof.
-by move=> ?; rewrite !dual_addeE lte_oppl lte_oppr lte_suber_addr ?fin_numN.
+by move=> ?; rewrite !dual_addeE lteNl lteNr lte_suber_addr ?fin_numN.
 Qed.
 
 Lemma lte_dsubel_addl x y z : z \is a fin_num -> (x - y < z) = (x < y + z).
 Proof.
-by move=> ?; rewrite !dual_addeE lte_oppl lte_oppr lte_suber_addl ?fin_numN.
+by move=> ?; rewrite !dual_addeE lteNl lteNr lte_suber_addl ?fin_numN.
 Qed.
 
 Lemma lee_dsubl_addr x y z : y \is a fin_num -> (x - y <= z) = (x <= z + y).
 Proof.
-by move=> ?; rewrite !dual_addeE lee_oppl lee_oppr lee_subr_addr ?fin_numN.
+by move=> ?; rewrite !dual_addeE leeNl leeNr lee_subr_addr ?fin_numN.
 Qed.
 
 Lemma lee_dsubl_addl x y z : y \is a fin_num -> (x - y <= z) = (x <= y + z).
 Proof.
-by move=> ?; rewrite !dual_addeE lee_oppl lee_oppr lee_subr_addl ?fin_numN.
+by move=> ?; rewrite !dual_addeE leeNl leeNr lee_subr_addl ?fin_numN.
 Qed.
 
 Lemma lee_dsubr_addr x y z : z \is a fin_num -> (x <= y - z) = (x + z <= y).
 Proof.
-by move=> ?; rewrite !dual_addeE lee_oppl lee_oppr lee_subl_addr ?fin_numN.
+by move=> ?; rewrite !dual_addeE leeNl leeNr lee_subl_addr ?fin_numN.
 Qed.
 
 Lemma lee_dsubr_addl x y z : z \is a fin_num -> (x <= y - z) = (z + x <= y).
 Proof.
-by move=> ?; rewrite !dual_addeE lee_oppl lee_oppr lee_subl_addl ?fin_numN.
+by move=> ?; rewrite !dual_addeE leeNl leeNr lee_subl_addl ?fin_numN.
 Qed.
 
 Lemma lee_dsubel_addr x y z : x \is a fin_num -> (x - y <= z) = (x <= z + y).
 Proof.
-by move=> ?; rewrite !dual_addeE lee_oppl lee_oppr lee_suber_addr ?fin_numN.
+by move=> ?; rewrite !dual_addeE leeNl leeNr lee_suber_addr ?fin_numN.
 Qed.
 
 Lemma lee_dsubel_addl x y z : x \is a fin_num -> (x - y <= z) = (x <= y + z).
 Proof.
-by move=> ?; rewrite !dual_addeE lee_oppl lee_oppr lee_suber_addl ?fin_numN.
+by move=> ?; rewrite !dual_addeE leeNl leeNr lee_suber_addl ?fin_numN.
 Qed.
 
 Lemma lee_dsuber_addr x y z : x \is a fin_num -> (x <= y - z) = (x + z <= y).
 Proof.
-by move=> ?; rewrite !dual_addeE lee_oppl lee_oppr lee_subel_addr ?fin_numN.
+by move=> ?; rewrite !dual_addeE leeNl leeNr lee_subel_addr ?fin_numN.
 Qed.
 
 Lemma lee_dsuber_addl x y z : x \is a fin_num -> (x <= y - z) = (z + x <= y).
 Proof.
-by move=> ?; rewrite !dual_addeE lee_oppl lee_oppr lee_subel_addl ?fin_numN.
+by move=> ?; rewrite !dual_addeE leeNl leeNr lee_subel_addl ?fin_numN.
 Qed.
 
 Lemma dsuber_gt0 x y : x \is a fin_num -> (0 < y - x) = (x < y).
@@ -3142,7 +3170,7 @@ Proof. by move=> r0; rewrite muleC lte_pdivl_mull// muleC. Qed.
 Lemma lte_ndivl_mulr r x y : (r < 0)%R -> (x < y * r^-1%:E) = (y < x * r%:E).
 Proof.
 rewrite -oppr0 ltrNr => r0; rewrite -{1}(opprK r) invrN.
-by rewrite EFinN muleN lte_oppr lte_pdivr_mulr// EFinN muleNN.
+by rewrite EFinN muleN lteNr lte_pdivr_mulr// EFinN muleNN.
 Qed.
 
 Lemma lte_ndivl_mull r x y : (r < 0)%R -> (x < r^-1%:E * y) = (y < r%:E * x).
@@ -3151,7 +3179,7 @@ Proof. by move=> r0; rewrite muleC lte_ndivl_mulr// muleC. Qed.
 Lemma lte_ndivr_mull r x y : (r < 0)%R -> (r^-1%:E * y < x) = (r%:E * x < y).
 Proof.
 rewrite -oppr0 ltrNr => r0; rewrite -{1}(opprK r) invrN.
-by rewrite EFinN mulNe lte_oppl lte_pdivl_mull// EFinN muleNN.
+by rewrite EFinN mulNe lteNl lte_pdivl_mull// EFinN muleNN.
 Qed.
 
 Lemma lte_ndivr_mulr r x y : (r < 0)%R -> (y * r^-1%:E < x) = (x * r%:E < y).
@@ -3184,7 +3212,7 @@ Proof. by move=> r0; rewrite muleC lee_pdivl_mull// muleC. Qed.
 Lemma lee_ndivl_mulr r x y : (r < 0)%R -> (x <= y * r^-1%:E) = (y <= x * r%:E).
 Proof.
 rewrite -oppr0 ltrNr => r0; rewrite -{1}(opprK r) invrN.
-by rewrite EFinN muleN lee_oppr lee_pdivr_mulr// EFinN muleNN.
+by rewrite EFinN muleN leeNr lee_pdivr_mulr// EFinN muleNN.
 Qed.
 
 Lemma lee_ndivl_mull r x y : (r < 0)%R -> (x <= r^-1%:E * y) = (y <= r%:E * x).
@@ -3193,7 +3221,7 @@ Proof. by move=> r0; rewrite muleC lee_ndivl_mulr// muleC. Qed.
 Lemma lee_ndivr_mull r x y : (r < 0)%R -> (r^-1%:E * y <= x) = (r%:E * x <= y).
 Proof.
 rewrite -oppr0 ltrNr => r0; rewrite -{1}(opprK r) invrN.
-by rewrite EFinN mulNe lee_oppl lee_pdivl_mull// EFinN muleNN.
+by rewrite EFinN mulNe leeNl lee_pdivl_mull// EFinN muleNN.
 Qed.
 
 Lemma lee_ndivr_mulr r x y : (r < 0)%R -> (y * r^-1%:E <= x) = (x * r%:E <= y).

--- a/theories/ereal.v
+++ b/theories/ereal.v
@@ -422,8 +422,8 @@ Qed.
 
 Lemma lb_ereal_inf S M : lbound S M -> M <= ereal_inf S.
 Proof.
-move=> SM; rewrite /ereal_inf lee_oppr; apply ub_ereal_sup => x [y Sy <-{x}].
-by rewrite lee_oppl oppeK; apply SM.
+move=> SM; rewrite /ereal_inf leeNr; apply ub_ereal_sup => x [y Sy <-{x}].
+by rewrite leeNl oppeK; apply SM.
 Qed.
 
 Lemma ub_ereal_sup_adherent S (e : R) : (0 < e)%R ->
@@ -431,7 +431,7 @@ Lemma ub_ereal_sup_adherent S (e : R) : (0 < e)%R ->
 Proof.
 move=> e0 Sr; have : ~ ubound S (ereal_sup S - e%:E).
   move/ub_ereal_sup; apply/negP.
-  by rewrite -ltNge lte_subl_addr // lte_addl // lte_fin.
+  by rewrite -ltNge lte_subl_addr // lteDl // lte_fin.
 move/asboolP; rewrite asbool_neg; case/existsp_asboolPn => /= x.
 by rewrite not_implyE => -[? ?]; exists x => //; rewrite ltNge; apply/negP.
 Qed.
@@ -440,7 +440,7 @@ Lemma lb_ereal_inf_adherent S (e : R) : (0 < e)%R ->
   ereal_inf S \is a fin_num -> exists2 x, S x & (x < ereal_inf S + e%:E).
 Proof.
 move=> e0; rewrite fin_numN => /(ub_ereal_sup_adherent e0)[x []].
-move=> y Sy <-; rewrite -lte_oppr => /lt_le_trans ex; exists y => //.
+move=> y Sy <-; rewrite -lteNr => /lt_le_trans ex; exists y => //.
 by apply: ex; rewrite fin_num_oppeD// oppeK.
 Qed.
 
@@ -452,8 +452,8 @@ Qed.
 
 Lemma ereal_inf_lt S x : ereal_inf S < x -> exists2 y, S y & y < x.
 Proof.
-rewrite lte_oppl => /ereal_sup_gt[_ [y Sy <-]].
-by rewrite lte_oppl oppeK => xlty; exists y.
+rewrite lteNl => /ereal_sup_gt[_ [y Sy <-]].
+by rewrite lteNl oppeK => xlty; exists y.
 Qed.
 
 End ereal_supremum.
@@ -528,7 +528,7 @@ Qed.
 
 Lemma ereal_inf_lb S : lbound S (ereal_inf S).
 Proof.
-by move=> x Sx; rewrite /ereal_inf lee_oppl; apply ereal_sup_ub; exists x.
+by move=> x Sx; rewrite /ereal_inf leeNl; apply ereal_sup_ub; exists x.
 Qed.
 
 Lemma ereal_inf_le S x : (exists2 y, S y & y <= x) -> ereal_inf S <= x.
@@ -838,19 +838,19 @@ case: x => [r /=| |].
 - rewrite predeqE => S; split=> [[M [Mreal MS]]|[x [M [Mreal Mx]] <-]].
     exists (-%E @` S).
       exists (- M)%R; rewrite realN Mreal; split => // x Mx.
-      by exists (- x); [apply MS; rewrite lte_oppl | rewrite oppeK].
+      by exists (- x); [apply MS; rewrite lteNl | rewrite oppeK].
     rewrite predeqE => x; split=> [[y [z Sz <- <-]]|Sx]; first by rewrite oppeK.
     by exists (- x); [exists x | rewrite oppeK].
   exists (- M)%R; rewrite realN; split => // y yM.
-  exists (- y); by [apply Mx; rewrite lte_oppr|rewrite oppeK].
+  exists (- y); by [apply Mx; rewrite lteNr|rewrite oppeK].
 - rewrite predeqE => S; split=> [[M [Mreal MS]]|[x [M [Mreal Mx]] <-]].
     exists (-%E @` S).
       exists (- M)%R; rewrite realN Mreal; split => // x Mx.
-      by exists (- x); [apply MS; rewrite lte_oppr | rewrite oppeK].
+      by exists (- x); [apply MS; rewrite lteNr | rewrite oppeK].
     rewrite predeqE => x; split=> [[y [z Sz <- <-]]|Sx]; first by rewrite oppeK.
     by exists (- x); [exists x | rewrite oppeK].
   exists (- M)%R; rewrite realN; split => // y yM.
-  exists (- y); by [apply Mx; rewrite lte_oppl|rewrite oppeK].
+  exists (- y); by [apply Mx; rewrite lteNl|rewrite oppeK].
 Qed.
 
 Lemma nbhsNKe (R : realFieldType) (z : \bar R) (A : set (\bar R)) :

--- a/theories/esum.v
+++ b/theories/esum.v
@@ -134,14 +134,14 @@ Lemma esumD [R : realType] [T : choiceType] (I : set T) (a b : T -> \bar R) :
 Proof.
 move=> ag0 bg0; apply/eqP; rewrite eq_le; apply/andP; split.
   rewrite ub_ereal_sup//= => x [X [finX XI]] <-; rewrite fsbig_split//=.
-  by rewrite lee_add// ereal_sup_ub//=; exists X.
+  by rewrite leeD// ereal_sup_ub//=; exists X.
 wlog : a b ag0 bg0 / \esum_(i in I) a i \isn't a fin_num => [saoo|]; last first.
   move=> /fin_numPn[->|/[dup] aoo ->]; first by rewrite leNye.
   rewrite (@le_trans _ _ +oo)//; first by rewrite /adde/=; case: esum.
   rewrite leye_eq; apply/eqP/eq_infty => y; rewrite esum_ge//.
   have : y%:E < \esum_(i in I) a i by rewrite aoo// ltry.
   move=> /ereal_sup_gt[_ [X [finX XI]] <-] /ltW yle; exists X => //=.
-  rewrite (le_trans yle)// fsbig_split// lee_addl// fsume_ge0// => // i.
+  rewrite (le_trans yle)// fsbig_split// leeDl// fsume_ge0// => // i.
   by move=> /XI; exact: bg0.
 case: (boolP (\esum_(i in I) a i \is a fin_num)) => sa; last exact: saoo.
 case: (boolP (\esum_(i in I) b i \is a fin_num)) => sb; last first.
@@ -156,7 +156,7 @@ have saX : \sum_(i \in X) a i \is a fin_num.
 rewrite lee_subr_addr// addeC -lee_subr_addr// ub_ereal_sup//= => _ [Y [finY YI]] <-.
 rewrite lee_subr_addr// addeC esum_ge//; exists (X `|` Y).
   by split; [rewrite finite_setU|rewrite subUset].
-rewrite fsbig_split ?finite_setU//= lee_add// lee_fsum_nneg_subset//= ?finite_setU//.
+rewrite fsbig_split ?finite_setU//= leeD// lee_fsum_nneg_subset//= ?finite_setU//.
 - exact/subsetP/subsetUl.
 - by move=> x; rewrite !inE in_setU andb_orr andNb/= => /andP[_] /[!inE] /YI/ag0.
 - exact/subsetP/subsetUr.
@@ -250,7 +250,7 @@ apply: (@le_trans _ _
   rewrite (_ : [fset x | x in Y & x \in X] = Y `&` fset_set X)%fset; last first.
     by apply/fsetP => x; rewrite 2!inE/= in_fset_set.
   rewrite (fsetIidPr _).
-    rewrite fsbig_finite// lee_addl// big_seq sume_ge0//=.
+    rewrite fsbig_finite// leeDl// big_seq sume_ge0//=.
     move=> [x y] /imfsetP[[x1 y1]] /[!inE] /andP[] /imfset2P[x2]/= /[!inE].
     rewrite andbT in_fset_set//; last exact: finite_set_fst.
     move=> /[!inE] x2X [y2] /[!inE] /andP[] /[!in_fset_set]; last first.
@@ -281,7 +281,7 @@ Lemma lee_sum_fset_nat (R : realDomainType)
 Proof.
 move=> f0 Fn; rewrite [leRHS](bigID (mem F))/=.
 suff -> : \sum_(0 <= i < n | P i && (i \in F)) f i = \sum_(i <- F | P i) f i.
-  by rewrite lee_addl ?sume_ge0// => i /andP[/f0].
+  by rewrite leeDl ?sume_ge0// => i /andP[/f0].
 rewrite -big_filter -[RHS]big_filter; apply: perm_big.
 rewrite uniq_perm ?filter_uniq ?index_iota ?iota_uniq ?fset_uniq//.
 move=> i; rewrite ?mem_filter.
@@ -462,7 +462,7 @@ Implicit Types (D : set T) (f : T -> \bar R).
 Lemma summable_pinfty D f : summable D f -> forall x, D x -> `| f x | < +oo.
 Proof.
 move=> Dfoo x Dx; apply: le_lt_trans Dfoo.
-rewrite (esumID [set x])// setI1 mem_set// esum_set1// lee_addl//.
+rewrite (esumID [set x])// setI1 mem_set// esum_set1// leeDl//.
 exact: esum_ge0.
 Qed.
 
@@ -489,13 +489,13 @@ Proof. by move=> Df; rewrite summableN; exact: summableD. Qed.
 Lemma summable_funepos D f : summable D f -> summable D f^\+.
 Proof.
 apply: le_lt_trans; apply le_esum => t Dt.
-by rewrite -/((abse \o f) t) fune_abse gee0_abs// lee_addl.
+by rewrite -/((abse \o f) t) fune_abse gee0_abs// leeDl.
 Qed.
 
 Lemma summable_funeneg D f : summable D f -> summable D f^\-.
 Proof.
 apply: le_lt_trans; apply le_esum => t Dt.
-by rewrite -/((abse \o f) t) fune_abse gee0_abs// lee_addr.
+by rewrite -/((abse \o f) t) fune_abse gee0_abs// leeDr.
 Qed.
 
 End summable_lemmas.
@@ -620,9 +620,9 @@ have /eqP : esum D (f \- g)^\+ + esum_posneg D g = esum D (f \- g)^\- + esum_pos
     by move=> t Dt; rewrite le_maxr lexx orbT.
     by move=> t Dt; rewrite le_maxr lexx orbT.
   apply eq_esum => i Di; have [fg|fg] := leP 0 (f i - g i).
-    rewrite max_r 1?lee_oppl ?oppe0// add0e subeK//.
+    rewrite max_r 1?leeNl ?oppe0// add0e subeK//.
     by rewrite fin_num_abs (summable_pinfty Dg).
-  rewrite add0e max_l; last by rewrite lee_oppr oppe0 ltW.
+  rewrite add0e max_l; last by rewrite leeNr oppe0 ltW.
   rewrite fin_num_oppeB//; last by rewrite fin_num_abs (summable_pinfty Dg).
   by rewrite -addeA addeCA addeA subeK// fin_num_abs (summable_pinfty Df).
 rewrite [X in _ == X -> _]addeC -sube_eq; last 2 first.

--- a/theories/hoelder.v
+++ b/theories/hoelder.v
@@ -467,7 +467,7 @@ rewrite [leRHS](_ : _ = ('N_p%:E[f] + 'N_p%:E[g]) *
     - rewrite fin_num_poweR// -powR_Lnorm ?gt_eqF// fin_num_poweR//.
       by rewrite ge0_fin_numE ?Lnorm_ge0.
     - by rewrite ge0_adde_def// inE Lnorm_ge0.
-  apply: lee_add.
+  apply: leeD.
   - pose h := (@powR R ^~ (p - 1) \o normr \o (f \+ g))%R; pose i := (f \* h)%R.
     rewrite [leLHS](_ : _ = 'N_1[i]%R); last first.
       rewrite Lnorm1; apply: eq_integral => x _.

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -840,7 +840,7 @@ Proof. by split=> x; rewrite subr_ge0 fg. Qed.
 Lemma le_sintegral : (sintegral m f <= sintegral m g)%E.
 Proof.
 have gfgf : g =1 f \+ (g \- f) by move=> x /=; rewrite addrC subrK.
-by rewrite (eq_sintegral _ _ gfgf) sintegralD// lee_addl // sintegral_ge0.
+by rewrite (eq_sintegral _ _ gfgf) sintegralD// leeDl // sintegral_ge0.
 Qed.
 
 End le_sintegral.
@@ -1215,7 +1215,7 @@ rewrite le_eqVlt => /predU1P[|] mufoo; last first.
   have : forall x, cvgn (g^~ x) -> (G x <= limn (g ^~ x))%R.
     move=> x cg; rewrite -lee_fin -(EFin_lim cg).
     by have /cvg_lim gxfx := @gf x; rewrite (le_trans (Gf _))// gxfx.
-  move=> /(nd_sintegral_lim_lemma mu nd_g)/(lee_add2r e%:num%:E).
+  move=> /(nd_sintegral_lim_lemma mu nd_g)/(leeD2r e%:num%:E).
   by apply: le_trans; exact: ltW.
 suff : limn (sintegral mu \o g) = +oo.
   by move=> ->; rewrite -ge0_integralTE// mufoo.
@@ -1873,7 +1873,7 @@ have -> : A `\` D = (A `\` K) `|` (K `\` D).
 apply: le_lt_trans.
   apply: measureU2; apply: measurableD => //; apply: closed_measurable.
   by apply: compact_closed; first exact: Rhausdorff.
-by rewrite [_ eps]splitr EFinD lte_add.
+by rewrite [_ eps]splitr EFinD lteD.
 Qed.
 
 End lusin.
@@ -2853,7 +2853,7 @@ apply/eqP; rewrite eq_le; apply/andP; split; last first.
       by rewrite measure_addE; exact: nneseries_split.
     rewrite integral_measure_add//; congr (_ + _).
     by rewrite -ge0_integral_measure_sum.
-  by apply: lee_addl; exact: integral_ge0.
+  by apply: leeDl; exact: integral_ge0.
 rewrite ge0_integralE//=; apply: ub_ereal_sup => /= _ [g /= gf] <-.
 rewrite -integralT_nnsfun (integral_measure_series_nnsfun _ mD).
 apply: lee_nneseries => n _.
@@ -2906,7 +2906,7 @@ move=> mf f0 AB; rewrite -(setDUK AB) integral_setU//; last 4 first.
   - by rewrite setDUK.
   - by move=> x; rewrite setDUK//; exact: f0.
   - by rewrite disj_set2E setDIK.
-by apply: lee_addl; apply: integral_ge0 => x [Bx _]; exact: f0.
+by apply: leeDl; apply: integral_ge0 => x [Bx _]; exact: f0.
 Qed.
 
 Lemma integral_set0 (f : T -> \bar R) : \int[mu]_(x in set0) f x = 0.
@@ -3071,8 +3071,8 @@ rewrite ge0_integralD // in foo; last 2 first.
 - exact: measurable_funepos.
 - exact: measurable_funeneg.
 apply: ltpinfty_adde_def.
-- by apply: le_lt_trans foo; rewrite lee_addl// integral_ge0.
-- by rewrite inE (@le_lt_trans _ _ 0)// lee_oppl oppe0 integral_ge0.
+- by apply: le_lt_trans foo; rewrite leeDl// integral_ge0.
+- by rewrite inE (@le_lt_trans _ _ 0)// leeNl oppe0 integral_ge0.
 Qed.
 
 Lemma integrable_funepos f : mu_int f -> mu_int f^\+.
@@ -3082,7 +3082,7 @@ move=> /integrableP[Df foo]; apply/integrableP; split.
 apply: le_lt_trans foo; apply: ge0_le_integral => //.
 - by apply/measurableT_comp => //; exact: measurable_funepos.
 - exact/measurableT_comp.
-- by move=> t Dt; rewrite -/((abse \o f) t) fune_abse gee0_abs// lee_addl.
+- by move=> t Dt; rewrite -/((abse \o f) t) fune_abse gee0_abs// leeDl.
 Qed.
 
 Lemma integrable_funeneg f : mu_int f -> mu_int f^\-.
@@ -3092,7 +3092,7 @@ move=> /integrableP[Df foo]; apply/integrableP; split.
 apply: le_lt_trans foo; apply: ge0_le_integral => //.
 - by apply/measurableT_comp => //; exact: measurable_funeneg.
 - exact/measurableT_comp.
-- by move=> t Dt; rewrite -/((abse \o f) t) fune_abse gee0_abs// lee_addr.
+- by move=> t Dt; rewrite -/((abse \o f) t) fune_abse gee0_abs// leeDr.
 Qed.
 
 Lemma integral_funeneg_lt_pinfty f : mu_int f ->
@@ -3103,9 +3103,9 @@ move=> /integrableP[mf]; apply: le_lt_trans; apply: ge0_le_integral => //.
 - exact: measurableT_comp.
 - move=> x Dx; have [fx0|/ltW fx0] := leP (f x) 0.
     rewrite lee0_abs// /funeneg.
-    by move: fx0; rewrite -{1}oppe0 -lee_oppr => /max_idPl ->.
+    by move: fx0; rewrite -{1}oppe0 -leeNr => /max_idPl ->.
   rewrite gee0_abs// /funeneg.
-  by move: (fx0); rewrite -{1}oppe0 -lee_oppl => /max_idPr ->.
+  by move: (fx0); rewrite -{1}oppe0 -leeNl => /max_idPr ->.
 Qed.
 
 Lemma integral_funepos_lt_pinfty f : mu_int f ->
@@ -3116,7 +3116,7 @@ move=> /integrableP[mf]; apply: le_lt_trans; apply: ge0_le_integral => //.
 - exact: measurableT_comp.
 - move=> x Dx; have [fx0|/ltW fx0] := leP (f x) 0.
     rewrite lee0_abs// /funepos.
-    by move: (fx0) => /max_idPr ->; rewrite -lee_oppr oppe0.
+    by move: (fx0) => /max_idPr ->; rewrite -leeNr oppe0.
   by rewrite gee0_abs// /funepos; move: (fx0) => /max_idPl ->.
 Qed.
 
@@ -3129,7 +3129,7 @@ rewrite fin_numElt; apply/andP; split.
 case: fi => mf; apply: le_lt_trans; apply: ge0_le_integral => //.
 - exact/measurable_funeneg.
 - exact/measurableT_comp.
-- by move=> x Dx; rewrite -/((abse \o f) x) (fune_abse f) lee_addr.
+- by move=> x Dx; rewrite -/((abse \o f) x) (fune_abse f) leeDr.
 Qed.
 
 Lemma integrable_pos_fin_num f :
@@ -3141,7 +3141,7 @@ rewrite fin_numElt; apply/andP; split.
 case: fi => mf; apply: le_lt_trans; apply: ge0_le_integral => //.
 - exact/measurable_funepos.
 - exact/measurableT_comp.
-- by move=> x Dx; rewrite -/((abse \o f) x) (fune_abse f) lee_addl.
+- by move=> x Dx; rewrite -/((abse \o f) x) (fune_abse f) leeDl.
 Qed.
 
 End integrable_theory.
@@ -3981,7 +3981,7 @@ Lemma integral_fune_lt_pinfty (f : T -> \bar R) :
 Proof.
 move=> intf; rewrite (funeposneg f) integralB//;
   [|exact: integrable_funepos|exact: integrable_funeneg].
-rewrite lte_add_pinfty ?integral_funepos_lt_pinfty// lte_oppl ltNye_eq.
+rewrite lte_add_pinfty ?integral_funepos_lt_pinfty// lteNl ltNye_eq.
 by rewrite integrable_neg_fin_num.
 Qed.
 
@@ -3989,7 +3989,7 @@ Lemma integral_fune_fin_num (f : T -> \bar R) :
   mu.-integrable D f -> \int[mu]_(x in D) f x \is a fin_num.
 Proof.
 move=> h; apply/fin_numPlt; rewrite integral_fune_lt_pinfty// andbC/= -/(- +oo).
-rewrite lte_oppl -integralN; first exact/integral_fune_lt_pinfty/integrableN.
+rewrite lteNl -integralN; first exact/integral_fune_lt_pinfty/integrableN.
 by rewrite fin_num_adde_defl// fin_numN integrable_neg_fin_num.
 Qed.
 
@@ -4169,19 +4169,19 @@ move: (f_f Dx); case: (f x) => [r|/=|/=].
 - move/cvgeyPge/(_ (fine (g x) + 1)%R) => [n _]/(_ _ (leqnn n))/= h.
   have : (fine (g x) + 1)%:E <= g x.
     by rewrite (le_trans h)// (le_trans _ (absfg n Dx))// lee_abs.
-  by case: (g x) (fing Dx) => [r _| |]//; rewrite leNgt EFinD lte_addl ?lte01.
+  by case: (g x) (fing Dx) => [r _| |]//; rewrite leNgt EFinD lteDl ?lte01.
 - move/cvgeNyPle/(_ (- (fine (g x) + 1))%R) => [n _]/(_ _ (leqnn n)) h.
   have : (fine (g x) + 1)%:E <= g x.
-    move: h; rewrite EFinN lee_oppr => /le_trans ->//.
+    move: h; rewrite EFinN leeNr => /le_trans ->//.
     by rewrite (le_trans _ (absfg n Dx))// -abseN lee_abs.
-  by case: (g x) (fing Dx) => [r _| |]//; rewrite leNgt EFinD lte_addl ?lte01.
+  by case: (g x) (fing Dx) => [r _| |]//; rewrite leNgt EFinD lteDl ?lte01.
 Qed.
 
 Let gg_ n x : D x -> 0 <= 2%:E * g x - g_ n x.
 Proof.
 move=> Dx; rewrite subre_ge0; last by rewrite fin_numM// fing.
 rewrite -(fineK (fing Dx)) -EFinM mulr_natl mulr2n /g_.
-rewrite (le_trans (lee_abs_sub _ _))// [in leRHS]EFinD lee_add//.
+rewrite (le_trans (lee_abs_sub _ _))// [in leRHS]EFinD leeD//.
   by rewrite fineK// ?fing// absfg.
 have f_fx : `|(f_ n x)| @[n --> \oo] --> `|f x| by apply: cvg_abse; exact: f_f.
 move/cvg_lim : (f_fx) => <-//.
@@ -4235,7 +4235,7 @@ rewrite [X in _ <= X -> _](_ : _ = \int[mu]_(x in D) (2%:E * g x)  + -
       - by move=> x Dx; rewrite /= abse_id.
   rewrite limn_einf_shift // -limn_einfN; congr (_ + limn_einf _).
   by rewrite funeqE => n /=; rewrite -integral_ge0N// => x Dx; rewrite /g_.
-rewrite addeC -lee_subl_addr// subee// lee_oppr oppe0 => lim_ge0.
+rewrite addeC -lee_subl_addr// subee// leeNr oppe0 => lim_ge0.
 by apply/limn_esup_le_cvg => // n; rewrite integral_ge0// => x _; rewrite /g_.
 Qed.
 
@@ -5066,7 +5066,7 @@ exists h; split => //; rewrite [eps%:num]splitr; apply: le_lt_trans.
 rewrite integralD//; first last.
 - by apply: integrable_abse; under eq_fun do rewrite EFinB; apply: integrableB.
 - by apply: integrable_abse; under eq_fun do rewrite EFinB; apply: integrableB.
-rewrite EFinD lte_add// -(setDKU AE) integral_setU => //; first last.
+rewrite EFinD lteD// -(setDKU AE) integral_setU => //; first last.
 - by rewrite /disj_set setDKI.
 - rewrite setDKU //; do 2 apply: measurableT_comp => //.
   exact: measurable_funB.
@@ -5507,7 +5507,7 @@ apply: le_lt_trans (fubini1a.1 imf); apply: ge0_le_integral => //.
   - apply: measurableT_comp => //.
     by apply: measurable_funepos => //; exact: measurableT_comp.
   - by apply: measurableT_comp => //; exact/measurableT_comp.
-  - by move=> y _; rewrite gee0_abs// -/((abse \o f) (x, y)) fune_abse lee_addl.
+  - by move=> y _; rewrite gee0_abs// -/((abse \o f) (x, y)) fune_abse leeDl.
 Qed.
 
 Let integrable_Fminus : m1.-integrable setT Fminus.
@@ -5523,7 +5523,7 @@ apply: le_lt_trans (fubini1a.1 imf); apply: ge0_le_integral => //.
   + apply: measurableT_comp => //; apply: measurable_funeneg => //.
     exact: measurableT_comp.
   + by apply: measurableT_comp => //; exact: measurableT_comp.
-  + by move=> y _; rewrite gee0_abs// -/((abse \o f) (x, y)) fune_abse lee_addr.
+  + by move=> y _; rewrite gee0_abs// -/((abse \o f) (x, y)) fune_abse leeDr.
 Qed.
 
 Lemma integrable_fubini_F : m1.-integrable setT F.
@@ -5562,7 +5562,7 @@ apply: le_lt_trans (fubini1b.1 imf); apply: ge0_le_integral => //.
   - apply: measurableT_comp => //.
     by apply: measurable_funepos => //; exact: measurableT_comp.
   - by apply: measurableT_comp => //; exact: measurableT_comp.
-  - by move=> x _; rewrite gee0_abs// -/((abse \o f) (x, y)) fune_abse lee_addl.
+  - by move=> x _; rewrite gee0_abs// -/((abse \o f) (x, y)) fune_abse leeDl.
 Qed.
 
 Let integrable_Gminus : m2.-integrable setT Gminus.
@@ -5578,7 +5578,7 @@ apply: le_lt_trans (fubini1b.1 imf); apply: ge0_le_integral => //.
   + apply: measurableT_comp => //.
     by apply: measurable_funeneg => //; exact: measurableT_comp.
   + by apply: measurableT_comp => //; exact: measurableT_comp.
-  + by move=> x _; rewrite gee0_abs// -/((abse \o f) (x, y)) fune_abse lee_addr.
+  + by move=> x _; rewrite gee0_abs// -/((abse \o f) (x, y)) fune_abse leeDr.
 Qed.
 
 Lemma fubini1 : \int[m1]_x F x = \int[m1 \x m2]_z f z.

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -150,7 +150,7 @@ set I := [set` i]; set J := [set` j].
 have [->|/set0P I0] := eqVneq I set0; first by rewrite hlength0 hlength_itv_ge0.
 have [J0|/set0P J0] := eqVneq J set0.
   by move/subset_itvP; rewrite -/J J0 subset0 -/I => ->.
-move=> /subset_itvP ij; apply: lee_sub => /=.
+move=> /subset_itvP ij; apply: leeB => /=.
   have [ui|ui] := asboolP (has_ubound I).
     have [uj /=|uj] := asboolP (has_ubound J); last by rewrite leey.
     by rewrite lee_fin le_sup // => r Ir; exists r; split => //; apply: ij.
@@ -1724,7 +1724,7 @@ Proof.
 move=> mD; apply: (measurability (ErealGenCInfty.measurableE R)) => //.
 move=> _ [_ [x ->] <-]; rewrite (_ : _ @^-1` _ = `]-oo, (- x)%:E]%classic).
   by apply: measurableI => //; exact: emeasurable_itv.
-by rewrite predeqE => y; rewrite preimage_itv !in_itv/= andbT in_itv lee_oppr.
+by rewrite predeqE => y; rewrite preimage_itv !in_itv/= andbT in_itv leeNr.
 Qed.
 
 End standard_emeasurable_fun.
@@ -1986,7 +1986,7 @@ wlog : eps epspos D mD finD / exists ab : R * R, D `<=` `[ab.1, ab.2]%classic.
     by apply/propext; split => [[]|[[]]].
   have mV : measurable V.
     by apply: closed_measurable; apply: compact_closed => //; exact: Rhausdorff.
-  rewrite [eps]splitr EFinD (measureU mu) // ?lte_add //.
+  rewrite [eps]splitr EFinD (measureU mu) // ?lteD //.
   - by apply: measurableD => //; exact: measurableI.
   - exact: measurableD.
   - by rewrite eqEsubset; split => z // [[[_ + _] [_]]].
@@ -2021,7 +2021,7 @@ apply/lee_addgt0Pr => e e0.
 have [B [cB BA /= ABe]] := lebesgue_regularity_inner mA muA e0.
 rewrite -{1}(setDKU BA) (@le_trans _ _ (mu B + mu (A `\` B)))//.
   by rewrite setUC outer_measureU2.
-by rewrite lee_add//; [apply: ereal_sup_ub => /=; exists B|exact/ltW].
+by rewrite leeD//; [apply: ereal_sup_ub => /=; exists B|exact/ltW].
 Qed.
 
 Lemma lebesgue_regularity_inner_sup (D : set R) : measurable D ->
@@ -2048,7 +2048,7 @@ move=> V [/[dup] /compact_measurable mV cptV VFND] FDV1 M1FD.
 rewrite (@le_trans _ _ (mu V))//; last first.
   apply: ereal_sup_ub; exists V => //=; split => //.
   exact: (subset_trans VFND (@subIsetr _ _ _)).
-rewrite -(@lee_add2lE _ 1)// {1}addeC -EFinD (le_trans M1FD)//.
+rewrite -(@leeD2lE _ 1)// {1}addeC -EFinD (le_trans M1FD)//.
 rewrite /mu (@measureDI _ _ _ _ (F N `&` D) _ _ mV)/=; last exact: measurableI.
 rewrite ltW// lte_le_add // ?ge0_fin_numE //; last first.
   by rewrite measureIr//; apply: measurableI.
@@ -2322,7 +2322,7 @@ have [N F5e] : exists N, \sum_(N <= n <oo) \esum_(i in F n) mu (closure (B i)) <
   set X : \bar R := (X in fine X).
   have Xoo : X < +oo.
     apply: le_lt_trans foo.
-    by rewrite (nneseries_split N)// lee_addr//; exact: sume_ge0.
+    by rewrite (nneseries_split N)// leeDr//; exact: sume_ge0.
   rewrite fineK ?ge0_fin_numE//; last exact: nneseries_ge0.
   apply: lee_nneseries => //; first by move=> i _; exact: esum_ge0.
   move=> n Nn; rewrite measure_bigcup//=.

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -2359,7 +2359,7 @@ Proof.
 move=> A B; rewrite ?inE => mA mB AB; have [|muBfin] := leP +oo%E (mu B).
   by rewrite leye_eq => /eqP ->; rewrite leey.
 rewrite -[leRHS]SetRing.RmuE// -[B](setDUK AB) measureU/= ?setDIK//.
-- by rewrite SetRing.RmuE ?lee_addl.
+- by rewrite SetRing.RmuE ?leeDl.
 - exact: sub_gen_smallest.
 - by apply: measurableD; exact: sub_gen_smallest.
 Qed.
@@ -2437,8 +2437,8 @@ Qed.
 (* have Bm : measurable (B : set rT). *)
 (*   by rewrite -[B]bigcup_mkord; apply: fin_bigcup_measurable => //= i /ltnW/Am. *)
 (* rewrite measureU // ?setDIK//; last exact: measurableD. *)
-(* rewrite (@le_trans _ _ (ammu B + ammu (A n))) // ?lee_add2l //; last first. *)
-(*   by rewrite big_ord_recr /= lee_add2r// IHn// => i /ltnW/Am. *)
+(* rewrite (@le_trans _ _ (ammu B + ammu (A n))) // ?leeD2l //; last first. *)
+(*   by rewrite big_ord_recr /= leeD2r// IHn// => i /ltnW/Am. *)
 (* by rewrite le_measure // ?inE// ?setDE//; exact: measurableD. *)
 (* Qed. *)
 
@@ -3596,7 +3596,7 @@ Lemma caratheodory_measurable_setU_le (X A B : set T) :
   mu (X `&` (A `|` B)) + mu (X `&` ~` (A `|` B)) <= mu X.
 Proof.
 move=> mA mB; pose Y := X `&` A `|` X `&` B `&` ~` A.
-have /(lee_add2r (mu (X `&` ~` (A `|` B)))) :
+have /(leeD2r (mu (X `&` ~` (A `|` B)))) :
     mu Y <= mu (X `&` A) + mu (X `&` B `&` ~` A).
   pose Z := bigcup2 (X `&` A) (X `&` B `&` ~` A).
   have -> : Y = \bigcup_k Z k.
@@ -3710,8 +3710,8 @@ suff : forall n, \sum_(k < n) mu (X `&` A k) + mu (X `&` ~` A') <= mu X.
   - by rewrite addeNy leNye.
 move=> n.
 apply: (@le_trans _ _ (\sum_(k < n) mu (X `&` A k) + mu (X `&` ~` B n))).
-  apply/lee_add2l/le_outer_measure; apply: setIS; exact/subsetC/bigsetU_bigcup.
-rewrite [in leRHS](caratheodory_measurable_bigsetU MA n) lee_add2r//.
+  apply/leeD2l/le_outer_measure; apply: setIS; exact/subsetC/bigsetU_bigcup.
+rewrite [in leRHS](caratheodory_measurable_bigsetU MA n) leeD2r//.
 by rewrite caratheodory_additive.
 Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0",
@@ -3722,7 +3722,7 @@ Lemma caratheodory_measurable_trivIset_bigcup (A : (set T) ^nat) :
   (forall n, M (A n)) -> trivIset setT A -> M (\bigcup_k (A k)).
 Proof.
 move=> MA tA; apply: le_caratheodory_measurable => X /=.
-have /(lee_add2r (mu (X `&` ~` \bigcup_k A k))) := outer_measure_bigcup_lim A X.
+have /(leeD2r (mu (X `&` ~` \bigcup_k A k))) := outer_measure_bigcup_lim A X.
 by move/le_trans; apply; exact: caratheodory_lime_le.
 Qed.
 
@@ -3787,7 +3787,7 @@ suff : forall X, mu X = \sum_(k <oo) mu (X `&` A k) + mu (X `&` ~` B).
 move=> X.
 have mB : mu.-cara.-measurable B := caratheodory_measurable_bigcup mA.
 apply/eqP; rewrite eq_le (caratheodory_lime_le mA tA X) andbT.
-have /(lee_add2r (mu (X `&` ~` B))) := outer_measure_bigcup_lim mu A X.
+have /(leeD2r (mu (X `&` ~` B))) := outer_measure_bigcup_lim mu A X.
 by rewrite -le_caratheodory_measurable // => ?; rewrite -mB.
 Qed.
 
@@ -3821,7 +3821,7 @@ move=> A0 /nonnegP[{}e].
 rewrite (@le_trans _ _ (lim ((fun n => (\sum_(0 <= i < n | P i) A i) +
     \sum_(0 <= i < n) (e%:num / (2 ^ i.+1)%:R)%:E) @ \oo))) //.
   rewrite nneseriesD // limeD //.
-  - rewrite lee_add2l //; apply: lee_lim => //.
+  - rewrite leeD2l //; apply: lee_lim => //.
     + exact: is_cvg_nneseries.
     + exact: is_cvg_nneseries.
     + by near=> n; exact: lee_sum_nneg_subset.
@@ -3831,7 +3831,7 @@ rewrite (@le_trans _ _ (lim ((fun n => (\sum_(0 <= i < n | P i) A i) +
 suff cvggeo : (fun n => \sum_(0 <= i < n) (e%:num / (2 ^ i.+1)%:R)%:E) @ \oo -->
     e%:num%:E.
   rewrite limeD //.
-  - by rewrite lee_add2l // (cvg_lim _ cvggeo).
+  - by rewrite leeD2l // (cvg_lim _ cvggeo).
   - exact: is_cvg_nneseries.
   - by apply: is_cvg_nneseries => ?; rewrite lee_fin divr_ge0.
   - by rewrite (cvg_lim _ cvggeo) //= fin_num_adde_defl.
@@ -4198,7 +4198,7 @@ rewrite -(eq_eseriesr (fun _ _ => SetRing.RmuE _ (mB _))) => //.
 have RmB i : measurable (B i : set rT) by exact: sub_gen_smallest.
 set BA := eseries (fun n => Rmu (B n `&` A)).
 set BNA := eseries (fun n => Rmu (B n `&` ~` A)).
-apply: (@le_trans _ _ (limn BA + limn BNA)); [apply: lee_add|].
+apply: (@le_trans _ _ (limn BA + limn BNA)); [apply: leeD|].
   - rewrite (_ : BA = eseries (fun n => mu_ext mu (B n `&` A))); last first.
       rewrite funeqE => n; apply: eq_bigr => k _.
       by rewrite /= measurable_Rmu_extE //; exact: measurableI.

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -251,11 +251,11 @@ Proof.
 apply/seteqP; split => // x _; have [x0|x0] := ltP 0%R x.
   exists `|ceil x|.+1 => //.
   rewrite /ball /= sub0r normrN gtr0_norm// (le_lt_trans (ceil_ge _))//.
-  by rewrite -natr1 natr_absz -abszE gtz0_abs// ?ceil_gt0// ltr_spaddr.
+  by rewrite -natr1 natr_absz -abszE gtz0_abs// ?ceil_gt0// ltr_pwDr.
 exists `|ceil (- x)|.+1 => //.
 rewrite /ball /= sub0r normrN ler0_norm// (le_lt_trans (ceil_ge _))//.
-rewrite -natr1 natr_absz -abszE gez0_abs ?ceil_ge0// 1?ler_oppr ?oppr0//.
-by rewrite ltr_spaddr.
+rewrite -natr1 natr_absz -abszE gez0_abs ?ceil_ge0// 1?lerNr ?oppr0//.
+by rewrite ltr_pwDr.
 Qed.
 
 Section lower_semicontinuous.
@@ -2832,20 +2832,20 @@ have yE u v x : u @ F --> +oo -> v @ F --> x%:E -> u \+ v @ F --> +oo.
   move=> /cvgeyPge/= foo /fine_cvgP[Fg gb]; apply/cvgeyPgey.
   near=> A; near=> n; have /(_ _)/wrap[//|Fgn] := near Fg n.
   rewrite -lee_subl_addr// (@le_trans _ _ (A - (x - 1))%:E)//; last by near: n.
-  rewrite ?EFinB lee_sub// lee_subl_addr// -[v n]fineK// -EFinD lee_fin.
+  rewrite ?EFinB leeB// lee_subl_addr// -[v n]fineK// -EFinD lee_fin.
   by rewrite ler_distlDr// ltW//; near: n; apply: cvgr_dist_lt.
 have NyE u v x : u @ F --> -oo -> v @ F --> x%:E -> u \+ v @ F --> -oo.
   move=> /cvgeNyPle/= foo /fine_cvgP -[Fg gb]; apply/cvgeNyPleNy.
   near=> A; near=> n; have /(_ _)/wrap[//|Fgn] := near Fg n.
   rewrite -lee_subr_addr// (@le_trans _ _ (A - (x + 1))%:E)//; first by near: n.
-  rewrite ?EFinB ?EFinD lee_sub// -[v n]fineK// -EFinD lee_fin.
+  rewrite ?EFinB ?EFinD leeB// -[v n]fineK// -EFinD lee_fin.
   by rewrite ler_distlCDr// ltW//; near: n; apply: cvgr_dist_lt.
 have yyE u v : u @ F --> +oo -> v @ F --> +oo -> u \+ v @ F --> +oo.
   move=> /cvgeyPge foo /cvgeyPge goo; apply/cvgeyPge => A; near=> y.
-  by rewrite -[leLHS]adde0 lee_add//; near: y; [apply: foo|apply: goo].
+  by rewrite -[leLHS]adde0 leeD//; near: y; [apply: foo|apply: goo].
 have NyNyE u v : u @ F --> -oo -> v @ F --> -oo -> u \+ v @ F --> -oo.
   move=> /cvgeNyPle foo /cvgeNyPle goo; apply/cvgeNyPle => A; near=> y.
-  by rewrite -[leRHS]adde0 lee_add//; near: y; [apply: foo|apply: goo].
+  by rewrite -[leRHS]adde0 leeD//; near: y; [apply: foo|apply: goo].
 have addfC u v : u \+ v = v \+ u.
   by apply/funeqP => x; rewrite /= addeC.
 move: a b => [a| |] [b| |] //= _; rewrite ?(addey, addye, addeNy, addNye)//=;
@@ -2886,7 +2886,7 @@ Proof.
 case=> [r|A /= [r [rreal rA]]|A /= [r [rreal rA]]]/=.
 - exact/(cvg_comp (@norm_continuous _ [the normedModType R of R^o] r)).
 - by exists r; split => // y ry; apply: rA; rewrite (lt_le_trans ry)// lee_abs.
-- exists (- r)%R; rewrite realN; split => // y; rewrite EFinN -lte_oppr => yr.
+- exists (- r)%R; rewrite realN; split => // y; rewrite EFinN -lteNr => yr.
   by apply: rA; rewrite (lt_le_trans yr)// -abseN lee_abs.
 Qed.
 
@@ -3215,10 +3215,10 @@ suff: \forall t \near (nbhs x, nbhs y),
 rewrite -near2_pair; near=> a b => /=.
 have abxy : (edist (a, b) <= edist (x, a) + edist (x, y) + edist (y, b))%E.
   rewrite (edist_sym x a) -addeA.
-  by rewrite (le_trans (@edist_triangle _ x _)) ?lee_add ?edist_triangle.
+  by rewrite (le_trans (@edist_triangle _ x _)) ?leeD ?edist_triangle.
 have xyab : (edist (x, y) <= edist (x, a) + edist (a, b) + edist (y, b))%E.
   rewrite (edist_sym y b) -addeA.
-  by rewrite (le_trans (@edist_triangle _ a _))// ?lee_add// ?edist_triangle.
+  by rewrite (le_trans (@edist_triangle _ a _))// ?leeD// ?edist_triangle.
 have xafin : edist (x, a) \is a fin_num.
   by apply/edist_finP; exists 1 =>//; near: a; exact: nbhsx_ballx.
 have ybfin : edist (y, b) \is a fin_num.
@@ -3229,7 +3229,7 @@ have xyabfin: (edist (x, y) - edist (a, b))%E \is a fin_num
   by rewrite fin_numB abfin efin.
 rewrite -fineB// -fine_abse// -lee_fin fineK ?abse_fin_num//.
 rewrite (@le_trans _ _ (edist (x, a) + edist (y, b))%E)//; last first.
-  by rewrite [eps%:num]splitr/= EFinD lee_add//; apply: edist_fin => //=;
+  by rewrite [eps%:num]splitr/= EFinD leeD//; apply: edist_fin => //=;
        [near: a | near: b]; exact: nbhsx_ballx.
 have [ab_le_xy|/ltW xy_le_ab] := leP (edist (a, b)) (edist (x, y)).
   by rewrite gee0_abs ?subre_ge0// lee_subl_addr// addeAC.
@@ -3293,7 +3293,7 @@ apply/lee_addgt0Pr => _/posnumP[eps].
 have [//|? [a Aa <-] yaeps] := @lb_ereal_inf_adherent R _ eps%:num _ fyn.
 apply: le_trans; first by apply: (@ereal_inf_lb _ _ (edist (x, a))); exists a.
 apply: le_trans; first exact: (@edist_triangle _ _ _ y).
-by rewrite -addeA lee_add2lE // ltW.
+by rewrite -addeA leeD2lE // ltW.
 Qed.
 
 Lemma edist_inf_continuous : continuous edist_inf.
@@ -3311,7 +3311,7 @@ have [] := eqVneq (edist_inf z) +oo%E.
   have /gee0P[|[r' r'pos war']] := edist_ge0 (w, a).
     by rewrite war => ->; apply: zAp; exists a.
   have := @edist_triangle _ _ z w a; rewrite war'; apply: contra_leP => _.
-  rewrite (@le_lt_trans _ _ (1 + r'%:E)%E) ?lee_add2r ?edist_fin//.
+  rewrite (@le_lt_trans _ _ (1 + r'%:E)%E) ?leeD2r ?edist_fin//.
   by rewrite -EFinD [edist (z, a)]zAp ?ltey //; exists a.
 rewrite -ltey -ge0_fin_numE ?edist_inf_ge0 // => fz_fin.
 rewrite /continuous_at -[edist_inf z]fineK //; apply/fine_cvgP.

--- a/theories/numfun.v
+++ b/theories/numfun.v
@@ -165,7 +165,7 @@ Proof. by move=> f0 x; rewrite inE => Dx; apply/max_idPl/f0. Qed.
 
 Lemma ge0_funenegE f : (forall x, D x -> 0 <= f x) -> {in D, f^\- =1 cst 0}.
 Proof.
-by move=> f0 x; rewrite inE => Dx; apply/max_idPr; rewrite lee_oppl oppe0 f0.
+by move=> f0 x; rewrite inE => Dx; apply/max_idPr; rewrite leeNl oppe0 f0.
 Qed.
 
 Lemma le0_funeposE f : (forall x, D x -> f x <= 0) -> {in D, f^\+ =1 cst 0}.
@@ -173,7 +173,7 @@ Proof. by move=> f0 x; rewrite inE => Dx; exact/max_idPr/f0. Qed.
 
 Lemma le0_funenegE f : (forall x, D x -> f x <= 0) -> {in D, f^\- =1 \- f}.
 Proof.
-by move=> f0 x; rewrite inE => Dx; apply/max_idPl; rewrite lee_oppr oppe0 f0.
+by move=> f0 x; rewrite inE => Dx; apply/max_idPl; rewrite leeNr oppe0 f0.
 Qed.
 
 Lemma gt0_funeposM r f : (0 < r)%R ->
@@ -205,16 +205,16 @@ Proof.
 rewrite funeqE => x /=; have [fx0|/ltW fx0] := leP (f x) 0.
 - rewrite lee0_abs// /funepos /funeneg.
   move/max_idPr : (fx0) => ->; rewrite add0e.
-  by move: fx0; rewrite -{1}oppe0 lee_oppr => /max_idPl ->.
+  by move: fx0; rewrite -{1}oppe0 leeNr => /max_idPl ->.
 - rewrite gee0_abs// /funepos /funeneg; move/max_idPl : (fx0) => ->.
-  by move: fx0; rewrite -{1}oppe0 lee_oppl => /max_idPr ->; rewrite adde0.
+  by move: fx0; rewrite -{1}oppe0 leeNl => /max_idPr ->; rewrite adde0.
 Qed.
 
 Lemma funeposneg f : f = (fun x => f^\+ x - f^\- x).
 Proof.
 rewrite funeqE => x; rewrite /funepos /funeneg; have [|/ltW] := leP (f x) 0.
-  by rewrite -{1}oppe0 -lee_oppr => /max_idPl ->; rewrite oppeK add0e.
-by rewrite -{1}oppe0 -lee_oppl => /max_idPr ->; rewrite sube0.
+  by rewrite -{1}oppe0 -leeNr => /max_idPl ->; rewrite oppeK add0e.
+by rewrite -{1}oppe0 -leeNl => /max_idPr ->; rewrite sube0.
 Qed.
 
 Lemma add_def_funeposneg f x : (f^\+ x +? - f^\- x).
@@ -226,22 +226,22 @@ Qed.
 Lemma funeD_Dpos f g : f \+ g = (f \+ g)^\+ \- (f \+ g)^\-.
 Proof.
 apply/funext => x; rewrite /funepos /funeneg; have [|/ltW] := leP 0 (f x + g x).
-- by rewrite -{1}oppe0 -lee_oppl => /max_idPr ->; rewrite sube0.
-- by rewrite -{1}oppe0 -lee_oppr => /max_idPl ->; rewrite oppeK add0e.
+- by rewrite -{1}oppe0 -leeNl => /max_idPr ->; rewrite sube0.
+- by rewrite -{1}oppe0 -leeNr => /max_idPl ->; rewrite oppeK add0e.
 Qed.
 
 Lemma funeD_posD f g : f \+ g = (f^\+ \+ g^\+) \- (f^\- \+ g^\-).
 Proof.
 apply/funext => x; rewrite /funepos /funeneg.
 have [|fx0] := leP 0 (f x); last rewrite add0e.
-- rewrite -{1}oppe0 lee_oppl => /max_idPr ->; have [|/ltW] := leP 0 (g x).
-    by rewrite -{1}oppe0 lee_oppl => /max_idPr ->; rewrite adde0 sube0.
-  by rewrite -{1}oppe0 -lee_oppr => /max_idPl ->; rewrite adde0 sub0e oppeK.
-- move/ltW : (fx0); rewrite -{1}oppe0 lee_oppr => /max_idPl ->.
+- rewrite -{1}oppe0 leeNl => /max_idPr ->; have [|/ltW] := leP 0 (g x).
+    by rewrite -{1}oppe0 leeNl => /max_idPr ->; rewrite adde0 sube0.
+  by rewrite -{1}oppe0 -leeNr => /max_idPl ->; rewrite adde0 sub0e oppeK.
+- move/ltW : (fx0); rewrite -{1}oppe0 leeNr => /max_idPl ->.
   have [|] := leP 0 (g x); last rewrite add0e.
-    by rewrite -{1}oppe0 lee_oppl => /max_idPr ->; rewrite adde0 oppeK addeC.
+    by rewrite -{1}oppe0 leeNl => /max_idPr ->; rewrite adde0 oppeK addeC.
   move gg' : (g x) => g'; move: g' gg' => [g' gg' g'0|//|goo _].
-  + move/ltW : (g'0); rewrite -{1}oppe0 -lee_oppr => /max_idPl => ->.
+  + move/ltW : (g'0); rewrite -{1}oppe0 -leeNr => /max_idPl => ->.
     by rewrite fin_num_oppeD// 2!oppeK.
   + by rewrite /maxe /=; case: (f x) fx0.
 Qed.

--- a/theories/realfun.v
+++ b/theories/realfun.v
@@ -695,7 +695,7 @@ by rewrite /inf_ball /ereal_inf; congr (- _); rewrite /sup_ball -image_comp.
 Qed.
 
 Let inf_ball_le f a r s : (s <= r)%R -> inf_ball f a r <= inf_ball f a s.
-Proof. by move=> sr; rewrite /inf_ball lee_oppl oppeK sup_ball_le. Qed.
+Proof. by move=> sr; rewrite /inf_ball leeNl oppeK sup_ball_le. Qed.
 
 Let inf_ball_is_cvg f a : cvg (inf_ball f a e @[e --> 0^'+]).
 Proof.
@@ -773,9 +773,9 @@ move=> fg; rewrite !lime_sup_lim -limeD//; last first.
   by rewrite -!lime_sup_lim.
 apply: lee_lim => //.
 - apply: nondecreasing_at_right_is_cvge; near=> e => x y; rewrite !in_itv/=.
-  by move=> /andP[? ?] /andP[? ?] xy; apply: lee_add => //; exact: sup_ball_le.
+  by move=> /andP[? ?] /andP[? ?] xy; apply: leeD => //; exact: sup_ball_le.
 - near=> a0; apply: ub_ereal_sup => _ /= [a1 [a1ae a1a]] <-.
-  by apply: lee_add; apply: ereal_sup_ub => /=; exists a1.
+  by apply: leeD; apply: ereal_sup_ub => /=; exists a1.
 Unshelve. all: by end_near. Qed.
 
 Lemma lime_sup_le f g a :
@@ -881,7 +881,7 @@ have H (e : {posnum R}) :
       rewrite (le_lt_trans _ farl)//; apply: ereal_inf_lb => /=; exists r => //.
       by rewrite in_itv/= r0.
     by rewrite fal ltxx.
-  by rewrite -leNgt; apply: le_trans; rewrite lee_add2r// fal.
+  by rewrite -leNgt; apply: le_trans; rewrite leeD2r// fal.
 move=> e; have [d /andP[lfp fpe]] := H e.
 exists d => r /= [] prd rp.
 by rewrite (le_lt_trans _ fpe)//; apply: ereal_sup_ub => /=; exists r.
@@ -893,7 +893,7 @@ Local Lemma lime_infP f a l :
 Proof.
 move=> /(congr1 oppe); rewrite -lime_supN => /lime_supP => H e.
 have [d {}H] := H e.
-by exists d => r /H; rewrite lte_oppl oppeD// EFinN oppeK.
+by exists d => r /H; rewrite lteNl oppeD// EFinN oppeK.
 Qed.
 
 Lemma lime_sup_inf_at_right f a l :
@@ -917,13 +917,13 @@ apply/cvgrPdist_le => _/posnumP[e].
 have [d1 Hd1] : exists d1 : {posnum R},
     l%:E - e%:num%:E <= ereal_inf [set f x | x in ball a d1%:num `\ a].
   have : l%:E - e%:num%:E < lime_inf f a.
-    by rewrite inffpl lte_subl_addr// lte_addl.
+    by rewrite inffpl lte_subl_addr// lteDl.
   rewrite lime_infE => /ereal_sup_gt[x /= [r]]; rewrite in_itv/= andbT.
   move=> r0 <-{x} H; exists (PosNum r0); rewrite ltW//.
   by rewrite -inf_ballE.
 have [d2 Hd2] : exists d2 : {posnum R},
     ereal_sup [set f x | x in ball a d2%:num `\ a] <= l%:E + e%:num%:E.
-  have : lime_sup f a < l%:E + e%:num%:E by rewrite supfpl lte_addl.
+  have : lime_sup f a < l%:E + e%:num%:E by rewrite supfpl lteDl.
   rewrite lime_supE => /ereal_inf_lt[x /= [r]]; rewrite in_itv/= andbT.
   by move=> r0 <-{x} H; exists (PosNum r0); rewrite ltW.
 pose d := minr d1%:num d2%:num.
@@ -1791,7 +1791,7 @@ Lemma variation_le a b f g s :
   variation a b (f \+ g)%R s <= variation a b f s + variation a b g s.
 Proof.
 rewrite [in leRHS]/variation -big_split/=.
-apply: ler_sum => k _; apply: le_trans; last exact: ler_norm_add.
+apply: ler_sum => k _; apply: le_trans; last exact: ler_normD.
 by rewrite /= addrACA addrA opprD addrA.
 Qed.
 
@@ -2131,7 +2131,7 @@ have BVabfg : BV a b (f \+ g).
 apply: ub_ereal_sup => y /= [r' [s' abs <-{r'} <-{y}]].
 apply: (@le_trans _ _ (variation a b f s' + variation a b g s')%:E).
   exact: variation_le.
-by rewrite EFinD lee_add// ereal_sup_le//;
+by rewrite EFinD leeD// ereal_sup_le//;
   (eexists; last exact: lexx); (eexists; last reflexivity);
   exact: variations_variation.
 Qed.
@@ -2233,7 +2233,7 @@ move=> x y xab yab xy; have ax : a <= x.
   by move: xab; rewrite in_itv //= => /andP [].
 rewrite /neg_tv lee_pmul2r // lee_subr_addl // addeCA -EFinB.
 rewrite [TV a y _](total_variationD _ ax xy) //.
-apply: lee_add => //; apply: le_trans; last exact: total_variation_ge.
+apply: leeD => //; apply: le_trans; last exact: total_variation_ge.
 by rewrite lee_fin ler_norm.
 Qed.
 
@@ -2324,7 +2324,7 @@ rewrite {1}variation_prev; last exact: itv_partition1.
 rewrite /= -addeA -lte_subr_addr; last by rewrite fin_numD; apply/andP.
 rewrite EFinD -lte_fin ?fineK // oppeD //= ?fin_num_adde_defl // opprK addeA.
 move/lt_trans; apply.
-rewrite [x in (_ < x%:E)%E]Num.Theory.splitr EFinD addeC lte_add2lE //.
+rewrite [x in (_ < x%:E)%E]Num.Theory.splitr EFinD addeC lteD2lE //.
 rewrite -addeA.
 apply: (@le_lt_trans _ _ (variation x t f (t :: nil))%:E).
   rewrite [in leRHS]variation_prev; last exact: itv_partition1.

--- a/theories/sequences.v
+++ b/theories/sequences.v
@@ -1452,8 +1452,8 @@ Implicit Types u : (\bar T)^nat.
 Lemma ereal_nondecreasing_oppn u_ :
   nondecreasing_seq (-%E \o u_) = nonincreasing_seq u_.
 Proof.
-rewrite propeqE; split => ni_u m n mn; last by rewrite lee_oppr oppeK ni_u.
-by rewrite -(oppeK (u_ m)) -lee_oppr ni_u.
+rewrite propeqE; split => ni_u m n mn; last by rewrite leeNr oppeK ni_u.
+by rewrite -(oppeK (u_ m)) -leeNr ni_u.
 Qed.
 
 End sequences_ereal_realDomainType.
@@ -2149,10 +2149,10 @@ Lemma maxe_cvg_0_cvg_fin_num u x : x < 0 -> (forall k, u k <= 0) ->
   maxe (u n) x @[n --> \oo] --> 0 ->
   \forall n \near \oo, u n \is a fin_num.
 Proof.
-rewrite -[in x < _]oppe0 lte_oppr => x0 u0.
+rewrite -[in x < _]oppe0 lteNr => x0 u0.
 under eq_fun do rewrite -(oppeK (u _)) -[in maxe _ _](oppeK x) -oppe_min.
 rewrite -[in _ --> _]oppe0 => /cvgeNP/mine_cvg_0_cvg_fin_num-/(_ x0).
-have Nu0 k : 0 <= - u k by rewrite lee_oppr oppe0.
+have Nu0 k : 0 <= - u k by rewrite leeNr oppe0.
 by move=> /(_ Nu0)[n _ nu]; exists n => // m/= nm; rewrite -fin_numN nu.
 Qed.
 
@@ -2163,7 +2163,7 @@ Proof.
 rewrite -[in (r < _)%R]oppr0 ltrNr => r0 u0.
 under eq_fun do rewrite -(oppeK (u _)) -[in maxe _ _](oppeK r%:E) -oppe_min.
 rewrite -[in _ --> _]oppe0 => /cvgeNP/mine_cvg_minr_cvg-/(_ r0).
-have Nu0 k : 0 <= - u k by rewrite lee_oppr oppe0.
+have Nu0 k : 0 <= - u k by rewrite leeNr oppe0.
 move=> /(_ Nu0)/(cvgNP _ _).2; rewrite oppr0.
 by under eq_cvg do rewrite /GRing.opp /= oppr_min fineN !opprK.
 Qed.
@@ -2171,10 +2171,10 @@ Qed.
 Lemma maxe_cvg_0_cvg_0 u x : x < 0 -> (forall k, u k <= 0) ->
   maxe (u n) x @[n --> \oo] --> 0 -> u n @[n --> \oo] --> 0.
 Proof.
-rewrite -[in x < _]oppe0 lte_oppr => x0 u0.
+rewrite -[in x < _]oppe0 lteNr => x0 u0.
 under eq_fun do rewrite -(oppeK (u _)) -[in maxe _ _](oppeK x) -oppe_min.
 rewrite -[in _ --> _]oppe0 => /cvgeNP/mine_cvg_0_cvg_0-/(_ x0).
-have Nu0 k : 0 <= - u k by rewrite lee_oppr oppe0.
+have Nu0 k : 0 <= - u k by rewrite leeNr oppe0.
 by move=> /(_ Nu0); rewrite -[in _ --> _]oppe0 => /cvgeNP.
 Qed.
 
@@ -2644,7 +2644,7 @@ apply/eqP; rewrite eq_le; apply/andP; split.
   rewrite lee_subl_addr//; apply: ereal_inf_lb.
   by exists m => //; rewrite addeC.
 - apply: lb_ereal_inf => /= _ [m /= mn] <-.
-  by rewrite lee_add2l//; apply: ereal_inf_lb; exists m => /=.
+  by rewrite leeD2l//; apply: ereal_inf_lb; exists m => /=.
 Qed.
 
 Lemma limn_esup_le_cvg u l : limn_esup u <= l -> (forall n, l <= u n) ->


### PR DESCRIPTION
##### Motivation for this change

use the same naming conventions as in MathComp

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [ ] added corresponding documentation in the headers~~

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
