### PR TITLE
fixes #981 (`sub_additive` vs `subadditive`)

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -4,6 +4,16 @@
 
 ### Added
 
+- in `classical_sets.v`:
+  + lemma `bigcup_recl`
+
+- in `sequences.v`:
+  + lemma `nneseries_recl`
+
+- in `measure.v`:
+  + definition `subset_sigma_subadditive`
+  + factory `isSubsetOuterMeasure`
+
 ### Changed
 
 ### Renamed
@@ -23,10 +33,22 @@
   + `lee_subr_addr` -> `leeBrDr`
   + `lee_subr_addl` -> `leeBrDl`
 
+- in `measure.v`:
+  + `sub_additive` -> `subadditive`
+  + `sigma_sub_additive` -> `measurable_subset_sigma_subadditive`
+  + `content_sub_additive` -> `content_subadditive`
+  + `ring_sigma_sub_additive` -> `ring_sigma_subadditive`
+  + `Content_SubSigmaAdditive_isMeasure` -> `Content_SigmaSubAdditive_isMeasure`
+  + `measure_sigma_sub_additive` -> `measure_sigma_subadditive`
+  + `measure_sigma_sub_additive_tail` -> `measure_sigma_subadditive_tail`
+
 ### Generalized
 
 - in `constructive_ereal.v`:
   + `gee_pMl` (was `gee_pmull`)
+
+- in `sequences.v`:
+  + lemmas `eseries0`, `nneseries_split`
 
 ### Deprecated
 

--- a/classical/classical_sets.v
+++ b/classical/classical_sets.v
@@ -1879,6 +1879,27 @@ Lemma bigcapID (Q : set I) (F : I -> set T) (P : set I) :
     (\bigcap_(i in P `&` Q) F i) `&` (\bigcap_(i in P `&` ~` Q) F i).
 Proof. by rewrite -bigcap_setU -setIUr setUv setIT. Qed.
 
+Lemma bigcup_sub F A P :
+  (forall i, P i -> F i `<=` A) -> \bigcup_(i in P) F i `<=` A.
+Proof. by move=> FD t [n An Fnt]; exact: (FD n). Qed.
+
+Lemma sub_bigcap F A P :
+  (forall i, P i -> A `<=` F i) -> A `<=` \bigcap_(i in P) F i.
+Proof. by move=> AF t At n Pn; exact: AF. Qed.
+
+Lemma subset_bigcup P F G : (forall i, P i -> F i `<=` G i) ->
+  \bigcup_(i in P) F i `<=` \bigcup_(i in P) G i.
+Proof.
+by move=> FG; apply: bigcup_sub => i Pi + /(FG _ Pi); apply: bigcup_sup.
+Qed.
+
+Lemma subset_bigcap P F G : (forall i, P i -> F i `<=` G i) ->
+  \bigcap_(i in P) F i `<=` \bigcap_(i in P) G i.
+Proof.
+move=> FG; apply: sub_bigcap => i Pi x Fx; apply: FG => //.
+exact: bigcap_inf Fx.
+Qed.
+
 End bigop_lemmas.
 Arguments bigcup_setD1 {T I} x.
 Arguments bigcap_setD1 {T I} x.
@@ -1915,27 +1936,11 @@ apply: setC_inj; rewrite setC_bigcap setCI -bigcup2inE /bigcap2 /bigcup2.
 by apply: eq_bigcupr => // -[|[|[]]].
 Qed.
 
-Lemma bigcup_sub T I (F : I -> set T) (D : set T) (P : set I) :
-  (forall i, P i -> F i `<=` D) -> \bigcup_(i in P) F i `<=` D.
-Proof. by move=> FD t [n Pn Fnt]; apply: (FD n). Qed.
-
-Lemma sub_bigcap T I (F : I -> set T) (D : set T) (P : set I) :
-  (forall i, P i -> D `<=` F i) -> D `<=` \bigcap_(i in P) F i.
-Proof. by move=> DF t Dt n Pn; apply: DF. Qed.
-
-Lemma subset_bigcup T I [P : set I] [F G : I -> set T] :
-  (forall i, P i -> F i `<=` G i) ->
-  \bigcup_(i in P) F i `<=` \bigcup_(i in P) G i.
+Lemma bigcup_recl T (F : nat -> set T) :
+  \bigcup_n F n = F 0%N `|` \bigcup_(n in ~` `I_1) F n.
 Proof.
-by move=> FG; apply: bigcup_sub => i Pi + /(FG _ Pi); apply: bigcup_sup.
-Qed.
-
-Lemma subset_bigcap T I [P : set I] [F G : I -> set T] :
-  (forall i, P i -> F i `<=` G i) ->
-  \bigcap_(i in P) F i `<=` \bigcap_(i in P) G i.
-Proof.
-move=> FG; apply: sub_bigcap => i Pi x Fx; apply: FG => //.
-exact: bigcap_inf Fx.
+by apply/seteqP; split => [t [[_ F0t|n _ Fnt]]|t [F0t|[n /= n0 Fnt]]];
+  [left|right; by exists n.+1|exists 0%N|exists n].
 Qed.
 
 Lemma bigcup_image {aT rT I} (P : set aT) (f : aT -> I) (F : I -> set rT) :

--- a/theories/charge.v
+++ b/theories/charge.v
@@ -1494,7 +1494,7 @@ have hnu S : measurable S -> \int[mu]_(x in S) h x <= nu S.
   rewrite -(setD0 S) -(setDv AP) setDDr.
   have mSIAP : measurable (S `&` AP) by exact: measurableI.
   have mSDAP : measurable (S `\` AP) by exact: measurableD.
-  rewrite integral_setU //.
+  rewrite ge0_integral_setU //.
   - rewrite measureU//.
       by apply: leeD; [exact: hnuN|exact: hnuP].
     by rewrite setDE setIACA setICl setI0.
@@ -1503,14 +1503,14 @@ have hnu S : measurable S -> \int[mu]_(x in S) h x <= nu S.
 have int_h_M : \int[mu]_x h x > M.
   have mCAP := measurableC mAP.
   have disj_AP : [disjoint AP & ~` AP] by exact/disj_set2P/setICr.
-  rewrite -(setUv AP) integral_setU ?setUv// /h.
+  rewrite -(setUv AP) ge0_integral_setU ?setUv// /h.
   under eq_integral do rewrite ifT//.
   under [X in _ < _ + X]eq_integral.
     by move=> x; rewrite inE /= => xE0p; rewrite memNset//; over.
   rewrite ge0_integralD//; last 2 first.
     - by move=> x _; exact: f_ge0.
     - by apply: measurable_funTS; exact: mf.
-  rewrite integral_cst // addeAC -integral_setU//; last 2 first.
+  rewrite integral_cst // addeAC -ge0_integral_setU//; last 2 first.
     by rewrite setUv//; exact: mf.
     by move=> x _; exact: f_ge0.
   rewrite setUv int_fRNE -lte_subel_addl; last first.
@@ -1568,7 +1568,7 @@ have mf_ k : measurable_fun setT (f_ k).
 have if_T k : integrable mu setT (f_ k).
   apply/integrableP; split => //.
   under eq_integral do rewrite gee0_abs//.
-  rewrite -(setUv (E k)) integral_setU //; last 3 first.
+  rewrite -(setUv (E k)) ge0_integral_setU //; last 3 first.
     - exact: measurableC.
     - by rewrite setUv.
     - exact/disj_set2P/subsets_disjoint.
@@ -1584,7 +1584,7 @@ have int_f_E j S : measurable S -> \int[mu]_(x in S) f_ j x = nu (S `&` E j).
   move=> mS.
   have mSIEj := measurableI _ _ mS (mE j).
   have mSDEj := measurableD mS (mE j).
-  rewrite -{1}(setUIDK S (E j)) (integral_setU _ mSIEj mSDEj)//; last 2 first.
+  rewrite -{1}(setUIDK S (E j)) (ge0_integral_setU _ mSIEj mSDEj)//; last 2 first.
     - by rewrite setUIDK; exact: (measurable_funS measurableT).
     - by apply/disj_set2P; rewrite setDE setIACA setICr setI0.
   rewrite /f_ -(eq_integral _ (g_ j)); last first.

--- a/theories/hoelder.v
+++ b/theories/hoelder.v
@@ -265,18 +265,19 @@ pose f a b n : R := match n with 0%nat => a | 1%nat => b | _ => 0 end.
 have mf a b : measurable_fun setT (f a b) by [].
 have := hoelder [the measure _ _ of counting] (mf a1 a2) (mf b1 b2) p0 q0 pq.
 rewrite !Lnorm_counting//.
-rewrite (nneseries_split 2); last by move=> k; rewrite lee_fin powR_ge0.
-rewrite ereal_series_cond eseries0 ?adde0; last first.
+rewrite (nneseries_split 0 2); last by move=> k; rewrite lee_fin powR_ge0.
+rewrite add0n ereal_series_cond eseries0 ?adde0; last first.
   by move=> [//|] [//|n _]; rewrite /f /= mulr0 normr0 powR0.
-rewrite 2!big_ord_recr /= big_ord0 add0e powRr1 ?normr_ge0 ?powRr1 ?normr_ge0//.
-rewrite (nneseries_split 2); last by move=> k; rewrite lee_fin powR_ge0.
+rewrite big_mkord 2!big_ord_recr/= big_ord0 add0e.
+rewrite powRr1 ?normr_ge0 ?powRr1 ?normr_ge0//.
+rewrite (nneseries_split 0 2); last by move=> k; rewrite lee_fin powR_ge0.
 rewrite ereal_series_cond eseries0 ?adde0; last first.
   by move=> [//|] [//|n _]; rewrite /f /= normr0 powR0// gt_eqF.
-rewrite 2!big_ord_recr /= big_ord0 add0e -EFinD poweR_EFin.
-rewrite (nneseries_split 2); last by move=> k; rewrite lee_fin powR_ge0.
+rewrite big_mkord 2!big_ord_recr /= big_ord0 add0e -EFinD poweR_EFin.
+rewrite (nneseries_split 0 2); last by move=> k; rewrite lee_fin powR_ge0.
 rewrite ereal_series_cond eseries0 ?adde0; last first.
   by move=> [//|] [//|n _]; rewrite /f /= normr0 powR0// gt_eqF.
-rewrite 2!big_ord_recr /= big_ord0 add0e -EFinD poweR_EFin.
+rewrite big_mkord 2!big_ord_recr /= big_ord0 add0e -EFinD poweR_EFin.
 rewrite -EFinM invr1 powRr1; last by rewrite addr_ge0.
 do 2 (rewrite ger0_norm; last by rewrite mulr_ge0).
 by do 4 (rewrite ger0_norm; last by []).

--- a/theories/kernel.v
+++ b/theories/kernel.v
@@ -236,7 +236,7 @@ exists (fun n => if n is O then [the _.-ker _ ~> _ of k] else
   [the _.-ker _ ~> _ of @kzero _ _ X Y R]).
   by case => [|_]; [exact: measure_uub|exact: kzero_uub].
 move=> t U mU/=; rewrite /mseries.
-rewrite (nneseries_split 1%N)// big_ord_recl/= big_ord0 adde0.
+rewrite (nneseries_split _ 1%N)// big_mkord big_ord_recl/= big_ord0 adde0.
 rewrite ereal_series (@eq_eseriesr _ _ (fun=> 0%E)); last by case.
 by rewrite eseries0// adde0.
 Qed.

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -1864,7 +1864,7 @@ move=> D [/= mD Deps KDf]; exists (K `\` D); split => //.
     exact: measurableD.
   rewrite setDE setC_bigcap setI_bigcupr.
   apply: (@le_trans _ _(\sum_(k <oo) mu (A `\` gK k))).
-    apply: measure_sigma_sub_additive => //; [|apply: bigcup_measurable => + _].
+  apply: measure_sigma_subadditive => //; [|apply: bigcup_measurable => + _].
       by move=> k /=; apply: measurableD => //; apply: mgK.
     by move=> k /=; apply: measurableD => //; apply: mgK.
   apply: (@le_trans _ _(\sum_(k <oo) (e2n k)%:E)); last exact: epsilon_trick0.
@@ -2879,7 +2879,8 @@ apply/eqP; rewrite eq_le; apply/andP; split; last first.
     transitivity (\int[measure_add [the measure _ _ of msum m_ n]
                                    [the measure _ _ of mseries m_ n]]_(x in D) f x).
       congr (\int[_]_(_ in D) _); apply/funext => A.
-      by rewrite measure_addE; exact: nneseries_split.
+      rewrite measure_addE/= /msum -(big_mkord xpredT (m_ ^~ A)).
+      exact: nneseries_split.
     rewrite integral_measure_add//; congr (_ + _).
     by rewrite -ge0_integral_measure_sum.
   by apply: leeDl; exact: integral_ge0.
@@ -6072,7 +6073,7 @@ have Bset0 i : B i !=set0 by exists i; exact: ballxx.
 have [E [uE ED tEB DE]] := @vitali_lemma_finite_cover _ _ B is_ballB Bset0 D.
 rewrite (@le_trans _ _ (3%:R%:E * \sum_(i <- E) mu (B i)))//.
   have {}DE := subset_trans KDB DE.
-  apply: (le_trans (@content_sub_additive _ _ _ [the measure _ _ of mu]
+  apply: (le_trans (@content_subadditive _ _ _ [the measure _ _ of mu]
       K (fun i => 3%:R *` B (nth 0%R E i)) (size E) _ _ _)) => //.
   - by move=> k ?; rewrite scale_ballE//; exact: measurable_ball.
   - by apply: closed_measurable; apply: compact_closed => //; exact: Rhausdorff.

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -283,11 +283,11 @@ HB.instance Definition _ := isContent.Build _ _ R
 
 Hint Extern 0 ((_ .-ocitv).-measurable _) => solve [apply: is_ocitv] : core.
 
-Lemma hlength_sigma_sub_additive :
-  sigma_sub_additive (hlength : set (ocitv_type R) -> _).
+Lemma hlength_sigma_subadditive :
+  measurable_subset_sigma_subadditive (hlength : set (ocitv_type R) -> _).
 Proof.
-move=> I A /(_ _)/cid2-/all_sig[b]/all_and2[_]/(_ _)/esym AE.
-move=> [a _ <-]; rewrite hlength_itv ?lte_fin/= -EFinB => lebig.
+move=> I A /(_ _)/cid2-/all_sig[b]/all_and2[_]/(_ _)/esym AE => -[a _ <-].
+rewrite /subset_sigma_subadditive hlength_itv ?lte_fin/= -EFinB => lebig.
 case: ifPn => a12; last by rewrite nneseries_esum// esum_ge0.
 apply/lee_addgt0Pr => _ /posnumP[e].
 rewrite [e%:num]splitr [in leRHS]EFinD addeA -leeBlDr//.
@@ -325,8 +325,8 @@ do !case: ifPn => //= ?; do ?by rewrite ?adde_ge0 ?lee_fin// ?subr_ge0// ?ltW.
 by rewrite addrAC lee_fin lerD// subr_le0 leNgt.
 Qed.
 
-HB.instance Definition _ := Content_SubSigmaAdditive_isMeasure.Build _ _ _
-  hlength hlength_sigma_sub_additive.
+HB.instance Definition _ := Content_SigmaSubAdditive_isMeasure.Build _ _ _
+  hlength hlength_sigma_subadditive.
 
 Lemma hlength_sigma_finite : sigma_finite setT (hlength : set (ocitv_type R) -> _).
 Proof.
@@ -933,7 +933,7 @@ rewrite measure_bigcup//; last first.
   move=> /fmorph_inj.
   have /set_bij_inj /[apply] := bijpinv_bij (fun=> 0) bijf.
   by rewrite in_setE => /(_ Logic.I Logic.I); exact/eqP.
-by rewrite eseries0// => n _; exact: lebesgue_measure_set1.
+by rewrite eseries0// => n _ _; exact: lebesgue_measure_set1.
 Qed.
 
 Section measurable_fun_measurable.
@@ -2113,7 +2113,7 @@ pose badn k := projT1 (cid (badn' k)); exists (\bigcup_k (E k (badn k))); split.
 - apply: (@le_lt_trans _ _ (eps/2)%R%:E); first last.
     by rewrite lte_fin ltr_pdivrMr // ltr_pMr // Rint_ltr_addr1 // ?Rint1.
   apply: le_trans.
-    apply: (measure_sigma_sub_additive _ (fun k => mE k (badn k)) _ _) => //.
+    apply: (measure_sigma_subadditive _ (fun k => mE k (badn k)) _ _) => //.
     exact: bigcup_measurable.
   apply: le_trans; first last.
     by apply: (@epsilon_trick0 R _ xpredT); rewrite divr_ge0 //; exact: ltW.
@@ -2320,7 +2320,7 @@ have [N F5e] : exists N, \sum_(N <= n <oo) \esum_(i in F n) mu (closure (B i)) <
   set X : \bar R := (X in fine X).
   have Xoo : X < +oo.
     apply: le_lt_trans foo.
-    by rewrite (nneseries_split N)// leeDr//; exact: sume_ge0.
+    by rewrite (nneseries_split _ N)// leeDr//; exact: sume_ge0.
   rewrite fineK ?ge0_fin_numE//; last exact: nneseries_ge0.
   apply: lee_nneseries => //; first by move=> i _; exact: esum_ge0.
   move=> n Nn; rewrite measure_bigcup//=.
@@ -2392,7 +2392,7 @@ have {}ZNF5 : mu (Z r%:num) <=
     exact: le_outer_measure.
   apply: (@le_trans _ _ (\sum_(N <= i <oo) mu
                            (\bigcup_(j in F i) closure (5%:R *` B j)))).
-    apply: measure_sigma_sub_additive_tail => //.
+    apply: measure_sigma_subadditive_tail => //.
       move=> n; apply: bigcup_measurable => k _.
       by apply: measurable_closure; exact: is_scale_ball.
     apply: bigcup_measurable => k _; apply: bigcup_measurable => k' _.
@@ -2403,7 +2403,7 @@ have {}ZNF5 : mu (Z r%:num) <=
       (if i \in F n then closure (5%:R *` B i) else set0)); last first.
     congr (limn _); apply/funext => x.
     by under [RHS]eq_bigr do rewrite (fun_if mu) measure0.
-  apply: measure_sigma_sub_additive => //.
+  apply: measure_sigma_subadditive => //.
   + move=> m; case: ifPn => // _.
     by apply: measurable_closure; exact: is_scale_ball.
   + apply: bigcup_measurable => k _; case: ifPn => // _.

--- a/theories/lebesgue_stieltjes_measure.v
+++ b/theories/lebesgue_stieltjes_measure.v
@@ -401,17 +401,17 @@ rewrite -sumEFin fsbig_finite//= set_fsetK// big_seq [in X in (_ <= X)%E]big_seq
 by apply: lee_sum => i iD; rewrite wlength_itv_bnd// Dab.
 Qed.
 
-Lemma wlength_sigma_sub_additive (f : cumulative R) :
-  sigma_sub_additive (wlength f).
+Lemma wlength_sigma_subadditive (f : cumulative R) :
+  measurable_subset_sigma_subadditive (wlength f).
 Proof.
-move=> I A /(_ _)/cid2-/all_sig[b]/all_and2[_]/(_ _)/esym AE.
-move=> [a _ <-]; rewrite wlength_itv ?lte_fin/= -EFinB => lebig.
+move=> I A /(_ _)/cid2-/all_sig[b]/all_and2[_]/(_ _)/esym AE => -[a _ <-].
+rewrite /subset_sigma_subadditive wlength_itv ?lte_fin/= -EFinB => lebig.
 case: ifPn => a12; last by rewrite nneseries_esum ?esum_ge0.
 wlog wlogh : b A AE lebig / forall n, (b n).1 <= (b n).2.
   move=> /= h.
   set A' := fun n => if (b n).1 >= (b n).2 then set0 else A n.
   set b' := fun n => if (b n).1 >= (b n).2 then (0, 0) else b n.
-  rewrite [X in (_ <= X)%E](_ : _ = \sum_(n <oo) wlength f (A' n))%E; last first.
+  rewrite [leRHS](_ : _ = \sum_(n <oo) wlength f (A' n))%E; last first.
     apply: (@eq_eseriesr _ (wlength f \o A) (wlength f \o A')) => k.
     rewrite /= /A' AE; case: ifPn => // bn.
     by rewrite set_itv_ge//= bnd_simp -leNgt.
@@ -472,8 +472,8 @@ by rewrite AE leeD2l// lee_fin lerBlDl natrX De.
 Qed.
 
 HB.instance Definition _ (f : cumulative R) :=
-  Content_SubSigmaAdditive_isMeasure.Build _ _ _
-    (wlength f) (wlength_sigma_sub_additive f).
+  Content_SigmaSubAdditive_isMeasure.Build _ _ _
+    (wlength f) (wlength_sigma_subadditive f).
 
 Lemma wlength_sigma_finite (f : R -> R) :
   sigma_finite [set: (ocitv_type R)] (wlength f).
@@ -504,6 +504,9 @@ HB.instance Definition _ (f : cumulative R) := @Measure_isSigmaFinite.Build _ _ 
 
 End wlength_extension.
 Arguments lebesgue_stieltjes_measure {R}.
+
+#[deprecated(since="mathcomp-analysis 1.1.0", note="renamed `wlength_sigma_subadditive`")]
+Notation wlength_sigma_sub_additive := wlength_sigma_subadditive (only parsing).
 
 Section lebesgue_stieltjes_measure.
 Variable R : realType.


### PR DESCRIPTION
##### Motivation for this change

fixes #981 


##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
