### PR TITLE
Order topology

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -80,6 +80,19 @@
   + lemma `integrable_locally_restrict`
   + lemma `near_davg`
   + lemma `lebesgue_pt_restrict`
+- in file `set_interval.v`,
+  + new definitions `itv_is_ray`, `itv_is_bd_open`, and `itv_open_ends`.
+  + new lemmas `itv_open_ends_rside`, `itv_open_ends_rinfty`,
+    `itv_open_ends_lside`, `itv_open_ends_linfty`,
+    `is_open_itv_itv_is_bd_openP`, `itv_open_endsI`, `itv_setU`, and
+    `itv_setI`.
+- in file `topology.v`,
+  + new definition `order_topology`.
+  + new lemmas `discrete_nat`, `rray_open`, `lray_open`, `itv_open`,
+    `itv_open_ends_open`, `rray_closed`, `lray_closed`, `itv_closed`,
+    `itv_closure`, `itv_closed_infimums`, `itv_closed_supremums`,
+    `order_hausdorff`, `clopen_bigcup_clopen`, `zero_dimensional_ray`,
+    `order_nbhs_itv`, `open_order_weak`, and `real_order_nbhsE`.
 
 ### Changed
 - in `topology.v`:
@@ -113,6 +126,9 @@
 
 - in `normedtype.v`:
   + lemma `continuous_within_itvP`: change the statement to use the notation `[/\ _, _ & _]`
+
+- moved from `lebesgue_measure.v` to `set_interval.v`: `is_open_itv`, and
+    `open_itv_cover`
 
 ### Renamed
 

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -1517,11 +1517,6 @@ Context {R : realType}.
 Implicit Types (A : set R).
 Local Open Scope ereal_scope.
 
-Definition is_open_itv A := exists ab, A = `]ab.1, ab.2[%classic.
-
-Definition open_itv_cover A := [set F : (set R)^nat |
-  (forall i, is_open_itv (F i)) /\ A `<=` \bigcup_k (F k)].
-
 Let l := (@wlength R idfun).
 
 Lemma outer_measure_open_itv_cover A : (l^* A)%mu =

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -196,10 +196,7 @@ Require Import reals signed.
 (*                                     structure                              *)
 (*                                     the HB class is Topological.           *)
 (*                 ptopologicalType == a pointed topologicalType              *)
-<<<<<<< HEAD
-=======
 (*             orderTopologicalType == a topology built from intervals        *)
->>>>>>> 0c53f9bc (adding order topology and interval stuff)
 (*                             open == set of open sets                       *)
 (*                      open_nbhs p == set of open neighbourhoods of p        *)
 (*                          basis B == a family of open sets that converges   *)
@@ -235,10 +232,7 @@ Require Import reals signed.
 (*                                     It builds the mixin for a topological  *)
 (*                                     space from a subbase of open sets b    *)
 (*                                     indexed on domain D                    *)
-<<<<<<< HEAD
 (*                                                                            *)
-=======
->>>>>>> 0c53f9bc (adding order topology and interval stuff)
 (* We endow several standard types with the structure of topology, e.g.:      *)
 (* - products `(T * U)%type`                                                  *)
 (* - matrices `'M[T]_(m, n)`                                                  *)
@@ -250,10 +244,7 @@ Require Import reals signed.
 (*                                     topologicalType.                       *)
 (*                  sup_topology Tc == supremum topology of the family of     *)
 (*                                     topologicalType structures Tc on T     *)
-<<<<<<< HEAD
-=======
 (*                 order_topology T == the induced order topology on T        *)
->>>>>>> 0c53f9bc (adding order topology and interval stuff)
 (*              quotient_topology Q == the quotient topology corresponding to *)
 (*                                     quotient Q : quotType T where T has    *)
 (*                                     type topologicalType                   *)
@@ -4095,25 +4086,25 @@ Local Open Scope order_scope.
 Local Open Scope classical_set_scope.
 Context {d} {T : orderTopologicalType d}.
 
-Lemma open_rray (x : T) : open `]x,+oo[.
+Lemma rray_open (x : T) : open `]x,+oo[.
 Proof.
 rewrite openE /interior => z xoz; rewrite itv_nbhsE.
 by exists (`]x, +oo[)%O => //; split => //; left.
 Qed.
-Hint Resolve open_rray : core.
+Hint Resolve rray_open : core.
 
-Lemma open_lray (x : T) : open `]-oo,x[.
+Lemma lray_open (x : T) : open `]-oo,x[.
 Proof.
 rewrite openE /interior => z xoz; rewrite itv_nbhsE.
 by exists (`]-oo, x[)%O => //; split => //; left.
 Qed.
-Hint Resolve open_lray : core.
+Hint Resolve lray_open : core.
 
-Lemma open_itv (x y : T) : open `]x, y[.
+Lemma itv_open (x y : T) : open `]x, y[.
 Proof.
 by rewrite set_itv_splitI /=; apply: openI.
 Qed.
-Hint Resolve open_itv : core.
+Hint Resolve itv_open : core.
 
 Lemma itv_open_ends_open (i : interval T) : itv_open_ends i -> open [set` i].
 Proof.
@@ -4121,19 +4112,19 @@ case: i; rewrite /itv_open_ends => [[[]t1|[]]] [[]t2|[]] []? => //.
 by rewrite set_itvE; exact: openT.
 Qed.
 
-Lemma closed_rray (x : T) : closed `[x,+oo[.
+Lemma rray_closed (x : T) : closed `[x,+oo[.
 Proof. by rewrite -setCitvl closedC. Qed.
-Hint Resolve closed_rray : core.
+Hint Resolve rray_closed : core.
 
-Lemma closed_lray (x : T) : closed `]-oo,x].
+Lemma lray_closed (x : T) : closed `]-oo,x].
 Proof. by rewrite -setCitvr closedC. Qed.
-Hint Resolve closed_lray : core.
+Hint Resolve lray_closed : core.
 
-Lemma closed_itv (x y : T) : closed `[x, y].
+Lemma itv_closed (x y : T) : closed `[x, y].
 Proof.
 by rewrite set_itv_splitI; apply: closedI => /=. 
 Qed.
-Hint Resolve closed_itv : core.
+Hint Resolve itv_closed : core.
 
 Lemma itv_closure (x y : T) : closure `]x, y[ `<=` `[x,y].
 Proof.
@@ -4261,12 +4252,12 @@ by apply: (le_trans _ yq); rewrite bnd_simp.
 Qed.
 
 End order_topologies.
-Hint Resolve open_lray : core.
-Hint Resolve open_rray : core.
-Hint Resolve open_itv : core.
-Hint Resolve closed_lray : core.
-Hint Resolve closed_rray : core.
-Hint Resolve closed_itv : core.
+Hint Resolve lray_open : core.
+Hint Resolve rray_open : core.
+Hint Resolve itv_open : core.
+Hint Resolve lray_closed : core.
+Hint Resolve rray_closed : core.
+Hint Resolve itv_closed : core.
 
 Section bool_ord_topology.
 Local Open Scope classical_set_scope.
@@ -4385,13 +4376,13 @@ Proof.
 rewrite ?openE /= /interior => + x Ux => /(_ x Ux); rewrite itv_nbhsE /=.
 move=> [][][[]l|[]] [[]r|[]][][]//= _ xlr /filterS; apply.
 - exists (`]l, r[%classic); split => //=; exists `]\val l, \val r[%classic.
-    exact: open_itv.
+    exact: itv_open.
   rewrite eqEsubset; split => z; rewrite preimage_itv //=.
 - exists (`]l, +oo[%classic); split => //=; exists `]\val l, +oo[%classic.
-    exact: open_rray.
+    exact: rray_open.
   rewrite eqEsubset; split => z; rewrite preimage_itv //=.
 - exists (`]-oo, r[%classic); split => //=; exists `]-oo, \val r[%classic.
-    exact: open_lray.
+    exact: lray_open.
   rewrite eqEsubset; split => z; rewrite preimage_itv //=.
 - rewrite set_itvE; exact: filterT.
 Qed.

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -4079,7 +4079,6 @@ HB.structure Definition OrderNbhs d :=
 HB.structure Definition OrderTopological d := 
   { T of Topological T & Order.Total d T & Order_isNbhs d T } .
 
-From mathcomp Require Import set_interval.
 Section order_topologies.
 
 Local Open Scope order_scope.


### PR DESCRIPTION
With pointed stuff out of the way, we can start really mixing types for great good! The adds 
- Order topology! A mixin that states the order and `nbhs`s are compatible
- Some basic lemmas about order topologies (the zero-dimensional stuff is just an annoying thing I need for building cantor-space isomorphisms that also preserve order structure). 
- A side note: order topologies are, at the moment, hausdorff since orders are anti-symmetric. This isn't terrible, but most other lemmas will generalize nicely once https://github.com/math-comp/math-comp/pull/1169 lands, and intervals are generalized.
- A `order_topology` alias for attaching the "induced order topology" to an ordered set
- A bunch of lemmas about intervals and sets
- Order instances for `bool`, `nat`, and `realFieldType`

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
