### PR TITLE
not_near_at_leftP

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -31,6 +31,9 @@
   + lemmas `total_variation_nondecreasing`, `total_variation_bounded_variation`
 - new file `theories/all_analysis.v`
 
+- in `normedtype.v`:
+  + lemma `not_near_at_leftP`
+
 ### Changed
 
 - in `forms.v`:

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -1308,6 +1308,16 @@ apply: contrapT; apply: pePf; apply/andP; split.
 - by near: t; apply: nbhs_right_lt; rewrite ltrDl.
 Unshelve. all: by end_near. Qed.
 
+Lemma not_near_at_leftP T (f : R -> T) (p : R) (P : pred T) :
+  ~ (\forall x \near p^'-, P (f x)) ->
+  forall e : {posnum R}, exists2 x : R, p - e%:num < x < p & ~ P (f x).
+Proof.
+move=> pPf e; apply: contrapT => /forallPNP pePf; apply: pPf; near=> t.
+apply: contrapT; apply: pePf; apply/andP; split.
+- by near: t; apply: nbhs_left_gt; rewrite ltrBlDr ltrDl.
+- by near: t; exact: nbhs_left_lt.
+Unshelve. all: by end_near. Qed.
+
 Lemma withinN (A : set R) a :
   within A (nbhs (- a)) = - x @[x --> within (-%R @` A) (nbhs a)].
 Proof.


### PR DESCRIPTION
##### Motivation for this change

missing, `at_left` version of lemma of `not_near_at_rightP`.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
