### PR TITLE
fix missing type-level equivalence in contra

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -10,6 +10,14 @@
 - in `lebesgue_integral.v`
   + lemma `ge0_integralZr`
 
+- in `contra.v`:
+  + in module `Internals`
+    * variant `equivT`
+    * definitions `equivT_refl`, `equivT_transl`, `equivT_sym`, `equivT_trans`,
+      `equivT_transr`, `equivT_Prop`, `equivT_LR` (hint view), `equivT_RL` (hint view)
+  + definition `notP`
+  + hint view for `move/` and `apply/` for `Internals.equivT_LR`, `Internals.equivT_RL`
+
 ### Changed
 
 - move from `kernel.v` to `measure.v`


### PR DESCRIPTION
##### Motivation for this change
The type-level equivalence was missing from the inference algorithm for contra.
<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
