### PR TITLE
fixes #1080 (change sigma_finiteP)

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -10,6 +10,9 @@
   + definition `mset`, `pset`, `pprobability`
   + lemmas `lt0_mset`, `gt1_mset`
 
+- in `measure.v`:
+  + lemma `sigma_finiteP` generalized to an equivalence and changed to use `[/\ ..., .. & ....]`
+
 ### Renamed
 
 - in `constructive_ereal.v`:

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -4629,19 +4629,19 @@ Let B := [set A | measurable A /\ measurable_fun setT (phi A)].
 Lemma measurable_fun_xsection A : measurable A -> measurable_fun setT (phi A).
 Proof.
 move: A; suff : measurable `<=` B by move=> + A => /[apply] -[].
-have /sigma_finiteP [F F_T [F_nd F_oo]] := sigma_finiteT m2 => X mX.
+have /sigma_finiteP [F [F_T F_nd F_oo]] := sigma_finiteT m2 => X mX.
 have -> : X = \bigcup_n (X `&` (setT `*` F n)).
   by rewrite -setI_bigcupr -setM_bigcupr -F_T setMTT setIT.
 apply: xsection_ndseq_closed.
   move=> m n mn; apply/subsetPset; apply: setIS; apply: setSM => //.
   exact/subsetPset/F_nd.
 move=> n; rewrite -/B; have [? ?] := F_oo n.
-pose m2Fn := [the measure _ _ of mrestr m2 (F_oo n).1].
+pose m2Fn := mrestr m2 (F_oo n).1.
 have m2Fn_bounded : exists M, forall X, measurable X -> (m2Fn X < M%:E)%E.
   exists (fine (m2Fn (F n)) + 1) => Y mY.
   rewrite [in ltRHS]EFinD lte_spadder// fineK; last first.
-    by rewrite ge0_fin_numE ?measure_ge0//= /mrestr/= setIid.
-  by rewrite /= /mrestr/= setIid le_measure// inE//; exact: measurableI.
+    by rewrite ge0_fin_numE ?measure_ge0//= /m2Fn /mrestr setIid.
+  by rewrite /m2Fn /mrestr/= setIid le_measure// inE//; exact: measurableI.
 pose phi' A := m2Fn \o xsection A.
 pose B' := [set A | measurable A /\ measurable_fun setT (phi' A)].
 have subset_B' : measurable `<=` B' by exact: measurable_prod_subset_xsection.
@@ -4664,14 +4664,14 @@ Let B := [set A | measurable A /\ measurable_fun setT (phi A)].
 Lemma measurable_fun_ysection A : measurable A -> measurable_fun setT (phi A).
 Proof.
 move: A; suff : measurable `<=` B by move=> + A => /[apply] -[].
-have /sigma_finiteP[F F_T [F_nd F_oo]] := sigma_finiteT m1 => X mX.
+have /sigma_finiteP[F [F_T F_nd F_oo]] := sigma_finiteT m1 => X mX.
 have -> : X = \bigcup_n (X `&` (F n `*` setT)).
   by rewrite -setI_bigcupr -setM_bigcupl -F_T setMTT setIT.
 apply: ysection_ndseq_closed.
   move=> m n mn; apply/subsetPset; apply: setIS; apply: setSM => //.
   exact/subsetPset/F_nd.
 move=> n; have [? ?] := F_oo n; rewrite -/B.
-pose m1Fn := [the measure _ _ of mrestr m1 (F_oo n).1].
+pose m1Fn := mrestr m1 (F_oo n).1.
 have m1Fn_bounded : exists M, forall X, measurable X -> (m1Fn X < M%:E)%E.
   exists (fine (m1Fn (F n)) + 1) => Y mY.
   rewrite [in ltRHS]EFinD lte_spadder// fineK; last first.
@@ -4761,8 +4761,8 @@ Variable m2 : {sigma_finite_measure set T2 -> \bar R}.
 
 Let product_measure_sigma_finite : sigma_finite setT (m1 \x m2).
 Proof.
-have /sigma_finiteP[F TF [ndF Foo]] := sigma_finiteT m1.
-have /sigma_finiteP[G TG [ndG Goo]] := sigma_finiteT m2.
+have /sigma_finiteP[F [TF ndF Foo]] := sigma_finiteT m1.
+have /sigma_finiteP[G [TG ndG Goo]] := sigma_finiteT m2.
 exists (fun n => F n `*` G n).
  rewrite -setMTT TF TG predeqE => -[x y]; split.
     move=> [/= [n _ Fnx] [k _ Gky]]; exists (maxn n k) => //; split.
@@ -4784,8 +4784,8 @@ Lemma product_measure_unique
   forall X : set (T1 * T2), measurable X -> (m1 \x m2) X = m' X.
 Proof.
 move=> m'E.
-have /sigma_finiteP[F TF [ndF Foo]] := sigma_finiteT m1.
-have /sigma_finiteP[G TG [ndG Goo]] := sigma_finiteT m2.
+have /sigma_finiteP[F [TF ndF Foo]] := sigma_finiteT m1.
+have /sigma_finiteP[G [TG ndG Goo]] := sigma_finiteT m2.
 have UFGT : \bigcup_k (F k `*` G k) = setT.
   rewrite -setMTT TF TG predeqE => -[x y]; split.
     by move=> [n _ []/= ? ?]; split; exists n.

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -3243,7 +3243,7 @@ Context d (R : realFieldType) (T : ringOfSetsType d).
 Variable mu : {content set T -> \bar R}.
 
 Theorem Boole_inequality (A : (set T) ^nat) n :
-    (forall i, `I_n i -> measurable (A i)) ->
+    (forall i, (i < n)%N -> measurable (A i)) ->
   mu (\big[setU/set0]_(i < n) A i) <= \sum_(i < n) mu (A i).
 Proof.
 move=> Am; rewrite content_sub_additive// -bigcup_mkord.
@@ -3257,21 +3257,20 @@ Section sigma_finite_lemma.
 Context d (T : ringOfSetsType d) (R : realFieldType) (A : set T)
         (mu : {content set T -> \bar R}).
 
-Lemma sigma_finiteP : sigma_finite A mu ->
-  exists2 F, A = \bigcup_i F i &
-    nondecreasing_seq F /\ forall i, measurable (F i) /\ mu (F i) < +oo.
+Lemma sigma_finiteP : sigma_finite A mu <->
+  exists F, [/\ A = \bigcup_i F i,
+    nondecreasing_seq F & forall i, measurable (F i) /\ mu (F i) < +oo].
 Proof.
-move=> [S AS moo]; exists (fun n => \big[setU/set0]_(i < n.+1) S i).
-  rewrite AS predeqE => t; split => [[i _ Sit]|[i _]].
-    by exists i => //; rewrite big_ord_recr /=; right.
-  by rewrite -bigcup_mkord => -[j /= ji Sjt]; exists j.
-split=> [|i].
-- apply/nondecreasing_seqP => i; rewrite [in leRHS]big_ord_recr /=.
-  by apply/subsetPset; left.
-- split; first by apply: bigsetU_measurable => j _; exact: (moo j).1.
-  rewrite (@le_lt_trans _ _ (\sum_(j < i.+1) mu (S j)))//.
-    by apply: Boole_inequality => j _; exact: (moo j).1.
-  by apply/lte_sum_pinfty => j _; exact: (moo j).2.
+split=> [[F AUF mF]|[F [? ? ?]]]; last by exists F.
+exists (fun n => \big[setU/set0]_(i < n.+1) F i); split.
+- rewrite AUF; apply/seteqP; split.
+    by apply: subset_bigcup => i _; exact: bigsetU_sup.
+  by apply: bigcup_sub => i _; exact: bigsetU_bigcup.
+- by move=> i j ij; exact/subsetPset/subset_bigsetU.
+- move=> i; split; first by apply: bigsetU_measurable => j _; exact: (mF j).1.
+  rewrite (le_lt_trans (Boole_inequality _ _))//.
+    by move=> j _; exact: (mF _).1.
+  by apply/lte_sum_pinfty => j _; exact: (mF j).2.
 Qed.
 
 End sigma_finite_lemma.


### PR DESCRIPTION
##### Motivation for this change

fixes #1080 

as discussed during the last mathcomp-analysis dev meeting https://github.com/math-comp/analysis/wiki/2024-02-09-Meeting

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [ ] added corresponding documentation in the headers~~

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
