### PR TITLE
lemmas about Lebesgue's outer measure

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -17,8 +17,8 @@
 
 - in `lebesgue_measure.v`:
   + definitions `is_open_itv`, `open_itv_cover`
-  + lemmas `outer_measure_open_itv_cover`, `outer_measure_open`, `outer_measure_Gdelta`,
-    `negligible_outer_measure`
+  + lemmas `outer_measure_open_itv_cover`, `outer_measure_open_le`,
+    `outer_measure_open`, `outer_measure_Gdelta`, `negligible_outer_measure`
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -12,6 +12,13 @@
 
 - in `functions.v`:
   + lemmas `mul_funC`
+- in `sequences.v`:
+  + lemma `cvg_geometric_eseries_half`
+
+- in `lebesgue_measure.v`:
+  + definitions `is_open_itv`, `open_itv_cover`
+  + lemmas `outer_measure_open_itv_cover`, `outer_measure_open`, `outer_measure_Gdelta`,
+    `negligible_outer_measure`
 
 ### Changed
 

--- a/theories/sequences.v
+++ b/theories/sequences.v
@@ -1446,6 +1446,16 @@ Arguments eseries {R} u_ n : simpl never.
 Arguments etelescope {R} u_ n : simpl never.
 Notation "[ 'series' E ]_ n" := (eseries [sequence E%E]_n) : ereal_scope.
 
+Lemma cvg_geometric_eseries_half {R : archiFieldType} (r : R) (n : nat) :
+  eseries (fun k => (r / (2 ^ (k + n.+1))%:R)%:E) @ \oo --> (r / 2 ^+ n)%:E.
+Proof.
+apply: cvg_EFin => //.
+  by apply: nearW => //= x; rewrite /eseries/= sumEFin.
+rewrite [X in X @ _ --> _](_ : _ = series (fun k => r / (2 ^ (k + n.+1))%:R)); last first.
+  by apply/funext => x; rewrite /= /eseries/= sumEFin.
+exact: cvg_geometric_series_half.
+Qed.
+
 Section eseries_ops.
 Variable (R : numDomainType).
 Local Open Scope ereal_scope.


### PR DESCRIPTION
##### Motivation for this change
Four lemmas about the Lebesgue measure.
The second one is actually the most interesting because we use to prove
an important corollary of the Vitali's theorem (PR to come)

- `outer_measure_open_itv_cover`:
  definition of the outer measure in terms of covers of open intervals
  (proposition 20 in Li)
- `outer_measure_open`:
  for a set A with bounded outer measure and an epsilon,
  there is an open that contains A and whose measure is
  less than the outer measure A + epsilon,
  (proposition 21 1) in Li)
- `outer_measure_Gdelta`:
  for a set A with bounded outer measure, there exists a G-delta sets
  that contains A and whose measure is the same as A
  (proposition 21 2) in Li)
- `negligible_outer_measure`:
  a set N is negligible for the lebesgue measure iff its outer measure is 0
  (corollary 22 in Li)


##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
