### PR TITLE
fixes #1190 (`notin_setE`)

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -58,6 +58,9 @@
   + `measure_sigma_sub_additive` -> `measure_sigma_subadditive`
   + `measure_sigma_sub_additive_tail` -> `measure_sigma_subadditive_tail`
 
+- in `classical_sets.v`:
+  + `notin_set` -> `notin_setE`
+
 ### Generalized
 
 - in `constructive_ereal.v`:
@@ -76,6 +79,9 @@
   + lemmas ` measurable_prod_measurableType`, `measurable_prod_g_measurableTypeR` (from `measurableType` to `algebraOfSetsType`)
 
 ### Deprecated
+
+- in `classical_sets.v`:
+  + `notin_set` (use `notin_setE` instead)
 
 ### Removed
 

--- a/classical/cardinality.v
+++ b/classical/cardinality.v
@@ -402,7 +402,7 @@ move=> /set0P[x Ax]; right; apply/surjfunPex.
 exists (fun y => if f y \in A then f y else x).
 apply/seteqP; split.
   by move=> x' /[dup] /= /'surj_f [y By <-] Afy; exists y; rewrite ?ifT// inE.
-by apply/image_subP => y By; case: ifPn; rewrite (inE, notin_set).
+by apply/image_subP => y By; case: ifPn; rewrite (inE, notin_setE).
 Qed.
 
 Lemma card_le_II n m : (`I_n #<= `I_m) = (n <= m)%N.
@@ -777,7 +777,7 @@ Lemma fset_setD {T : choiceType} (A B : set T) :
 Proof.
 move=> fA fB; apply/fsetP=> x.
 rewrite ?(inE, in_fset_set)//; last exact: finite_setD.
-by apply/idP/andP; rewrite ?inE => -[]; rewrite ?notin_set.
+by apply/idP/andP; rewrite ?inE => -[]; rewrite ?notin_setE.
 Qed.
 
 Lemma fset_setD1 {T : choiceType} (x : T) (A : set T) :

--- a/classical/classical_sets.v
+++ b/classical/classical_sets.v
@@ -511,7 +511,7 @@ Lemma set_memK {A} {u : T} : cancel (@set_mem A u) mem_set. Proof. by []. Qed.
 Lemma memNset (A : set T) (u : T) : ~ A u -> u \in A = false.
 Proof. by apply: contra_notF; rewrite inE. Qed.
 
-Lemma notin_set (A : set T) x : (x \notin A : Prop) = ~ (A x).
+Lemma notin_setE (A : set T) x : (x \notin A : Prop) = ~ (A x).
 Proof. by apply/propext; split=> /asboolPn. Qed.
 
 Lemma setTPn (A : set T) : A != setT <-> exists t, ~ A t.
@@ -527,13 +527,13 @@ Lemma in_set0 (x : T) : (x \in set0) = false. Proof. by rewrite memNset. Qed.
 Lemma in_setT (x : T) : x \in setT. Proof. by rewrite mem_set. Qed.
 
 Lemma in_setC (x : T) A : (x \in ~` A) = (x \notin A).
-Proof. by apply/idP/idP; rewrite inE notin_set. Qed.
+Proof. by apply/idP/idP; rewrite inE notin_setE. Qed.
 
 Lemma in_setI (x : T) A B : (x \in A `&` B) = (x \in A) && (x \in B).
 Proof. by apply/idP/andP; rewrite !inE. Qed.
 
 Lemma in_setD (x : T) A B : (x \in A `\` B) = (x \in A) && (x \notin B).
-Proof. by apply/idP/andP; rewrite !inE notin_set. Qed.
+Proof. by apply/idP/andP; rewrite !inE notin_setE. Qed.
 
 Lemma in_setU (x : T) A B : (x \in A `|` B) = (x \in A) || (x \in B).
 Proof. by apply/idP/orP; rewrite !inE. Qed.
@@ -755,7 +755,7 @@ Proof.  by move=> Aa; rewrite setDUK//= => x ->. Qed.
 
 Lemma setI1 A a : A `&` [set a] = if a \in A then [set a] else set0.
 Proof.
-by apply/predeqP => b; case: ifPn; rewrite (inE, notin_set) => Aa;
+by apply/predeqP => b; case: ifPn; rewrite (inE, notin_setE) => Aa;
    split=> [[]|]//; [move=> -> //|move=> /[swap] -> /Aa].
 Qed.
 
@@ -1091,6 +1091,8 @@ Hint Resolve subsetUl subsetUr subIsetl subIsetr subDsetl subDsetr : core.
 Notation setvI := setICl (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6", note="Use setICr instead.")]
 Notation setIv := setICr (only parsing).
+#[deprecated(since="mathcomp-analysis 1.2.0", note="Use notin_setE instead.")]
+Notation notin_set := notin_setE (only parsing).
 Arguments setU_id2r {T} C {A B}.
 
 Section set_order.
@@ -1205,7 +1207,7 @@ have [Bt|Bt] := boolP (true \in B); have [Bf|Bf] := boolP (false \in B).
   apply/seteqP; split => -[]// /mem_set; last by move=> _; exact: set_mem.
   by rewrite (negbTE Bt).
 - suff : B = set0 by move=> ->; apply/or4P; rewrite eqxx/= !orbT.
-  by apply/seteqP; split => -[]//=; rewrite 2!notin_set in Bt, Bf.
+  by apply/seteqP; split => -[]//=; rewrite 2!notin_setE in Bt, Bf.
 Qed.
 
 (* TODO: other lemmas that relate fset and classical sets *)
@@ -1434,7 +1436,7 @@ Qed.
 Lemma notin_setI_preimage T R D (f : T -> R) i :
   i \notin f @` D -> D `&` f @^-1` [set i] = set0.
 Proof.
-by rewrite notin_set/=; apply: contra_notP => /eqP/set0P[t [Dt fit]]; exists t.
+by rewrite notin_setE/=; apply: contra_notP => /eqP/set0P[t [Dt fit]]; exists t.
 Qed.
 
 Lemma comp_preimage T1 T2 T3 (A : set T3) (g : T1 -> T2) (f : T2 -> T3) :
@@ -1772,8 +1774,8 @@ Lemma bigcup_mkcond P F :
   \bigcup_(i in P) F i = \bigcup_i if i \in P then F i else set0.
 Proof.
 rewrite predeqE => x; split=> [[i Pi Fix]|[i _]].
-  by exists i => //; case: ifPn; rewrite (inE, notin_set).
-by case: ifPn; rewrite (inE, notin_set) => Pi Fix; exists i.
+  by exists i => //; case: ifPn; rewrite (inE, notin_setE).
+by case: ifPn; rewrite (inE, notin_setE) => Pi Fix; exists i.
 Qed.
 
 Lemma bigcup_mkcondr P Q F :
@@ -3210,13 +3212,13 @@ Qed.
 Lemma notin_xsectionM X1 X2 x : x \notin X1 -> xsection (X1 `*` X2) x = set0.
 Proof.
 move=> xX1; rewrite /xsection /= predeqE => y; split => //.
-by rewrite /xsection/= inE => -[] /=; rewrite notin_set in xX1.
+by rewrite /xsection/= inE => -[] /=; rewrite notin_setE in xX1.
 Qed.
 
 Lemma notin_ysectionM X1 X2 y : y \notin X2 -> ysection (X1 `*` X2) y = set0.
 Proof.
 move=> yX2; rewrite /xsection /= predeqE => x; split => //.
-by rewrite /ysection/= inE => -[_]; rewrite notin_set in yX2.
+by rewrite /ysection/= inE => -[_]; rewrite notin_setE in yX2.
 Qed.
 
 Lemma xsection_bigcup (F : nat -> set (T1 * T2)) x :

--- a/classical/fsbigop.v
+++ b/classical/fsbigop.v
@@ -133,8 +133,8 @@ rewrite uniq_perm ?filter_uniq//= => i; rewrite mem_filter.
 set g := fun i => if i \in A then f i else idx.
 have gAf : setT `&` g @^-1` [set~ idx] = (A `&` f @^-1` [set~ idx]).
   rewrite setTI; apply/predeqP => x; split; rewrite /preimage/g/=.
-    by case: ifPn; rewrite (inE, notin_set).
-  by case: ifPn; rewrite (inE, notin_set) => ? [].
+    by case: ifPn; rewrite (inE, notin_setE).
+  by case: ifPn; rewrite (inE, notin_setE) => ? [].
 case: finite_supportP => //.
   rewrite -gAf; case: finite_supportP=> //=; first by rewrite ?inE andbF.
   by move=> X _ gidx <-//.
@@ -214,7 +214,7 @@ Lemma fsbig_widen (T : choiceType) [R : Type] [idx : R]
   \big[op/idx]_(i \in P) f i = \big[op/idx]_(i \in D) f i.
 Proof.
 move=> PD DPf; rewrite fsbig_mkcond [RHS]fsbig_mkcond.
-apply: eq_fsbigr => x _; rewrite /patch; case: ifPn; rewrite (inE, notin_set).
+apply: eq_fsbigr => x _; rewrite /patch; case: ifPn; rewrite (inE, notin_setE).
   by move=> Px; rewrite ifT// inE; apply: PD.
 by move=> Px; case: ifP => //; rewrite inE => Dx; rewrite DPf.
 Qed.

--- a/classical/functions.v
+++ b/classical/functions.v
@@ -1839,7 +1839,7 @@ Lemma patchT f : {in A, patch f =1 f}. Proof. by rewrite /patch => x ->. Qed.
 Lemma patchN f : {in [predC A], patch f =1 d}.
 Proof. by rewrite /patch => x /negPf/= ->. Qed.
 Lemma patchC f : {in ~` A, patch f =1 d}.
-Proof. by move=> u /set_mem/= NAu; rewrite patchN ?inE//= notin_set. Qed.
+Proof. by move=> u /set_mem/= NAu; rewrite patchN ?inE//= notin_setE. Qed.
 
 HB.instance Definition _ f :=
   SurjFun.copy (patch f) [fun patch f in A].
@@ -1870,7 +1870,7 @@ Lemma preimage_restrict (aT : Type) (rT : pointedType)
   (f \_ D) @^-1` B = (if point \in B then ~` D else set0) `|` D `&` f @^-1` B.
 Proof.
 rewrite /preimage/= /patch; apply/predeqP => x /=; split.
-  case: ifPn; rewrite ?(inE, notin_set); first by right.
+  case: ifPn; rewrite ?(inE, notin_setE); first by right.
   by move=> NDx Bp; rewrite ifT ?inE//=; left.
 move=> [|[Dx Bfx]]; last by rewrite ifT ?inE.
 by case: ifP; rewrite // inE => Bp NDx; case: ifPn; rewrite // inE.

--- a/theories/charge.v
+++ b/theories/charge.v
@@ -1483,7 +1483,7 @@ have hnuP S : measurable S -> S `<=` AP -> \int[mu]_(x in S) h x <= nu S.
 have hnuN S : measurable S -> S `<=` ~` AP -> \int[mu]_(x in S) h x <= nu S.
   move=> mS ScAP; rewrite /h; under eq_integral.
     move=> x xS; rewrite ifF; last first.
-      by apply/negbTE; rewrite notin_set; apply: ScAP; apply: set_mem.
+      by apply/negbTE; rewrite notin_setE; apply: ScAP; apply: set_mem.
     over.
   exact: int_fRN_ub.
 have hnu S : measurable S -> \int[mu]_(x in S) h x <= nu S.

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -1484,14 +1484,14 @@ Proof.
 move=> ltab fdrvbl fcont faefb.
 have [cmax cmaxab fcmax] := EVT_max (ltW ltab) fcont.
 have [cmaxeaVb|] := boolP (cmax \in [set a; b]); last first.
-  rewrite notin_set => /not_orP[/eqP cnea /eqP cneb].
+  rewrite notin_setE => /not_orP[/eqP cnea /eqP cneb].
   have {}cmaxab : cmax \in `]a, b[%R.
     by rewrite in_itv /= !lt_def !(itvP cmaxab) cnea eq_sym cneb.
   exists cmax => //; apply: derive1_at_max (ltW ltab) fdrvbl cmaxab _ => t tab.
   by apply: fcmax; rewrite in_itv /= !ltW // (itvP tab).
 have [cmin cminab fcmin] := EVT_min (ltW ltab) fcont.
 have [cmineaVb|] := boolP (cmin \in [set a; b]); last first.
-  rewrite notin_set => /not_orP[/eqP cnea /eqP cneb].
+  rewrite notin_setE => /not_orP[/eqP cnea /eqP cneb].
   have {}cminab : cmin \in `]a, b[%R.
     by rewrite in_itv /= !lt_def !(itvP cminab) cnea eq_sym cneb.
   exists cmin => //; apply: derive1_at_min (ltW ltab) fdrvbl cminab _ => t tab.

--- a/theories/esum.v
+++ b/theories/esum.v
@@ -423,12 +423,12 @@ move=> Jtriv a_ge0.
 pose J' i := if a @` J i == [set 0] then set0 else J i.
 pose a' x := if x \in \bigcup_(k in K) J k then a x else 0.
 have a'E k x : K k -> J k x -> a' x = a x.
-  move=> Kk Jkx; rewrite /a'; case: ifPn; rewrite ?(inE, notin_set)//=.
+  move=> Kk Jkx; rewrite /a'; case: ifPn; rewrite ?(inE, notin_setE)//=.
   by case; exists k.
 have a'_ge0 x : a' x >= 0 by rewrite /a'; case: ifPn; rewrite // ?inE => /a_ge0.
 transitivity (\esum_(i in \bigcup_(k in K) J' k) a' i).
   rewrite esum_mkcond [RHS]esum_mkcond /a'; apply: eq_esum => x _.
-  do 2!case: ifPn; rewrite ?(inE, notin_set)//= => J'x Jx.
+  do 2!case: ifPn; rewrite ?(inE, notin_setE)//= => J'x Jx.
   apply: contra_not_eq J'x => Nax.
   move: Jx => [k kK Jkx]; exists k=> //; rewrite /J'/=; case: ifPn=> //=.
   move=> /eqP/(congr1 (@^~ (a x)))/=; rewrite propeqE => -[+ _].
@@ -439,7 +439,7 @@ rewrite esum_bigcupT//; last first.
   by have := Jtriv i j Ai0 Aj0; apply; exists x.
 apply: eq_esum => i Ki.
 rewrite esum_mkcond [RHS]esum_mkcond; apply: eq_esum => x _.
-do 2!case: ifPn; rewrite ?(inE, notin_set)//=.
+do 2!case: ifPn; rewrite ?(inE, notin_setE)//=.
 - by move=> /a'E->//.
 - by rewrite /J'; case: ifPn => //.
 move=> Jix; rewrite /J'; case: ifPn=> //=.

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -765,7 +765,7 @@ rewrite sintegralE (fsbig_widen _ [set 0%R; 1%R]) => //; last 2 first.
 have N01 : (0 <> 1:> R)%R by move=> /esym/eqP; rewrite oner_eq0.
 rewrite fsbigU//=; last by move=> t [->]//.
 rewrite !fsbig_set1 mul0e add0e mul1e.
-by rewrite preimage_indic ifT ?inE// ifN ?notin_set.
+by rewrite preimage_indic ifT ?inE// ifN ?notin_setE.
 Qed.
 
 (* NB: not used *)
@@ -1423,7 +1423,7 @@ apply/negP => /andP[/allP An0]; rewrite mulf_eq0 => /orP[|].
   by apply/negP; near: n; exists 1%N => //= m /=; rewrite lt0n pnatr_eq0.
 rewrite pnatr_eq0 => /eqP.
 have [//|] := boolP (x \in B n).
-rewrite notin_set /B /setI /= => /not_andP[] // /negP.
+rewrite notin_setE /B /setI /= => /not_andP[] // /negP.
 rewrite -ltNge => fxn _.
 have K : (`|floor (fine (f x) * 2 ^+ n)| < n * 2 ^ n)%N.
   rewrite -ltz_nat gez0_abs; last by rewrite floor_ge0 mulr_ge0// ltW.
@@ -2568,7 +2568,7 @@ rewrite sintegralE (fsbig_widen _ [set 0%R; x%:num])/=.
 - have [->|x0] := eqVneq x%:num 0%R; first by rewrite setUid fsbig_set1 !mul0e.
   rewrite fsbigU0//=; last by move=> y [->]/esym; apply/eqP.
   rewrite !fsbig_set1 mul0e add0e preimage_restrict//.
-  by rewrite ifN ?set0U ?setIidl//= notin_set => /esym; exact/eqP.
+  by rewrite ifN ?set0U ?setIidl//= notin_setE => /esym; exact/eqP.
 - by move=> y [t _ <-] /=; rewrite /patch; case: ifPn; [right|left].
 - by move=> y [_ /=/preimage10->]; rewrite measure0 mule0.
 Qed.
@@ -3635,7 +3635,7 @@ pose f' : T -> R := indic Df_neq0.
 have le_f_M t : D t -> `|f t| <= M%:E * (f' t)%:E.
   move=> Dt; rewrite /f' indicE; have [|] := boolP (t \in Df_neq0).
     by rewrite inE => -[_ _]; rewrite mule1 fM.
-  by rewrite notin_set=> /not_andP[//|/negP/negPn/eqP ->]; rewrite abse0 mule0.
+  by rewrite notin_setE=> /not_andP[//|/negP/negPn/eqP ->]; rewrite abse0 mule0.
 have : 0 <= \int[mu]_(x in D) `|f x|  <= `|M|%:E * mu Df_neq0.
   rewrite integral_ge0//= /Df_neq0 -{2}(setIid D) setIAC -integral_indic//.
   rewrite -/Df_neq0 -ge0_integralZl//; last 2 first.
@@ -3854,7 +3854,7 @@ rewrite [RHS](ge0_negligible_integral mN)//; last 2 first.
 - apply: eq_integral => x;rewrite in_setD => /andP[_ xN].
   apply: contrapT; rewrite indicE; have [|?] := boolP (x \in D).
     rewrite inE => Dx; rewrite !mule1.
-    move: xN; rewrite notin_set; apply: contra_not => fxgx; apply: subN => /=.
+    move: xN; rewrite notin_setE; apply: contra_not => fxgx; apply: subN => /=.
     exact/not_implyP.
   by rewrite !mule0.
 Qed.
@@ -3929,7 +3929,7 @@ rewrite [X in measurable X](_ : _ = D `&` ~` N `&` (f @^-1` `]x%:E, +oo[)
   - have [->|fgy] := eqVneq (f y) (g y).
       have [yN|yN] := boolP (y \in N).
         by right; split => //; rewrite inE in yN.
-      by left; split => //; rewrite notin_set in yN.
+      by left; split => //; rewrite notin_setE in yN.
     by right; split => //; split => //; apply: subN => /= /(_ Dy); exact/eqP.
   - split => //; have [<-//|fgy] := eqVneq (f y) (g y).
     by exfalso; apply/Ny/subN => /= /(_ Dy); exact/eqP.
@@ -3988,19 +3988,19 @@ transitivity (\int[mu]_(x in D) (EFin \o (g1 \+ g2)%R) x).
     rewrite EFinD /g1 /g2 /restrict /=; have [|] := boolP (x \in A `&` B).
       by rewrite in_setI => /andP[xA xB] /=; rewrite !fineK.
     by rewrite in_setI negb_and => /orP[|];
-      rewrite in_setI negb_and /= (mem_set Dx)/= notin_set/=.
+      rewrite in_setI negb_and /= (mem_set Dx)/= notin_setE/=.
 - rewrite (_ : _ \o _ = (EFin \o g1) \+ (EFin \o g2))// integralD_EFin//.
   congr (_ + _); apply: ae_eq_integral => //.
   + apply: (filterS2 _ _ (integrable_ae mD if1) (integrable_ae mD if2)).
     move=> x + + Dx => /(_ Dx) f1fin /(_ Dx) f2fin /=; rewrite /g1 /restrict /=.
     have [/=|] := boolP (x \in A `&` B); first by rewrite fineK.
     by rewrite in_setI negb_and => /orP[|];
-      rewrite in_setI negb_and /= (mem_set Dx) /= notin_set/=.
+      rewrite in_setI negb_and /= (mem_set Dx) /= notin_setE/=.
   + apply: (filterS2 _ _ (integrable_ae mD if1) (integrable_ae mD if2)).
     move=> x + + Dx => /(_ Dx) f1fin /(_ Dx) f2fin /=; rewrite /g2 /restrict /=.
     have [/=|] := boolP (x \in A `&` B); first by rewrite fineK.
     by rewrite in_setI negb_and => /orP[|];
-      rewrite in_setI negb_and /= (mem_set Dx) /= notin_set.
+      rewrite in_setI negb_and /= (mem_set Dx) /= notin_setE.
 Qed.
 
 End integralD.

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -1716,7 +1716,7 @@ Proof.
 move=> F mF tF mUF; rewrite /dirac indicE; have [|aFn] /= := boolP (a \in _).
   rewrite inE => -[n _ Fna].
   have naF m : m != n -> a \notin F m.
-    move=> mn; rewrite notin_set => Fma.
+    move=> mn; rewrite notin_setE => Fma.
     move/trivIsetP : tF => /(_ _ _ Logic.I Logic.I mn).
     by rewrite predeqE => /(_ a)[+ _]; exact.
   apply/cvg_ballP => _/posnumP[e]; near=> m.
@@ -2202,7 +2202,7 @@ exists (B `&` [set X | X != set0]); split.
 - by move=> X Y/= [XB _] [YB _]; exact: Btriv.
 - by move=> X/= /[!inE] -[] /Bm.
 rewrite bigcup_mkcondr; apply: eq_bigcupr => X Bx; case: ifPn => //.
-by rewrite notin_set/= => /negP/negPn/eqP.
+by rewrite notin_setE/= => /negP/negPn/eqP.
 Qed.
 
 Definition decomp (A : set rT) : set (set T) :=
@@ -2612,13 +2612,13 @@ move=> XEbig; rewrite measure_semi_bigcup//= -?XEbig//; last first.
 rewrite [leLHS](_ : _ = \sum_(i <oo | g i != set0) mu (g i)); last first.
   rewrite !nneseries_esum// esum_mkcond [RHS]esum_mkcond; apply: eq_esum.
   move=> i _; rewrite ifT ?inE//=; case: ifPn => //.
-  by rewrite notin_set /= -/(g _) => /negP/negPn/eqP ->.
+  by rewrite notin_setE /= -/(g _) => /negP/negPn/eqP ->.
 rewrite -(esum_pred_image mu g)//.
 rewrite [leLHS](_ : _ = \esum_(X in range g) mu X); last first.
   rewrite esum_mkcond [RHS]esum_mkcond; apply: eq_esum.
-  move=> Y _; case: ifPn; rewrite ?(inE, notin_set)/=.
+  move=> Y _; case: ifPn; rewrite ?(inE, notin_setE)/=.
     by move=> [i giN0 giY]; rewrite ifT// ?inE//=; exists i.
-  move=> Ngx; case: ifPn; rewrite ?(inE, notin_set)//=.
+  move=> Ngx; case: ifPn; rewrite ?(inE, notin_setE)//=.
   move=> [i _ giY]; apply: contra_not_eq Ngx; rewrite -giY => mugi.
   by exists i => //; apply: contra_neq mugi => ->; rewrite measure0.
 have -> : range g = \bigcup_i (decomp (seqDU B i)).

--- a/theories/numfun.v
+++ b/theories/numfun.v
@@ -273,10 +273,10 @@ Lemma image_indic D A :
               (if A `&` D != set0 then [set 1 : R] else set0).
 Proof.
 rewrite /indic; apply/predeqP => x; split => [[t At /= <-]|].
-  by rewrite /indic; case: (boolP (t \in D)); rewrite ?(inE, notin_set) => Dt;
+  by rewrite /indic; case: (boolP (t \in D)); rewrite ?(inE, notin_setE) => Dt;
      [right|left]; rewrite ifT//=; apply/set0P; exists t.
 by move=> []; case: ifPn; rewrite ?negbK// => /set0P[t [At Dt]] ->;
-   exists t => //; case: (boolP (t \in D)); rewrite ?(inE, notin_set).
+   exists t => //; case: (boolP (t \in D)); rewrite ?(inE, notin_setE).
 Qed.
 
 Lemma preimage_indic (D : set T) (B : set R) :
@@ -286,13 +286,13 @@ Proof.
 rewrite /preimage/= /indic; apply/seteqP; split => x;
   case: ifPn => B1; case: ifPn => B0 //=.
 - have [|] := boolP (x \in D); first by rewrite inE.
-  by rewrite notin_set in B0.
-- have [|] := boolP (x \in D); last by rewrite notin_set.
-  by rewrite notin_set in B1.
+  by rewrite notin_setE in B0.
+- have [|] := boolP (x \in D); last by rewrite notin_setE.
+  by rewrite notin_setE in B1.
 - by have [xD|xD] := boolP (x \in D);
-    [rewrite notin_set in B1|rewrite notin_set in B0].
+    [rewrite notin_setE in B1|rewrite notin_setE in B0].
 - by have [xD|xD] := boolP (x \in D); [rewrite inE in B1|rewrite inE in B0].
-- have [xD|] := boolP (x \in D); last by rewrite notin_set.
+- have [xD|] := boolP (x \in D); last by rewrite notin_setE.
   by rewrite inE in B1.
 - have [|xD] := boolP (x \in D); first by rewrite inE.
   by rewrite inE in B0.

--- a/theories/probability.v
+++ b/theories/probability.v
@@ -64,7 +64,7 @@ Notation "{ 'RV' P >-> R }" := (@random_variable _ _ R P) : form_scope.
 Lemma notin_range_measure d (T : measurableType d) (R : realType)
     (P : {measure set T -> \bar R}) (X : T -> R) r :
   r \notin range X -> P (X @^-1` [set r]) = 0%E.
-Proof. by rewrite notin_set => hr; rewrite preimage10. Qed.
+Proof. by rewrite notin_setE => hr; rewrite preimage10. Qed.
 
 Lemma probability_range d (T : measurableType d) (R : realType)
   (P : probability T R) (X : {RV P >-> R}) : P (X @^-1` range X) = 1%E.
@@ -751,7 +751,7 @@ rewrite eseries_mkcond; apply: eq_eseriesr => k _.
 rewrite /enum_prob patchE; case: ifPn => nX; rewrite ?mul0e//.
 rewrite diracE; have [kA|] := boolP (_ \in A).
   by rewrite mule1 setIidr// => _ /= ->; exact: set_mem.
-rewrite notin_set => kA.
+rewrite notin_setE => kA.
 rewrite mule0 (disjoints_subset _ _).2 ?preimage_set0 ?measure0//.
 by apply: subsetCr; rewrite sub1set inE.
 Qed.
@@ -780,7 +780,7 @@ rewrite -[in LHS](_ : \bigcup_k (if k \in dRV_dom X then
   exists ((dRV_enum X)^-1%function (X t)) => //.
   case: ifPn=> [_|].
     by rewrite invK// inE.
-  by rewrite notin_set/=; apply; apply: funS.
+  by rewrite notin_setE/=; apply; apply: funS.
 have tA : trivIset (dRV_dom X) (fun k => [set dRV_enum X k]).
   by move=> i j iX jX [r [/= ->{r}]] /inj; rewrite !inE; exact.
 have {tA}/trivIset_mkcond tXA :

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -5944,7 +5944,7 @@ Variant nbhs_subspace_spec x : Prop -> Prop -> bool -> set_system T -> Type :=
 Lemma nbhs_subspaceP_subproof x :
   nbhs_subspace_spec x (A x) (~ A x) (x \in A) (nbhs_subspace x).
 Proof.
-rewrite /nbhs_subspace; case:(boolP (x \in A)); rewrite ?(inE, notin_set) => xA.
+rewrite /nbhs_subspace; case:(boolP (x \in A)); rewrite ?(inE, notin_setE) => xA.
   by rewrite (@propext (A x) True)// not_True; constructor.
 by rewrite (@propext (A x) False)// not_False; constructor.
 Qed.


### PR DESCRIPTION
##### Motivation for this change
fixes #1190 

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [ ] added corresponding documentation in the headers~~

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
