### PR TITLE
Add ln_lt0 since it is missing

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- in `exp.v`
+  + lemma `ln_lt0`
+
 ### Changed
 
 - move from `kernel.v` to `measure.v`

--- a/theories/exp.v
+++ b/theories/exp.v
@@ -658,6 +658,11 @@ Proof.
 by move=> x_ge1; rewrite -ler_expR expR0 lnK// qualifE/= (lt_le_trans _ x_ge1).
 Qed.
 
+Lemma ln_lt0 (x : R) : 0 < x < 1 -> ln x < 0.
+Proof.
+by move=> /andP[x_gt0 x_lt1]; rewrite -ltr_expR expR0 lnK.
+Qed.
+
 Lemma ln_gt0 x : 1 < x -> 0 < ln x.
 Proof.
 by move=> x_gt1; rewrite -ltr_expR expR0 lnK // qualifE/= (lt_trans _ x_gt1).

--- a/theories/exp.v
+++ b/theories/exp.v
@@ -659,9 +659,7 @@ by move=> x_ge1; rewrite -ler_expR expR0 lnK// qualifE/= (lt_le_trans _ x_ge1).
 Qed.
 
 Lemma ln_lt0 x : 0 < x < 1 -> ln x < 0.
-Proof.
-by move=> /andP[x_gt0 x_lt1]; rewrite -ltr_expR expR0 lnK.
-Qed.
+Proof. by move=> /andP[x_gt0 x_lt1]; rewrite -ltr_expR expR0 lnK. Qed.
 
 Lemma ln_gt0 x : 1 < x -> 0 < ln x.
 Proof.

--- a/theories/exp.v
+++ b/theories/exp.v
@@ -658,7 +658,7 @@ Proof.
 by move=> x_ge1; rewrite -ler_expR expR0 lnK// qualifE/= (lt_le_trans _ x_ge1).
 Qed.
 
-Lemma ln_lt0 (x : R) : 0 < x < 1 -> ln x < 0.
+Lemma ln_lt0 x : 0 < x < 1 -> ln x < 0.
 Proof.
 by move=> /andP[x_gt0 x_lt1]; rewrite -ltr_expR expR0 lnK.
 Qed.


### PR DESCRIPTION
##### Motivation for this change

Adds lemma ln_lt0 since the library already has ln_ge0, ln_le0 and ln_gt0.

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
