### PR TITLE
fixes #1248 (`to_set` / `xsection`)

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -110,6 +110,8 @@
     `parameterized_integral_left`, `parameterized_integral_cvg_at_left`,
     `parameterized_integral_continuous`
   + corollary `continuous_FTC2`
+- in `classical_sets.v`:
+  + lemmas `xsectionP`, `ysectionP`
 
 ### Changed
 
@@ -237,6 +239,9 @@
   + definition `ceil` (use `Num.ceil` instead)
   + lemmas `floor0`, `floor1`
   + lemma `le_floor` (use `Num.Theory.floor_le` instead)
+
+- in `topology.v`, `function_spaces.v`, `normedtype.v`:
+  + local notation `to_set`
 
 ### Infrastructure
 

--- a/classical/classical_sets.v
+++ b/classical/classical_sets.v
@@ -3313,8 +3313,14 @@ Proof. by move=> x Axy; exists y; rewrite /ysection/= inE in Axy. Qed.
 Lemma mem_xsection x y A : (y \in xsection A x) = ((x, y) \in A).
 Proof. by apply/idP/idP => [|]; [rewrite inE|rewrite /xsection !inE /= inE]. Qed.
 
+Lemma xsectionP x y A : xsection A x y <-> A (x, y).
+Proof. by rewrite /xsection/= inE. Qed.
+
 Lemma mem_ysection x y A : (x \in ysection A y) = ((x, y) \in A).
 Proof. by apply/idP/idP => [|]; [rewrite inE|rewrite /ysection !inE /= inE]. Qed.
+
+Lemma ysectionP x y A : ysection A y x <-> A (x, y).
+Proof. by rewrite /ysection/= inE. Qed.
 
 Lemma xsection0 x : xsection set0 x = set0.
 Proof. by rewrite predeqE /xsection => y; split => //=; rewrite inE. Qed.

--- a/theories/cantor.v
+++ b/theories/cantor.v
@@ -397,18 +397,18 @@ Let ent_balls' (E : set (T * T)) :
   exists M : set (set T), entourage E -> [/\
     finite_set M,
     forall A, M A -> exists a, A a /\
-      A `<=` closure [set y | split_ent E (a, y)],
+      A `<=` closure (xsection (split_ent E) a),
     exists A B : set T, M A /\ M B /\ A != B,
     \bigcup_(A in M) A = [set: T] &
     M `<=` closed].
 Proof.
 have [entE|?] := pselect (entourage E); last by exists point.
 move: cptT; rewrite compact_cover.
-pose fs x := interior [set y | split_ent E (x, y)].
+pose fs x := interior (xsection (split_ent E) x).
 move=> /(_ T [ set: T] fs)[t _|t _ |].
 - exact: open_interior.
-- exists t => //.
-  by rewrite /fs /interior -nbhs_entourageE; exists (split_ent E).
+- exists t => //; rewrite /fs /interior.
+  by rewrite -nbhs_entourageE; exists (split_ent E) => // ? /xsectionP.
 move=> M' _ Mcov; exists
   ((closure \o fs) @` [set` M'] `|` [set [set t0]; [set t1]]).
 move=> _; split=> [|A [|]| | |].
@@ -416,10 +416,10 @@ move=> _; split=> [|A [|]| | |].
   exact: finite_set2.
 - move=> [z M'z] <-; exists z; split.
   + apply: subset_closure; apply: nbhs_singleton; apply: nbhs_interior.
-    by rewrite -nbhs_entourageE; exists (split_ent E).
+      by rewrite -nbhs_entourageE; exists (split_ent E) => // t /xsectionP.
   + by apply: closure_subset; exact: interior_subset.
 - by case => ->; [exists t0 | exists t1]; split => // t ->;
-    apply: subset_closure; exact: entourage_refl.
+    apply/subset_closure/xsectionP; exact: entourage_refl.
 - exists [set t0], [set t1]; split;[|split].
   + by right; left.
   + by right; right.
@@ -512,10 +512,11 @@ have [//| | |? []//| |? []// | |] := @tree_map_props
       by move=> ? [? ?] [? ?]; exists (existT _ _ ebC).
     case: pselect; last by move => ? ? [].
     by move=> e _ [? ?] [? ?]; exists (projT1 (cid e)).
-  suff : E (x, y) by move/ExU; move/eqP/disjoints_subset: UVI0 => /[apply].
+  suff : E (x, y).
+    by move/xsectionP/ExU; move/eqP/disjoints_subset: UVI0 => /[apply].
   have [z [Dz DzE]] := Csub _ cbD.
-  have /ent_closure:= DzE _ Dx => /(_ (ent_count_unif n))/ctE [_ /= Exz].
-  have /ent_closure:= DzE _ Dy => /(_ (ent_count_unif n))/ctE [Ezy _].
+  have /ent_closure := DzE _ Dx => /(_ (ent_count_unif n))/xsectionP/ctE [_ /= Exz].
+  have /ent_closure := DzE _ Dy => /(_ (ent_count_unif n))/xsectionP/ctE [Ezy _].
   exact: (@entourage_split _ (*[the uniformType of T]*) z).
 by move=> f [ctsf surjf _]; exists f.
 Qed.

--- a/theories/ereal.v
+++ b/theories/ereal.v
@@ -1284,7 +1284,7 @@ rewrite predeq2E => x A; split.
       rewrite /= /e' lt_min; apply/andP; split.
         by rewrite subr_gt0 lt_contract lte_fin ltrBlDr ltrDl.
       by rewrite subr_gt0 lt_contract lte_fin ltrDl.
-    case=> [r' /= re'r'| |]/=.
+    case=> [r' /= /xsectionP/= re'r'| |]/=.
     * rewrite /ereal_ball in re'r'.
       have [r'r|rr'] := lerP (contract r'%:E) (contract r%:E).
         apply: reA; rewrite /ball /= ltr_norml//.
@@ -1308,7 +1308,7 @@ rewrite predeq2E => x A; split.
         by rewrite ltrBlDr subrK.
       rewrite ltrBlDr -lte_fin -(contractK (_ + r)%:E)%R.
       by rewrite addrC -(contractK r'%:E) // lt_expand ?inE ?contract_le1.
-    * rewrite /ereal_ball [contract +oo]/=.
+    * move=> /xsectionP/=; rewrite /ereal_ball [contract +oo]/=.
       rewrite lt_min => /andP[re'1 re'2].
       have [cr0|cr0] := lerP 0 (contract r%:E).
         move: re'2; rewrite ler0_norm; last first.
@@ -1323,7 +1323,7 @@ rewrite predeq2E => x A; split.
       exfalso.
       move: h; apply/negP; rewrite -leNgt.
       by case/ler_normlP : (contract_le1 (r%:E + e%:num%:E)).
-    * rewrite /ereal_ball [contract -oo]/=; rewrite opprK.
+    * move=> /xsectionP/=; rewrite /ereal_ball [contract -oo]/= opprK.
       rewrite lt_min => /andP[re'1 _].
       move: re'1.
       rewrite ger0_norm; last first.
@@ -1336,7 +1336,7 @@ rewrite predeq2E => x A; split.
   + exists (diag (1 - contract M%:E))%R; rewrite /diag.
       exists (1 - contract M%:E)%R => //=.
       by rewrite subr_gt0 (le_lt_trans _ (contract_lt1 M)) // ler_norm.
-    case=> [r| |]/=.
+    case=> [r| |]/= /xsectionP/=.
     * rewrite /ereal_ball [_ +oo]/= => rM1.
       apply: MA; rewrite lte_fin.
       rewrite ger0_norm in rM1; last first.
@@ -1354,10 +1354,9 @@ rewrite predeq2E => x A; split.
       exists (1 + contract M%:E)%R => //=.
       rewrite -ltrBlDl sub0r.
       by move: (contract_lt1 M); rewrite ltr_norml => /andP[].
-    case=> [r| |].
+    case=> [r| |] /xsectionP/=.
     * rewrite /ereal_ball => /= rM1.
-      apply MA.
-      rewrite lte_fin.
+      apply: MA; rewrite lte_fin.
       rewrite ler0_norm in rM1; last first.
         rewrite lerBlDl addr0 ltW //.
         by move: (contract_lt1 r); rewrite ltr_norml => /andP[].
@@ -1372,13 +1371,14 @@ rewrite predeq2E => x A; split.
     * rewrite /ereal_ball /= => _; exact: MA.
 - case: x => [r [E [_/posnumP[e] reA] sEA] | [E [_/posnumP[e] reA] sEA] |
                [E [_/posnumP[e] reA] sEA]] //=.
-  + by apply nbhs_fin_inbound with e => ? ?; exact/sEA/reA.
+  + by apply nbhs_fin_inbound with e => ? ?; exact/sEA/xsectionP/reA.
   + have [|] := boolP (e%:num <= 1)%R.
-      by move/nbhs_oo_up_e1; apply => ? ?; exact/sEA/reA.
-    by rewrite -ltNge => /nbhs_oo_up_1e; apply => ? ?; exact/sEA/reA.
+      by move/nbhs_oo_up_e1; apply => ? ?; exact/sEA/xsectionP/reA.
+    by rewrite -ltNge => /nbhs_oo_up_1e; apply => ? ?; exact/sEA/xsectionP/reA.
   + have [|] := boolP (e%:num <= 1)%R.
-      by move/nbhs_oo_down_e1; apply => ? ?; exact/sEA/reA.
-    by rewrite -ltNge => /nbhs_oo_down_1e; apply => ? ?; exact/sEA/reA.
+      move/nbhs_oo_down_e1; apply => ? ?; apply: sEA.
+      by rewrite /xsection/= inE; exact: reA.
+    by rewrite -ltNge =>/nbhs_oo_down_1e; apply => ? ?; exact/sEA/xsectionP/reA.
 Qed.
 
 HB.instance Definition _ := Nbhs_isPseudoMetric.Build R (\bar R)

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -6568,12 +6568,12 @@ have locg_B n : locally_integrable [set: R] (g_B n).
       by rewrite normr0 lee_fin.
 have locf_g_B n : locally_integrable setT (f_ k \- g_B n)%R.
   apply: locally_integrableB => //; split.
-  + by move/EFin_measurable_fun : mf.
-  + exact: openT.
-  + move=> K _ cK; rewrite (le_lt_trans _ intf)//=.
+  - by move/EFin_measurable_fun : mf.
+  - exact: openT.
+  - move=> K _ cK; rewrite (le_lt_trans _ intf)//=.
     apply: ge0_subset_integral => //.
-    * exact: compact_measurable.
-    * by do 2 apply: measurableT_comp => //; move/EFin_measurable_fun : mf.
+    + exact: compact_measurable.
+    + by do 2 apply: measurableT_comp => //; move/EFin_measurable_fun : mf.
 have mEHL i : measurable (HLf_g_Be i).
   rewrite /HLf_g_Be -[X in measurable X]setTI.
   apply: emeasurable_fun_o_infty => //.
@@ -6607,7 +6607,7 @@ have davgfEe : B k `&` [set x | (f_ k)^* x > e%:E] `<=` Ee.
   rewrite {1}(splitr e) EFinD -lteBrDl// => /ltW/le_trans; apply.
   by rewrite leeBlDl// leeD.
 suff: mu Ee = 0 by exists Ee.
-have HL_null n : mu (HLf_g_Be n) <= (3%:R / (e / 2))%:E * n.+1%:R^-1%:E.
+have HL_null n : mu (HLf_g_Be n) <= (3 / (e / 2))%:E * n.+1%:R^-1%:E.
   rewrite (le_trans (maximal_inequality _ _ )) ?divr_gt0//.
   rewrite lee_pmul2l ?lte_fin ?divr_gt0//.
   set h := (fun x => `|(f_ k \- g_ n) x|%:E) \_ (B k).

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -2306,7 +2306,7 @@ Lemma ae_pointwise_almost_uniform
     (f_ : (T -> R)^nat) (g : T -> R) (A : set T) (eps : R):
   (forall n, measurable_fun A (f_ n)) -> measurable_fun A g ->
   measurable A -> mu A < +oo ->
-  {ae mu, (forall x, A x -> f_ ^~ x @\oo --> g x)} ->
+  {ae mu, (forall x, A x -> f_ ^~ x @ \oo --> g x)} ->
   (0 < eps)%R -> exists B, [/\ measurable B, mu B < eps%:E &
     {uniform A `\` B, f_ @ \oo --> g}].
 Proof.

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -3521,9 +3521,6 @@ Context (A : set T).
 
 Local Notation "A ^-1" := [set xy | A (xy.2, xy.1)] : classical_set_scope.
 
-Local Notation "'to_set' A x" := [set y | A (x, y)]
-  (at level 0, A at level 0) : classical_set_scope.
-
 (* Urysohn's lemma guarantees a continuous function : T -> R
    where "f @` A = [set 0]" and "f @` B = [set 1]".
    The idea is to leverage countable_uniformity to build that function
@@ -3670,7 +3667,7 @@ exists (Uniform.class urysohnType), (apxU (U, ~` B)); split => //.
   by have /subset_closure ? := AU _ Aa; case.
 move=> x ? [E gE] /(@filterS T); apply; move: gE.
 rewrite /= /ury_unif filterI_iterE; case => K /= [i _] /= uiK KE.
-suff : @nbhs T T x to_set K (x) by apply: filterS => y /KE.
+suff : @nbhs T T x [set y | K (x, y)] by apply: filterS => y /KE/xsectionP.
 elim: i K uiK {E KE}; last by move=> ? H ? [N] /H ? [M] /H ? <-; apply: filterI.
 move=> K [->|]; first exact: filterT.
 move=> [[/= P Q] [/= oP oQ AP cPQ <-]]; rewrite /apxU /=.
@@ -3776,7 +3773,7 @@ rewrite openE => /(_ _ nBx); rewrite /interior /= -nbhs_entourageE.
 case=> E entE EnB.
 pose T' := [the pseudoMetricType Rdefinitions.R of gauge.type entE].
 exists (Uniform.class T); exists E; split => //; last by move => ?.
-by rewrite -subset0 => -[? w [/= [-> ? ?]]]; exact: (EnB w).
+by rewrite -subset0 => -[? w [/= [-> ? /xsectionP ?]]]; exact: (EnB w).
 Qed.
 
 Lemma uniform_completely_regular {R : realType} {T : uniformType} :
@@ -3795,7 +3792,7 @@ Lemma uniform_regular {X : uniformType} : @regular_space X.
 Proof.
 move=> x A; rewrite /= -nbhs_entourageE => -[E entE].
 move/(subset_trans (ent_closure entE)) => ExA.
-by exists [set y | split_ent E (x, y)]; first by exists (split_ent E).
+by exists (xsection (split_ent E) x) => //; exists (split_ent E).
 Qed.
 
 Lemma regular_openP {T : topologicalType} (x : T) :
@@ -5700,7 +5697,7 @@ Lemma vitali_lemma_finite (s : seq I) :
     forall i, i \in s -> exists j, [/\ j \in D,
       B i `&` B j !=set0,
       radius (B j) >= radius (B i) &
-      B i `<=` 3%:R *` B j] ] }.
+      B i `<=` 3 *` B j] ] }.
 Proof.
 pose LE x y := radius (B x) <= radius (B y).
 have LE_trans : transitive LE by move=> x y z; exact: le_trans.

--- a/theories/numfun.v
+++ b/theories/numfun.v
@@ -555,7 +555,7 @@ have [|?] := pselect (forall x, A x -> `|f x| <= M); last by exists point.
 by move=> bd pm cf; have [g ?] := tietze_step' pm cf bd; exists g.
 Qed.
 
-Let onem_twothirds : 1 - 2/3%:R = 1/3%:R :> R.
+Let onem_twothirds : 1 - 2/3 = 1/3 :> R.
 Proof. by apply/eqP; rewrite subr_eq/= -mulrDl nat1r divrr// unitfE. Qed.
 
 Lemma continuous_bounded_extension (f : X -> R^o) M :
@@ -569,7 +569,7 @@ pose f_ := fix F n :=
 pose g_ n := projT1 (tietze_step (f_ n) (M2d3 n)).
 have fgE n : f_ n - f_ n.+1 = g_ n by rewrite /= opprB addrC subrK.
 have twothirds1 : `|2/3| < 1 :> R.
-  by rewrite gtr0_norm //= ltr_pdivrMr// mul1r ltr_nat.
+  by rewrite gtr0_norm//= ltr_pdivrMr// mul1r ltr_nat.
 have f_geo n : {within A, continuous f_ n} /\
     (forall x, A x -> `|f_ n x| <= geometric M%:num (2/3) n).
   elim: n => [|n [ctsN bdN]]; first by split=> //= x ?; rewrite expr0 mulr1 fbd.
@@ -581,8 +581,7 @@ have g_cts n : continuous (g_ n).
 have g_bd n : forall x, `|g_ n x| <= geometric ((1/3) * M%:num) (2/3) n.
   have [ctsN bdfN] := f_geo n; rewrite /geometric /= -[_ * M%:num * _]mulrA.
   by have [_ _] := projT2 (tietze_step (f_ n) _) ctsN (MN0 n) bdfN.
-pose h_ : nat -> arrow_uniform_type X R^o :=
-  @series {uniform X -> _} g_.
+pose h_ : nat -> arrow_uniform_type X R^o := @series {uniform X -> _} g_.
 have cvgh' : cvg (h_ @ \oo).
   apply/cauchy_cvgP/cauchy_ballP => eps epos; near_simpl.
   suff : \forall x & x' \near \oo, (x' <= x)%N -> ball (h_ x) eps (h_ x').


### PR DESCRIPTION
##### Motivation for this change

TODO: maybe also rename `xsection` to `xsect`, that's clear enough.

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
