### PR TITLE
`at_left` version of an `at_right` lemma

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -36,6 +36,9 @@
 - in `mathcomp_extra.v`:
   + lemmas `intr1D`, `intrD1`, `floor_eq`, `floorN`
 
+- in `realfun.v`:
+  + lemma `nondecreasing_at_left_is_cvgr`
+
 ### Changed
 
 - in `topology.v`:

--- a/theories/realfun.v
+++ b/theories/realfun.v
@@ -365,6 +365,22 @@ by eexists; apply: (@nondecreasing_at_right_cvgr _ _ (BLeft b));
   [rewrite bnd_simp|near: b..].
 Unshelve. all: by end_near. Qed.
 
+Lemma nondecreasing_at_left_is_cvgr f a :
+    (\forall x \near a^'-, {in `]x, a[ &, {homo f : n m / n <= m}}) ->
+    (\forall x \near a^'-, has_ubound [set f y | y in `]x, a[]) ->
+  cvg (f x @[x --> a^'-]).
+Proof.
+move=> ndf ubf; suff: cvg ((f \o -%R) x @[x --> (- a)^'+]).
+  move=> /cvg_ex[/= l fal].
+  by apply/cvg_ex; exists l; exact/cvg_at_leftNP.
+apply: @nonincreasing_at_right_is_cvgr.
+- rewrite at_rightN near_simpl; apply: filterS ndf => x ndf y z.
+  by rewrite -2!oppr_itvoo => yxa zxa yz; rewrite ndf// lerNr opprK.
+- rewrite at_rightN near_simpl; apply: filterS ubf => x [r ubf].
+  exists r => _/= [s sax <-]; rewrite ubf//=; exists (- s) => //.
+  by rewrite oppr_itvoo.
+Qed.
+
 End fun_cvg_realType.
 Arguments nondecreasing_at_right_cvgr {R f a} b.
 Arguments nondecreasing_at_right_cvgr {R f a} b.

--- a/theories/realfun.v
+++ b/theories/realfun.v
@@ -383,7 +383,6 @@ Qed.
 
 End fun_cvg_realType.
 Arguments nondecreasing_at_right_cvgr {R f a} b.
-Arguments nondecreasing_at_right_cvgr {R f a} b.
 
 Section fun_cvg_ereal.
 Context {R : realType}.


### PR DESCRIPTION
##### Motivation for this change

the proof is obtained by exploiting the symmetry between `at_left` and `at_right`

proof used in work in progress by @IshiguroYoshihiro 

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [ ] added corresponding documentation in the headers~~

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
