### PR TITLE
to avoid a universe inconsistency with ring

### DIFF
--- a/classical/wochoice.v
+++ b/classical/wochoice.v
@@ -259,7 +259,7 @@ move=> Rxx Rtr Cch sCS.
 pose CSch X := `[< [/\ chain R X, {subset C <= X} & {subset X <= S}] >].
 pose Rch (X Y : {pred T}) := `[< {subset X <= Y} >].
 have: {in CSch & &, transitive Rch}.
-  by apply: in3W => X Y Z /asboolP-sXY /asboolP-sYZ; apply/asboolP=> x /sXY/sYZ.
+  by move=> X Y Z ? ? ? /asboolP-sXY /asboolP-sYZ; apply/asboolP => x /sXY/sYZ.
 have /Zorn's_lemma/[apply]: {in CSch, reflexive Rch} by move=> X _; apply/asboolP.
 case=> [XX CSchXX XXwo | M /asboolP[Mch sCM sMS] maxM]; last first.
   exists M; split=> // X Xch sMX sXS.
@@ -301,7 +301,7 @@ have initRtr: transitive initR.
   move=> R2 R1 R3 /asboolP[D12 R12] /asboolP[D23 R23]; apply/asboolP.
   split=> [x /D12/D23// | x y D1x D3y]; rewrite R23 ?(D12 x) //.
   by case D2y: (y \in R2.1); [apply: R12 | rewrite (contraFF (D12 y))].
-have: {in pwo & &, transitive initR} by apply: in3W.
+have: {in pwo & &, transitive initR} by move=> X Y Z ? ? ?; exact: initRtr.
 have/Zorn's_lemma/[apply]: {in pwo, reflexive initR} by [].
 case=> [C pwoC Cch | [D R] /asboolP/=pwoR maxR].
   have /(@wo_chainW ({pred T} * rel T)%type) {}Cch := Cch.


### PR DESCRIPTION
##### Motivation for this change

It is possible that MathComp-Analysis 1.3.0 is not compatible with the ring tactics
in the sense that `From mathcomp Require Import ring.` triggers a universe inconsistency.
(Just try to import `ring` after anything that requires `wochoice`.)
That is not the first time that `wochoice.v` causes such a bug (https://github.com/math-comp/analysis/pull/1198#issuecomment-2049307161).
It happens that avoiding the `in3W` lemma provides a way to void the problem.
(Tested on the `prob_lang` branches that rely a lot of `ring`, `field`, and `lra`.)
Hence this PR that I think should be merged asap and provided in MathComp-Analysis 1.4.0 asap.

##### Checklist

~~- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`~~

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [ ] added corresponding documentation in the headers~~

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
