### PR TITLE
fixes #1313 and moves Egorov

### DIFF
--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -6051,21 +6051,16 @@ Let norm1 D f := \int[mu]_(y in D) `|(f y)%:E|.
 
 Lemma maximal_inequality f c :
   locally_integrable setT f -> (0 < c)%R ->
-  mu [set x | HL f x > c%:E] <= (3%:R / c)%:E * norm1 setT f.
+  mu [set x | HL f x > c%:E] <= (3 / c)%:E * norm1 setT f.
 Proof.
 move=> /= locf c0.
-have r_proof x : HL f x > c%:E -> {r | (0 < r)%R &
-    \int[mu]_(y in ball x r) `|(f y)%:E| > c%:E * mu (ball x r)}.
-  move=> /ereal_sup_gt/cid2[y /= /cid2[r]].
-  rewrite in_itv/= andbT => rg0 <-{y} Hc; exists r => //.
-  rewrite -(@fineK _ (mu (ball x r))) ?ge0_fin_numE//; last first.
-    by rewrite lebesgue_measure_ball ?ltry// ltW.
-  rewrite -lte_pdivlMr// 1?muleC// fine_gt0//.
-  by rewrite lebesgue_measure_ball 1?ltW// ltry lte_fin mulrn_wgt0.
 rewrite lebesgue_regularity_inner_sup//; last first.
   rewrite -[X in measurable X]setTI; apply: emeasurable_fun_o_infty => //.
   exact: measurable_HL_maximal.
 apply: ub_ereal_sup => /= x /= [K [cK Kcmf <-{x}]].
+have r_proof x : HL f x > c%:E -> {r | (0 < r)%R & iavg f (ball x r) > c%:E}.
+  move=> /ereal_sup_gt/cid2[y /= /cid2[r]].
+  by rewrite in_itv/= andbT => rg0 <-{y} Hc; exists r.
 pose r_ x :=
   if pselect (HL f x > c%:E) is left H then s2val (r_proof _ H) else 1%R.
 have r_pos (x : R) : (0 < r_ x)%R.
@@ -6073,7 +6068,13 @@ have r_pos (x : R) : (0 < r_ x)%R.
 have cMfx_int x : c%:E < HL f x ->
     \int[mu]_(y in ball x (r_ x)) `|(f y)|%:E > c%:E * mu (ball x (r_ x)).
   move=> cMfx; rewrite /r_; case: pselect => //= => {}cMfx.
-  by case: (r_proof _ cMfx).
+  case: (r_proof _ cMfx) => /= r r0.
+  have ? : 0%R < (fine (mu (ball x r)))%:E.
+    rewrite lte_fin fine_gt0// (lebesgue_measure_ball _ (ltW r0))// ltry.
+    by rewrite lte_fin mulrn_wgt0.
+  rewrite /iavg -(@lte_pmul2r _ (fine (mu (ball x r)))%:E)//.
+  rewrite muleAC -[in X in _ < X]EFinM mulVf ?gt_eqF// mul1e fineK//.
+  by rewrite ge0_fin_numE// (lebesgue_measure_ball _ (ltW r0)) ltry.
 set B := fun r => ball r (r_ r).
 have {}Kcmf : K `<=` cover [set i | HL f i > c%:E] (fun i => ball i (r_ i)).
   by move=> r /Kcmf /= cMfr; exists r => //; exact: ballxx.
@@ -6086,10 +6087,10 @@ have KDB : K `<=` cover [set` D] B.
 have is_ballB i : is_ball (B i) by exact: is_ball_ball.
 have Bset0 i : B i !=set0 by exists i; exact: ballxx.
 have [E [uE ED tEB DE]] := @vitali_lemma_finite_cover _ _ B is_ballB Bset0 D.
-rewrite (@le_trans _ _ (3%:R%:E * \sum_(i <- E) mu (B i)))//.
+rewrite (@le_trans _ _ (3%:E * \sum_(i <- E) mu (B i)))//.
   have {}DE := subset_trans KDB DE.
-  apply: (le_trans (@content_subadditive _ _ _ [the measure _ _ of mu]
-      K (fun i => 3%:R *` B (nth 0%R E i)) (size E) _ _ _)) => //.
+  apply: (le_trans (@content_subadditive _ _ _ mu K
+      (fun i => 3 *` B (nth 0%R E i)) (size E) _ _ _)) => //.
   - by move=> k ?; rewrite scale_ballE//; exact: measurable_ball.
   - by apply: closed_measurable; apply: compact_closed => //; exact: Rhausdorff.
   - apply: (subset_trans DE); rewrite /cover bigcup_seq.

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -13,7 +13,7 @@ Require Export lebesgue_stieltjes_measure.
 (*                                                                            *)
 (* This file further develops the theory of measurable functions (including   *)
 (* Egorov's theorem), contains a formalization of the Lebesgue measure using  *)
-(* the Measure Extension theorem from measure.v, and prove properties of the  *)
+(* the Measure Extension theorem from measure.v, and proves properties of the *)
 (* Lebesgue measure such as Vitali's theorem, i.e., given a Vitali cover $V$  *)
 (* of $A$, there exists a countable subcollection $D \subseteq V$ of pairwise *)
 (* disjoint closed balls such that $\lambda(A \setminus \bigcup_k D_k) = 0$.  *)

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -15,7 +15,7 @@ Require Import ereal reals signed topology prodnormedzmodule function_spaces.
 (* We used these definitions to prove the intermediate value theorem and      *)
 (* the Heine-Borel theorem, which states that the compact sets of             *)
 (* $\mathbb{R}^n$ are the closed and bounded sets, Urysohn's lemma, Vitali's  *)
-(* covering lemmas (finite case), etc.                                        *)
+(* covering lemmas (finite case and infinite case), etc.                      *)
 (*                                                                            *)
 (* * Limit superior and inferior:                                             *)
 (*   limf_esup f F, limf_einf f F == limit sup/inferior of f at "filter" F    *)

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -6129,8 +6129,8 @@ split; first last.
   move=> ? ? _; exists V; last by rewrite -setIA setIid.
   by move: oV; rewrite openE /interior; apply.
 rewrite -open_subspaceIT => oUA.
-have oxF : (forall (x : T), (U `&` A) x ->
-    exists V, (open_nbhs (x : T) V) /\ (V `&` A `<=` U `&` A)).
+have oxF : forall x : T, (U `&` A) x ->
+    exists V, (open_nbhs (x : T) V) /\ (V `&` A `<=` U `&` A).
   move=> x /[dup] UAx /= [??]; move: (oUA _ UAx);
     case: nbhs_subspaceP => // ?.
   rewrite withinE /= => [[V nbhsV UV]]; rewrite -setIA setIid in UV.
@@ -6248,12 +6248,12 @@ Qed.
 End Subspace.
 
 Global Instance subspace_filter {T : topologicalType}
-     (A : set T) (x : subspace A) :
-   Filter (nbhs_subspace x) := nbhs_subspace_filter x.
+    (A : set T) (x : subspace A) :
+  Filter (nbhs_subspace x) := nbhs_subspace_filter x.
 
 Global Instance subspace_proper_filter {T : topologicalType}
-     (A : set T) (x : subspace A) :
-   ProperFilter (nbhs_subspace x) := nbhs_subspace_filter x.
+    (A : set T) (x : subspace A) :
+  ProperFilter (nbhs_subspace x) := nbhs_subspace_filter x.
 
 Notation "{ 'within' A , 'continuous' f }" :=
   (continuous (f : subspace A -> _)) : classical_set_scope.


### PR DESCRIPTION
##### Motivation for this change

fixes #1313 

This PR also shuffles the contents of the file `lebesgue_measure.v`
so that lemmas that do not depend on Lebesgue's measure appear
before it (the Egorov theorem in particular).

##### Checklist

~~- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`~~

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
