### PR TITLE
Improve compatibility lemmas in Rstruct

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- in `mathcomp_extra.v`:
+  + lemma `Pos_to_natE`
+
+- in `Rstruct.v`:
+  + lemma `IZposRE`
+
 - in `classical_sets.v`:
   + lemma `bigcup_recl`
 
@@ -135,6 +141,9 @@
   + `integral_pushforward` -> `ge0_integral_pushforward`
 
 ### Generalized
+
+- in `Rstruct.v`:
+  + lemmas `RinvE`, `RdivE`
 
 - in `constructive_ereal.v`:
   + `gee_pMl` (was `gee_pmull`)

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -4,12 +4,6 @@
 
 ### Added
 
-- in `mathcomp_extra.v`:
-  + lemma `Pos_to_natE`
-
-- in `Rstruct.v`:
-  + lemma `IZposRE`
-
 - in `classical_sets.v`:
   + lemma `bigcup_recl`
 
@@ -73,6 +67,12 @@
 
 - in `measure.v`:
   + lemma `measurableID`
+
+- in `mathcomp_extra.v`:
+  + lemma `Pos_to_natE`
+
+- in `Rstruct.v`:
+  + lemma `IZRposE`
 
 ### Changed
 

--- a/classical/mathcomp_extra.v
+++ b/classical/mathcomp_extra.v
@@ -364,3 +364,12 @@ rewrite /Order.min/=; case: ifPn => xz; case: ifPn => yz; rewrite ?ltxx//.
 Qed.
 
 End order_min.
+
+Section positive.
+Lemma Pos_to_natE p : Pos.to_nat p = nat_of_pos p.
+Proof.
+by elim: p => //= p <-; rewrite ?Pnat.Pos2Nat.inj_xI ?Pnat.Pos2Nat.inj_xO;
+   change (2 * Pos.to_nat p)%coq_nat with (2 * Pos.to_nat p)%nat;
+   rewrite mul2n NatTrec.doubleE.
+Qed.
+End positive.

--- a/classical/mathcomp_extra.v
+++ b/classical/mathcomp_extra.v
@@ -366,10 +366,11 @@ Qed.
 End order_min.
 
 Section positive.
+
 Lemma Pos_to_natE p : Pos.to_nat p = nat_of_pos p.
 Proof.
-by elim: p => //= p <-; rewrite ?Pnat.Pos2Nat.inj_xI ?Pnat.Pos2Nat.inj_xO;
-   change (2 * Pos.to_nat p)%coq_nat with (2 * Pos.to_nat p)%nat;
-   rewrite mul2n NatTrec.doubleE.
+by elim: p => //= p <-;
+  rewrite ?(Pnat.Pos2Nat.inj_xI,Pnat.Pos2Nat.inj_xO) NatTrec.doubleE -mul2n.
 Qed.
+
 End positive.

--- a/theories/Rstruct.v
+++ b/theories/Rstruct.v
@@ -30,6 +30,7 @@ Require Import Epsilon FunctionalExtensionality Ranalysis1 Rsqrt_def.
 Require Import Rtrigo1 Reals.
 From mathcomp Require Import all_ssreflect ssralg poly mxpoly ssrnum.
 From HB Require Import structures.
+Require Import mathcomp_extra.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
@@ -456,11 +457,23 @@ Lemma RmultE x y : Rmult x y = x * y. Proof. by []. Qed.
 
 Lemma RoppE x : Ropp x = - x. Proof. by []. Qed.
 
-Lemma RinvE x : x != 0 -> Rinv x = x^-1.
+Let neq0_RinvE x : x != 0 -> Rinv x = x^-1.
 Proof. by move=> x_neq0; rewrite -[RHS]/(if _ then _ else _) x_neq0. Qed.
 
-Lemma RdivE x y : y != 0 -> Rdiv x y = x / y.
-Proof. by move=> y_neq0; rewrite /Rdiv RinvE. Qed.
+Lemma RinvE (x : R) : Rinv x = x^-1.
+Proof.
+have [-> | ] := eqVneq x R0; last exact: neq0_RinvE.
+rewrite /GRing.inv /GRing.mul /= /Rinvx eqxx /=.
+rewrite RinvImpl.Rinv_def.
+case: (Req_appart_dec 0 R0) => //.
+by move=> /[dup] -[] => /RltP; rewrite Order.POrderTheory.ltxx.
+Qed.
+
+Lemma RdivE (x y : R) : Rdiv x y = x / y.
+Proof. by rewrite /Rdiv RinvE. Qed.
+
+Lemma IZposRE (p : positive) : IZR (Z.pos p) = INR (nat_of_pos p).
+Proof. by rewrite -Pos_to_natE INR_IPR. Qed.
 
 Lemma INRE n : INR n = n%:R.
 Proof. elim: n => // n IH; by rewrite S_INR IH RplusE -addn1 natrD. Qed.

--- a/theories/Rstruct.v
+++ b/theories/Rstruct.v
@@ -460,23 +460,25 @@ Lemma RoppE x : Ropp x = - x. Proof. by []. Qed.
 Let neq0_RinvE x : x != 0 -> Rinv x = x^-1.
 Proof. by move=> x_neq0; rewrite -[RHS]/(if _ then _ else _) x_neq0. Qed.
 
-Lemma RinvE (x : R) : Rinv x = x^-1.
+Lemma RinvE x : Rinv x = x^-1.
 Proof.
-have [-> | ] := eqVneq x R0; last exact: neq0_RinvE.
+have [->| ] := eqVneq x R0; last exact: neq0_RinvE.
 rewrite /GRing.inv /GRing.mul /= /Rinvx eqxx /=.
-rewrite RinvImpl.Rinv_def.
-case: (Req_appart_dec 0 R0) => //.
-by move=> /[dup] -[] => /RltP; rewrite Order.POrderTheory.ltxx.
+rewrite RinvImpl.Rinv_def; case: Req_appart_dec => //.
+by move=> /[dup] -[] /RltP; rewrite Order.POrderTheory.ltxx.
 Qed.
 
-Lemma RdivE (x y : R) : Rdiv x y = x / y.
-Proof. by rewrite /Rdiv RinvE. Qed.
-
-Lemma IZposRE (p : positive) : IZR (Z.pos p) = INR (nat_of_pos p).
-Proof. by rewrite -Pos_to_natE INR_IPR. Qed.
+Lemma RdivE x y : Rdiv x y = x / y. Proof. by rewrite /Rdiv RinvE. Qed.
 
 Lemma INRE n : INR n = n%:R.
 Proof. elim: n => // n IH; by rewrite S_INR IH RplusE -addn1 natrD. Qed.
+
+(**md Though not strictly about the type of real numbers from the Coq
+  standard library, the following lemma `IZRposE` is often needed in
+  practice as its left-hand side often appears as a result of other
+  rewritings using `R*E` lemmas. *)
+Lemma IZRposE (p : positive) : IZR (Z.pos p) = INR (nat_of_pos p).
+Proof. by rewrite -Pos_to_natE INR_IPR. Qed.
 
 Lemma RsqrtE x : 0 <= x -> sqrt x = Num.sqrt x.
 Proof.

--- a/theories/Rstruct.v
+++ b/theories/Rstruct.v
@@ -30,7 +30,7 @@ Require Import Epsilon FunctionalExtensionality Ranalysis1 Rsqrt_def.
 Require Import Rtrigo1 Reals.
 From mathcomp Require Import all_ssreflect ssralg poly mxpoly ssrnum.
 From HB Require Import structures.
-Require Import mathcomp_extra.
+From mathcomp Require Import mathcomp_extra.
 
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/theories/Rstruct.v
+++ b/theories/Rstruct.v
@@ -473,18 +473,16 @@ Lemma RdivE x y : Rdiv x y = x / y. Proof. by rewrite /Rdiv RinvE. Qed.
 Lemma INRE n : INR n = n%:R.
 Proof. elim: n => // n IH; by rewrite S_INR IH RplusE -addn1 natrD. Qed.
 
-(**md Though not strictly about the type of real numbers from the Coq
-  standard library, the following lemma `IZRposE` is often needed in
-  practice as its left-hand side often appears as a result of other
-  rewritings using `R*E` lemmas. *)
+(**md Note that rewrites using the following lemma `IZRposE` are
+  systematically followed by a rewrite using the lemma `INRE`. *)
 Lemma IZRposE (p : positive) : IZR (Z.pos p) = INR (nat_of_pos p).
 Proof. by rewrite -Pos_to_natE INR_IPR. Qed.
 
 Lemma RsqrtE x : 0 <= x -> sqrt x = Num.sqrt x.
 Proof.
 move => x0; apply/eqP; have [t1 t2] := conj (sqrtr_ge0 x) (sqrt_pos x).
-rewrite eq_sym -(eqrXn2 (_: 0 < 2)%N t1) //; last by apply /RleP.
-rewrite sqr_sqrtr // !exprS expr0 mulr1 -RmultE ?sqrt_sqrt //; by apply/RleP.
+rewrite eq_sym -(eqrXn2 (_: 0 < 2)%N t1) //; last exact/RleP.
+by rewrite sqr_sqrtr // !exprS expr0 mulr1 -RmultE ?sqrt_sqrt //; exact/RleP.
 Qed.
 
 Lemma RpowE x n : pow x n = x ^+ n.


### PR DESCRIPTION
##### Motivation for this change

- Lemmas `RinvE` and `RdivE` are generalized:
originally these lemmas took proofs that the argument to be inverted is not zero.
This PR removes it and unconditionally equates the corresponding operations for stdlib reals and mca reals.

- Lemma `IZposRE` is added:
Like `INRE`, this lemma is meant to be used for translating natural number literals in stdlib reals to mca literals.
Its intermediate step `Pos_to_natE` is added too.

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~- [ ] added corresponding documentation in the headers~

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
