### PR TITLE
integration by parts

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -27,6 +27,8 @@
   + definitions `is_open_itv`, `open_itv_cover`
   + lemmas `outer_measure_open_itv_cover`, `outer_measure_open_le`,
     `outer_measure_open`, `outer_measure_Gdelta`, `negligible_outer_measure`
+- in `ftc.v`:
+  + lemma `continuous_integration_by_parts`
 
 - in `classical_sets.v`:
   + scope `relation_scope` with delimiter `relation`

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -28,7 +28,7 @@
   + lemmas `outer_measure_open_itv_cover`, `outer_measure_open_le`,
     `outer_measure_open`, `outer_measure_Gdelta`, `negligible_outer_measure`
 - in `ftc.v`:
-  + lemma `continuous_integration_by_parts`
+  + lemmas `integration_by_parts`, `Rintegration_by_parts`
 
 - in `classical_sets.v`:
   + scope `relation_scope` with delimiter `relation`
@@ -64,6 +64,17 @@
   + module `NGenCInfty`
     * definition `G`
     * lemmas `measurable_itv_bounded`, `measurableE`
+- in `continuous_FTC1_closed`:
+  + corollary `continuous_FTC1_closed`
+
+- in `lebesgue_integral.v`:
+  + lemma `locally_integrableS`
+
+- in `normedtype.v`:
+  + lemmas `nbhs_right_ltW`, `cvg_patch`
+
+- in `set_interval.v`:
+  + lemma `subset_itvSoo`
 
 ### Changed
 
@@ -91,6 +102,11 @@
 
 - moved from `numfun.v` to `cardinality.v`:
   + lemma `fset_set_comp`
+- in `ftc.v`:
+  + lemma `FTC1_lebesgue_pt`, corollaries `FTC1`, `FTC1Ny`: integrability hypothesis weakened
+
+- in `lebesgue_integral.v`:
+  + lemma `nice_lebesgue_differentiation`: change the local integrability hypothesis to easy application
 
 ### Renamed
 
@@ -114,6 +130,9 @@
   + in factory `isUniform`:
     * `entourage_refl` -> `entourage_diagonal`
 
+- in `set_interval.v`:
+  + `subset_itvS` -> `subset_itvScc`
+
 ### Generalized
 
 - in `derive.v`:
@@ -124,6 +143,9 @@
 
 - in `lebesgue_integral.v`
   + lemma `ge0_integral_closed_ball`
+
+- in `FTC.v`:
+  + lemma `continuous_FTC2` (continuity hypothesis weakened)
 
 ### Deprecated
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -108,6 +108,9 @@
 - in `lebesgue_integral.v`:
   + lemma `nice_lebesgue_differentiation`: change the local integrability hypothesis to easy application
 
+- in `normedtype.v`:
+  + lemma `continuous_within_itvP`: change the statement to use the notation `[/\ _, _ & _]`
+
 ### Renamed
 
 - in `lebesgue_measure.v`:

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -76,7 +76,8 @@
 - in `set_interval.v`:
   + lemma `subset_itvSoo`
 
-### Changed
+- in `lebesgue_integral.v`:
+  + lemma `integrable_locally_restrict`
 
 ### Changed
 - in `topology.v`:
@@ -135,6 +136,9 @@
 
 - in `set_interval.v`:
   + `subset_itvS` -> `subset_itvScc`
+
+- in `lebesgue_integral.v`
+  + lemma `integrable_locally` -> `open_integrable_locally`
 
 ### Generalized
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -78,6 +78,8 @@
 
 - in `lebesgue_integral.v`:
   + lemma `integrable_locally_restrict`
+  + lemma `near_davg`
+  + lemma `lebesgue_pt_restrict`
 
 ### Changed
 - in `topology.v`:

--- a/classical/set_interval.v
+++ b/classical/set_interval.v
@@ -98,7 +98,7 @@ move: c a ax ac => [[|] c [[|]/= a ax|[|]//=]|[//|]]; rewrite ?bnd_simp.
 - by move=> [[|]|[|]//].
 Qed.
 
-Lemma subset_itvS (a b : itv_bound T) (c e : T) :
+Lemma subset_itvScc (a b : itv_bound T) (c e : T) :
     (BLeft c <= a)%O -> (b <= BRight e)%O ->
   [set` Interval a b] `<=` [set` `[c, e]].
 Proof.
@@ -113,6 +113,22 @@ rewrite (le_trans ca az)/=.
 move: b be zb => [[|]/= b|[|]//]; rewrite bnd_simp => be.
   by move=> /ltW/le_trans; exact.
 by move=> /le_trans; exact.
+Qed.
+
+Lemma subset_itvSoo (a b : itv_bound T) (c e : T) :
+    (BLeft c < a)%O -> (b < BRight e)%O ->
+  [set` Interval a b] `<=` [set` `]c, e[].
+Proof.
+move=> ca be z/=; rewrite !in_itv/= => /andP[az zb].
+case: a ca az => [[|]/=|[|]//] a; rewrite bnd_simp => ca az.
+  rewrite (lt_le_trans ca az)/=.
+  move: b be zb => [[|]/= b|[|]//]; rewrite bnd_simp => be.
+    by move=> /lt_le_trans; exact.
+  by move=> /le_lt_trans; exact.
+rewrite (le_lt_trans ca az)/=.
+move: b be zb => [[|]/= b|[|]//]; rewrite bnd_simp => be.
+  by move=> /lt_le_trans; exact.
+by move=> /le_lt_trans; exact.
 Qed.
 
 Lemma interval_set1 x : `[x, x]%classic = [set x] :> set T.
@@ -209,6 +225,8 @@ Qed.
 
 End set_itv_porderType.
 Arguments neitv {d T} _.
+#[deprecated(since="mathcomp-analysis 1.4.0", note="renamed to subset_itvScc")]
+Notation subset_itvS := subset_itvScc (only parsing).
 
 Section set_itv_orderType.
 Variables (d : Order.disp_t) (T : orderType d).

--- a/classical/set_interval.v
+++ b/classical/set_interval.v
@@ -102,17 +102,16 @@ Lemma subset_itvScc (a b : itv_bound T) (c e : T) :
     (BLeft c <= a)%O -> (b <= BRight e)%O ->
   [set` Interval a b] `<=` [set` `[c, e]].
 Proof.
-move=> ca be z/=; rewrite !in_itv/= => /andP[az zb].
+move=> ca be z/=; rewrite !in_itv/==> /andP[az zb].
 case: a ca az => [[|]/=|[|]//] a; rewrite bnd_simp => ca az.
-  rewrite (le_trans ca az)/=.
+- rewrite (le_trans ca az)/=.
   move: b be zb => [[|]/= b|[|]//]; rewrite bnd_simp => be.
     by move=> /ltW/le_trans; exact.
   by move=> /le_trans; exact.
-move/ltW in az.
-rewrite (le_trans ca az)/=.
-move: b be zb => [[|]/= b|[|]//]; rewrite bnd_simp => be.
-  by move=> /ltW/le_trans; exact.
-by move=> /le_trans; exact.
+- rewrite (le_trans ca (ltW az))/=.
+  move: b be zb => [[|]/= b|[|]//]; rewrite bnd_simp => be.
+    by move=> /ltW/le_trans; exact.
+  by move=> /le_trans; exact.
 Qed.
 
 Lemma subset_itvSoo (a b : itv_bound T) (c e : T) :

--- a/theories/ftc.v
+++ b/theories/ftc.v
@@ -542,3 +542,46 @@ exact: integral_fune_fin_num.
 Unshelve. all: by end_near. Qed.
 
 End corollary_FTC1.
+
+Section integration_by_parts.
+Context {R : realType}.
+Notation mu := lebesgue_measure.
+Local Open Scope ereal_scope.
+Implicit Types (F G f g : R -> R) (a b : R).
+
+Lemma continuous_integration_by_parts F G f g a b :
+    (a < b)%R ->
+    {in `[a, b], continuous f} -> {in `[a, b], continuous F} ->
+    derivable_oo_continuous_bnd F a b ->
+    {in `]a, b[, F^`() =1 f} ->
+    {in `[a, b], continuous g} -> {in `[a, b], continuous G} ->
+    derivable_oo_continuous_bnd G a b ->
+    {in `]a, b[, G^`() =1 g} ->
+  (\int[mu]_(x in `[a, b]) (F x * g x)%:E = (F b * G b - F a * G a)%:E -
+   \int[mu]_(x in `[a, b]) (f x * G x)%:E).
+Proof.
+move=> ab cf cF Fab Ff cg cG Gab Gg.
+have cfg : {in `[a, b], continuous (f * G + F * g)%R}.
+  move=> z zab; apply: continuousD; apply: continuousM;
+    [exact: cf|exact: cG|exact: cF|exact: cg].
+have FGab : derivable_oo_continuous_bnd (F * G)%R a b.
+  move: Fab Gab => /= [abF FFa FFb] [abG GGa GGb];split; [|exact:cvgM..].
+  by move=> z zab; apply: derivableM; [exact: abF|exact: abG].
+have FGfg : {in `]a, b[, (F * G)^`() =1 f * G + F * g}%R.
+  move: Fab Gab => /= [abF FFa FFb] [abG GGa GGb] z zba.
+  rewrite derive1E deriveM; [|exact: abF|exact: abG].
+  by rewrite -derive1E Gg// -derive1E Ff// addrC (mulrC f).
+have := continuous_FTC2 ab cfg FGab FGfg; rewrite -EFinB => <-.
+under [X in _ = X - _]eq_integral do rewrite EFinD.
+have ? : mu.-integrable `[a, b] (fun x => ((f * G) x)%:E).
+  apply: continuous_compact_integrable => //; first exact: segment_compact.
+  apply: continuous_in_subspaceT => z /[!inE] zab.
+  by apply: continuousM; [exact: cf|exact: cG].
+rewrite /= integralD//=.
+- by rewrite addeAC subee ?add0e// integral_fune_fin_num.
+- apply: continuous_compact_integrable => //; first exact: segment_compact.
+  apply: continuous_in_subspaceT => z /[!inE] zab.
+  by apply: continuousM; [exact: cF|exact: cg].
+Qed.
+
+End integration_by_parts.

--- a/theories/ftc.v
+++ b/theories/ftc.v
@@ -561,8 +561,8 @@ Lemma parameterized_integral_continuous a b (f : R -> R) : a < b ->
   mu.-integrable `[a, b] (EFin \o f) ->
   {within `[a, b], continuous (fun x => int a x f)}.
 Proof.
-move=> ab intf; apply/(continuous_within_itvP _ ab); split; last first.
-  split; last exact: parameterized_integral_cvg_at_left.
+move=> ab intf; apply/(continuous_within_itvP _ ab); split; first last.
+  exact: parameterized_integral_cvg_at_left.
   apply/cvg_at_right_filter.
   rewrite {2}/int /parameterized_integral interval_set1 Rintegral_set1.
   exact: (parameterized_integral_cvg_left ab).
@@ -744,10 +744,9 @@ have GbcFb : G x @[x --> b^'-] --> (- c + F b)%R.
   rewrite (_ : (G \- F)%R + F = G)//.
   by apply/funext => x/=; rewrite subrK.
 have contF : {within `[a, b], continuous F}.
-  apply/(continuous_within_itvP _ ab); split; last exact: (conj Fa Fb).
-  move=> z zab.
-  apply/differentiable_continuous/derivable1_diffP.
-  by case: dF => /= dF _ _; apply: dF.
+  apply/(continuous_within_itvP _ ab); split => //.
+  move=> z zab; apply/differentiable_continuous/derivable1_diffP.
+  by case: dF => /= + _ _; exact.
 have iabfab : mu.-integrable `[a, b] (EFin \o fab).
   by rewrite -restrict_EFin; apply/integrable_restrict => //; rewrite setIidr.
 have Ga : G x @[x --> a^'+] --> G a.

--- a/theories/ftc.v
+++ b/theories/ftc.v
@@ -37,12 +37,11 @@ Implicit Types (f : R -> R) (a : itv_bound R).
 
 Let FTC0 f a x (u : R) : (x < u)%R ->
   mu.-integrable [set` Interval a (BRight u)] (EFin \o f) ->
-  locally_integrable setT (f \_ [set` Interval a (BRight u)]) ->
   let F y := (\int[mu]_(t in [set` Interval a (BRight y)]) f t)%R in
   a < BRight x -> lebesgue_pt f x ->
     h^-1 *: (F (h + x) - F x) @[h --> 0%R^'] --> f x.
 Proof.
-move=> xz intf locf F ax fx.
+move=> xz intf F ax fx.
 apply: cvg_at_right_left_dnbhs.
 - apply/cvg_at_rightP => d [d_gt0 d0].
   pose E x n := `[x, x + d n[%classic%R.
@@ -70,15 +69,15 @@ apply: cvg_at_right_left_dnbhs.
     rewrite -[in X in X - _]integral_itv_bndo_bndc//=; last first.
       apply: (@measurable_funS _ _ _ _ [set` Interval a (BRight u)]) => //.
         by apply: subset_itvl; rewrite bnd_simp.
-      by have [/(measurable_restrictT _ _).2 + _ _] := locf; apply.
+      by move/integrableP : intf => [/EFin_measurable_fun].
     rewrite (@itv_bndbnd_setU _ _ _ (BLeft x))//=; last 2 first.
-      by case: a ax F {intf locf} => [[|] a|[|]]// /ltW.
+      by case: a ax F {intf} => [[|] a|[|]]// /ltW.
       by rewrite bnd_simp lerDl ltW.
     rewrite integral_setU_EFin//=.
     + rewrite addeAC -[X in _ - X]integral_itv_bndo_bndc//=; last first.
         apply (@measurable_funS _ _ _ _ [set` Interval a (BRight u)]) => //.
           by apply: subset_itvl; rewrite bnd_simp ltW.
-        by have [/(measurable_restrictT _ _).2 + _ _] := locf; apply.
+        by move/integrableP : intf => [/EFin_measurable_fun].
       rewrite subee ?add0e// integral_fune_fin_num//=.
       apply: integrableS intf => //=.
       by apply: subset_itvl; rewrite bnd_simp ltW.
@@ -87,7 +86,7 @@ apply: cvg_at_right_left_dnbhs.
         by rewrite bnd_simp lerDl ltW.
       apply (@measurable_funS _ _ _ _ [set` Interval a (BRight u)]) => //.
         by apply: subset_itvl; rewrite bnd_simp.
-      by have [/(measurable_restrictT _ _).2+ _ _] := locf; apply.
+      by move/integrableP : intf => [/EFin_measurable_fun].
     + apply/disj_setPRL; rewrite setCitv/=.
       exact: subset_trans (subset_itvl _) (@subsetUr _ _ _).
   suff: (d n)^-1 *: fine (\int[mu]_(t in E x n) (f t)%:E) @[n --> \oo] --> f x.
@@ -109,34 +108,34 @@ apply: cvg_at_right_left_dnbhs.
     by near: n; apply: filterS ixdf => k ->.
   have {}locf : \forall r \near 0^'+,
       locally_integrable [set: R] (f \_ (closed_ball x r)).
-    case: a intf locf F ax ixdf => [| [|//] intf locf _ ax ixdf]; last first.
-      near=> r.
-      rewrite closed_ball_itv//.
-      apply: locally_integrableS locf => //.
-      apply: (@subset_trans _ `]-oo, (x + r)]) => //; first exact: subset_itvr.
-      apply: subset_itvl; rewrite bnd_simp -lerBrDl.
-      by near: r; apply: nbhs_right_ltW; rewrite subr_gt0.
-    move=> b a intf locf _ ax ixdf.
-    case: b in intf locf ax ixdf *; rewrite /= lte_fin in ax.
+    case: a intf F ax ixdf => [| [|//] intf _ ax ixdf]; last first.
+      near=> r; rewrite closed_ball_itv//.
+      apply: (@locally_integrableS _ _ `]-oo, u]) => //.
+        apply: (@subset_trans _ `]-oo, (x + r)]) => //; first exact: subset_itvr.
+        apply: subset_itvl; rewrite bnd_simp -lerBrDl.
+        by near: r; apply: nbhs_right_ltW; rewrite subr_gt0.
+      exact: integrable_locally_restrict.
+    move=> b a intf _ ax ixdf.
+    case: b in intf ax ixdf *; rewrite /= lte_fin in ax.
     + near=> r.
       rewrite closed_ball_itv//.
       apply: (@locally_integrableS _ _ `[a, (x + r)]) => //.
-        apply: subset_itvr.
-        rewrite bnd_simp -lerBlDr opprK -lerBrDl.
+        apply: subset_itvr; rewrite bnd_simp -lerBlDr opprK -lerBrDl.
         by near: r; apply: nbhs_right_ltW; rewrite subr_gt0.
-      apply: locally_integrableS locf => //.
-      apply: subset_itvl; rewrite bnd_simp/= -lerBrDl.
-      by near: r; apply: nbhs_right_ltW; rewrite subr_gt0.
+      apply: (@locally_integrableS _ _ `[a, u]) => //.
+        apply: subset_itvl; rewrite bnd_simp/= -lerBrDl.
+        by near: r; apply: nbhs_right_ltW; rewrite subr_gt0.
+      exact: integrable_locally_restrict.
     + near=> r.
       apply: (@locally_integrableS _ _ `]a, (x + r)]) => //.
         exact: measurable_closed_ball.
-        rewrite closed_ball_itv//.
-        apply: subset_itvr.
+        rewrite closed_ball_itv//; apply: subset_itvr.
         rewrite bnd_simp -ltrBlDr opprK -ltrBrDl.
         by near: r; apply: nbhs_right_lt; rewrite subr_gt0.
-      apply: locally_integrableS locf => //.
-      apply: subset_itvl; rewrite bnd_simp/= -lerBrDl.
-      by near: r; apply: nbhs_right_ltW; rewrite subr_gt0.
+      apply: (@locally_integrableS _ _ `]a, u]) => //.
+        apply: subset_itvl; rewrite bnd_simp/= -lerBrDl.
+        by near: r; apply: nbhs_right_ltW; rewrite subr_gt0.
+      exact: integrable_locally_restrict.
   have := nice_lebesgue_differentiation nice_E locf fx.
   rewrite {ixdf} -/mu.
   rewrite [g in g n @[n --> _] --> _ -> _](_ : _ =
@@ -175,14 +174,14 @@ apply: cvg_at_right_left_dnbhs.
       (fun n => \int[mu]_(t in [set` Interval a (BRight (x + d n))]) (f t)%:E -
                 \int[mu]_(t in [set` Interval a (BRight x)]) (f t)%:E) =1
       (fun n => - \int[mu]_(y in E x n) (f y)%:E)}.
-    case: a ax intf locf {F}; last first.
-      move=> [_ intf locf|//].
+    case: a ax intf {F}; last first.
+      move=> [_ intf|//].
       near=> n.
       rewrite -[in LHS]integral_itv_bndo_bndc//=; last first.
          apply: (@measurable_funS _ _ _ _ `]-oo, u]) => //.
            apply: subset_itvl; rewrite bnd_simp.
            by rewrite -lerBrDl (@le_trans _ _ 0%R)// ?ltW// subr_gt0.
-         by case: locf => /(measurable_restrictT _ _).2 + _ _; apply.
+         by move/integrableP : intf => [/EFin_measurable_fun].
       rewrite -/mu -[LHS]oppeK; congr oppe.
       rewrite oppeB; last first.
         rewrite fin_num_adde_defl// fin_numN// integral_fune_fin_num//=.
@@ -196,7 +195,7 @@ apply: cvg_at_right_left_dnbhs.
           apply: (@measurable_funS _ _ _ _ `]-oo, u]) => //.
             apply: subset_itvl; rewrite bnd_simp//.
             by rewrite -lerBrDl (@le_trans _ _ 0%R)// ltW// subr_gt0.
-          by have [/(measurable_restrictT _ _).2 + _ _] := locf; apply.
+          by move/integrableP : intf => [/EFin_measurable_fun].
         rewrite subee ?add0e// integral_fune_fin_num//=.
         apply: integrableS intf => //=.
         apply: subset_itvl; rewrite bnd_simp.
@@ -206,9 +205,9 @@ apply: cvg_at_right_left_dnbhs.
           by rewrite bnd_simp ler_wnDr// ltW.
         apply: (@measurable_funS _ _ _ _ `]-oo, u]) => //.
           by apply: subset_itvl; rewrite bnd_simp// ltW.
-        by have [/(measurable_restrictT _ _).2 + _ _] := locf; apply.
+        by move/integrableP : intf => [/EFin_measurable_fun].
       + by apply/disj_setPLR; rewrite setCitv/=; exact: subsetUl.
-    move=> b a ax intf locf.
+    move=> b a ax intf.
     move/cvgrPdist_le : (d0) => /(_ (x - a)%R).
     rewrite subr_gt0 => /(_ ax)[m /= _]d0xa.
     move/cvgrPdist_le : d0 => /(_ (u - x)%R).
@@ -219,7 +218,7 @@ apply: cvg_at_right_left_dnbhs.
       apply: (@measurable_funS _ _ _ _ [set` Interval (BSide b a) (BRight u)]) => //.
         apply: subset_itvl; rewrite bnd_simp.
         by rewrite -lerBrDl (@le_trans _ _ 0%R)// ltW// subr_gt0.
-      by have [/(measurable_restrictT _ _).2 + _ _] := locf; apply.
+      by move/integrableP : intf => [/EFin_measurable_fun].
     rewrite -/mu -[LHS]oppeK; congr oppe.
     rewrite oppeB; last first.
       rewrite fin_num_adde_defl// fin_numN// integral_fune_fin_num//=.
@@ -227,7 +226,7 @@ apply: cvg_at_right_left_dnbhs.
       by apply: subset_itvl; rewrite bnd_simp ltW.
     rewrite addeC.
     rewrite (@itv_bndbnd_setU _ _ _ (BRight (x - - d n)%R))//; last 2 first.
-      case: b in ax intf locf * => /=; rewrite bnd_simp.
+      case: b in ax intf * => /=; rewrite bnd_simp.
         rewrite lerBrDl addrC -lerBrDl.
         by have := d0xa _ mn; rewrite sub0r gtr0_norm.
       rewrite lerBrDl -lerBrDr.
@@ -238,13 +237,13 @@ apply: cvg_at_right_left_dnbhs.
         apply: (@measurable_funS _ _ _ _ [set` Interval (BSide b a) (BRight u)]) => //.
           apply: subset_itvl; rewrite bnd_simp//.
           by rewrite -lerBrDl opprK (@le_trans _ _ 0%R)// ltW// subr_gt0.
-        by have [/(measurable_restrictT _ _).2 + _ _] := locf; apply.
+        by move/integrableP : intf => [/EFin_measurable_fun].
       rewrite opprK subee ?add0e// integral_fune_fin_num => //=.
       apply: integrableS intf => //.
       apply: subset_itvl.
       by rewrite bnd_simp -lerBrDl (@le_trans _ _ 0%R)// ltW// subr_gt0.
     + rewrite -itv_bndbnd_setU//; last 2 first.
-        case: b in ax intf locf * => /=; rewrite bnd_simp.
+        case: b in ax intf * => /=; rewrite bnd_simp.
           rewrite lerBrDl addrC -lerBrDl.
           by have := d0xa _ mn; rewrite sub0r gtr0_norm.
         rewrite lerBrDl -lerBrDr.
@@ -252,7 +251,7 @@ apply: cvg_at_right_left_dnbhs.
         by rewrite opprK bnd_simp -lerBrDl subrr ltW.
       apply: (@measurable_funS _ _ _ _ [set` Interval (BSide b a) (BRight u)]) => //.
         by apply: subset_itvl; rewrite bnd_simp ltW.
-      by have [/(measurable_restrictT _ _).2 + _ _] := locf; apply.
+      by move/integrableP : intf => [/EFin_measurable_fun].
     + apply/disj_setPLR; rewrite opprK setCitv/=.
       exact: subset_trans (subset_itvr _) (subsetUl _).
   suff: ((d n)^-1 * - fine (\int[mu]_(y in E x n) (f y)%:E))%R
@@ -265,36 +264,38 @@ apply: cvg_at_right_left_dnbhs.
       apply: integral_fune_fin_num => //; apply: integrableS intf => //.
       by apply: subset_itvl; rewrite bnd_simp ltW.
     by congr fine => /=; apply/esym; rewrite (addrC _ x); near: n.
-  have {}locf : \forall r \near 0^'+, locally_integrable [set: R] (f \_ (closed_ball x r)).
-    case: a intf locf F ax ixdf => [|[|//] intf locf _ _ ixdf]; last first.
+  have {}locf : \forall r \near 0^'+,
+      locally_integrable [set: R] (f \_ (closed_ball x r)).
+    case: a intf F ax ixdf => [|[|//] intf _ _ ixdf]; last first.
       near=> r.
       rewrite closed_ball_itv//.
       apply: (@locally_integrableS _ _ [set` `]-oo, (x + r)]]) => //.
         exact: subset_itvr.
-      apply: locally_integrableS locf => //.
-      apply: subset_itvl; rewrite bnd_simp -lerBrDl.
-      by near: r; apply: nbhs_right_ltW; rewrite subr_gt0.
-    move=> b a intf locf _; rewrite /= lte_fin => ax ixdf.
-    case: b in intf locf ixdf *.
+      apply: (@locally_integrableS _ _ `]-oo, u]%classic) => //.
+        apply: subset_itvl; rewrite bnd_simp -lerBrDl.
+        by near: r; apply: nbhs_right_ltW; rewrite subr_gt0.
+      exact: integrable_locally_restrict.
+    move=> b a intf _; rewrite /= lte_fin => ax ixdf.
+    case: b in intf ixdf *.
       near=> r.
       rewrite closed_ball_itv//.
       apply: (@locally_integrableS _ _ `[a, (x + r)]) => //.
-        apply: subset_itvr.
-        rewrite bnd_simp -lerBlDr opprK -lerBrDl.
+        apply: subset_itvr; rewrite bnd_simp -lerBlDr opprK -lerBrDl.
         by near: r; apply: nbhs_right_ltW; rewrite subr_gt0.
-      apply: locally_integrableS locf => //.
-      apply: subset_itvl; rewrite bnd_simp -lerBrDl.
-      by near: r; apply: nbhs_right_ltW; rewrite subr_gt0.
+      apply: (@locally_integrableS _ _ `[a, u]) => //.
+        apply: subset_itvl; rewrite bnd_simp -lerBrDl.
+        by near: r; apply: nbhs_right_ltW; rewrite subr_gt0.
+      exact: integrable_locally_restrict.
     near=> r.
     apply: (@locally_integrableS _ _ `]a, (x + r)]) => //.
       exact: measurable_closed_ball.
-      rewrite closed_ball_itv//.
-      apply: subset_itvr.
+      rewrite closed_ball_itv//; apply: subset_itvr.
       rewrite bnd_simp -ltrBlDr opprK -ltrBrDl.
       by near: r; apply: nbhs_right_lt; rewrite subr_gt0.
-    apply: locally_integrableS locf => //.
-    apply: subset_itvl; rewrite bnd_simp -lerBrDl.
-    by near: r; apply: nbhs_right_ltW; rewrite subr_gt0.
+    apply: (@locally_integrableS _ _ `]a, u]) => //.
+      apply: subset_itvl; rewrite bnd_simp -lerBrDl.
+      by near: r; apply: nbhs_right_ltW; rewrite subr_gt0.
+    exact: integrable_locally_restrict.
   have := nice_lebesgue_differentiation nice_E locf fx.
   rewrite {ixdf} -/mu.
   move/fine_cvgP => [_ /=].
@@ -337,16 +338,14 @@ Unshelve. all: by end_near. Qed.
 (* NB: right-closed interval *)
 Lemma FTC1_lebesgue_pt f a x (u : R) : (x < u)%R ->
   mu.-integrable [set` Interval a (BRight u)] (EFin \o f) ->
-  locally_integrable setT (f \_ [set` Interval a (BRight u)]) ->
   let F y := (\int[mu]_(t in [set` Interval a (BRight y)]) (f t))%R in
   a < BRight x -> lebesgue_pt f x ->
   derivable F x 1 /\ F^`() x = f x.
 Proof.
-move=> xu intf locf F ax fx; split; last first.
-  apply/cvg_lim; [exact: Rhausdorff|].
-  exact: (@FTC0 _ _ _ u).
+move=> xu intf F ax fx; split; last first.
+  by apply/cvg_lim; [exact: Rhausdorff|exact: (@FTC0 _ _ _ u)].
 apply/cvg_ex; exists (f x).
-have /= := FTC0 xu intf locf ax fx.
+have /= := FTC0 xu intf ax fx.
 set g := (f in f n @[n --> _] --> _ -> _).
 set h := (f in _ -> f n @[n --> _] --> _).
 suff : g = h by move=> <-.
@@ -359,15 +358,10 @@ Corollary FTC1 f a :
   let F x := (\int[mu]_(t in [set` Interval a (BRight x)]) (f t))%R in
   {ae mu, forall x, a < BRight x -> derivable F x 1 /\ F^`() x = f x}.
 Proof.
-move=> intf locf F.
-move: (locf).
-move/lebesgue_differentiation.
+move=> intf locf F; move: (locf) => /lebesgue_differentiation.
 apply: filterS; first exact: (ae_filter_ringOfSetsType mu).
 move=> i fi ai.
-apply: (@FTC1_lebesgue_pt _ _ _ (i + 1)%R) => //.
-  by rewrite ltrDl.
-apply: (@locally_integrableS _ _ setT) => //.
-by rewrite patch_setT.
+by apply: (@FTC1_lebesgue_pt _ _ _ (i + 1)%R) => //; rewrite ltrDl.
 Qed.
 
 Corollary FTC1Ny f :
@@ -383,16 +377,15 @@ Qed.
 
 Corollary continuous_FTC1 f a x (u : R) : (x < u)%R ->
   mu.-integrable [set` Interval a (BRight u)] (EFin \o f) ->
-  locally_integrable setT (f \_ [set` Interval a (BRight u)]) ->
   let F x := (\int[mu]_(t in [set` Interval a (BRight x)]) (f t))%R in
   a < BRight x -> {for x, continuous f} ->
   derivable F x 1 /\ F^`() x = f x.
 Proof.
-move=> xu fi locf F ax fx.
+move=> xu fi F ax fx.
 have lfx : lebesgue_pt f x; last first.
-  have /= /(_ ax lfx)/= [dfx f'xE] := @FTC1_lebesgue_pt f a x _ xu fi locf.
+  have /= /(_ ax lfx)/= [dfx f'xE] := @FTC1_lebesgue_pt f a x _ xu fi.
   by split; [exact: dfx|rewrite f'xE].
-case: a fi locf F ax => [|[|//] fi locf _ _]; last first.
+case: a fi F ax => [|[|//] fi _ _]; last first.
   near (0%R:R)^'+ => e; apply: (@continuous_lebesgue_pt _ _ _ (ball x e)) => //.
   - exact: ball_open_nbhs.
   - exact: measurable_ball.
@@ -400,12 +393,11 @@ case: a fi locf F ax => [|[|//] fi locf _ _]; last first.
     apply: measurable_funS => //.
     rewrite ball_itv.
     apply: (@subset_trans _ (`](x - e)%R, u])) => //.
-      apply: subset_itvl; rewrite bnd_simp.
-      rewrite -lerBrDl.
+      apply: subset_itvl; rewrite bnd_simp -lerBrDl.
       by near: e; apply: nbhs_right_ltW; rewrite subr_gt0.
     exact: subset_itvr.
-move=> b a fi locf _ /=; rewrite lte_fin => ax.
-case: b fi locf => [|] fi locf.
+move=> b a fi _ /=; rewrite lte_fin => ax.
+case: b fi => [|] fi.
   near (0%R:R)^'+ => e; apply: (@continuous_lebesgue_pt _ _ _ (ball x e)) => //.
   - exact: ball_open_nbhs.
   - exact: measurable_ball.
@@ -413,11 +405,9 @@ case: b fi locf => [|] fi locf.
     apply: measurable_funS => //.
     rewrite ball_itv.
     apply: (@subset_trans _ (`](x - e)%R, u])) => //.
-      apply: subset_itvl; rewrite bnd_simp.
-      rewrite -lerBrDl.
+      apply: subset_itvl; rewrite bnd_simp -lerBrDl.
       by near: e; apply: nbhs_right_ltW; rewrite subr_gt0.
-    apply: subset_itvr; rewrite bnd_simp.
-    rewrite lerBrDr -lerBrDl.
+    apply: subset_itvr; rewrite bnd_simp lerBrDr -lerBrDl.
     by near: e; apply: nbhs_right_ltW; rewrite subr_gt0.
 near (0%R:R)^'+ => e; apply: (@continuous_lebesgue_pt _ _ _ (ball x e)) => //.
 - exact: ball_open_nbhs.
@@ -429,14 +419,13 @@ near (0%R:R)^'+ => e; apply: (@continuous_lebesgue_pt _ _ _ (ball x e)) => //.
     apply: subset_itvl; rewrite bnd_simp.
     rewrite -lerBrDl.
     by near: e; apply: nbhs_right_ltW; rewrite subr_gt0.
-  apply: subset_itvr; rewrite bnd_simp.
-  rewrite lerBrDr -lerBrDl.
+  apply: subset_itvr; rewrite bnd_simp lerBrDr -lerBrDl.
   by near: e; apply: nbhs_right_ltW; rewrite subr_gt0.
 Unshelve. all: by end_near. Qed.
 
 Corollary continuous_FTC1_closed f (a x : R) (u : R) : (x < u)%R ->
-  locally_integrable setT (f \_ `[a, u]) ->
-  let F x := (\int[mu]_(t in `[a, x]) f t)%R in
+  locally_integrable setT (f \_ [set` `[a, u]]) ->
+  let F x := (\int[mu]_(t in [set` `[a, x]]) (f t))%R in
   (a < x)%R -> {for x, continuous f} ->
   derivable F x 1 /\ F^`() x = f x.
 Proof.
@@ -723,7 +712,6 @@ have [k FGk] : exists k : R, {in `]a, b[, (F - G =1 cst k)%R}.
   by rewrite in_itv/= midf_lt//= midf_lt.
 have [c GFc] : exists c : R, forall x, x \in `]a, b[ -> (F x - G x)%R = c.
   by exists k => x xab; rewrite -[k]/(cst k x) -(FGk x xab).
-have Ga0 : G a = 0%R by rewrite /G interval_set1// Rintegral_set1.
 case: (dF) => _ Fa Fb.
 have GacFa : G x @[x --> a^'+] --> (- c + F a)%R.
   have Fap : Filter a^'+ by exact: at_right_proper_filter.
@@ -756,6 +744,7 @@ have Ga : G x @[x --> a^'+] --> G a.
    by rewrite /G interval_set1 Rintegral_set1.
 have Gb : G x @[x --> b^'-] --> G b.
   exact: (parameterized_integral_cvg_at_left ab iabfab).
+have Ga0 : G a = 0%R by rewrite /G interval_set1// Rintegral_set1.
 have cE : c = F a.
   apply/eqP; rewrite -(opprK c) eq_sym -addr_eq0 addrC.
   by have := cvg_unique _ GacFa Ga; rewrite Ga0 => ->.

--- a/theories/ftc.v
+++ b/theories/ftc.v
@@ -35,13 +35,14 @@ Notation mu := (@lebesgue_measure R).
 Local Open Scope ereal_scope.
 Implicit Types (f : R -> R) (a : itv_bound R).
 
-Let FTC0 f a x (u : R) : (x < u)%R ->
-  mu.-integrable [set` Interval a (BRight u)] (EFin \o f) ->
-  let F y := (\int[mu]_(t in [set` Interval a (BRight y)]) f t)%R in
-  a < BRight x -> lebesgue_pt f x ->
+Let FTC0 f a : mu.-integrable setT (EFin \o f) ->
+  let F x := (\int[mu]_(t in [set` Interval a (BRight x)]) f t)%R in
+  forall x, a < BRight x -> lebesgue_pt f x ->
     h^-1 *: (F (h + x) - F x) @[h --> 0%R^'] --> f x.
 Proof.
-move=> xz intf F ax fx.
+move=> intf F x ax fx.
+have locf : locally_integrable setT f.
+  by apply: open_integrable_locally => //; exact: openT.
 apply: cvg_at_right_left_dnbhs.
 - apply/cvg_at_rightP => d [d_gt0 d0].
   pose E x n := `[x, x + d n[%classic%R.
@@ -50,92 +51,39 @@ apply: cvg_at_right_left_dnbhs.
     by rewrite -EFinD addrAC subrr add0r.
   have nice_E y : nicely_shrinking y (E y).
     split=> [n|]; first exact: measurable_itv.
-    exists (2, fun n => PosNum (d_gt0 n)); split => //= [n z|n].
+    exists (2, (fun n => PosNum (d_gt0 n))); split => //= [n z|n].
       rewrite /E/= in_itv/= /ball/= ltr_distlC => /andP[yz ->].
       by rewrite (lt_le_trans _ yz)// ltrBlDr ltrDl.
     rewrite (lebesgue_measure_ball _ (ltW _))// -/mu muE -EFinM lee_fin.
     by rewrite mulr_natl.
-  have ixdf : {near \oo,
-      (fun n => \int[mu]_(t in [set` Interval a (BRight (x + d n))]) (f t)%:E -
-                \int[mu]_(t in [set` Interval a (BRight x)]) (f t)%:E) =1
-      (fun n => \int[mu]_(y in E x n) (f y)%:E)}.
-    move/cvgrPdist_le : d0 => /(_ (u - x)%R).
-    rewrite subr_gt0 => /(_ xz) [m _ d0].
-    near=> n.
-    have xdu : (x + d n <= u)%R.
-      rewrite -lerBrDl.
-      have /= := d0 n; rewrite sub0r normrN gtr0_norm//; apply.
-      by near: n; exists m.
+  have ixdf n : \int[mu]_(t in [set` Interval a (BRight (x + d n))]) (f t)%:E -
+                \int[mu]_(t in [set` Interval a (BRight x)]) (f t)%:E =
+                \int[mu]_(y in E x n) (f y)%:E.
     rewrite -[in X in X - _]integral_itv_bndo_bndc//=; last first.
-      apply: (@measurable_funS _ _ _ _ [set` Interval a (BRight u)]) => //.
-        by apply: subset_itvl; rewrite bnd_simp.
-      by move/integrableP : intf => [/EFin_measurable_fun].
+      by case: locf => + _ _; exact: measurable_funS.
     rewrite (@itv_bndbnd_setU _ _ _ (BLeft x))//=; last 2 first.
-      by case: a ax F {intf} => [[|] a|[|]]// /ltW.
+      by case: a ax F => [[|] a|[|]]// /ltW.
       by rewrite bnd_simp lerDl ltW.
     rewrite integral_setU_EFin//=.
-    + rewrite addeAC -[X in _ - X]integral_itv_bndo_bndc//=; last first.
-        apply (@measurable_funS _ _ _ _ [set` Interval a (BRight u)]) => //.
-          by apply: subset_itvl; rewrite bnd_simp ltW.
-        by move/integrableP : intf => [/EFin_measurable_fun].
-      rewrite subee ?add0e// integral_fune_fin_num//=.
-      apply: integrableS intf => //=.
-      by apply: subset_itvl; rewrite bnd_simp ltW.
-    + rewrite -itv_bndbnd_setU//; last 2 first.
-        exact/ltW/lt_ereal_bnd/(lt_le_trans ax).
-        by rewrite bnd_simp lerDl ltW.
-      apply (@measurable_funS _ _ _ _ [set` Interval a (BRight u)]) => //.
-        by apply: subset_itvl; rewrite bnd_simp.
-      by move/integrableP : intf => [/EFin_measurable_fun].
-    + apply/disj_setPRL; rewrite setCitv/=.
-      exact: subset_trans (subset_itvl _) (@subsetUr _ _ _).
-  suff: (d n)^-1 *: fine (\int[mu]_(t in E x n) (f t)%:E) @[n --> \oo] --> f x.
-    apply: cvg_trans; apply: near_eq_cvg.
-    move/cvgrPdist_le : d0 => /(_ (u - x)%R).
-    rewrite subr_gt0 => /(_ xz)[m /= _] H.
-    near=> n.
-    have dxu : ((d n + x)%E <= u)%R.
-      rewrite -lerBrDr.
-      have /= := H n; rewrite sub0r normrN gtr0_norm//; apply.
-      by near: n; exists m.
-    congr (_ *: _); rewrite -fineB/=;
-      [|apply: integral_fune_fin_num..] => //=; last 2 first.
-        apply: integrableS intf => //=.
-        by apply: subset_itvl; rewrite bnd_simp.
-        apply: integrableS intf => //=.
-        by apply: subset_itvl; rewrite bnd_simp ltW.
-    rewrite /= (addrC (d n) x).
-    by near: n; apply: filterS ixdf => k ->.
-  have {}locf : \forall r \near 0^'+,
-      locally_integrable [set: R] (f \_ (closed_ball x r)).
-    case: a intf F ax ixdf => [| [|//] intf _ ax ixdf]; last first.
-      near=> r; rewrite closed_ball_itv//.
-      apply: (@locally_integrableS _ _ `]-oo, u]) => //.
-        apply: (@subset_trans _ `]-oo, (x + r)]) => //; first exact: subset_itvr.
-        apply: subset_itvl; rewrite bnd_simp -lerBrDl.
-        by near: r; apply: nbhs_right_ltW; rewrite subr_gt0.
-      exact: integrable_locally_restrict.
-    move=> b a intf _ ax ixdf.
-    case: b in intf ax ixdf *; rewrite /= lte_fin in ax.
-    + near=> r.
-      rewrite closed_ball_itv//.
-      apply: (@locally_integrableS _ _ `[a, (x + r)]) => //.
-        apply: subset_itvr; rewrite bnd_simp -lerBlDr opprK -lerBrDl.
-        by near: r; apply: nbhs_right_ltW; rewrite subr_gt0.
-      apply: (@locally_integrableS _ _ `[a, u]) => //.
-        apply: subset_itvl; rewrite bnd_simp/= -lerBrDl.
-        by near: r; apply: nbhs_right_ltW; rewrite subr_gt0.
-      exact: integrable_locally_restrict.
-    + near=> r.
-      apply: (@locally_integrableS _ _ `]a, (x + r)]) => //.
-        exact: measurable_closed_ball.
-        rewrite closed_ball_itv//; apply: subset_itvr.
-        rewrite bnd_simp -ltrBlDr opprK -ltrBrDl.
-        by near: r; apply: nbhs_right_lt; rewrite subr_gt0.
-      apply: (@locally_integrableS _ _ `]a, u]) => //.
-        apply: subset_itvl; rewrite bnd_simp/= -lerBrDl.
-        by near: r; apply: nbhs_right_ltW; rewrite subr_gt0.
-      exact: integrable_locally_restrict.
+    - rewrite addeAC -[X in _ - X]integral_itv_bndo_bndc//=; last first.
+        by case: locf => + _ _; exact: measurable_funS.
+      rewrite subee ?add0e//.
+      by apply: integral_fune_fin_num => //; exact: integrableS intf.
+    - by case: locf => + _ _; exact: measurable_funS.
+    - apply/disj_setPRL => z/=.
+      rewrite /E /= !in_itv/= => /andP[xz zxdn].
+      move: a ax {F} => [[|] t/=|[_ /=|//]].
+      - rewrite lte_fin => tx.
+        by apply/negP; rewrite negb_and -leNgt xz orbT.
+      - rewrite lte_fin => tx.
+        by apply/negP; rewrite negb_and -!leNgt xz orbT.
+      - by apply/negP; rewrite -leNgt.
+  rewrite [f in f n @[n --> _] --> _](_ : _ =
+      fun n => (d n)^-1 *: fine (\int[mu]_(t in E x n) (f t)%:E)); last first.
+    apply/funext => n; congr (_ *: _); rewrite -fineB/=.
+    by rewrite /= (addrC (d n) x) ixdf.
+    by apply: integral_fune_fin_num => //; exact: integrableS intf.
+    by apply: integral_fune_fin_num => //; exact: integrableS intf.
   have := nice_lebesgue_differentiation nice_E locf fx.
   rewrite {ixdf} -/mu.
   rewrite [g in g n @[n --> _] --> _ -> _](_ : _ =
@@ -144,18 +92,11 @@ apply: cvg_at_right_left_dnbhs.
   move/fine_cvgP => [_ /=].
   set g := _ \o _ => gf.
   set h := (f in f n @[n --> \oo] --> _).
-  apply: cvg_trans gf; apply: near_eq_cvg.
-  move/cvgrPdist_le : d0 => /(_ (u - x)%R).
-  rewrite subr_gt0 => /(_ xz)[m /= _] H.
-  near=> n.
-  rewrite /g /h /= fineM// integral_fune_fin_num//; first exact: (nice_E _).1.
-  apply: integrableS intf => //=; first exact: (nice_E _).1.
-  apply: subset_trans (@subset_itvl _ _ _ (BLeft (x + d n)) _ _); last first.
-    rewrite bnd_simp -lerBrDl.
-    have /= := H n; rewrite sub0r normrN gtr0_norm//; apply.
-    by near: n; exists m.
-  apply: subset_itvr => //.
-  exact/ltW/lt_ereal_bnd/(lt_le_trans ax).
+  suff : g = h by move=> <-.
+  apply/funext => n.
+  rewrite /g /h /= fineM//.
+  apply: integral_fune_fin_num => //; first exact: (nice_E _).1.
+  by apply: integrableS intf => //; exact: (nice_E _).1.
 - apply/cvg_at_leftP => d [d_gt0 d0].
   have {}Nd_gt0 n : (0 < - d n)%R by rewrite ltrNr oppr0.
   pose E x n := `]x + d n, x]%classic%R.
@@ -165,174 +106,112 @@ apply: cvg_at_right_left_dnbhs.
   have nice_E y : nicely_shrinking y (E y).
     split=> [n|]; first exact: measurable_itv.
     exists (2, (fun n => PosNum (Nd_gt0 n))); split => //=.
-    + by rewrite -oppr0; exact: cvgN.
-    + move=> n; rewrite /E ball_itv opprK.
-      by apply: subset_itvl; rewrite bnd_simp ltrDl.
-    + move=> n; rewrite lebesgue_measure_ball//; last exact: ltW.
-      by rewrite -/mu muE -EFinM lee_fin mulr_natl.
+      by rewrite -oppr0; exact: cvgN.
+    move=> n z.
+      rewrite /E/= in_itv/= /ball/= => /andP[yz zy].
+      by rewrite ltr_distlC opprK yz /= (le_lt_trans zy)// ltrDl.
+    move=> n.
+    rewrite lebesgue_measure_ball//; last exact: ltW.
+    by rewrite -/mu muE -EFinM lee_fin mulr_natl.
   have ixdf : {near \oo,
       (fun n => \int[mu]_(t in [set` Interval a (BRight (x + d n))]) (f t)%:E -
                 \int[mu]_(t in [set` Interval a (BRight x)]) (f t)%:E) =1
       (fun n => - \int[mu]_(y in E x n) (f y)%:E)}.
-    case: a ax intf {F}; last first.
-      move=> [_ intf|//].
-      near=> n.
+    case: a ax {F}; last first.
+      move=> [_|//].
+      apply: nearW => n.
       rewrite -[in LHS]integral_itv_bndo_bndc//=; last first.
-         apply: (@measurable_funS _ _ _ _ `]-oo, u]) => //.
-           apply: subset_itvl; rewrite bnd_simp.
-           by rewrite -lerBrDl (@le_trans _ _ 0%R)// ?ltW// subr_gt0.
-         by move/integrableP : intf => [/EFin_measurable_fun].
+        by case: locf => + _ _; exact: measurable_funS.
       rewrite -/mu -[LHS]oppeK; congr oppe.
       rewrite oppeB; last first.
-        rewrite fin_num_adde_defl// fin_numN// integral_fune_fin_num//=.
-        apply: integrableS intf => //=.
-        by apply: subset_itvl => //=; rewrite bnd_simp ltW.
+        rewrite fin_num_adde_defl// fin_numN//.
+        by apply: integral_fune_fin_num => //; exact: integrableS intf.
       rewrite addeC.
       rewrite (_ : `]-oo, x] = `]-oo, (x + d n)%R] `|` E x n)%classic; last first.
         by rewrite -itv_bndbnd_setU//= bnd_simp ler_wnDr// ltW.
       rewrite integral_setU_EFin//=.
-      + rewrite addeAC -[X in X - _]integral_itv_bndo_bndc//; last first.
-          apply: (@measurable_funS _ _ _ _ `]-oo, u]) => //.
-            apply: subset_itvl; rewrite bnd_simp//.
-            by rewrite -lerBrDl (@le_trans _ _ 0%R)// ltW// subr_gt0.
-          by move/integrableP : intf => [/EFin_measurable_fun].
-        rewrite subee ?add0e// integral_fune_fin_num//=.
-        apply: integrableS intf => //=.
-        apply: subset_itvl; rewrite bnd_simp.
-        by rewrite -lerBrDl (@le_trans _ _ 0%R)// ltW// subr_gt0.
-      + exact: (nice_E _).1.
-      + rewrite -itv_bndbnd_setU//; last first.
-          by rewrite bnd_simp ler_wnDr// ltW.
-        apply: (@measurable_funS _ _ _ _ `]-oo, u]) => //.
-          by apply: subset_itvl; rewrite bnd_simp// ltW.
-        by move/integrableP : intf => [/EFin_measurable_fun].
-      + by apply/disj_setPLR; rewrite setCitv/=; exact: subsetUl.
-    move=> b a ax intf.
-    move/cvgrPdist_le : (d0) => /(_ (x - a)%R).
-    rewrite subr_gt0 => /(_ ax)[m /= _]d0xa.
-    move/cvgrPdist_le : d0 => /(_ (u - x)%R).
-    rewrite subr_gt0 => /(_ xz)[k /= _]d0ux.
+      - rewrite addeAC.
+        rewrite -[X in X - _]integral_itv_bndo_bndc//; last first.
+          by case: locf => + _ _; exact: measurable_funS.
+        rewrite subee ?add0e//.
+        by apply: integral_fune_fin_num => //; exact: integrableS intf.
+      - exact: (nice_E _).1.
+      - by case: locf => + _ _; exact: measurable_funS.
+      - apply/disj_setPLR => z/=.
+        rewrite /E /= !in_itv/= leNgt => xdnz.
+        by apply/negP; rewrite negb_and xdnz.
+    move=> b a ax.
+    move/cvgrPdist_le : d0.
+    move/(_ (x - a)%R); rewrite subr_gt0 => /(_ ax)[m _ /=] h.
     near=> n.
     have mn : (m <= n)%N by near: n; exists m.
     rewrite -[in X in X - _]integral_itv_bndo_bndc//=; last first.
-      apply: (@measurable_funS _ _ _ _ [set` Interval (BSide b a) (BRight u)]) => //.
-        apply: subset_itvl; rewrite bnd_simp.
-        by rewrite -lerBrDl (@le_trans _ _ 0%R)// ltW// subr_gt0.
-      by move/integrableP : intf => [/EFin_measurable_fun].
+      by case: locf => + _ _; exact: measurable_funS.
     rewrite -/mu -[LHS]oppeK; congr oppe.
     rewrite oppeB; last first.
-      rewrite fin_num_adde_defl// fin_numN// integral_fune_fin_num//=.
-      apply: integrableS intf => //.
-      by apply: subset_itvl; rewrite bnd_simp ltW.
+      rewrite fin_num_adde_defl// fin_numN//.
+      by apply: integral_fune_fin_num => //; exact: integrableS intf.
     rewrite addeC.
     rewrite (@itv_bndbnd_setU _ _ _ (BRight (x - - d n)%R))//; last 2 first.
-      case: b in ax intf * => /=; rewrite bnd_simp.
+      case: b in ax * => /=; rewrite bnd_simp.
         rewrite lerBrDl addrC -lerBrDl.
-        by have := d0xa _ mn; rewrite sub0r gtr0_norm.
+        by have := h _ mn; rewrite sub0r gtr0_norm.
       rewrite lerBrDl -lerBrDr.
-      by have := d0xa _ mn; rewrite sub0r gtr0_norm.
+      by have := h _ mn; rewrite sub0r gtr0_norm.
       by rewrite opprK bnd_simp -lerBrDl subrr ltW.
     rewrite integral_setU_EFin//=.
-    + rewrite addeAC -[X in X - _]integral_itv_bndo_bndc//; last first.
-        apply: (@measurable_funS _ _ _ _ [set` Interval (BSide b a) (BRight u)]) => //.
-          apply: subset_itvl; rewrite bnd_simp//.
-          by rewrite -lerBrDl opprK (@le_trans _ _ 0%R)// ltW// subr_gt0.
-        by move/integrableP : intf => [/EFin_measurable_fun].
-      rewrite opprK subee ?add0e// integral_fune_fin_num => //=.
-      apply: integrableS intf => //.
-      apply: subset_itvl.
-      by rewrite bnd_simp -lerBrDl (@le_trans _ _ 0%R)// ltW// subr_gt0.
-    + rewrite -itv_bndbnd_setU//; last 2 first.
-        case: b in ax intf * => /=; rewrite bnd_simp.
-          rewrite lerBrDl addrC -lerBrDl.
-          by have := d0xa _ mn; rewrite sub0r gtr0_norm.
-        rewrite lerBrDl -lerBrDr.
-        by have := d0xa _ mn; rewrite sub0r gtr0_norm.
-        by rewrite opprK bnd_simp -lerBrDl subrr ltW.
-      apply: (@measurable_funS _ _ _ _ [set` Interval (BSide b a) (BRight u)]) => //.
-        by apply: subset_itvl; rewrite bnd_simp ltW.
-      by move/integrableP : intf => [/EFin_measurable_fun].
-    + apply/disj_setPLR; rewrite opprK setCitv/=.
-      exact: subset_trans (subset_itvr _) (subsetUl _).
+    - rewrite addeAC -[X in X - _]integral_itv_bndo_bndc//; last first.
+        by case: locf => + _ _; exact: measurable_funS.
+      rewrite opprK subee ?add0e//.
+      by apply: integral_fune_fin_num => //; exact: integrableS intf.
+    - by case: locf => + _ _; exact: measurable_funS.
+    - apply/disj_setPLR => z/=.
+      rewrite /E /= !in_itv/= => /andP[az zxdn].
+      by apply/negP; rewrite negb_and -leNgt zxdn.
   suff: ((d n)^-1 * - fine (\int[mu]_(y in E x n) (f y)%:E))%R
           @[n --> \oo] --> f x.
     apply: cvg_trans; apply: near_eq_cvg; near=> n;  congr (_ *: _).
     rewrite /F -fineN -fineB; last 2 first.
-      apply: integral_fune_fin_num => //; apply: integrableS intf => //.
-      apply: subset_itvl; rewrite bnd_simp.
-      by rewrite -lerBrDr (@le_trans _ _ 0%R)// ltW// subr_gt0.
-      apply: integral_fune_fin_num => //; apply: integrableS intf => //.
-      by apply: subset_itvl; rewrite bnd_simp ltW.
+      by apply: integral_fune_fin_num => //; exact: integrableS intf.
+      by apply: integral_fune_fin_num => //; exact: integrableS intf.
     by congr fine => /=; apply/esym; rewrite (addrC _ x); near: n.
-  have {}locf : \forall r \near 0^'+,
-      locally_integrable [set: R] (f \_ (closed_ball x r)).
-    case: a intf F ax ixdf => [|[|//] intf _ _ ixdf]; last first.
-      near=> r.
-      rewrite closed_ball_itv//.
-      apply: (@locally_integrableS _ _ [set` `]-oo, (x + r)]]) => //.
-        exact: subset_itvr.
-      apply: (@locally_integrableS _ _ `]-oo, u]%classic) => //.
-        apply: subset_itvl; rewrite bnd_simp -lerBrDl.
-        by near: r; apply: nbhs_right_ltW; rewrite subr_gt0.
-      exact: integrable_locally_restrict.
-    move=> b a intf _; rewrite /= lte_fin => ax ixdf.
-    case: b in intf ixdf *.
-      near=> r.
-      rewrite closed_ball_itv//.
-      apply: (@locally_integrableS _ _ `[a, (x + r)]) => //.
-        apply: subset_itvr; rewrite bnd_simp -lerBlDr opprK -lerBrDl.
-        by near: r; apply: nbhs_right_ltW; rewrite subr_gt0.
-      apply: (@locally_integrableS _ _ `[a, u]) => //.
-        apply: subset_itvl; rewrite bnd_simp -lerBrDl.
-        by near: r; apply: nbhs_right_ltW; rewrite subr_gt0.
-      exact: integrable_locally_restrict.
-    near=> r.
-    apply: (@locally_integrableS _ _ `]a, (x + r)]) => //.
-      exact: measurable_closed_ball.
-      rewrite closed_ball_itv//; apply: subset_itvr.
-      rewrite bnd_simp -ltrBlDr opprK -ltrBrDl.
-      by near: r; apply: nbhs_right_lt; rewrite subr_gt0.
-    apply: (@locally_integrableS _ _ `]a, u]) => //.
-      apply: subset_itvl; rewrite bnd_simp -lerBrDl.
-      by near: r; apply: nbhs_right_ltW; rewrite subr_gt0.
-    exact: integrable_locally_restrict.
   have := nice_lebesgue_differentiation nice_E locf fx.
   rewrite {ixdf} -/mu.
   move/fine_cvgP => [_ /=].
   set g := _ \o _ => gf.
-  apply: cvg_trans gf.
-  move: a ax intf {F} => [[t/=|t/=]|[|//]]; rewrite ?lte_fin => tx intf.
-  + move/cvgrPdist_le : d0 => /= /(_ (x - t)%R).
-    rewrite subr_gt0 => /(_ tx)[k /= _] H.
-    apply: near_eq_cvg; near=> n.
-    rewrite /g /= fineM//=; last first.
-      apply: integral_fune_fin_num => //=; first exact: (nice_E _).1.
-      apply: integrableS (intf)%R => //=; first exact: (nice_E _).1.
-      apply: (@subset_trans _ `[t, x]).
-        apply: subset_itvr; rewrite bnd_simp -lerBlDr addrC -(opprK t) lerBlDr.
-        have /= := H n; rewrite gtr0_norm ?sub0r//; apply.
-        by near: n; exists k.
-      by apply: subset_itvl; rewrite bnd_simp ltW.
-    by rewrite muE/= invrN mulNr -mulrN.
-  + move/cvgrPdist_le : d0 => /= /(_ (x - t)%R).
-    rewrite subr_gt0 => /(_ tx)[k /= _] H.
-    apply: near_eq_cvg; near=> n.
-    rewrite /g /= fineM//=; last first.
-      apply: integral_fune_fin_num => //=; first exact: (nice_E _).1.
-      apply: integrableS (intf)%R => //=; first exact: (nice_E _).1.
-      apply: (@subset_trans _ `]t, x]).
-        apply: subset_itvr; rewrite bnd_simp -lerBlDr addrC -(opprK t) lerBlDr.
-        have /= := H n; rewrite gtr0_norm ?sub0r//; apply.
-        by near: n; exists k.
-      by apply: subset_itvl; rewrite bnd_simp ltW.
-    by rewrite muE/= invrN mulNr -mulrN.
-  + rewrite (@eq_cvg _ _ _ _ g)// => n.
-    rewrite /g /= fineM//=; last first.
-      apply: integral_fune_fin_num => //=; first exact: (nice_E _).1.
-      apply: integrableS intf => //=; first exact: (nice_E _).1.
-      apply: (@subset_trans _ (`]-oo, x])); first exact: subset_itvr.
-      by apply: subset_itvl; rewrite bnd_simp ltW.
-    by rewrite muE/= invrN mulNr mulrN.
+  rewrite (@eq_cvg _ _ _ _ g)// => n.
+  rewrite /g /= fineM//=; last first.
+    apply: integral_fune_fin_num => //; first exact: (nice_E _).1.
+    by apply: integrableS intf => //; exact: (nice_E _).1.
+  by rewrite muE/= invrN mulNr -mulrN.
+Unshelve. all: by end_near. Qed.
+
+Let FTC0_restrict f a x (u : R) : (x < u)%R ->
+  mu.-integrable [set` Interval a (BRight u)] (EFin \o f) ->
+  let F y := (\int[mu]_(t in [set` Interval a (BRight y)]) f t)%R in
+  a < BRight x -> lebesgue_pt f x ->
+  h^-1 *: (F (h + x) - F x) @[h --> 0%R^'] --> f x.
+Proof.
+move=> xz + F ax fx.
+rewrite integrable_mkcond//= (restrict_EFin f) => intf.
+have /(@FTC0 _ a intf _ ax) : lebesgue_pt (f \_ [set` Interval a (BRight u)]) x.
+  exact: lebesgue_pt_restrict.
+rewrite patchE mem_set; last first.
+  rewrite /= in_itv/= (ltW xz) andbT.
+  move: a ax {F intf} => [[a|//]|[]//].
+  by rewrite lte_fin => /ltW.
+apply: cvg_trans; apply: near_eq_cvg; near=> r; congr (_ *: (_ - _)).
+- apply: eq_Rintegral => y yaxr.
+  rewrite patchE mem_set//=.
+  move: yaxr => /=; rewrite !in_itv/= inE/= in_itv/= => /andP[->/=].
+  move=> /le_trans; apply.
+  rewrite -lerBrDr.
+  have [r0|r0] := leP r 0%R; first by rewrite (le_trans r0)// subr_ge0 ltW.
+  rewrite -(gtr0_norm r0).
+  by near: r; apply: dnbhs0_le; rewrite subr_gt0.
+- apply: eq_Rintegral => y yaxr; rewrite patchE mem_set//=.
+  move: yaxr => /=; rewrite !in_itv/= inE/= in_itv/= => /andP[->/=].
+  by move=> /le_trans; apply; exact/ltW.
 Unshelve. all: by end_near. Qed.
 
 (* NB: right-closed interval *)
@@ -343,9 +222,9 @@ Lemma FTC1_lebesgue_pt f a x (u : R) : (x < u)%R ->
   derivable F x 1 /\ F^`() x = f x.
 Proof.
 move=> xu intf F ax fx; split; last first.
-  by apply/cvg_lim; [exact: Rhausdorff|exact: (@FTC0 _ _ _ u)].
+  by apply/cvg_lim; [exact: Rhausdorff|exact: (@FTC0_restrict _ _ _ u)].
 apply/cvg_ex; exists (f x).
-have /= := FTC0 xu intf ax fx.
+have /= := FTC0_restrict xu intf ax fx.
 set g := (f in f n @[n --> _] --> _ -> _).
 set h := (f in _ -> f n @[n --> _] --> _).
 suff : g = h by move=> <-.

--- a/theories/ftc.v
+++ b/theories/ftc.v
@@ -192,23 +192,19 @@ Let FTC0_restrict f a x (u : R) : (x < u)%R ->
   a < BRight x -> lebesgue_pt f x ->
   h^-1 *: (F (h + x) - F x) @[h --> 0%R^'] --> f x.
 Proof.
-move=> xz + F ax fx.
+move=> xu + F ax fx.
 rewrite integrable_mkcond//= (restrict_EFin f) => intf.
-have /(@FTC0 _ a intf _ ax) : lebesgue_pt (f \_ [set` Interval a (BRight u)]) x.
+have /(@FTC0 _ _ intf _ ax) : lebesgue_pt (f \_ [set` Interval a (BRight u)]) x.
   exact: lebesgue_pt_restrict.
 rewrite patchE mem_set; last first.
-  rewrite /= in_itv/= (ltW xz) andbT.
-  move: a ax {F intf} => [[a|//]|[]//].
-  by rewrite lte_fin => /ltW.
+  rewrite /= in_itv/= (ltW xu) andbT.
+  by move: a ax {F intf} => [[a|]|[]]//=; rewrite lte_fin => /ltW.
 apply: cvg_trans; apply: near_eq_cvg; near=> r; congr (_ *: (_ - _)).
-- apply: eq_Rintegral => y yaxr.
-  rewrite patchE mem_set//=.
-  move: yaxr => /=; rewrite !in_itv/= inE/= in_itv/= => /andP[->/=].
-  move=> /le_trans; apply.
-  rewrite -lerBrDr.
+- apply: eq_Rintegral => y yaxr; rewrite patchE mem_set//=.
+  move: yaxr; rewrite /= !in_itv/= inE/= in_itv/= => /andP[->/=].
+  move=> /le_trans; apply; rewrite -lerBrDr.
   have [r0|r0] := leP r 0%R; first by rewrite (le_trans r0)// subr_ge0 ltW.
-  rewrite -(gtr0_norm r0).
-  by near: r; apply: dnbhs0_le; rewrite subr_gt0.
+  by rewrite -(gtr0_norm r0); near: r; apply: dnbhs0_le; rewrite subr_gt0.
 - apply: eq_Rintegral => y yaxr; rewrite patchE mem_set//=.
   move: yaxr => /=; rewrite !in_itv/= inE/= in_itv/= => /andP[->/=].
   by move=> /le_trans; apply; exact/ltW.
@@ -254,53 +250,44 @@ apply: filterS; first exact: (ae_filter_ringOfSetsType mu).
 by move=> r /=; apply; rewrite ltNyr.
 Qed.
 
+Let itv_continuous_lebesgue_pt f a x (u : R) : (x < u)%R ->
+  measurable_fun [set` Interval a (BRight u)] f ->
+  a < BRight x ->
+  {for x, continuous f} -> lebesgue_pt f x.
+Proof.
+move=> xu fi + fx.
+move: a fi => [b a fi /[1!(@lte_fin R)] ax|[|//] fi _].
+- near (0%R:R)^'+ => e; apply: (@continuous_lebesgue_pt _ _ _ (ball x e)) => //.
+  + exact: ball_open_nbhs.
+  + exact: measurable_ball.
+  + apply: measurable_funS fi => //; rewrite ball_itv.
+    apply: (@subset_trans _ `](x - e)%R, u]) => //.
+      apply: subset_itvl; rewrite bnd_simp -lerBrDl.
+      by near: e; apply: nbhs_right_ltW; rewrite subr_gt0.
+    apply: subset_itvr; rewrite bnd_simp lerBrDr -lerBrDl.
+    by near: e; apply: nbhs_right_ltW; rewrite subr_gt0.
+- near (0%R:R)^'+ => e; apply: (@continuous_lebesgue_pt _ _ _ (ball x e)) => //.
+  + exact: ball_open_nbhs.
+  + exact: measurable_ball.
+  + apply: measurable_funS fi => //; rewrite ball_itv.
+    apply: (@subset_trans _ `](x - e)%R, u]) => //.
+      apply: subset_itvl; rewrite bnd_simp -lerBrDl.
+      by near: e; apply: nbhs_right_ltW; rewrite subr_gt0.
+    exact: subset_itvr.
+Unshelve. all: by end_near. Qed.
+
 Corollary continuous_FTC1 f a x (u : R) : (x < u)%R ->
   mu.-integrable [set` Interval a (BRight u)] (EFin \o f) ->
   let F x := (\int[mu]_(t in [set` Interval a (BRight x)]) (f t))%R in
   a < BRight x -> {for x, continuous f} ->
   derivable F x 1 /\ F^`() x = f x.
 Proof.
-move=> xu fi F ax fx.
-have lfx : lebesgue_pt f x; last first.
-  have /= /(_ ax lfx)/= [dfx f'xE] := @FTC1_lebesgue_pt f a x _ xu fi.
+move=> xu fi F ax fx; suff lfx : lebesgue_pt f x.
+  have /(_ ax lfx)[dfx f'xE] := @FTC1_lebesgue_pt _ a _ _ xu fi.
   by split; [exact: dfx|rewrite f'xE].
-case: a fi F ax => [|[|//] fi _ _]; last first.
-  near (0%R:R)^'+ => e; apply: (@continuous_lebesgue_pt _ _ _ (ball x e)) => //.
-  - exact: ball_open_nbhs.
-  - exact: measurable_ball.
-  - have /measurable_int/EFin_measurable_fun := fi.
-    apply: measurable_funS => //.
-    rewrite ball_itv.
-    apply: (@subset_trans _ (`](x - e)%R, u])) => //.
-      apply: subset_itvl; rewrite bnd_simp -lerBrDl.
-      by near: e; apply: nbhs_right_ltW; rewrite subr_gt0.
-    exact: subset_itvr.
-move=> b a fi _ /=; rewrite lte_fin => ax.
-case: b fi => [|] fi.
-  near (0%R:R)^'+ => e; apply: (@continuous_lebesgue_pt _ _ _ (ball x e)) => //.
-  - exact: ball_open_nbhs.
-  - exact: measurable_ball.
-  - have /measurable_int/EFin_measurable_fun := fi.
-    apply: measurable_funS => //.
-    rewrite ball_itv.
-    apply: (@subset_trans _ (`](x - e)%R, u])) => //.
-      apply: subset_itvl; rewrite bnd_simp -lerBrDl.
-      by near: e; apply: nbhs_right_ltW; rewrite subr_gt0.
-    apply: subset_itvr; rewrite bnd_simp lerBrDr -lerBrDl.
-    by near: e; apply: nbhs_right_ltW; rewrite subr_gt0.
-near (0%R:R)^'+ => e; apply: (@continuous_lebesgue_pt _ _ _ (ball x e)) => //.
-- exact: ball_open_nbhs.
-- exact: measurable_ball.
-- have /measurable_int/EFin_measurable_fun := fi.
-  apply: measurable_funS => //.
-  rewrite ball_itv.
-  apply: (@subset_trans _ (`](x - e)%R, u])) => //.
-    apply: subset_itvl; rewrite bnd_simp.
-    rewrite -lerBrDl.
-    by near: e; apply: nbhs_right_ltW; rewrite subr_gt0.
-  apply: subset_itvr; rewrite bnd_simp lerBrDr -lerBrDl.
-  by near: e; apply: nbhs_right_ltW; rewrite subr_gt0.
-Unshelve. all: by end_near. Qed.
+apply: itv_continuous_lebesgue_pt xu _ ax fx.
+by move/integrableP : fi => -[/EFin_measurable_fun].
+Qed.
 
 Corollary continuous_FTC1_closed f (a x : R) (u : R) : (x < u)%R ->
   mu.-integrable `[a, u] (EFin \o f) ->
@@ -497,6 +484,17 @@ Notation mu := lebesgue_measure.
 Local Open Scope ereal_scope.
 Implicit Types (f : R -> R) (a b : R).
 
+(* TODO: move? *)
+Let within_continuous_restrict f a b : (a < b)%R ->
+  {within `[a, b], continuous f} -> {in `]a, b[, continuous (f \_ `[a, b])}.
+Proof.
+move=> ab + x xab; move=> /(_ x).
+rewrite {1}/continuous_at => xf.
+rewrite /prop_for /continuous_at  patchE.
+rewrite mem_set ?mulr1 /=; last exact: subset_itv_oo_cc.
+exact: cvg_patch.
+Qed.
+
 Corollary continuous_FTC2 f F a b : (a < b)%R ->
   {within `[a, b], continuous f} ->
   derivable_oo_continuous_bnd F a b ->
@@ -508,45 +506,13 @@ pose fab := f \_ `[a, b].
 pose G x : R := (\int[mu]_(t in `[a, x]) fab t)%R.
 have iabf : mu.-integrable `[a, b] (EFin \o f).
   by apply: continuous_compact_integrable => //; exact: segment_compact.
-have locfab : locally_integrable [set: R] fab.
-  split.
-  - move: iabf => /(integrable_mkcond _ _).1 /=.
-    move=> /(_ (measurable_itv _)) /integrableP[+ _].
-    by rewrite restrict_EFin => /EFin_measurable_fun.
-  - exact: openT.
-  - move=> K _ cK.
-    under eq_integral.
-      move=> x xK.
-      rewrite /fab.
-      rewrite -[_%:E]/((EFin \o (normr \o f \_ `[a, b])) x).
-      rewrite -restrict_normr.
-      rewrite -restrict_EFin.
-      over.
-    rewrite /=.
-    rewrite -integral_mkcondr/=.
-    move: iabf => /integrableP[mabf].
-    apply: le_lt_trans; apply: ge0_subset_integral => //=.
-      by apply: measurableI => //; exact: compact_measurable.
-    apply/EFin_measurable_fun => //=;apply/measurableT_comp => //.
-    exact/EFin_measurable_fun.
 have G'f : {in `]a, b[, forall x, G^`() x = fab x /\ derivable G x 1}.
   move=> x /[!in_itv]/= /andP[ax xb].
-  have : mu.-integrable `[a, b] (EFin \o fab).
-    rewrite -[X in _.-integrable X _]setIid.
-    apply/(integrable_restrict _ _ _ _).2 => //=.
-    rewrite restrict_EFin -patch_setI setIid -restrict_EFin.
-    apply/(integrable_restrict _ _ _ _).1 => //=.
-    by rewrite setIid.
-  move/(@continuous_FTC1_closed _ fab a x b xb) => /(_ ax).
-  have : {for x, continuous fab}.
-    have : x \in `[a, b] by rewrite in_itv/= (ltW ax) (ltW xb).
-    move: cf => /(_ x).
-    rewrite {1}/continuous_at => xf xab.
-    rewrite /prop_for /continuous_at {2}/fab/= patchE.
-    rewrite mem_set ?mulr1 /=; last by rewrite in_itv/= (ltW ax) (ltW xb).
-    apply: cvg_patch => //.
-    by rewrite in_itv/= ax xb.
-  by move=> /[swap] /[apply] -[].
+  have ifab : mu.-integrable `[a, b] (EFin \o fab).
+    by rewrite -restrict_EFin; apply/integrable_restrict => //=; rewrite setIid.
+  have cfab : {for x, continuous fab}.
+    by apply: within_continuous_restrict => //; rewrite in_itv/= ax xb.
+  by have [] := continuous_FTC1_closed xb ifab ax cfab.
 have F'G'0 : {in `]a, b[, (F^`() - G^`() =1 cst 0)%R}.
   move=> x xab; rewrite !fctE (G'f x xab).1 /fab.
   by rewrite patchE mem_set/= ?F'f ?subrr//; exact: subset_itv_oo_cc.

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -5817,7 +5817,7 @@ Local Notation mu := lebesgue_measure.
 Definition locally_integrable D f := [/\ measurable_fun D f, open D &
   forall K, K `<=` D -> compact K -> \int[mu]_(x in K) `|f x|%:E < +oo].
 
-Lemma integrable_locally D f : open D ->
+Lemma open_integrable_locally D f : open D ->
   mu.-integrable D (EFin \o f) -> locally_integrable D f.
 Proof.
 move=> oD /integrableP[mf foo]; split => //; first exact/EFin_measurable_fun.
@@ -5890,6 +5890,24 @@ apply: ge0_le_integral => //=; first exact: compact_measurable.
   case: ifPn => xA; case: ifPn => xB //; last by rewrite normr0.
   move: AB => /(_ x).
   by move/set_mem : xA => /[swap] /[apply] /mem_set; rewrite (negbTE xB).
+Qed.
+
+Lemma integrable_locally_restrict f (A : set R) : measurable A ->
+  mu.-integrable A (EFin \o f) -> locally_integrable [set: R] (f \_ A).
+Proof.
+move=> mA intf; split.
+- move/integrableP : intf => [mf _].
+  by apply/(measurable_restrictT _ _).1 => //; exact/EFin_measurable_fun.
+- exact: openT.
+- move=> K _ cK.
+  move/integrableP : intf => [mf].
+  rewrite integral_mkcond/=.
+  under eq_integral do rewrite restrict_EFin restrict_normr.
+  apply: le_lt_trans.
+  apply: ge0_subset_integral => //=; first exact: compact_measurable.
+  apply/EFin_measurable_fun/measurableT_comp/EFin_measurable_fun => //=.
+  move/(measurable_restrictT _ _).1 : mf => /=.
+  by rewrite restrict_EFin; exact.
 Qed.
 
 End locally_integrable.

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -6819,6 +6819,41 @@ Qed.
 
 End nicely_shrinking.
 
+(* TODO: move *)
+Lemma locally_integrableS {R : realType} (A B : set R) (f : R -> R) :
+  measurable A -> measurable B -> A `<=` B ->
+  locally_integrable setT (f \_ B) ->
+  locally_integrable setT (f \_ A).
+Proof.
+move=> mA mB AB [mfB oT ifB].
+have ? : measurable_fun [set: R] (f \_ A).
+  apply/(measurable_restrictT _ _).1 => //; apply: (measurable_funS _ AB) => //.
+  exact/(measurable_restrictT _ _).2.
+split => // K KT cK; apply: le_lt_trans (ifB _ KT cK).
+apply: ge0_le_integral => //=; first exact: compact_measurable.
+- apply/EFin_measurable_fun; apply/measurableT_comp => //.
+  exact/measurable_funTS.
+- apply/EFin_measurable_fun; apply/measurableT_comp => //.
+  exact/measurable_funTS.
+- move=> x Kx; rewrite lee_fin !patchE.
+  case: ifPn => xA; case: ifPn => xB //; last by rewrite normr0.
+  move: AB => /(_ x).
+  move/set_mem : xA => /[swap] /[apply] /mem_set.
+  by rewrite (negbTE xB).
+Qed.
+
+Section set_itv_porderType.
+Variables (d : Order.disp_t) (T : porderType d).
+Implicit Types (x y : T).
+
+Lemma subset_itv' x y z u : (x < y)%O -> (z < u)%O -> `[y, z] `<=` `]x, u[.
+Proof.
+move=> xy zu w/=; rewrite !in_itv/= => /andP[yw wz].
+by rewrite (lt_le_trans xy)//= (le_lt_trans wz).
+Qed.
+
+End set_itv_porderType.
+
 Section nice_lebesgue_differentiation.
 Local Open Scope ereal_scope.
 Context {R : realType}.
@@ -6826,13 +6861,16 @@ Variable E : R -> (set R)^nat.
 Hypothesis hE : forall x, nicely_shrinking x (E x).
 Local Notation mu := lebesgue_measure.
 
-Lemma nice_lebesgue_differentiation (f : R -> R) :
-  locally_integrable setT f ->
-  forall x, lebesgue_pt f x ->
+#[local] Hint Extern 0 (measurable (closed_ball _ _)) =>
+  solve [apply: measurable_closed_ball] : core.
+
+Lemma nice_lebesgue_differentiation (f : R -> R) (x : R) :
+  (\forall r \near 0^'+, locally_integrable setT (f \_ (closed_ball x r))) ->
+  lebesgue_pt f x ->
   (fine (mu (E x n)))^-1%:E * \int[mu]_(y in E x n) (f y)%:E
     @[n --> \oo] --> (f x)%:E.
 Proof.
-move=> locf x fx; apply: (cvge_sub0 _ _).1 => //=; apply/cvg_abse0P.
+move=> locf fx; apply: (cvge_sub0 _ _).1 => //=; apply/cvg_abse0P.
 pose r_ x : {posnum R} ^nat := (sval (cid (hE x).2)).2.
 pose C := (sval (cid (hE x).2)).1.
 have C_gt0 : (0 < C)%R by rewrite /C /sval/=; case: cid => -[? ?] [].
@@ -6843,12 +6881,15 @@ have E_r_ n : E x n `<=` ball x (r_ x n)%:num.
 have muEr_ n : mu (ball x (r_ x n)%:num) <= C%:E * mu (E x n).
   by rewrite /C /r_ /sval/=; case: cid => -[? ?] [].
 apply: (@squeeze_cvge _ _ _ _ (cst 0) _
-  (fun n => C%:E * davg f x (r_ x n)%:num)); last 2 first.
-  exact: cvg_cst.
+  (fun n => C%:E * davg f x (r_ x n)%:num)); [|exact: cvg_cst|]; last first.
   move/cvge_at_rightP: fx => /(_ (fun r => (r_ x r)%:num)) fx.
-  by rewrite -(mule0 C%:E); apply: cvgeM => //;[exact: mule_def_fin |
+  by rewrite -(mule0 C%:E); apply: cvgeM => //; [exact: mule_def_fin |
     exact: cvg_cst | apply: fx; split => //; exact: r_0].
+case: locf => r /= r0 locf.
+move: (r_0 x) => /cvgrPdist_lt/(_ _ r0) {}r_0.
 near=> n.
+have {}locf : locally_integrable setT (f \_ (closed_ball x (r_ x n)%:num)%E).
+  by apply: (locf (r_ x n)%:num) => //=; near: n.
 apply/andP; split => //=.
 apply: (@le_trans _ _ ((fine (mu (E x n)))^-1%:E *
                        `| \int[mu]_(y in E x n) ((f y)%:E + (- f x)%:E) |)).
@@ -6866,24 +6907,26 @@ apply: (@le_trans _ _ ((fine (mu (E x n)))^-1%:E *
     by rewrite (nicely_shrinking_gt0 (hE x)).
   rewrite abseM gee0_abs; last by rewrite lee_fin// invr_ge0// fine_ge0.
   rewrite lee_pmul//; first by rewrite lee_fin// invr_ge0// fine_ge0.
-  rewrite integralD//=.
-  - exact: (hE x).1.
-  - apply/integrableP; split.
-      by apply/EFin_measurable_fun; case: locf => + _ _; exact: measurable_funS.
+  rewrite integralD//=; first exact: (hE x).1.
+    apply/integrableP; split.
+      apply/EFin_measurable_fun.
+      apply: (@measurable_funS _ _ _ _ (closed_ball x (r_ x n)%:num)) => //=.
+      + by apply: (subset_trans (E_r_ _)); exact: subset_closed_ball.
+      + by case: locf => /(measurable_restrictT _ _).2 + _ _; apply.
     rewrite (@le_lt_trans _ _
-      (\int[mu]_(y in closed_ball x (r_ x n)%:num) `|(f y)%:E|))//.
+        (\int[mu]_(y in closed_ball x (r_ x n)%:num) `|(f y)%:E|))//.
       apply: ge0_subset_integral => //.
       + exact: (hE _).1.
-      + exact: measurable_closed_ball.
       + apply: measurableT_comp => //; apply/EFin_measurable_fun => //.
-        by case: locf => + _ _; exact: measurable_funS.
+        by case: locf => /(measurable_restrictT _ _).2 + _ _; apply.
       + by apply: (subset_trans (E_r_ n)) => //; exact: subset_closed_ball.
+    rewrite integralEpatch //=.
+    under eq_integral do rewrite restrict_EFin restrict_normr.
     by case: locf => _ _; apply => //; exact: closed_ballR_compact.
   apply/integrableP; split; first exact: measurable_cst.
   rewrite integral_cst //=; last exact: (hE _).1.
   by rewrite lte_mul_pinfty// (nicely_shrinking_lty (hE x)).
-rewrite muleA lee_pmul//.
-- by rewrite lee_fin invr_ge0// fine_ge0.
+rewrite muleA lee_pmul//; first by rewrite lee_fin invr_ge0// fine_ge0.
 - rewrite -(@invrK _ C) -EFinM -invfM lee_fin lef_pV2//; last 2 first.
     rewrite posrE fine_gt0// (nicely_shrinking_gt0 (hE x))//=.
     by rewrite (nicely_shrinking_lty (hE x)).
@@ -6893,15 +6936,19 @@ rewrite muleA lee_pmul//.
     by rewrite lebesgue_measure_ball// ltry andbT lte_fin mulrn_wgt0.
   rewrite fineK; last by rewrite ge0_fin_numE// (nicely_shrinking_lty (hE x)).
   exact: muEr_.
-- apply: le_trans.
-  + apply: le_abse_integral => //; first exact: (hE x).1.
+- apply: (@le_trans _ _ (\int[mu]_(x0 in E x n) (normr (f x0 - f x))%:E)).
+  + apply: le_abse_integral => //=; first exact: (hE x).1.
     apply/EFin_measurable_fun; apply/measurable_funB => //.
-    by case: locf => + _ _; exact: measurable_funS.
+    apply: (@measurable_funS _ _ _ _ (closed_ball x (r_ x n)%:num)) => //=.
+    * by apply: (subset_trans (E_r_ _)); exact: subset_closed_ball.
+    * by case: locf => /(measurable_restrictT _ _).2 + _ _; apply.
   + apply: ge0_subset_integral => //; first exact: (hE x).1.
-    exact: measurable_ball.
-  + apply/EFin_measurable_fun; apply: measurableT_comp => //.
+      exact: measurable_ball.
+    apply/EFin_measurable_fun; apply: measurableT_comp => //.
     apply/measurable_funB => //.
-    by case: locf => + _ _; exact: measurable_funS.
+    apply: (@measurable_funS _ _ _ _ (closed_ball x (r_ x n)%:num)) => //=.
+      exact: subset_closed_ball.
+    by case: locf => /(measurable_restrictT _ _).2 + _ _; apply.
 Unshelve. all: by end_near. Qed.
 
 End nice_lebesgue_differentiation.

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -5872,6 +5872,26 @@ by rewrite integral_cst//= ?mul1e; [exact: compact_finite_measure|
                                     exact: compact_measurable].
 Qed.
 
+Lemma locally_integrableS (A B : set R) f :
+  measurable A -> measurable B -> A `<=` B ->
+  locally_integrable setT (f \_ B) -> locally_integrable setT (f \_ A).
+Proof.
+move=> mA mB AB [mfB oT ifB].
+have ? : measurable_fun [set: R] (f \_ A).
+  apply/(measurable_restrictT _ _).1 => //; apply: (measurable_funS _ AB) => //.
+  exact/(measurable_restrictT _ _).2.
+split => // K KT cK; apply: le_lt_trans (ifB _ KT cK).
+apply: ge0_le_integral => //=; first exact: compact_measurable.
+- apply/EFin_measurable_fun; apply/measurableT_comp => //.
+  exact/measurable_funTS.
+- apply/EFin_measurable_fun; apply/measurableT_comp => //.
+  exact/measurable_funTS.
+- move=> x Kx; rewrite lee_fin !patchE.
+  case: ifPn => xA; case: ifPn => xB //; last by rewrite normr0.
+  move: AB => /(_ x).
+  by move/set_mem : xA => /[swap] /[apply] /mem_set; rewrite (negbTE xB).
+Qed.
+
 End locally_integrable.
 
 Section iavg.
@@ -6818,41 +6838,6 @@ by rewrite lebesgue_measure_ball// ltry.
 Qed.
 
 End nicely_shrinking.
-
-(* TODO: move *)
-Lemma locally_integrableS {R : realType} (A B : set R) (f : R -> R) :
-  measurable A -> measurable B -> A `<=` B ->
-  locally_integrable setT (f \_ B) ->
-  locally_integrable setT (f \_ A).
-Proof.
-move=> mA mB AB [mfB oT ifB].
-have ? : measurable_fun [set: R] (f \_ A).
-  apply/(measurable_restrictT _ _).1 => //; apply: (measurable_funS _ AB) => //.
-  exact/(measurable_restrictT _ _).2.
-split => // K KT cK; apply: le_lt_trans (ifB _ KT cK).
-apply: ge0_le_integral => //=; first exact: compact_measurable.
-- apply/EFin_measurable_fun; apply/measurableT_comp => //.
-  exact/measurable_funTS.
-- apply/EFin_measurable_fun; apply/measurableT_comp => //.
-  exact/measurable_funTS.
-- move=> x Kx; rewrite lee_fin !patchE.
-  case: ifPn => xA; case: ifPn => xB //; last by rewrite normr0.
-  move: AB => /(_ x).
-  move/set_mem : xA => /[swap] /[apply] /mem_set.
-  by rewrite (negbTE xB).
-Qed.
-
-Section set_itv_porderType.
-Variables (d : Order.disp_t) (T : porderType d).
-Implicit Types (x y : T).
-
-Lemma subset_itv' x y z u : (x < y)%O -> (z < u)%O -> `[y, z] `<=` `]x, u[.
-Proof.
-move=> xy zu w/=; rewrite !in_itv/= => /andP[yw wz].
-by rewrite (lt_le_trans xy)//= (le_lt_trans wz).
-Qed.
-
-End set_itv_porderType.
 
 Section nice_lebesgue_differentiation.
 Local Open Scope ereal_scope.

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -1330,6 +1330,11 @@ move=> xz; exists (z - x) => //=; first by rewrite subr_gt0.
 by move=> y /= + xy; rewrite distrC ?ger0_norm ?subr_ge0 1?ltW// ltrD2r.
 Qed.
 
+Lemma nbhs_right_ltW x z : x < z -> \forall y \near nbhs x^'+, y <= z.
+Proof.
+by move=> xz; near=> y; apply/ltW; near: y; exact: nbhs_right_lt.
+Unshelve. all: by end_near. Qed.
+
 Lemma nbhs_right_ltDr x e : 0 < e -> \forall y \near x ^'+, y - x < e.
 Proof.
 move=> e0; near=> y; rewrite ltrBlDr; near: y.
@@ -1639,7 +1644,6 @@ Arguments cvgr_neq0 {R V T F FF f}.
   H : x \is_near _ |- _ => near: x; exact: nbhs_right_ge end : core.
 #[global] Hint Extern 0 (is_true (?x <= _)) => match goal with
   H : x \is_near _ |- _ => near: x; exact: nbhs_left_le end : core.
-
 
 #[global] Hint Extern 0 (ProperFilter _^'-) =>
   (apply: at_left_proper_filter) : typeclass_instances.
@@ -5329,6 +5333,27 @@ Proof. by rewrite !(boundr_in_itv, boundl_in_itv). Qed.
 Lemma near_in_itv {R : realFieldType} (a b : R) :
   {in `]a, b[, forall y, \forall z \near y, z \in `]a, b[}.
 Proof. exact: interval_open. Qed.
+
+Lemma cvg_patch {R : realType} (f : R -> R^o) (a b : R) (x : R) : (a < b)%R ->
+  x \in `]a, b[ ->
+  f @ (x : subspace `[a, b]) --> f x ->
+  (f \_ `[a, b] x) @[x --> x] --> f x.
+Proof.
+move=> ab xab xf; apply/cvgrPdist_lt => /= e e0.
+move/cvgrPdist_lt : xf => /(_ e e0) xf.
+near=> z.
+rewrite patchE ifT//; last first.
+  rewrite inE; apply: subset_itv_oo_cc.
+  by near: z; exact: near_in_itv.
+near: z.
+rewrite /prop_near1 /nbhs/= /nbhs_subspace ifT// in xf; last first.
+  by rewrite inE/=; exact: subset_itv_oo_cc xab.
+case: xf => x0 /= x00 xf.
+near=> z.
+apply: xf => //=.
+rewrite inE; apply: subset_itv_oo_cc.
+by near: z; exact: near_in_itv.
+Unshelve. all: by end_near. Qed.
 
 Notation "f @`[ a , b ]" :=
   (`[minr (f a) (f b), maxr (f a) (f b)]) : ring_scope.

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -2135,31 +2135,30 @@ Arguments cvg_at_leftE {R V} f x.
 
 Lemma continuous_within_itvP {R : realType } a b (f : R -> R) :
   a < b ->
-  {within `[a,b], continuous f} <->
-  {in `]a,b[, continuous f} /\ f @ a^'+ --> f a /\ f @b^'- --> f b.
+  {within `[a, b], continuous f} <->
+  [/\ {in `]a, b[, continuous f}, f @ a^'+ --> f a & f @b^'- --> f b].
 Proof.
 move=> ab; split=> [abf|].
-  split.
-    suff : {in `]a, b[%classic, continuous f}.
+  have [aab bab] : a \in `[a, b] /\ b \in `[a, b].
+    by rewrite !in_itv/= !lexx (ltW ab).
+  split; [|apply/cvgrPdist_lt => eps eps_gt0 /=..].
+  - suff : {in `]a, b[%classic, continuous f}.
       by move=> P c W; apply: P; rewrite inE.
     rewrite -continuous_open_subspace; last exact: interval_open.
     by move: abf; exact/continuous_subspaceW/subset_itvW.
-  have [aab bab] : a \in `[a, b] /\ b \in `[a, b].
-    by rewrite !in_itv/= !lexx (ltW ab).
-  split; apply/cvgrPdist_lt => eps eps_gt0 /=.
-  + move/continuous_withinNx/cvgrPdist_lt/(_ _ eps_gt0) : (abf a).
+  - move/continuous_withinNx/cvgrPdist_lt/(_ _ eps_gt0) : (abf a).
     rewrite /dnbhs/= near_withinE !near_simpl// /prop_near1 /nbhs/=.
     rewrite -nbhs_subspace_in// /within/= near_simpl.
     apply: filter_app; exists (b - a); rewrite /= ?subr_gt0// => c cba + ac.
     apply=> //; rewrite ?gt_eqF// !in_itv/= (ltW ac)/=; move: cba => /=.
     by rewrite ltr0_norm ?subr_lt0// opprB ltrD2r => /ltW.
-  + move/continuous_withinNx/cvgrPdist_lt/(_ _ eps_gt0) : (abf b).
+  - move/continuous_withinNx/cvgrPdist_lt/(_ _ eps_gt0) : (abf b).
     rewrite /dnbhs/= near_withinE !near_simpl /prop_near1 /nbhs/=.
     rewrite -nbhs_subspace_in// /within/= near_simpl.
     apply: filter_app; exists (b - a); rewrite /= ?subr_gt0// => c cba + ac.
     apply=> //; rewrite ?lt_eqF// !in_itv/= (ltW ac)/= andbT; move: cba => /=.
     by rewrite gtr0_norm ?subr_gt0// ltrD2l ltrNr opprK => /ltW.
-case=> ctsoo [ctsL ctsR]; apply/subspace_continuousP => x /andP[].
+case=> ctsoo ctsL ctsR; apply/subspace_continuousP => x /andP[].
 rewrite !bnd_simp/= !le_eqVlt => /predU1P[<-{x}|ax] /predU1P[|].
 - by move/eqP; rewrite lt_eqF.
 - move=> _; apply/cvgrPdist_lt => eps eps_gt0 /=.

--- a/theories/realfun.v
+++ b/theories/realfun.v
@@ -2499,14 +2499,14 @@ Lemma total_variation_continuous a b (f : R -> R) : a < b ->
   BV a b f ->
   {within `[a,b], continuous (fine \o TV a ^~ f)}.
 Proof.
-move=> ab /(@continuous_within_itvP _ _ _ _ ab) [int [l r]] bdf.
-apply/continuous_within_itvP; (repeat split) => //.
+move=> ab /(@continuous_within_itvP _ _ _ _ ab) [int l r] bdf.
+apply/continuous_within_itvP => //; split.
 - move=> x /[dup] xab; rewrite in_itv /= => /andP [ax xb].
   apply/left_right_continuousP; split.
     apply: (total_variation_left_continuous _ (ltW xb)) => //.
-    by have /left_right_continuousP [] := int x xab.
+    by have /left_right_continuousP[] := int x xab.
   apply: (total_variation_right_continuous _ xb) => //; first exact: ltW.
-  by have /left_right_continuousP [] := int x xab.
+  by have /left_right_continuousP[] := int x xab.
 - exact: (total_variation_right_continuous _ ab).
 - exact: (total_variation_left_continuous ab).
 Qed.

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -5602,8 +5602,6 @@ have := ball_triangle yz_he (ball_sym zx_he).
 by rewrite -mulr2n -(mulr_natr (_ / _) 2) divfK// => /ltW.
 Qed.
 
-
-
 Definition dense (T : topologicalType) (S : set T) :=
   forall (O : set T), O !=set0 -> open O -> O `&` S !=set0.
 


### PR DESCRIPTION
##### Motivation for this change

~~preliminary~~ usable version of integration by parts

(and "within continuous" version of `continuous_FTC2`)

NB: we've been trying to "weaken" the hypotheses of lemmas in `ftc.v` to avoid requiring integrability over the whole set in the hope to ease their applications (this seems to be confirmed by the use of the new version of `continuous_FTC1` to prove change-of-variables lemma)

~~based on PR #1246~~ (merged)

FYI @IshiguroYoshihiro 

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [ ] added corresponding documentation in the headers~~

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
