### PR TITLE
minor additions and generalizations

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- in `derive.v`:
+  + lemma `derive_id`
+  + lemmas `deriveX_id`, `derive1X_id`
+  + lemma `derive_cst`
+  + lemma `deriveMr`, `deriveMl`
+
 ### Changed
 
 ### Renamed
@@ -11,6 +17,9 @@
 ### Generalized
 - in `reals.v`:
   + lemma `rat_in_itvoo`
+
+- in `derive.v`:
+  + lemma `derivable_cst`
 
 ### Deprecated
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -27,6 +27,7 @@
   + `measurable_EFin` -> `EFin_measurable`
   + `measurable_oppr` -> `oppr_measurable`
   + `measurable_normr` -> `normr_measurable`
+  + `measurable_fine` -> `fine_measurable`
 
 ### Generalized
 
@@ -47,6 +48,7 @@
   + notation `measurable_funN` (was deprecated since 0.6.3)
   + notation `measurable_fun_opp` (was deprecated since 0.6.3)
   + notation `measurable_fun_normr` (was deprecated since 0.6.3)
+  + notation `measurable_fun_fine` (was deprecated since 0.6.3)
 
 ### Infrastructure
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -28,6 +28,7 @@
   + `measurable_oppr` -> `oppr_measurable`
   + `measurable_normr` -> `normr_measurable`
   + `measurable_fine` -> `fine_measurable`
+  + `measurable_natmul` -> `natmul_measurable`
 
 ### Generalized
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -11,7 +11,7 @@
   + lemma `deriveMr`, `deriveMl`
 
 - in `functions.v`:
-  + lemmas `mull_funE`, `mulr_funE`
+  + lemmas `mul_funC`
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -10,6 +10,9 @@
   + lemma `derive_cst`
   + lemma `deriveMr`, `deriveMl`
 
+- in `functions.v`:
+  + lemmas `mull_funE`, `mulr_funE`
+
 ### Changed
 
 ### Renamed

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -22,6 +22,11 @@
   + `measurable_mulrl` -> `mulrl_measurable`
   + `measurable_mulrr` -> `mulrr_measurable`
   + `measurable_fun_pow` -> `measurable_funX`
+  + `measurable_oppe` -> `oppe_measurable`
+  + `measurable_abse` -> `abse_measurable`
+  + `measurable_EFin` -> `EFin_measurable`
+  + `measurable_oppr` -> `oppr_measurable`
+  + `measurable_normr` -> `normr_measurable`
 
 ### Generalized
 
@@ -36,6 +41,12 @@
   + notation `measurable_fun_sqr` (was deprecated since 0.6.3)
   + notation `measurable_fun_exprn` (was deprecated since 0.6.3)
   + notation `measurable_funrM` (was deprecated since 0.6.3)
+  + notation `emeasurable_fun_minus` (was deprecated since 0.6.3)
+  + notation `measurable_fun_abse` (was deprecated since 0.6.3)
+  + notation `measurable_fun_EFin` (was deprecated since 0.6.3)
+  + notation `measurable_funN` (was deprecated since 0.6.3)
+  + notation `measurable_fun_opp` (was deprecated since 0.6.3)
+  + notation `measurable_fun_normr` (was deprecated since 0.6.3)
 
 ### Infrastructure
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -6,7 +6,7 @@
 
 - in `derive.v`:
   + lemma `derive_id`
-  + lemmas `deriveX_id`, `derive1X_id`
+  + lemmas `exp_derive`, `exp_derive1`
   + lemma `derive_cst`
   + lemma `deriveMr`, `deriveMl`
 
@@ -17,9 +17,13 @@
 
 ### Renamed
 
+- in `lebesgue_measure.v`:
+  + `measurable_exprn` -> `exprn_measurable`
+  + `measurable_mulrl` -> `mulrl_measurable`
+  + `measurable_mulrr` -> `mulrr_measurable`
+  + `measurable_fun_pow` -> `measurable_funX`
+
 ### Generalized
-- in `reals.v`:
-  + lemma `rat_in_itvoo`
 
 - in `derive.v`:
   + lemma `derivable_cst`
@@ -27,6 +31,11 @@
 ### Deprecated
 
 ### Removed
+
+- in `lebesgue_measure.v`:
+  + notation `measurable_fun_sqr` (was deprecated since 0.6.3)
+  + notation `measurable_fun_exprn` (was deprecated since 0.6.3)
+  + notation `measurable_funrM` (was deprecated since 0.6.3)
 
 ### Infrastructure
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,10 @@ Text markup files may be edited directly though, should you have commit rights.
 ## `-->` vs. `cvg` vs. `lim`
 
 - `F --> x` means `F` tends to `x`. _This is the preferred way of stating a convergence._ **Lemmas about it use the string `cvg`.**
-- `lim F` is the limit of `F`, it makes sense only when `F` converges and defaults to a distinguished point otherwise. _It should only be used when there is no other expression for the limit._ **Lemmas about it use the string `lim`.**
-- `cvg F` is defined as `F --> lim F`, and is equivalent through `cvgP` and `cvg_ex` to the existence of some `x` such that `F --> x`. _When the limit is known, `F --> x` should be preferred._ **Lemmas about it use the string `is_cvg`.**
+- `lim F` is the limit of `F`, it makes sense only when `F` converges and defaults to a distinguished point otherwise.
+  _It should only be used when there is no other expression for the limit._ **Lemmas about it use the string `lim`.**
+- `cvg F` is defined as `F --> lim F`, and is equivalent through `cvgP` and `cvg_ex` to the existence of some `x` such that `F --> x`.
+  _When the limit is known, `F --> x` should be preferred._ **Lemmas about it use the string `is_cvg`.**
 
 ## `near` tactics vs. `filterS`, `filterS2`, `filterS3` lemmas
 
@@ -42,7 +44,9 @@ Landau notations can be written in four shapes:
 - `f x =o_(x \near F) (e x)` (i.e. pointwise with a simple right member, thus binary)
 - `f x = g x +o_(x \near F) (e x)` (i.e. pointwise with an additive right member, thus ternary)
 
-The outcome is an expression with the normal Leibniz equality `=` and term `'o_F` which is not parsable. See [this paper](https://doi.org/10.6092/issn.1972-5787/8124) for more explanation and the header of the file [landau.v](https://github.com/math-comp/analysis/blob/master/theories/landau.v).
+The outcome is an expression with the normal Leibniz equality `=` and term `'o_F` which is not parsable.
+See [this paper](https://doi.org/10.6092/issn.1972-5787/8124) for more explanation and
+the header of the file [landau.v](https://github.com/math-comp/analysis/blob/master/theories/landau.v).
 
 ## Deprecation
 
@@ -83,3 +87,10 @@ short name, and the `{mono ...}` lemma gets the suffix `in`.
 
 - The construction `_ !=set0` corresponds to suffix `nonempty`
 - The construction `_ != set0` corresponds to suffix `neq0`
+
+### Properties of functions
+
+- when a lemma is about a composite, we use the single letter suffix (when it exists)
+  + e.g., `cvgM`, `continuousM`, `deriveX`, or `measurable_funX`
+- when a lemma is about applied functions, we use the multi-letter prefix instead
+  + e.g., `mul_continuous`, `exp_derive`, or `exp_measurable_fun`

--- a/classical/functions.v
+++ b/classical/functions.v
@@ -2617,6 +2617,14 @@ Lemma fct_sumE (I T : Type) (M : zmodType) r (P : {pred I}) (f : I -> T -> M)
   (\sum_(i <- r | P i) f i) x = \sum_(i <- r | P i) f i x.
 Proof. by elim/big_rec2: _ => //= i y ? Pi <-. Qed.
 
+Lemma mull_funE (T : Type) {R : comSemiRingType} (f : T -> R) (r : R) :
+  r \*o f = r \o* f.
+Proof. by apply/funext => x/=; rewrite mulrC. Qed.
+
+Lemma mulr_funE (T : Type) {R : comSemiRingType} (f : T -> R) (r : R) :
+  r \o* f = r \*o f.
+Proof. by rewrite mull_funE. Qed.
+
 End function_space.
 
 Section function_space_lemmas.

--- a/classical/functions.v
+++ b/classical/functions.v
@@ -2617,13 +2617,9 @@ Lemma fct_sumE (I T : Type) (M : zmodType) r (P : {pred I}) (f : I -> T -> M)
   (\sum_(i <- r | P i) f i) x = \sum_(i <- r | P i) f i x.
 Proof. by elim/big_rec2: _ => //= i y ? Pi <-. Qed.
 
-Lemma mull_funE (T : Type) {R : comSemiRingType} (f : T -> R) (r : R) :
+Lemma mul_funC (T : Type) {R : comSemiRingType} (f : T -> R) (r : R) :
   r \*o f = r \o* f.
 Proof. by apply/funext => x/=; rewrite mulrC. Qed.
-
-Lemma mulr_funE (T : Type) {R : comSemiRingType} (f : T -> R) (r : R) :
-  r \o* f = r \*o f.
-Proof. by rewrite mull_funE. Qed.
 
 End function_space.
 

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -1308,7 +1308,7 @@ Qed.
 
 Lemma deriveMl f (r : R) (x v : V) :
   derivable f x v -> 'D_v (r \*o f) x = (r * 'D_v f x)%R.
-Proof. by move=> fxv; rewrite -deriveMr// mulr_funE. Qed.
+Proof. by move=> fxv; rewrite -deriveMr// mul_funC. Qed.
 
 Global Instance is_deriveM f g (x v : V) (df dg : R) :
   is_derive x v f df -> is_derive x v g dg ->

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -1300,18 +1300,15 @@ exact: der_mult.
 Qed.
 
 Lemma deriveMr f (r : R) (x v : V) :
-  derivable f x v -> 'D_v (fun x => f x * r) x = (r * 'D_v f x)%R.
+  derivable f x v -> 'D_v (r \o* f) x = (r * 'D_v f x)%R.
 Proof.
 move/deriveM => /(_ _ (derivable_cst _ _ _)) ->.
 by rewrite derive_cst scaler0 add0r.
 Qed.
 
 Lemma deriveMl f (r : R) (x v : V) :
-  derivable f x v -> 'D_v (fun x => r * f x) x = (r * 'D_v f x)%R.
-Proof.
-move=> fxv.
-by rewrite -deriveMr//; under eq_fun do rewrite mulrC.
-Qed.
+  derivable f x v -> 'D_v (r \*o f) x = (r * 'D_v f x)%R.
+Proof. by move=> fxv; rewrite -deriveMr// mulr_funE. Qed.
 
 Global Instance is_deriveM f g (x v : V) (df dg : R) :
   is_derive x v f df -> is_derive x v g dg ->

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -1379,16 +1379,16 @@ End Derive_lemmasVR.
 Lemma derive1_cst {R : numFieldType} (k : R) t : (cst k)^`() t = 0.
 Proof. by rewrite derive1E derive_cst. Qed.
 
-Lemma deriveX_id {R : numFieldType} n x v :
+Lemma exp_derive {R : numFieldType} n x v :
   'D_v (@GRing.exp R ^~ n.+1) x = n.+1%:R *: x ^+ n *: v.
 Proof.
 have /= := @deriveX R R id n x v (@derivable_id _ _ _ _).
 by rewrite fctE => ->; rewrite derive_id.
 Qed.
 
-Lemma derive1X_id {R : numFieldType} n x :
+Lemma exp_derive1 {R : numFieldType} n x :
   (@GRing.exp R ^~ n.+1)^`() x = n.+1%:R *: x ^+ n.
-Proof. by rewrite derive1E deriveX_id [LHS]mulr1. Qed.
+Proof. by rewrite derive1E exp_derive [LHS]mulr1. Qed.
 
 Lemma EVT_max (R : realType) (f : R -> R) (a b : R) : (* TODO : Filter not infered *)
   a <= b -> {within `[a, b], continuous f} -> exists2 c, c \in `[a, b]%R &

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -25,6 +25,18 @@ Require Import reals signed topology prodnormedzmodule normedtype landau forms.
 (*               f^`()  == the derivative of f of domain R                    *)
 (*               f^`(n) == the nth derivative of f of domain R                *)
 (* ```                                                                        *)
+(*                                                                            *)
+(* Naming convention in this file:                                            *)
+(* - lemmas of the form `... -> derivable f x v` are named `derivable*`       *)
+(*   (e.g., `derivableV`, `derivableM`)                                       *)
+(*   or `*derivable` (e.g., `diff_derivable`)                                 *)
+(* - lemmas of the form `D_v f x = ...` are named `derive*`                   *)
+(*   (e.g., `deriveVP, `deriveM`)                                             *)
+(* - lemmas of the form `f^`() x = ...` are named `derive1*`                  *)
+(*   (e.g., `derive1_cst`, `derive1_comp`)                                    *)
+(* - lemmas of the form `... -> is_derive x v f df` are named `is_derive*`    *)
+(*   (e.g., `is_derive_cst`)                                                  *)
+(*                                                                            *)
 (******************************************************************************)
 
 Set Implicit Arguments.
@@ -313,7 +325,7 @@ rewrite (_ : g = g1 + g2) ?funeqE // -(addr0 (_ _ v)); apply: cvgD.
   apply/nbhs_ballP.
   by exists e => //= x _ x0; apply eX; rewrite mulVr // ?unitfE //= subrr normr0.
 rewrite /g2.
-have [/eqP ->|v0] := boolP (v == 0).
+have [->|v0] := eqVneq v 0.
   rewrite (_ : (fun _ => _) = cst 0); first exact: cvg_cst.
   by rewrite funeqE => ?; rewrite scaler0 /k littleo_lim0 // scaler0.
 apply/cvgrPdist_lt => e e0.
@@ -812,7 +824,7 @@ Lemma diff_bilin (U V' W' : normedModType R) (f : {bilinear U -> V' -> W'}) p :
 Proof.
 pose d q := f p.1 q.2 + f q.1 p.2.
 move=> fc; have lind : linear d.
-  by move=> ???; rewrite /d linearPr linearPl scalerDr addrACA.
+  by move=> ? ? ?; rewrite /d linearPr linearPl scalerDr addrACA.
 pose dlM := GRing.isLinear.Build _ _ _ _ _ lind.
 pose dL : {linear _ -> _} := HB.pack d dlM.
 rewrite -/d -[d]/(dL : _ -> _).
@@ -1097,11 +1109,15 @@ apply: DeriveDef; last by rewrite deriveE // diff_val.
 exact/diff_derivable.
 Qed.
 
+Lemma derivable_cst (w : W) (x v : V) : derivable (cst w) x v.
+Proof. exact/diff_derivable. Qed.
+
 Lemma is_derive_eq f (x v : V) (df f' : W) :
   is_derive x v f f' -> f' = df -> is_derive x v f df.
 Proof. by move=> ? <-. Qed.
 
 End DeriveVW.
+Arguments derivable_cst {R V W}.
 
 Section Derive_lemmasVW.
 Variables (R : numFieldType) (V W : normedModType R).
@@ -1222,7 +1238,31 @@ move=> dfx; apply: DeriveDef; first exact: derivableZ.
 by rewrite deriveZ // derive_val.
 Qed.
 
+Lemma derive_cst (k : R) (x v : V) : 'D_v (cst k) x = 0.
+Proof. by rewrite derive_val. Qed.
+
 End Derive_lemmasVW.
+
+Section derive_id.
+Variables (R : numFieldType) (V : normedModType R).
+
+Lemma derivable_id (x v : V) : derivable id x v.
+Proof. exact/diff_derivable. Qed.
+
+Global Instance is_derive_id (x v : V) : is_derive x v id v.
+Proof.
+apply: (DeriveDef (@derivable_id _ _)).
+rewrite deriveE// (@diff_lin _ _ _ idfun)//=.
+by rewrite /continuous_at.
+Qed.
+
+Global Instance is_deriveNid (x v : V) : is_derive x v -%R (- v).
+Proof. exact: is_deriveN. Qed.
+
+Lemma derive_id (x v : V) : 'D_v id x = v.
+Proof. by have /derivableP := @derivable_id x v; rewrite derive_val. Qed.
+
+End derive_id.
 
 Section Derive_lemmasVR.
 Variables (R : numFieldType) (V : normedModType R).
@@ -1257,6 +1297,20 @@ Lemma derivableM f g (x v : V) :
 Proof.
 move=> df dg; apply/cvg_ex; exists (f x *: 'D_v g x + g x *: 'D_v f x).
 exact: der_mult.
+Qed.
+
+Lemma deriveMr f (r : R) (x v : V) :
+  derivable f x v -> 'D_v (fun x => f x * r) x = (r * 'D_v f x)%R.
+Proof.
+move/deriveM => /(_ _ (derivable_cst _ _ _)) ->.
+by rewrite derive_cst scaler0 add0r.
+Qed.
+
+Lemma deriveMl f (r : R) (x v : V) :
+  derivable f x v -> 'D_v (fun x => r * f x) x = (r * 'D_v f x)%R.
+Proof.
+move=> fxv.
+by rewrite -deriveMr//; under eq_fun do rewrite mulrC.
 Qed.
 
 Global Instance is_deriveM f g (x v : V) (df dg : R) :
@@ -1323,10 +1377,21 @@ move=> df dg; apply/cvg_ex; exists (- (f x) ^- 2 *: 'D_v f x).
 exact: der_inv.
 Qed.
 
-Lemma derive1_cst (k : V) t : (cst k)^`() t = 0.
-Proof. by rewrite derive1E derive_val. Qed.
-
 End Derive_lemmasVR.
+
+Lemma derive1_cst {R : numFieldType} (k : R) t : (cst k)^`() t = 0.
+Proof. by rewrite derive1E derive_cst. Qed.
+
+Lemma deriveX_id {R : numFieldType} n x v :
+  'D_v (@GRing.exp R ^~ n.+1) x = n.+1%:R *: x ^+ n *: v.
+Proof.
+have /= := @deriveX R R id n x v (@derivable_id _ _ _ _).
+by rewrite fctE => ->; rewrite derive_id.
+Qed.
+
+Lemma derive1X_id {R : numFieldType} n x :
+  (@GRing.exp R ^~ n.+1)^`() x = n.+1%:R *: x ^+ n.
+Proof. by rewrite derive1E deriveX_id [LHS]mulr1. Qed.
 
 Lemma EVT_max (R : realType) (f : R -> R) (a b : R) : (* TODO : Filter not infered *)
   a <= b -> {within `[a, b], continuous f} -> exists2 c, c \in `[a, b]%R &
@@ -1513,8 +1578,7 @@ have gaegb : g a = g b.
   by apply: lt0r_neq0; rewrite subr_gt0.
 have [c cab dgc0] := Rolle altb gdrvbl gcont gaegb.
 exists c; first exact: cab.
-have /fdrvbl dfc := cab; move/@derive_val: dgc0; rewrite deriveB //; last first.
-  exact/derivable1_diffP.
+have /fdrvbl dfc := cab; move/@derive_val: dgc0; rewrite deriveB //.
 move/eqP; rewrite [X in _ - X]deriveE // derive_val diff_val scale1r subr_eq0.
 move/eqP->; rewrite -mulrA mulVf ?mulr1 //; apply: lt0r_neq0.
 by rewrite subr_gt0.
@@ -1576,27 +1640,6 @@ rewrite derive1E'; last exact/differentiable_comp.
 rewrite diff_comp // !derive1E' //= -[X in 'd  _ _ X = _]mulr1.
 by rewrite [LHS]linearZ mulrC.
 Qed.
-
-Section is_derive_instances.
-Variables (R : numFieldType) (V : normedModType R).
-
-Lemma derivable_cst (x : V) : derivable (fun=> x) 0 (1 : R).
-Proof. exact/diff_derivable. Qed.
-
-Lemma derivable_id (x v : V) : derivable id x v.
-Proof. exact/diff_derivable. Qed.
-
-Global Instance is_derive_id (x v : V) : is_derive x v id v.
-Proof.
-apply: (DeriveDef (@derivable_id _ _)).
-rewrite deriveE// (@diff_lin _ _ _ idfun)//=.
-by rewrite /continuous_at.
-Qed.
-
-Global Instance is_deriveNid (x v : V) : is_derive x v -%R (- v).
-Proof. exact: is_deriveN. Qed.
-
-End is_derive_instances.
 
 (* Trick to trigger type class resolution *)
 Lemma trigger_derive (R : realType) (f : R -> R) x x1 y1 :

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -1052,7 +1052,7 @@ Lemma diff1E f x :
   differentiable f x -> 'd f x = (fun h => h *: f^`() x) :> (R -> U).
 Proof.
 pose d (h : R) := h *: 'd f x 1.
-move=> df; have lin_scal : linear d by move=> ???; rewrite /d scalerDl scalerA.
+move=> df; have lin_scal : linear d by move=> ? ? ?; rewrite /d scalerDl scalerA.
 pose scallM := GRing.isLinear.Build _ _ _ _ _ lin_scal.
 pose scalL : {linear _ -> _} := HB.pack d scallM.
 have -> : (fun h => h *: f^`() x) = scalL by rewrite derive1E'.

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -204,7 +204,7 @@ Definition cst_mfun x := [the {mfun aT >-> rT} of cst x].
 Lemma mfun_cst x : @cst_mfun x =1 cst x. Proof. by []. Qed.
 
 HB.instance Definition _ := @isMeasurableFun.Build _ _ rT
-  (@normr rT rT) (@measurable_normr rT setT).
+  (@normr rT rT) (@normr_measurable rT setT).
 
 HB.instance Definition _ :=
   isMeasurableFun.Build _ _ _ (@expR rT) (@measurable_expR rT).
@@ -2975,7 +2975,7 @@ Lemma integrableN f : mu_int f -> mu_int (-%E \o f).
 Proof.
 move=> /integrableP[mf foo]; apply/integrableP; split; last first.
   by rewrite /comp; under eq_fun do rewrite abseN.
-by rewrite /comp; apply: measurableT_comp =>//; exact: measurable_oppe.
+by rewrite /comp; exact: measurableT_comp.
 Qed.
 
 Lemma integrableZl (k : R) f : mu_int f -> mu_int (fun x => k%:E * f x).
@@ -4213,7 +4213,7 @@ rewrite [X in X <= _ -> _](_ : _ = \int[mu]_(x in D) (2%:E * g x) ); last first.
   rewrite is_cvg_limn_einfE//; last first.
     by apply: is_cvgeN; apply/cvg_ex; eexists; exact: cvg_g_.
   rewrite [X in _ + X](_ : _ = 0) ?adde0//; apply/cvg_lim => //.
-  by rewrite -(oppe0); apply: cvgeN; exact: cvg_g_.
+  by rewrite -oppe0; apply: cvgeN; exact: cvg_g_.
 have i2g : \int[mu]_(x in D) (2%:E * g x)  < +oo.
 rewrite integralZl// lte_mul_pinfty// ?lee_fin//; case: (integrableP _ _ _ ig) => _.
   apply: le_lt_trans; rewrite le_eqVlt; apply/orP; left; apply/eqP.

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -1833,8 +1833,8 @@ Proof. by apply: continuous_measurable_fun; exact: continuous_expR. Qed.
 #[global] Hint Extern 0 (measurable_fun _ expR) =>
   solve [apply: measurable_expR] : core.
 
-Lemma measurable_natmul {R : realType} D n :
-  measurable_fun D ((@GRing.natmul R)^~ n).
+Lemma natmul_measurable {R : realType} D n :
+  measurable_fun D (fun x : R => x *+ n).
 Proof.
 under eq_fun do rewrite -mulr_natr.
 by do 2 apply: measurable_funM => //.
@@ -1917,9 +1917,11 @@ Notation measurable_oppe := oppe_measurable (only parsing).
 Notation measurable_abse := abse_measurable (only parsing).
 #[deprecated(since="mathcomp-analysis 1.4.0", note="use `EFin_measurable` instead")]
 Notation measurable_EFin := EFin_measurable (only parsing).
+#[deprecated(since="mathcomp-analysis 1.4.0", note="use `natmul_measurable` instead")]
+Notation measurable_natmul := natmul_measurable (only parsing).
 
 (* NB: real-valued function *)
-(* TODO: rename to measurable_EFin after notation measurable_EFin is removed *)
+(* TODO: rename to measurable_EFin after notation measurable_EFin is removed? *)
 Lemma EFin_measurable_fun d (T : measurableType d) (R : realType) (D : set T)
     (g : T -> R) :
   measurable_fun D (EFin \o g) <-> measurable_fun D g.

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -903,7 +903,7 @@ Notation emeasurable_itv_bnd_pinfty := emeasurable_itv (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.2", note="use `emeasurable_itv` instead")]
 Notation emeasurable_itv_ninfty_bnd := emeasurable_itv (only parsing).
 
-Lemma measurable_fine (R : realType) (D : set (\bar R)) : measurable D ->
+Lemma fine_measurable (R : realType) (D : set (\bar R)) : measurable D ->
   measurable_fun D fine.
 Proof.
 move=> mD _ /= B mB; rewrite [X in measurable X](_ : _ `&` _ = if 0%R \in B then
@@ -919,9 +919,9 @@ case: ifPn => B0; apply/measurableI => //; last exact: measurable_image_EFin.
 by apply: measurableU; [exact: measurable_image_EFin|exact: measurableU].
 Qed.
 #[global] Hint Extern 0 (measurable_fun _ fine) =>
-  solve [exact: measurable_fine] : core.
-#[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_fine` instead")]
-Notation measurable_fun_fine := measurable_fine (only parsing).
+  solve [exact: fine_measurable] : core.
+#[deprecated(since="mathcomp-analysis 1.4.0", note="use `fine_measurable` instead")]
+Notation measurable_fine := fine_measurable (only parsing).
 
 Section lebesgue_measure_itv.
 Variable R : realType.

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -1616,13 +1616,13 @@ Section standard_measurable_fun.
 Variable R : realType.
 Implicit Types D : set R.
 
-Lemma measurable_oppr D : measurable_fun D (-%R).
+Lemma oppr_measurable D : measurable_fun D -%R.
 Proof.
 apply: measurable_funTS => /=; apply: continuous_measurable_fun.
-exact: (@opp_continuous R [the normedModType R of R^o]).
+exact: opp_continuous.
 Qed.
 
-Lemma measurable_normr D : measurable_fun D (@normr _ R).
+Lemma normr_measurable D : measurable_fun D (@normr _ R).
 Proof.
 move=> mD; apply: (measurability (RGenOInfty.measurableE R)) => //.
 move=> /= _ [_ [x ->] <-]; apply: measurableI => //.
@@ -1660,26 +1660,24 @@ by apply continuous_measurable_fun; exact: exprn_continuous.
 Qed.
 
 End standard_measurable_fun.
-#[global] Hint Extern 0 (measurable_fun _ (-%R)) =>
-  solve [exact: measurable_oppr] : core.
+#[global] Hint Extern 0 (measurable_fun _ -%R) =>
+  solve [exact: oppr_measurable] : core.
 #[global] Hint Extern 0 (measurable_fun _ normr) =>
-  solve [exact: measurable_normr] : core.
+  solve [exact: normr_measurable] : core.
 #[global] Hint Extern 0 (measurable_fun _ ( *%R _)) =>
   solve [exact: mulrl_measurable] : core.
 #[global] Hint Extern 0 (measurable_fun _ (fun x => x ^+ _)) =>
   solve [exact: exprn_measurable] : core.
-#[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_oppr` instead")]
-Notation measurable_fun_opp := measurable_oppr (only parsing).
-#[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_oppr` instead")]
-Notation measurable_funN := measurable_oppr (only parsing).
-#[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_normr` instead")]
-Notation measurable_fun_normr := measurable_normr (only parsing).
 #[deprecated(since="mathcomp-analysis 1.4.0", note="use `exprn_measurable` instead")]
 Notation measurable_exprn := exprn_measurable (only parsing).
 #[deprecated(since="mathcomp-analysis 1.4.0", note="use `mulrl_measurable` instead")]
 Notation measurable_mulrl := mulrl_measurable (only parsing).
 #[deprecated(since="mathcomp-analysis 1.4.0", note="use `mulrr_measurable` instead")]
 Notation measurable_mulrr := mulrr_measurable (only parsing).
+#[deprecated(since="mathcomp-analysis 1.4.0", note="use `oppr_measurable` instead")]
+Notation measurable_oppr := oppr_measurable (only parsing).
+#[deprecated(since="mathcomp-analysis 1.4.0", note="use `normr_measurable` instead")]
+Notation measurable_normr := normr_measurable (only parsing).
 
 Section measurable_fun_realType.
 Context d (T : measurableType d) (R : realType).
@@ -1874,14 +1872,14 @@ Notation measurable_fun_pow := measurable_funX (only parsing).
 Section standard_emeasurable_fun.
 Variable R : realType.
 
-Lemma measurable_EFin (D : set R) : measurable_fun D EFin.
+Lemma EFin_measurable (D : set R) : measurable_fun D EFin.
 Proof.
 move=> mD; apply: (measurability (ErealGenOInfty.measurableE R)) => //.
 move=> /= _ [_ [x ->]] <-; apply: measurableI => //.
 by rewrite preimage_itv_o_infty EFin_itv; exact: measurable_itv.
 Qed.
 
-Lemma measurable_abse (D : set (\bar R)) : measurable_fun D abse.
+Lemma abse_measurable (D : set (\bar R)) : measurable_fun D abse.
 Proof.
 move=> mD; apply: (measurability (ErealGenOInfty.measurableE R)) => //.
 move=> /= _ [_ [x ->] <-].
@@ -1889,8 +1887,7 @@ rewrite [X in _ @^-1` X](punct_eitv_bndy _ x) preimage_setU setIUr.
 apply: measurableU; last first.
   by rewrite preimage_abse_pinfty; apply: measurableI => //; exact: measurableU.
 apply: measurableI => //; exists (normr @^-1` `]x, +oo[%classic).
-  rewrite -[X in measurable X]setTI.
-  by apply: measurable_normr => //; exact: measurable_itv.
+  by rewrite -[X in measurable X]setTI; exact: normr_measurable.
 exists set0; first by constructor.
 rewrite setU0 predeqE => -[y| |]; split => /= => -[r];
   rewrite ?/= /= ?in_itv /= ?andbT => xr//.
@@ -1898,7 +1895,7 @@ rewrite setU0 predeqE => -[y| |]; split => /= => -[r];
   + by move=> [ry]; exists y => //=; rewrite /= in_itv/= andbT -ry.
 Qed.
 
-Lemma measurable_oppe (D : set (\bar R)) :
+Lemma oppe_measurable (D : set (\bar R)) :
   measurable_fun D (-%E : \bar R -> \bar R).
 Proof.
 move=> mD; apply: (measurability (ErealGenCInfty.measurableE R)) => //.
@@ -1909,19 +1906,20 @@ Qed.
 
 End standard_emeasurable_fun.
 #[global] Hint Extern 0 (measurable_fun _ abse) =>
-  solve [exact: measurable_abse] : core.
+  solve [exact: abse_measurable] : core.
 #[global] Hint Extern 0 (measurable_fun _ EFin) =>
-  solve [exact: measurable_EFin] : core.
-#[global] Hint Extern 0 (measurable_fun _ (-%E)) =>
-  solve [exact: measurable_oppe] : core.
-#[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_oppe` instead")]
-Notation emeasurable_fun_minus := measurable_oppe (only parsing).
-#[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_abse` instead")]
-Notation measurable_fun_abse := measurable_abse (only parsing).
-#[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_EFin` instead")]
-Notation measurable_fun_EFin := measurable_EFin (only parsing).
+  solve [exact: EFin_measurable] : core.
+#[global] Hint Extern 0 (measurable_fun _ -%E) =>
+  solve [exact: oppe_measurable] : core.
+#[deprecated(since="mathcomp-analysis 1.4.0", note="use `oppe_measurable` instead")]
+Notation measurable_oppe := oppe_measurable (only parsing).
+#[deprecated(since="mathcomp-analysis 1.4.0", note="use `abse_measurable` instead")]
+Notation measurable_abse := abse_measurable (only parsing).
+#[deprecated(since="mathcomp-analysis 1.4.0", note="use `EFin_measurable` instead")]
+Notation measurable_EFin := EFin_measurable (only parsing).
 
 (* NB: real-valued function *)
+(* TODO: rename to measurable_EFin after notation measurable_EFin is removed *)
 Lemma EFin_measurable_fun d (T : measurableType d) (R : realType) (D : set T)
     (g : T -> R) :
   measurable_fun D (EFin \o g) <-> measurable_fun D g.
@@ -2249,7 +2247,7 @@ Lemma pointwise_almost_uniform
 Proof.
 move=> mf mg mA finA fptwsg epspos; pose h q (z : T) : R := `|f_ q z - g z|%R.
 have mfunh q : measurable_fun A (h q).
-  by apply: measurableT_comp; [exact: measurable_normr |exact: measurable_funB].
+  by apply: measurableT_comp => //; exact: measurable_funB.
 pose E k n := \bigcup_(i in [set j | n <= j]%N)
   (A `&` [set x | h i x >= k.+1%:R^-1]%R).
 have Einc k : nonincreasing_seq (E k).

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -1641,19 +1641,19 @@ rewrite [X in measurable X](_ : _ = setT)// predeqE => r.
 by split => // _; rewrite /= in_itv /= andbT (lt_le_trans x0).
 Qed.
 
-Lemma measurable_mulrl D (k : R) : measurable_fun D ( *%R k).
+Lemma mulrl_measurable D (k : R) : measurable_fun D ( *%R k).
 Proof.
 apply: measurable_funTS => /=.
 by apply: continuous_measurable_fun; exact: mulrl_continuous.
 Qed.
 
-Lemma measurable_mulrr D (k : R) : measurable_fun D (fun x => x * k).
+Lemma mulrr_measurable D (k : R) : measurable_fun D (fun x => x * k).
 Proof.
 apply: measurable_funTS => /=.
 by apply: continuous_measurable_fun; exact: mulrr_continuous.
 Qed.
 
-Lemma measurable_exprn D n : measurable_fun D (fun x => x ^+ n).
+Lemma exprn_measurable D n : measurable_fun D (fun x => x ^+ n).
 Proof.
 apply measurable_funTS => /=.
 by apply continuous_measurable_fun; exact: exprn_continuous.
@@ -1665,21 +1665,21 @@ End standard_measurable_fun.
 #[global] Hint Extern 0 (measurable_fun _ normr) =>
   solve [exact: measurable_normr] : core.
 #[global] Hint Extern 0 (measurable_fun _ ( *%R _)) =>
-  solve [exact: measurable_mulrl] : core.
+  solve [exact: mulrl_measurable] : core.
 #[global] Hint Extern 0 (measurable_fun _ (fun x => x ^+ _)) =>
-  solve [exact: measurable_exprn] : core.
-#[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_exprn` instead")]
-Notation measurable_fun_sqr := measurable_exprn (only parsing).
+  solve [exact: exprn_measurable] : core.
 #[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_oppr` instead")]
 Notation measurable_fun_opp := measurable_oppr (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_oppr` instead")]
 Notation measurable_funN := measurable_oppr (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_normr` instead")]
 Notation measurable_fun_normr := measurable_normr (only parsing).
-#[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_exprn` instead")]
-Notation measurable_fun_exprn := measurable_exprn (only parsing).
-#[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_mulrl` instead")]
-Notation measurable_funrM := measurable_mulrl (only parsing).
+#[deprecated(since="mathcomp-analysis 1.4.0", note="use `exprn_measurable` instead")]
+Notation measurable_exprn := exprn_measurable (only parsing).
+#[deprecated(since="mathcomp-analysis 1.4.0", note="use `mulrl_measurable` instead")]
+Notation measurable_mulrl := mulrl_measurable (only parsing).
+#[deprecated(since="mathcomp-analysis 1.4.0", note="use `mulrr_measurable` instead")]
+Notation measurable_mulrr := mulrr_measurable (only parsing).
 
 Section measurable_fun_realType.
 Context d (T : measurableType d) (R : realType).
@@ -1714,11 +1714,11 @@ move=> mf mg; rewrite (_ : (_ \* _) = (fun x => 2%:R^-1 * (f x + g x) ^+ 2)
   \- (fun x => 2%:R^-1 * (f x ^+ 2)) \- (fun x => 2%:R^-1 * (g x ^+ 2))).
   apply: measurable_funB; first apply: measurable_funB.
   - apply: measurableT_comp => //.
-    by apply: measurableT_comp (measurable_exprn _) _; exact: measurable_funD.
+    by apply: measurableT_comp (exprn_measurable _) _; exact: measurable_funD.
   - apply: measurableT_comp => //.
-    exact: measurableT_comp (measurable_exprn _) _.
+    exact: measurableT_comp (exprn_measurable _) _.
   - apply: measurableT_comp => //.
-    exact: measurableT_comp (measurable_exprn _) _.
+    exact: measurableT_comp (exprn_measurable _) _.
 rewrite funeqE => x /=; rewrite -2!mulrBr sqrrD (addrC (f x ^+ 2)) -addrA.
 rewrite -(addrA (f x * g x *+ 2)) -opprB opprK (addrC (g x ^+ 2)) addrK.
 by rewrite -(mulr_natr (f x * g x)) -(mulrC 2) mulrA mulVr ?mul1r// unitfE.
@@ -1842,7 +1842,7 @@ under eq_fun do rewrite -mulr_natr.
 by do 2 apply: measurable_funM => //.
 Qed.
 
-Lemma measurable_fun_pow {R : realType} D (f : R -> R) n : measurable_fun D f ->
+Lemma measurable_funX {R : realType} D (f : R -> R) n : measurable_fun D f ->
   measurable_fun D (fun x => f x ^+ n).
 Proof.
 move=> mf.
@@ -1868,6 +1868,8 @@ Notation measurable_fun_power_pos := measurable_powR (only parsing).
 Notation measurable_power_pos := measurable_powR (only parsing).
 #[deprecated(since="mathcomp-analysis 0.6.3", note="use `measurable_maxr` instead")]
 Notation measurable_fun_max := measurable_maxr (only parsing).
+#[deprecated(since="mathcomp-analysis 1.4.0", note="use `measurable_funX` instead")]
+Notation measurable_fun_pow := measurable_funX (only parsing).
 
 Section standard_emeasurable_fun.
 Variable R : realType.

--- a/theories/probability.v
+++ b/theories/probability.v
@@ -1016,7 +1016,7 @@ Lemma measurable_binomial_pmf {R : realType} D n k :
 Proof.
 apply: (@measurableT_comp _ _ _ _ _ _ (fun x : R => x *+ 'C(n, k))%R) => /=.
   exact: measurable_natmul.
-apply: measurable_funM => //=; apply: measurable_fun_pow.
+apply: measurable_funM => //=; apply: measurable_funX.
 exact: measurable_funB.
 Qed.
 

--- a/theories/probability.v
+++ b/theories/probability.v
@@ -1015,9 +1015,8 @@ Lemma measurable_binomial_pmf {R : realType} D n k :
   measurable_fun D (@binomial_pmf R n ^~ k).
 Proof.
 apply: (@measurableT_comp _ _ _ _ _ _ (fun x : R => x *+ 'C(n, k))%R) => /=.
-  exact: measurable_natmul.
-apply: measurable_funM => //=; apply: measurable_funX.
-exact: measurable_funB.
+  exact: natmul_measurable.
+by apply: measurable_funM => //; apply: measurable_funX; exact: measurable_funB.
 Qed.
 
 Definition binomial_prob {R : realType} (n : nat) (p : R) : set nat -> \bar R :=


### PR DESCRIPTION
##### Motivation for this change

The lemmas proposed by this PR are slight generalizations (e.g., parameters of `derivable_cst`, `derive_cst` that generalized `derive1_cst`) or lemmas that are specialized variants of
already existing lemmas (e.g., `deriveX_id`, `deriveMr`, `derive_id`). Specialized variants might
look superfluous at first sight but they do save several micro steps in practical examples and
moreover since we have a naming convention (this PR documents it) for the file `derive.v`
these variants are expected results of `Search`. Certainly, there is more to do in this file but
that might already be a useful step.

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
