### PR TITLE
lexical ordering over nats

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -24,17 +24,17 @@
 - in `measure.v`:
   + lemma `measurable_fun_set1`
 - in file `classical_orders.v`,
-  + new definitions `same_prefix`, `first_diff`, `lexi_bigprod`, `start_with`,
-    `big_lexi_order`, and `big_lexi_ord`.
+  + new definitions `big_lexi_order`, `same_prefix`, `first_diff`,
+    `big_lexi_le`, and `start_with`.
   + new lemmas `same_prefix0`, `same_prefix_sym`, `same_prefix_leq`,
     `same_prefix_refl`, `same_prefix_trans`, `first_diff_sym`,
     `first_diff_unique`, `first_diff_SomeP`, `first_diff_NoneP`,
     `first_diff_lt`, `first_diff_eq`, `first_diff_dfwith`,
-    `lexi_bigprod_reflexive`, `lexi_bigprod_anti`, `lexi_bigprod_trans`,
-    `lexi_bigprod_total`, `start_with_prefix`, `lexi_bigprod_prefix_lt`,
-    `lexi_bigprod_prefix_gt`, `lexi_bigprod_between`,
-    `big_lexi_interval_prefix`, and `same_prefix_closed_itv`.
-  + lemma `leEbig_lexi_order`
+    `big_lexi_le_reflexive`, `big_lexi_le_anti`, `big_lexi_le_trans`,
+    `big_lexi_le_total`, `start_with_prefix`, `leEbig_lexi_order`,
+    `big_lexi_order_prefix_lt`, `big_lexi_order_prefix_gt`,
+    `big_lexi_order_between`, `big_lexi_order_interval_prefix`, and
+    `big_lexi_order_prefix_closed_itv`.
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -34,8 +34,7 @@
     `lexi_bigprod_total`, `start_with_prefix`, `lexi_bigprod_prefix_lt`,
     `lexi_bigprod_prefix_gt`, `lexi_bigprod_between`,
     `big_lexi_interval_prefix`, and `same_prefix_closed_itv`.
-
-
+  + lemma `leEbig_lexi_order`
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -24,16 +24,18 @@
 - in `measure.v`:
   + lemma `measurable_fun_set1`
 - in file `classical_orders.v`,
-  + new definitions `share_prefix`, `first_diff`, `lexi_bigprod`, `start_with`,
+  + new definitions `same_prefix`, `first_diff`, `lexi_bigprod`, `start_with`,
     `big_lexi_order`, and `big_lexi_ord`.
-  + new lemmas `share_prefix0`, `share_prefixC`, `share_prefixS`,
-    `share_prefix_refl`, `share_prefix_trans`, `first_diffC`,
+  + new lemmas `same_prefix0`, `same_prefix_sym`, `same_prefix_leq`,
+    `same_prefix_refl`, `same_prefix_trans`, `first_diff_sym`,
     `first_diff_unique`, `first_diff_SomeP`, `first_diff_NoneP`,
     `first_diff_lt`, `first_diff_eq`, `first_diff_dfwith`,
     `lexi_bigprod_reflexive`, `lexi_bigprod_anti`, `lexi_bigprod_trans`,
     `lexi_bigprod_total`, `start_with_prefix`, `lexi_bigprod_prefix_lt`,
     `lexi_bigprod_prefix_gt`, `lexi_bigprod_between`,
-    `big_lexi_interval_prefix`, and `shared_prefix_closed_itv`.
+    `big_lexi_interval_prefix`, and `same_prefix_closed_itv`.
+
+
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -23,6 +23,17 @@
 
 - in `measure.v`:
   + lemma `measurable_fun_set1`
+- in file `classical_orders.v`,
+  + new definitions `share_prefix`, `first_diff`, `lexi_bigprod`, `start_with`,
+    `big_lexi_order`, and `big_lexi_ord`.
+  + new lemmas `share_prefix0`, `share_prefixC`, `share_prefixS`,
+    `share_prefix_refl`, `share_prefix_trans`, `first_diffC`,
+    `first_diff_unique`, `first_diff_SomeP`, `first_diff_NoneP`,
+    `first_diff_lt`, `first_diff_eq`, `first_diff_dfwith`,
+    `lexi_bigprod_reflexive`, `lexi_bigprod_anti`, `lexi_bigprod_trans`,
+    `lexi_bigprod_total`, `start_with_prefix`, `lexi_bigprod_prefix_lt`,
+    `lexi_bigprod_prefix_gt`, `lexi_bigprod_between`,
+    `big_lexi_interval_prefix`, and `shared_prefix_closed_itv`.
 
 ### Changed
 

--- a/_CoqProject
+++ b/_CoqProject
@@ -18,6 +18,7 @@ classical/functions.v
 classical/cardinality.v
 classical/fsbigop.v
 classical/set_interval.v
+classical/classical_orders.v
 theories/all_analysis.v
 theories/constructive_ereal.v
 theories/ereal.v

--- a/classical/Make
+++ b/classical/Make
@@ -16,4 +16,5 @@ functions.v
 cardinality.v
 fsbigop.v
 set_interval.v
+classical_orders.v
 all_classical.v

--- a/classical/all_classical.v
+++ b/classical/all_classical.v
@@ -6,3 +6,4 @@ From mathcomp Require Export functions.
 From mathcomp Require Export cardinality.
 From mathcomp Require Export fsbigop.
 From mathcomp Require Export set_interval.
+From mathcomp Require Export classical_orders.

--- a/classical/classical_orders.v
+++ b/classical/classical_orders.v
@@ -235,8 +235,8 @@ Context {d} {K : nat -> bPOrderType d}.
 
 Local Lemma big_lex_bot x : (@big_lexi_ord _ K) (fun=> \bot)%O x.
 Proof. 
-rewrite /big_lexi_ord/lexi_bigprod; case E: (first_diff _ _) => //.
-exact: Order.le0x.
+rewrite /big_lexi_ord/lexi_bigprod.
+by case E: (first_diff _ _); [exact: Order.le0x | done].
 Qed.
 
 HB.instance Definition _ := @Order.hasBottom.Build _ 
@@ -249,8 +249,8 @@ Context {d} {K : nat -> tPOrderType d}.
 
 Local Lemma big_lex_top x : (@big_lexi_ord _ K) x (fun=> \top)%O.
 Proof. 
-rewrite /big_lexi_ord/lexi_bigprod; case E: (first_diff _ _) => //.
-apply: Order.lex1.
+rewrite /big_lexi_ord/lexi_bigprod.
+by case E: (first_diff _ _); [exact: Order.lex1 | done].
 Qed.
 
 HB.instance Definition _ := @Order.hasTop.Build _ 

--- a/classical/classical_orders.v
+++ b/classical/classical_orders.v
@@ -1,0 +1,385 @@
+From mathcomp Require Import all_ssreflect ssralg ssrnum interval.
+From mathcomp Require Import mathcomp_extra boolp classical_sets.
+From HB Require Import structures.
+From mathcomp Require Import functions set_interval.
+
+(**md**************************************************************************)
+(* # classical orders                                                         *)
+(*                                                                            *)
+(* This file provides some additional order theory that requires stronger     *)
+(* axioms than mathcomp's own orders expect                                   *)
+(*    share_prefix n == two elements in a product space agree up n            *)
+(*    first_diff x y == the first occurrence where x n != y n, or None        *)
+(*      lexi_bigprod == the (countably) infinte lexicographical ordering      *)
+(*    big_lexi_order == an alias for attack this order type                   *)
+(*  start_with n x y == x for the first n values, then swithces to y          *)
+(*                                                                            *)
+(******************************************************************************)
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+Import Order.TTheory GRing.Theory Num.Def Num.Theory.
+
+Local Open Scope classical_set_scope.
+
+Section big_lexi_order.
+
+Context {K : nat -> eqType} .
+
+Definition share_prefix n (t1 t2: forall n, K n) :=
+  (forall m, (m < n)%O -> t1 m = t2 m).
+
+Lemma share_prefix0 t1 t2 : share_prefix 0 t1 t2.
+Proof. by rewrite /share_prefix. Qed.
+
+Hint Resolve share_prefix0 : core.
+
+Lemma share_prefixC n t1 t2 : share_prefix n t1 t2 <-> share_prefix n t2 t1.
+Proof. by rewrite /share_prefix; split => + m mn => /(_ m mn). Qed.
+
+Lemma share_prefixS n m t1 t2 : 
+  n <= m -> share_prefix m t1 t2 -> share_prefix n t1 t2.
+Proof. 
+move=> nm + r rn; apply; move: nm; rewrite leq_eqVlt => /orP.
+by case=>[/eqP <- //|/(ltn_trans rn)]; exact.
+Qed.
+
+Lemma share_prefix_refl n x : share_prefix n x x.
+Proof. by move=> ? ?. Qed.
+
+Lemma share_prefix_trans n x y z : 
+  share_prefix n x y -> 
+  share_prefix n y z -> 
+  share_prefix n x z. 
+Proof. by move=> + + m mn => /(_ _ mn) ->; apply. Qed.
+
+Definition first_diff (t1 t2: forall n, K n) : option nat :=
+  xget None (Some  @` [set n | share_prefix n t1 t2 /\ t1 n <> t2 n]).
+
+Lemma first_diffC t1 t2 : first_diff t1 t2 = first_diff t2 t1.
+Proof.
+by rewrite /first_diff /=; congr (_ _ _); rewrite eqEsubset; split => z /=;
+  (case => w [wE /nesym NE]; exists w => //; split);
+  rewrite // share_prefixC.
+Qed.
+
+Lemma first_diff_unique (x y : forall n, K n) : forall (n m : nat), 
+  (share_prefix n x y /\ x n <> y n) ->
+  (share_prefix m x y /\ x m <> y m) ->
+  n = m.
+Proof.
+move=> n m [nPfx xyn] [mPfx xym]; apply/eqP.
+apply: contrapT; move/negP; rewrite neq_ltn => /orP; case => RN.
+  by move: xyn; have -> := mPfx _ RN.
+by move: xym; have -> := nPfx _ RN.
+Qed.
+ 
+Lemma first_diff_SomeP x y n : 
+  first_diff x y = Some n <-> share_prefix n x y /\ x n <> y n.
+Proof.
+split.
+  rewrite /first_diff; case: xgetP=> // ? -> []? [+ + <-/Some_inj nE]. 
+  by rewrite {}nE /= => ? ?; split.
+case=> pfx xNy; rewrite /first_diff; case: xgetP => //=; first last.
+  by move/(_ (Some n)); apply: absurd; exists n.
+case; last by move => ? [].
+by move=> m -> [o] [? ?] <-; congr(_ _); apply: (@first_diff_unique x y). 
+Qed.
+
+Lemma first_diff_NoneP t1 t2 : t1 = t2 <-> first_diff t1 t2 = None.
+Proof.
+split; rewrite /first_diff.
+  by move=> ->; case: xgetP => //; case => // ? ? [? /=] []//.
+case: xgetP; first by move=> ? -> [i /=] [?] ? <-.
+move=> /= R _; apply/functional_extensionality_dep.
+suff : forall n, forall x, x < n -> t1 x = t2 x.
+  by move=> + n => /(_ n.+1)/(_ n); apply.
+elim; first by move=> ?.
+move=> n IH x; rewrite leq_eqVlt => /orP [/eqP/succn_inj ->|xn]; last exact: IH.
+have /forall2NP/(_ n) [] := R (Some n) => // /not_andP.
+case; first by case/existsNP=> m /not_implyP [//] mx; apply: absurd; apply/IH.
+by move/contrapT ->.
+Qed.
+
+Lemma first_diff_lt a x y n m : 
+  n < m ->
+  first_diff a x = Some n ->
+  first_diff a y = Some m ->
+  first_diff x y = Some n.
+Proof.
+move=> nm /first_diff_SomeP [xpfx xE] /first_diff_SomeP [ypfx yE]. 
+apply/first_diff_SomeP; split.
+  by move=> o /[dup] on /xpfx <-; apply: ypfx; apply: (ltn_trans on).
+by have <- := ypfx _ nm; exact/nesym.
+Qed.
+
+Lemma first_diff_eq a x y n m: 
+  first_diff a x = Some n ->
+  first_diff a y = Some n ->
+  first_diff x y = Some m -> 
+  n <= m.
+Proof.
+case/first_diff_SomeP => axPfx axn /first_diff_SomeP [ayPfx ayn].
+case/first_diff_SomeP => xyPfx; rewrite leqNgt; apply: contra_notN => mn.
+by have <- := ayPfx _ mn; have <- := axPfx _ mn.
+Qed.
+
+Lemma first_diff_dfwith x i b : 
+  (x i) <> b <-> first_diff x (@dfwith _ K x i b) = Some i.
+Proof.
+split; first last.
+  by case/first_diff_SomeP => _ /=; apply: contra_not; rewrite dfwithin.
+move=> xNb; apply/first_diff_SomeP; split; last by rewrite dfwithin.
+move=> n ni; apply/eqP; rewrite dfwithout //.
+by apply/negP => /eqP E; move: ni; rewrite E ltexx.
+Qed.
+
+Definition lexi_bigprod  (R : forall n, K n -> K n -> bool) (t1 t2 : forall n, K n) :=
+  match first_diff t1 t2 with  
+  | Some n => R n (t1 n) (t2 n)
+  | None => true
+  end.
+
+Lemma lexi_bigprod_reflexive R : reflexive (lexi_bigprod R).
+Proof.
+move=> x; rewrite /lexi_bigprod /=.
+rewrite /lexi_bigprod/first_diff.
+by case: xgetP => //=; case=> // n /= _ [m [/= _]].
+Qed.
+
+Lemma lexi_bigprod_anti R : (forall n, antisymmetric (R n)) ->
+  antisymmetric (lexi_bigprod R).
+Proof.
+move=> antiR x y /andP [xy yx]; apply/first_diff_NoneP; move: xy yx.
+rewrite /lexi_bigprod first_diffC; case E: (first_diff y x) => [n|]// ? ?.
+case/first_diff_SomeP: E => _; apply: contra_notP => _.
+by apply: antiR; apply/andP; split.
+Qed.
+
+Lemma lexi_bigprod_trans R : 
+  (forall n, transitive (R n)) -> 
+  (forall n, antisymmetric (R n)) -> 
+  transitive (lexi_bigprod R).
+move=> Rtrans Ranti y x z; rewrite /lexi_bigprod /=.
+case Ep: (first_diff x y) => [p|]; last by move/first_diff_NoneP: Ep ->.
+case Er: (first_diff x z) => [r|]; last by move/first_diff_NoneP: Er ->.
+case Eq: (first_diff y z) => [q|]; first last.
+  by move: Ep Er; move/first_diff_NoneP: Eq => -> -> /Some_inj ->. 
+have := leqVgt p q; rewrite leq_eqVlt => /orP [/orP[]|].
+- move=> /eqP pqE; move: Ep Eq; rewrite pqE => Eqx Eqz.
+  rewrite first_diffC in Eqx; have := first_diff_eq Eqx Eqz Er.
+  rewrite leq_eqVlt => /orP [/eqP ->|qr]; first by exact: Rtrans.
+  case/first_diff_SomeP:Er => /(_ _ qr) -> _ ? ?; have : z q = y q.
+    by apply: Ranti; apply/andP; split.
+  by move=> E; case/first_diff_SomeP: Eqz=> + /nesym; rewrite E.
+- move=> pq; move: Er.
+  rewrite (@first_diff_lt y x z _ _ pq) ?[_ y x]first_diffC //.
+  by move/Some_inj <- => ? _; case/first_diff_SomeP:Eq => /(_ _ pq) <-.
+- move=> qp; move: Er.
+  rewrite first_diffC (@first_diff_lt y _ _ _ _ qp) // ?[_ y x]first_diffC //.
+  by move/Some_inj <- => _ ?; case/first_diff_SomeP:Ep => /(_ _ qp) ->.
+Qed.
+
+Lemma lexi_bigprod_total R : (forall n, total (R n)) -> total (lexi_bigprod R).
+Proof.
+move=> Rtotal; move=> x y.
+case E : (first_diff x y) => [n|]; first last.
+  by move/first_diff_NoneP:E ->; rewrite lexi_bigprod_reflexive.
+rewrite /lexi_bigprod E first_diffC E; exact: Rtotal.
+Qed.
+
+Definition start_with n (t1 t2: forall n, K n) (i : nat) : K i := 
+  if (i < n)%O then t1 i else t2 i.
+
+Lemma start_with_prefix n x y : share_prefix n x (start_with n x y).
+Proof. by move=> r rn; rewrite /start_with rn. Qed.
+
+End big_lexi_order.
+
+Definition big_lexi_order {I : Type} (T : I -> Type) : Type := forall i, T i.
+HB.instance Definition _ (I : Type) (K : I -> choiceType) := 
+  Choice.on (big_lexi_order K).
+
+Section big_lexi_porder.
+Context {d} {K : nat -> porderType d}.
+
+Definition big_lexi_ord : rel (big_lexi_order K) := 
+  lexi_bigprod (fun n k1 k2 => k1 <= k2)%O.
+
+Local Lemma big_lexi_ord_reflexive : reflexive big_lexi_ord.
+Proof. exact: lexi_bigprod_reflexive. Qed.
+
+Local Lemma big_lexi_ord_anti : antisymmetric big_lexi_ord.
+Proof. by apply: lexi_bigprod_anti => n; exact: le_anti. Qed.
+
+Local Lemma big_lexi_ord_trans : transitive big_lexi_ord.
+Proof. by apply: lexi_bigprod_trans=> n; [exact: le_trans| exact: le_anti]. Qed.
+
+HB.instance Definition _ := Order.Le_isPOrder.Build d (big_lexi_order K)
+  big_lexi_ord_reflexive big_lexi_ord_anti big_lexi_ord_trans.
+End big_lexi_porder.
+
+Section big_lexi_total.
+Context {d} {K : nat -> orderType d}.
+
+Local Lemma big_lexi_ord_total : total (@big_lexi_ord _ K).
+Proof. by apply: lexi_bigprod_total => ?; exact: le_total. Qed.
+
+HB.instance Definition _ := Order.POrder_isTotal.Build _ 
+  (big_lexi_order K) big_lexi_ord_total.
+
+End big_lexi_total.
+
+Section big_lexi_bottom.
+Context {d} {K : nat -> bPOrderType d}.
+
+Local Lemma big_lex_bot x : (@big_lexi_ord _ K) (fun=> \bot)%O x.
+Proof. 
+rewrite /big_lexi_ord/lexi_bigprod; case E: (first_diff _ _) => //.
+exact: Order.le0x.
+Qed.
+
+HB.instance Definition _ := @Order.hasBottom.Build _ 
+  (big_lexi_order K) (fun=> \bot)%O big_lex_bot.
+
+End big_lexi_bottom.
+
+Section big_lexi_top.
+Context {d} {K : nat -> tPOrderType d}.
+
+Local Lemma big_lex_top x : (@big_lexi_ord _ K) x (fun=> \top)%O.
+Proof. 
+rewrite /big_lexi_ord/lexi_bigprod; case E: (first_diff _ _) => //.
+apply: Order.lex1.
+Qed.
+
+HB.instance Definition _ := @Order.hasTop.Build _ 
+  (big_lexi_order K) (fun=> \top)%O big_lex_top.
+
+End big_lexi_top.
+
+Section big_lexi_intervals.
+Context {d} {K : nat -> orderType d}.
+Lemma lexi_bigprod_prefix_lt (b a x: big_lexi_order K) n: 
+  (a < b)%O -> 
+  first_diff a b = Some n ->
+  share_prefix n.+1 x b ->
+  (a < x)%O.
+Proof.
+move=> + /[dup] abD /first_diff_SomeP [pfa abN].
+case E1 : (first_diff a x) => [m|]; first last.
+  by move/first_diff_NoneP:E1 <- => _ /(_ n (ltnSn _)).
+move=> ab pfx; apply/andP; split.
+  by apply/negP => /eqP/first_diff_NoneP; rewrite first_diffC E1.
+move: ab; rewrite /Order.lt/= => /andP [?].
+rewrite /big_lexi_ord /lexi_bigprod E1 abD; suff : n = m. 
+  by have := pfx n (ltnSn _) => /[swap] -> ->.
+apply: (@first_diff_unique _ a x) => //=; last by case/first_diff_SomeP:E1.
+split; last by by have -> := pfx n (ltnSn _).
+by apply: (share_prefix_trans pfa); rewrite share_prefixC; exact: share_prefixS.
+Qed.
+
+Lemma lexi_bigprod_prefix_gt (b a x: big_lexi_order K) n:
+  (b < a)%O -> 
+  first_diff a b = Some n ->
+  share_prefix n.+1 x b ->
+  (x < a)%O.
+Proof.
+move=> + /[dup] abD /first_diff_SomeP [pfa abN].
+case E1 : (first_diff x a) => [m|]; first last.
+  by move/first_diff_NoneP:E1 -> => _ /(_ n (ltnSn _)).
+move=> ab pfx; apply/andP; split.
+  by apply/negP => /eqP/first_diff_NoneP; rewrite first_diffC E1.
+move: ab; rewrite /Order.lt/= => /andP [?].
+rewrite /big_lexi_ord /lexi_bigprod [_ b a]first_diffC E1 abD; suff : n = m. 
+  by have := pfx n (ltnSn _) => /[swap] -> ->.
+apply: (@first_diff_unique _ x a) => //=; last by case/first_diff_SomeP:E1.
+rewrite share_prefixC; split; last by have -> := pfx n (ltnSn _); apply/nesym.
+by apply: (share_prefix_trans pfa); rewrite share_prefixC; exact: share_prefixS.
+Qed.
+
+Lemma lexi_bigprod_between (a x b: big_lexi_order K) n:
+  (a <= x <= b)%O -> 
+  share_prefix n a b -> 
+  share_prefix n x a. 
+Proof.
+move=> axb; elim: n => // n IH.
+move=> pfxSn m mSn; have pfxA : share_prefix n a x.
+  by rewrite share_prefixC; apply: IH; apply: (share_prefixS _  pfxSn).
+have pfxB : share_prefix n x b.
+  apply (@share_prefix_trans _ n x a b); first by rewrite share_prefixC.
+  exact: (share_prefixS _  pfxSn).
+move: mSn; rewrite /Order.lt/= ltnS leq_eqVlt => /orP []; first last.
+  by move: pfxA; rewrite share_prefixC; exact.
+move/eqP ->; apply: le_anti; apply/andP; split.
+  case/andP:axb => ? +; rewrite {1}/Order.le/=/big_lexi_ord/lexi_bigprod.
+  have -> := pfxSn n (ltnSn _).
+  case E : (first_diff x b) => [r|]; last by move/first_diff_NoneP:E ->.
+  move=> xrb; have : n <= r. 
+    rewrite leqNgt; apply/negP=> /[dup] /pfxB xbE.
+    by case/first_diff_SomeP:E => _; rewrite xbE. 
+  rewrite leq_eqVlt => /orP [/eqP -> //|] => nr.
+  by case/first_diff_SomeP:E => /(_ n nr) ->. 
+case/andP:axb => + ?; rewrite {1}/Order.le/=/big_lexi_ord/lexi_bigprod.
+case E : (first_diff a x) => [r|]; last by move/first_diff_NoneP:E <-. 
+move=> xrb; have : n <= r. 
+  rewrite leqNgt; apply/negP=> /[dup] /pfxA xbE.
+  by case/first_diff_SomeP:E => _; rewrite xbE. 
+rewrite leq_eqVlt => /orP [/eqP -> //|] => nr.
+by case/first_diff_SomeP:E => /(_ n nr) ->. 
+Qed.
+
+Lemma big_lexi_interval_prefix (i : interval (big_lexi_order K))
+    (x : big_lexi_order K) : 
+  itv_open_ends i -> x \in i ->
+  exists n, (share_prefix n x `<=` [set` i]).
+Proof.
+move: i; case=> [][[]l|[]] [[]r|[]] [][]; rewrite ?in_itv /= ?andbT.
+- move=> /andP [] lx xr. 
+  case E1 : (first_diff l x) => [m|]; first last.
+    by move: lx; move/first_diff_NoneP: E1 ->; rewrite bnd_simp.
+  case E2 : (first_diff x r) => [n|]; first last.
+    by move: xr; move/first_diff_NoneP: E2 ->; rewrite bnd_simp.
+  exists (Order.max n m).+1 => p xppfx; rewrite set_itvE. 
+  apply/andP; split. 
+    apply: (lexi_bigprod_prefix_lt lx E1) => w wm; apply/sym_equal/xppfx.
+    by move/ltnSE/leq_ltn_trans: wm; apply; rewrite ltnS leq_max leqnn orbT.
+  rewrite first_diffC in E2.
+  apply: (lexi_bigprod_prefix_gt xr E2) => w wm; apply/sym_equal/xppfx.
+  by move/ltnSE/leq_ltn_trans: wm; apply; rewrite ltnS leq_max leqnn.
+- move=> lx. 
+  case E1 : (first_diff l x) => [m|]; first last.
+    by move: lx; move/first_diff_NoneP: E1 ->; rewrite bnd_simp.
+  exists m.+1 => p xppfx; rewrite set_itvE /=.
+  by apply: (lexi_bigprod_prefix_lt lx E1) => w wm; apply/sym_equal/xppfx.
+- move=> xr. 
+  case E2 : (first_diff x r) => [n|]; first last.
+    by move: xr; move/first_diff_NoneP: E2 ->; rewrite bnd_simp.
+  exists n.+1; rewrite first_diffC in E2 => p xppfx. 
+  rewrite set_itvE /=.
+  by apply: (lexi_bigprod_prefix_gt xr E2) => w wm; apply/sym_equal/xppfx.
+by move=> _; exists 0=> ? ?; rewrite set_itvE.
+Qed.
+End big_lexi_intervals.
+
+(** TODO: generalize to tbOrderType when that's available in mathcomp*)
+Lemma shared_prefix_closed_itv {d} {K : nat -> finOrderType d} n  
+  (x : big_lexi_order K) :
+  share_prefix n x = 
+    `[(start_with n x (fun=>\bot):big_lexi_order K)%O, (start_with n x (fun=>\top))%O].
+Proof.
+rewrite eqEsubset; split=> z; first last.
+  rewrite set_itvE /= => xbt; apply: share_prefix_trans.
+    apply: (@start_with_prefix _ _ _ (fun=> \bot)%O).
+  rewrite share_prefixC; apply: (lexi_bigprod_between xbt).
+  apply:share_prefix_trans; last by apply: @start_with_prefix.
+  by rewrite share_prefixC; apply: start_with_prefix.
+move=> pfxz; rewrite set_itvE /= /Order.le /= /big_lexi_ord /= /lexi_bigprod. 
+apply/andP; split.
+  case E : (first_diff _ _ ) => [m|] //; rewrite /start_with /=.
+  case mn : (_ < _)%O => //; last by rewrite le0x.
+  by (suff -> : x m = z m by done); apply: pfxz.
+case E : (first_diff _ _ ) => [m|] //; rewrite /start_with /=.
+case mn : (_ < _)%O => //; last by rewrite lex1.
+by (suff -> : x m = z m by done); exact: pfxz.
+Qed.

--- a/classical/classical_orders.v
+++ b/classical/classical_orders.v
@@ -8,13 +8,16 @@ From mathcomp Require Import functions set_interval.
 (*                                                                            *)
 (* This file provides some additional order theory that requires stronger     *)
 (* axioms than mathcomp's own orders expect                                   *)
+(* ```                                                                        *)
 (*    share_prefix n == two elements in a product space agree up n            *)
 (*    first_diff x y == the first occurrence where x n != y n, or None        *)
-(*      lexi_bigprod == the (countably) infinite lexicographical ordering      *)
+(*      lexi_bigprod == the (countably) infinite lexicographical ordering     *)
 (*    big_lexi_order == an alias for attack this order type                   *)
 (*  start_with n x y == x for the first n values, then switches to y          *)
+(* ```                                                                        *)
 (*                                                                            *)
 (******************************************************************************)
+
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
@@ -23,15 +26,12 @@ Import Order.TTheory GRing.Theory Num.Def Num.Theory.
 Local Open Scope classical_set_scope.
 
 Section big_lexi_order.
+Context {K : nat -> eqType}.
 
-Context {K : nat -> eqType} .
+Definition share_prefix n (t1 t2 : forall n, K n) :=
+  forall m, (m < n)%O -> t1 m = t2 m.
 
-Definition share_prefix n (t1 t2: forall n, K n) :=
-  (forall m, (m < n)%O -> t1 m = t2 m).
-
-Lemma share_prefix0 t1 t2 : share_prefix 0 t1 t2.
-Proof. by rewrite /share_prefix. Qed.
-
+Lemma share_prefix0 t1 t2 : share_prefix 0 t1 t2. Proof. by []. Qed.
 Hint Resolve share_prefix0 : core.
 
 Lemma share_prefixC n t1 t2 : share_prefix n t1 t2 <-> share_prefix n t2 t1.
@@ -40,65 +40,57 @@ Proof. by rewrite /share_prefix; split => + m mn => /(_ m mn). Qed.
 Lemma share_prefixS n m t1 t2 :
   n <= m -> share_prefix m t1 t2 -> share_prefix n t1 t2.
 Proof.
-move=> nm + r rn; apply; move: nm; rewrite leq_eqVlt => /orP.
-by case=>[/eqP <- //|/(ltn_trans rn)]; exact.
+move=> nm + r rn; apply.
+by move: nm; rewrite leq_eqVlt => /predU1P[<-//|]; exact: ltn_trans.
 Qed.
 
-Lemma share_prefix_refl n x : share_prefix n x x.
-Proof. by move=> ? ?. Qed.
+Lemma share_prefix_refl n x : share_prefix n x x. Proof. by []. Qed.
 
 Lemma share_prefix_trans n x y z :
   share_prefix n x y ->
   share_prefix n y z ->
   share_prefix n x z.
-Proof. by move=> + + m mn => /(_ _ mn) ->; apply. Qed.
+Proof. by move=> + + m mn => /(_ _ mn) ->; exact. Qed.
 
-Definition first_diff (t1 t2: forall n, K n) : option nat :=
-  xget None (Some  @` [set n | share_prefix n t1 t2 /\ t1 n <> t2 n]).
+Definition first_diff (t1 t2 : forall n, K n) : option nat :=
+  xget None (Some @` [set n | share_prefix n t1 t2 /\ t1 n != t2 n]).
 
 Lemma first_diffC t1 t2 : first_diff t1 t2 = first_diff t2 t1.
 Proof.
-by rewrite /first_diff /=; congr (_ _ _); rewrite eqEsubset; split => z /=;
-  (case => w [wE /nesym NE]; exists w => //; split);
-  rewrite // share_prefixC.
+rewrite /first_diff /=; congr (xget _ (image _ _)).
+under eq_set do rewrite eq_sym.
+by apply/seteqP; split => z/= [] /share_prefixC.
 Qed.
 
-Lemma first_diff_unique (x y : forall n, K n) : forall (n m : nat),
-  (share_prefix n x y /\ x n <> y n) ->
-  (share_prefix m x y /\ x m <> y m) ->
+Lemma first_diff_unique (x y : forall n, K n) n m :
+  share_prefix n x y -> x n != y n ->
+  share_prefix m x y -> x m != y m ->
   n = m.
 Proof.
-move=> n m [nPfx xyn] [mPfx xym]; apply/eqP.
-apply: contrapT; move/negP; rewrite neq_ltn => /orP; case => RN.
-  by move: xyn; have -> := mPfx _ RN.
-by move: xym; have -> := nPfx _ RN.
+move=> nfx xyn mfx xym; apply/eqP; rewrite eq_le 2!leNgt; apply/andP; split.
+by apply/negP => /nfx; exact/eqP.
+by apply/negP => /mfx; exact/eqP.
 Qed.
 
 Lemma first_diff_SomeP x y n :
-  first_diff x y = Some n <-> share_prefix n x y /\ x n <> y n.
+  first_diff x y = Some n <-> share_prefix n x y /\ x n != y n.
 Proof.
 split.
-  rewrite /first_diff; case: xgetP=> // ? -> []? [+ + <-/Some_inj nE].
-  by rewrite {}nE /= => ? ?; split.
-case=> pfx xNy; rewrite /first_diff; case: xgetP => //=; first last.
-  by move/(_ (Some n)); apply: absurd; exists n.
-case; last by move => ? [].
-by move=> m -> [o] [? ?] <-; congr(_ _); apply: (@first_diff_unique x y).
+  by rewrite /first_diff; case: xgetP=> //= -[m ->|//] [p + <-[]] => /[swap] ->.
+case=> pfx xNy; rewrite /first_diff; case: xgetP => /=; first last.
+  by move=> /(_ (Some n))/forall2NP/(_ n)[/not_andP[|]|].
+by move=> [m|m []//] -> [p [pxy xyp]] <-; rewrite (@first_diff_unique x y n p).
 Qed.
 
 Lemma first_diff_NoneP t1 t2 : t1 = t2 <-> first_diff t1 t2 = None.
 Proof.
-split; rewrite /first_diff.
-  by move=> ->; case: xgetP => //; case => // ? ? [? /=] []//.
-case: xgetP; first by move=> ? -> [i /=] [?] ? <-.
-move=> /= R _; apply/functional_extensionality_dep.
-suff : forall n, forall x, x < n -> t1 x = t2 x.
-  by move=> + n => /(_ n.+1)/(_ n); apply.
-elim; first by move=> ?.
-move=> n IH x; rewrite leq_eqVlt => /orP [/eqP/succn_inj ->|xn]; last exact: IH.
-have /forall2NP/(_ n) [] := R (Some n) => // /not_andP.
-case; first by case/existsNP=> m /not_implyP [//] mx; apply: absurd; apply/IH.
-by move/contrapT ->.
+rewrite /first_diff; split => [->|].
+  by case: xgetP => //= -[n|//] -> [m []]; rewrite eqxx.
+case: xgetP => [? -> [i /=] [?] ? <-//|/= R _].
+apply/functional_extensionality_dep.
+suff : forall n x, x < n -> t1 x = t2 x by move=> + n => /(_ n.+1)/(_ n); apply.
+elim => [//|n ih x]; rewrite ltnS leq_eqVlt => /predU1P[->|xn]; last exact: ih.
+by have /forall2NP/(_ n)[/not_andP[//|/negP/negPn/eqP ->]|] := R (Some n).
 Qed.
 
 Lemma first_diff_lt a x y n m :
@@ -108,9 +100,8 @@ Lemma first_diff_lt a x y n m :
   first_diff x y = Some n.
 Proof.
 move=> nm /first_diff_SomeP [xpfx xE] /first_diff_SomeP [ypfx yE].
-apply/first_diff_SomeP; split.
-  by move=> o /[dup] on /xpfx <-; apply: ypfx; apply: (ltn_trans on).
-by have <- := ypfx _ nm; exact/nesym.
+apply/first_diff_SomeP; split; last by rewrite -(ypfx _ nm) eq_sym.
+by move=> o /[dup] on /xpfx <-; apply: ypfx; exact: (ltn_trans on).
 Qed.
 
 Lemma first_diff_eq a x y n m :
@@ -119,76 +110,72 @@ Lemma first_diff_eq a x y n m :
   first_diff x y = Some m ->
   n <= m.
 Proof.
-case/first_diff_SomeP => axPfx axn /first_diff_SomeP [ayPfx ayn].
-case/first_diff_SomeP => xyPfx; rewrite leqNgt; apply: contra_notN => mn.
-by have <- := ayPfx _ mn; have <- := axPfx _ mn.
+case/first_diff_SomeP => axPfx axn /first_diff_SomeP[ayPfx ayn].
+case/first_diff_SomeP => xyPfx; rewrite leqNgt; apply: contra => mn.
+by rewrite -(ayPfx _ mn) -(axPfx _ mn).
 Qed.
 
-Lemma first_diff_dfwith x i b :
-  (x i) <> b <-> first_diff x (@dfwith _ K x i b) = Some i.
+Lemma first_diff_dfwith (x : forall n : nat, K n) i b :
+  x i != b <-> first_diff x (dfwith x i b) = Some i.
 Proof.
-split; first last.
-  by case/first_diff_SomeP => _ /=; apply: contra_not; rewrite dfwithin.
-move=> xNb; apply/first_diff_SomeP; split; last by rewrite dfwithin.
-move=> n ni; apply/eqP; rewrite dfwithout //.
-by apply/negP => /eqP E; move: ni; rewrite E ltexx.
+split => [xBn|/first_diff_SomeP[_]]; last by apply: contra; rewrite dfwithin.
+apply/first_diff_SomeP; split; last by rewrite dfwithin.
+by move=> n ni; rewrite dfwithout// gt_eqF.
 Qed.
 
-Definition lexi_bigprod (R : forall n, K n -> K n -> bool) (t1 t2 : forall n, K n) :=
-  match first_diff t1 t2 with
-  | Some n => R n (t1 n) (t2 n)
-  | None => true
-  end.
+Definition lexi_bigprod
+    (R : forall n, K n -> K n -> bool) (t1 t2 : forall n, K n) :=
+  if first_diff t1 t2 is Some n then R n (t1 n) (t2 n) else true.
 
 Lemma lexi_bigprod_reflexive R : reflexive (lexi_bigprod R).
 Proof.
-move=> x; rewrite /lexi_bigprod /=.
-rewrite /lexi_bigprod/first_diff.
-by case: xgetP => //=; case=> // n /= _ [m [/= _]].
+move=> x; rewrite /lexi_bigprod /= /first_diff.
+by case: xgetP => //= -[n _|//] [m []]; rewrite eqxx.
 Qed.
 
 Lemma lexi_bigprod_anti R : (forall n, antisymmetric (R n)) ->
   antisymmetric (lexi_bigprod R).
 Proof.
 move=> antiR x y /andP [xy yx]; apply/first_diff_NoneP; move: xy yx.
-rewrite /lexi_bigprod first_diffC; case E: (first_diff y x) => [n|]// ? ?.
-case/first_diff_SomeP: E => _; apply: contra_notP => _.
-by apply: antiR; apply/andP; split.
+rewrite /lexi_bigprod first_diffC; case E : (first_diff y x) => [n|]// Rxy Ryx.
+case/first_diff_SomeP : E => _ /eqP yxn.
+by have := antiR n (x n) (y n); rewrite Rxy Ryx => /(_ erefl)/esym.
 Qed.
 
 Lemma lexi_bigprod_trans R :
   (forall n, transitive (R n)) ->
   (forall n, antisymmetric (R n)) ->
   transitive (lexi_bigprod R).
+Proof.
 move=> Rtrans Ranti y x z; rewrite /lexi_bigprod /=.
 case Ep: (first_diff x y) => [p|]; last by move/first_diff_NoneP: Ep ->.
 case Er: (first_diff x z) => [r|]; last by move/first_diff_NoneP: Er ->.
 case Eq: (first_diff y z) => [q|]; first last.
-  by move: Ep Er; move/first_diff_NoneP: Eq => -> -> /Some_inj ->.
-have := leqVgt p q; rewrite leq_eqVlt => /orP [/orP[]|].
-- move=> /eqP pqE; move: Ep Eq; rewrite pqE => Eqx Eqz.
+  by move: Ep Er; move/first_diff_NoneP: Eq => -> -> [->].
+have [pq|qp|pqE]:= ltgtP p q.
+- move: Er.
+  rewrite (@first_diff_lt y x z _ _ pq) ?[_ y x]first_diffC// => -[<-] ? _.
+  by case/first_diff_SomeP:Eq => /(_ _ pq) <-.
+- move: Er.
+  rewrite first_diffC (@first_diff_lt y _ _ _ _ qp) // ?[_ y x]first_diffC//.
+  by move=> [<-] _ ?; case/first_diff_SomeP: Ep => /(_ _ qp) ->.
+- move: Ep Eq; rewrite pqE => Eqx Eqz.
   rewrite first_diffC in Eqx; have := first_diff_eq Eqx Eqz Er.
-  rewrite leq_eqVlt => /orP [/eqP ->|qr]; first by exact: Rtrans.
-  case/first_diff_SomeP:Er => /(_ _ qr) -> _ ? ?; have : z q = y q.
-    by apply: Ranti; apply/andP; split.
-  by move=> E; case/first_diff_SomeP: Eqz=> + /nesym; rewrite E.
-- move=> pq; move: Er.
-  rewrite (@first_diff_lt y x z _ _ pq) ?[_ y x]first_diffC //.
-  by move/Some_inj <- => ? _; case/first_diff_SomeP:Eq => /(_ _ pq) <-.
-- move=> qp; move: Er.
-  rewrite first_diffC (@first_diff_lt y _ _ _ _ qp) // ?[_ y x]first_diffC //.
-  by move/Some_inj <- => _ ?; case/first_diff_SomeP:Ep => /(_ _ qp) ->.
+  rewrite leq_eqVlt => /predU1P[->|qr]; first exact: Rtrans.
+  case/first_diff_SomeP : Er => /(_ _ qr) -> _ ? ?.
+  have E : z q = y q by apply: Ranti; apply/andP; split.
+  by case/first_diff_SomeP: Eqz; rewrite E eqxx.
 Qed.
 
 Lemma lexi_bigprod_total R : (forall n, total (R n)) -> total (lexi_bigprod R).
 Proof.
-move=> Rtotal; move=> x y.
+move=> Rtotal x y.
 case E : (first_diff x y) => [n|]; first last.
-  by move/first_diff_NoneP:E ->; rewrite lexi_bigprod_reflexive.
-rewrite /lexi_bigprod E first_diffC E; exact: Rtotal.
+  by move/first_diff_NoneP : E ->; rewrite lexi_bigprod_reflexive.
+by rewrite /lexi_bigprod E first_diffC E; exact: Rtotal.
 Qed.
 
-Definition start_with n (t1 t2: forall n, K n) (i : nat) : K i :=
+Definition start_with n (t1 t2 : forall n, K n) (i : nat) : K i :=
   if (i < n)%O then t1 i else t2 i.
 
 Lemma start_with_prefix n x y : share_prefix n x (start_with n x y).
@@ -213,7 +200,7 @@ Local Lemma big_lexi_ord_anti : antisymmetric big_lexi_ord.
 Proof. by apply: lexi_bigprod_anti => n; exact: le_anti. Qed.
 
 Local Lemma big_lexi_ord_trans : transitive big_lexi_ord.
-Proof. by apply: lexi_bigprod_trans=> n; [exact: le_trans| exact: le_anti]. Qed.
+Proof. by apply: lexi_bigprod_trans=> n; [exact: le_trans|exact: le_anti]. Qed.
 
 HB.instance Definition _ := Order.Le_isPOrder.Build d (big_lexi_order K)
   big_lexi_ord_reflexive big_lexi_ord_anti big_lexi_ord_trans.
@@ -235,8 +222,8 @@ Context {d} {K : nat -> bPOrderType d}.
 
 Local Lemma big_lex_bot x : (@big_lexi_ord _ K) (fun=> \bot)%O x.
 Proof.
-rewrite /big_lexi_ord/lexi_bigprod.
-by case E: (first_diff _ _); [exact: Order.le0x | done].
+rewrite /big_lexi_ord /lexi_bigprod.
+by case: first_diff => // ?; exact: Order.le0x.
 Qed.
 
 HB.instance Definition _ := @Order.hasBottom.Build _
@@ -249,8 +236,8 @@ Context {d} {K : nat -> tPOrderType d}.
 
 Local Lemma big_lex_top x : (@big_lexi_ord _ K) x (fun=> \top)%O.
 Proof.
-rewrite /big_lexi_ord/lexi_bigprod.
-by case E: (first_diff _ _); [exact: Order.lex1 | done].
+rewrite /big_lexi_ord /lexi_bigprod.
+by case: first_diff => // ?; exact: Order.lex1.
 Qed.
 
 HB.instance Definition _ := @Order.hasTop.Build _
@@ -260,6 +247,7 @@ End big_lexi_top.
 
 Section big_lexi_intervals.
 Context {d} {K : nat -> orderType d}.
+
 Lemma lexi_bigprod_prefix_lt (b a x: big_lexi_order K) n :
   (a < b)%O ->
   first_diff a b = Some n ->
@@ -268,97 +256,99 @@ Lemma lexi_bigprod_prefix_lt (b a x: big_lexi_order K) n :
 Proof.
 move=> + /[dup] abD /first_diff_SomeP [pfa abN].
 case E1 : (first_diff a x) => [m|]; first last.
-  by move/first_diff_NoneP:E1 <- => _ /(_ n (ltnSn _)).
+  by move/first_diff_NoneP:E1 <- => _ /(_ n (ltnSn _))/eqP; rewrite (negbTE abN).
 move=> ab pfx; apply/andP; split.
-  by apply/negP => /eqP/first_diff_NoneP; rewrite first_diffC E1.
-move: ab; rewrite /Order.lt/= => /andP [?].
-rewrite /big_lexi_ord /lexi_bigprod E1 abD; suff : n = m.
-  by have := pfx n (ltnSn _) => /[swap] -> ->.
-apply: (@first_diff_unique _ a x) => //=; last by case/first_diff_SomeP:E1.
-split; last by by have -> := pfx n (ltnSn _).
-by apply: (share_prefix_trans pfa); rewrite share_prefixC; exact: share_prefixS.
+  by apply/eqP => /first_diff_NoneP; rewrite first_diffC E1.
+move: ab; rewrite /Order.lt/= => /andP[ba].
+rewrite /big_lexi_ord /lexi_bigprod E1 abD.
+suff : n = m by have := pfx n (ltnSn _) => /[swap] -> ->.
+apply: (@first_diff_unique _ a x) => //=; [| |by case/first_diff_SomeP : E1..].
+- by apply/(share_prefix_trans pfa)/share_prefixC; exact: share_prefixS.
+- by rewrite (pfx n (ltnSn _)).
 Qed.
 
-Lemma lexi_bigprod_prefix_gt (b a x: big_lexi_order K) n :
+Lemma lexi_bigprod_prefix_gt (b a x : big_lexi_order K) n :
   (b < a)%O ->
   first_diff a b = Some n ->
   share_prefix n.+1 x b ->
   (x < a)%O.
 Proof.
-move=> + /[dup] abD /first_diff_SomeP [pfa abN].
+move=> + /[dup] abD /first_diff_SomeP[pfa /eqP abN].
 case E1 : (first_diff x a) => [m|]; first last.
-  by move/first_diff_NoneP:E1 -> => _ /(_ n (ltnSn _)).
+  by move/first_diff_NoneP : E1 -> => _ /(_ n (ltnSn _)).
 move=> ab pfx; apply/andP; split.
   by apply/negP => /eqP/first_diff_NoneP; rewrite first_diffC E1.
-move: ab; rewrite /Order.lt/= => /andP [?].
-rewrite /big_lexi_ord /lexi_bigprod [_ b a]first_diffC E1 abD; suff : n = m.
-  by have := pfx n (ltnSn _) => /[swap] -> ->.
-apply: (@first_diff_unique _ x a) => //=; last by case/first_diff_SomeP:E1.
-rewrite share_prefixC; split; last by have -> := pfx n (ltnSn _); apply/nesym.
-by apply: (share_prefix_trans pfa); rewrite share_prefixC; exact: share_prefixS.
+move: ab; rewrite /Order.lt/= => /andP [ab].
+rewrite /big_lexi_ord /lexi_bigprod [_ b a]first_diffC E1 abD.
+suff : n = m by have := pfx n (ltnSn _) => /[swap] -> ->.
+apply: (@first_diff_unique _ x a) => //=; [| |by case/first_diff_SomeP : E1..].
+- apply/share_prefixC/(share_prefix_trans pfa)/share_prefixC.
+  exact: share_prefixS.
+- by rewrite (pfx n (ltnSn _)) eq_sym; exact/eqP.
 Qed.
 
-Lemma lexi_bigprod_between (a x b: big_lexi_order K) n :
+Lemma lexi_bigprod_between (a x b : big_lexi_order K) n :
   (a <= x <= b)%O ->
   share_prefix n a b ->
   share_prefix n x a.
 Proof.
-move=> axb; elim: n => // n IH.
-move=> pfxSn m mSn; have pfxA : share_prefix n a x.
-  by rewrite share_prefixC; apply: IH; apply: (share_prefixS _  pfxSn).
+move=> axb; elim: n => // n IH pfxSn m mSn.
+have pfxA : share_prefix n a x.
+  exact/share_prefixC/IH/(share_prefixS _  pfxSn).
 have pfxB : share_prefix n x b.
-  apply (@share_prefix_trans _ n x a b); first by rewrite share_prefixC.
+  apply: (@share_prefix_trans _ n x a b); first exact/share_prefixC.
   exact: (share_prefixS _  pfxSn).
-move: mSn; rewrite /Order.lt/= ltnS leq_eqVlt => /orP []; first last.
+move: mSn; rewrite /Order.lt/= ltnS leq_eqVlt => /predU1P[->|]; first last.
   by move: pfxA; rewrite share_prefixC; exact.
-move/eqP ->; apply: le_anti; apply/andP; split.
-  case/andP:axb => ? +; rewrite {1}/Order.le/=/big_lexi_ord/lexi_bigprod.
-  have -> := pfxSn n (ltnSn _).
-  case E : (first_diff x b) => [r|]; last by move/first_diff_NoneP:E ->.
+apply: le_anti; apply/andP; split.
+  case/andP: axb => ? +; rewrite {1}/Order.le/= /big_lexi_ord /lexi_bigprod.
+  rewrite (pfxSn n (ltnSn _)).
+  case E : (first_diff x b) => [r|]; last by move/first_diff_NoneP : E ->.
   move=> xrb; have : n <= r.
     rewrite leqNgt; apply/negP=> /[dup] /pfxB xbE.
-    by case/first_diff_SomeP:E => _; rewrite xbE.
-  rewrite leq_eqVlt => /orP [/eqP -> //|] => nr.
-  by case/first_diff_SomeP:E => /(_ n nr) ->.
-case/andP:axb => + ?; rewrite {1}/Order.le/=/big_lexi_ord/lexi_bigprod.
-case E : (first_diff a x) => [r|]; last by move/first_diff_NoneP:E <-.
-move=> xrb; have : n <= r.
-  rewrite leqNgt; apply/negP=> /[dup] /pfxA xbE.
-  by case/first_diff_SomeP:E => _; rewrite xbE.
-rewrite leq_eqVlt => /orP [/eqP -> //|] => nr.
-by case/first_diff_SomeP:E => /(_ n nr) ->.
+    by case/first_diff_SomeP : E => _; rewrite xbE eqxx.
+  rewrite leq_eqVlt => /predU1P[->//|nr].
+  by case/first_diff_SomeP : E => /(_ n nr) ->.
+case/andP : axb => + ?; rewrite {1}/Order.le/= /big_lexi_ord /lexi_bigprod.
+case E : (first_diff a x) => [r|]; last by move/first_diff_NoneP : E => <-.
+move=> xrb.
+have : n <= r.
+  rewrite leqNgt; apply/negP => /[dup] /pfxA xbE.
+  by case/first_diff_SomeP : E => _; rewrite xbE eqxx.
+rewrite leq_eqVlt => /predU1P[->//|nr].
+by case/first_diff_SomeP : E => /(_ n nr) ->.
 Qed.
 
 Lemma big_lexi_interval_prefix (i : interval (big_lexi_order K))
     (x : big_lexi_order K) :
   itv_open_ends i -> x \in i ->
-  exists n, (share_prefix n x `<=` [set` i]).
+  exists n, share_prefix n x `<=` [set` i].
 Proof.
 move: i; case=> [][[]l|[]] [[]r|[]] [][]; rewrite ?in_itv /= ?andbT.
-- move=> /andP [] lx xr.
+- move=> /andP[lx xr].
   case E1 : (first_diff l x) => [m|]; first last.
-    by move: lx; move/first_diff_NoneP: E1 ->; rewrite bnd_simp.
+    by move: lx; move/first_diff_NoneP : E1 ->; rewrite bnd_simp.
   case E2 : (first_diff x r) => [n|]; first last.
-    by move: xr; move/first_diff_NoneP: E2 ->; rewrite bnd_simp.
+    by move: xr; move/first_diff_NoneP : E2 ->; rewrite bnd_simp.
   exists (Order.max n m).+1 => p xppfx; rewrite set_itvE.
   apply/andP; split.
-    apply: (lexi_bigprod_prefix_lt lx E1) => w wm; apply/sym_equal/xppfx.
-    by move/ltnSE/leq_ltn_trans: wm; apply; rewrite ltnS leq_max leqnn orbT.
+    apply: (lexi_bigprod_prefix_lt lx E1) => w wm; apply/esym/xppfx.
+    by move/ltnSE/leq_ltn_trans : wm; apply; rewrite ltnS leq_max leqnn orbT.
   rewrite first_diffC in E2.
-  apply: (lexi_bigprod_prefix_gt xr E2) => w wm; apply/sym_equal/xppfx.
-  by move/ltnSE/leq_ltn_trans: wm; apply; rewrite ltnS leq_max leqnn.
+  apply: (lexi_bigprod_prefix_gt xr E2) => w wm; apply/esym/xppfx.
+  by move/ltnSE/leq_ltn_trans : wm; apply; rewrite ltnS leq_max leqnn.
 - move=> lx.
   case E1 : (first_diff l x) => [m|]; first last.
-    by move: lx; move/first_diff_NoneP: E1 ->; rewrite bnd_simp.
+    by move: lx; move/first_diff_NoneP : E1 ->; rewrite bnd_simp.
   exists m.+1 => p xppfx; rewrite set_itvE /=.
-  by apply: (lexi_bigprod_prefix_lt lx E1) => w wm; apply/sym_equal/xppfx.
+  by apply: (lexi_bigprod_prefix_lt lx E1) => w wm; exact/esym/xppfx.
 - move=> xr.
   case E2 : (first_diff x r) => [n|]; first last.
-    by move: xr; move/first_diff_NoneP: E2 ->; rewrite bnd_simp.
+    by move: xr; move/first_diff_NoneP : E2 ->; rewrite bnd_simp.
   exists n.+1; rewrite first_diffC in E2 => p xppfx.
   rewrite set_itvE /=.
-  by apply: (lexi_bigprod_prefix_gt xr E2) => w wm; apply/sym_equal/xppfx.
-by move=> _; exists 0=> ? ?; rewrite set_itvE.
+  by apply: (lexi_bigprod_prefix_gt xr E2) => w wm; exact/esym/xppfx.
+by move=> _; exists 0 => ? ?; rewrite set_itvE.
 Qed.
 End big_lexi_intervals.
 
@@ -368,18 +358,14 @@ Lemma shared_prefix_closed_itv {d} {K : nat -> finOrderType d} n
   share_prefix n x =
     `[(start_with n x (fun=>\bot):big_lexi_order K)%O, (start_with n x (fun=>\top))%O].
 Proof.
-rewrite eqEsubset; split=> z; first last.
+rewrite eqEsubset; split=> [z pfxz|z]; first last.
   rewrite set_itvE /= => xbt; apply: share_prefix_trans.
-    apply: (@start_with_prefix _ _ _ (fun=> \bot)%O).
-  rewrite share_prefixC; apply: (lexi_bigprod_between xbt).
-  apply:share_prefix_trans; last by apply: @start_with_prefix.
-  by rewrite share_prefixC; apply: start_with_prefix.
-move=> pfxz; rewrite set_itvE /= /Order.le /= /big_lexi_ord /= /lexi_bigprod.
-apply/andP; split.
-  case E : (first_diff _ _ ) => [m|] //; rewrite /start_with /=.
-  case mn : (_ < _)%O => //; last by rewrite le0x.
-  by (suff -> : x m = z m by done); apply: pfxz.
-case E : (first_diff _ _ ) => [m|] //; rewrite /start_with /=.
-case mn : (_ < _)%O => //; last by rewrite lex1.
-by (suff -> : x m = z m by done); exact: pfxz.
+    exact: (@start_with_prefix _ _ _ (fun=> \bot)%O).
+  apply/share_prefixC/(lexi_bigprod_between xbt).
+  apply: share_prefix_trans; last exact: start_with_prefix.
+  exact/share_prefixC/start_with_prefix.
+rewrite set_itvE /= /Order.le /= /big_lexi_ord /= /lexi_bigprod.
+apply/andP; split;case E : (first_diff _ _ ) => [m|] //; rewrite /start_with /=.
+- by case: ifPn => [/pfxz -> //|]; rewrite le0x.
+- by case: ifPn => [/pfxz -> //|]; rewrite lex1.
 Qed.

--- a/classical/classical_orders.v
+++ b/classical/classical_orders.v
@@ -10,9 +10,9 @@ From mathcomp Require Import functions set_interval.
 (* axioms than mathcomp's own orders expect                                   *)
 (*    share_prefix n == two elements in a product space agree up n            *)
 (*    first_diff x y == the first occurrence where x n != y n, or None        *)
-(*      lexi_bigprod == the (countably) infinte lexicographical ordering      *)
+(*      lexi_bigprod == the (countably) infinite lexicographical ordering      *)
 (*    big_lexi_order == an alias for attack this order type                   *)
-(*  start_with n x y == x for the first n values, then swithces to y          *)
+(*  start_with n x y == x for the first n values, then switches to y          *)
 (*                                                                            *)
 (******************************************************************************)
 Set Implicit Arguments.
@@ -37,9 +37,9 @@ Hint Resolve share_prefix0 : core.
 Lemma share_prefixC n t1 t2 : share_prefix n t1 t2 <-> share_prefix n t2 t1.
 Proof. by rewrite /share_prefix; split => + m mn => /(_ m mn). Qed.
 
-Lemma share_prefixS n m t1 t2 : 
+Lemma share_prefixS n m t1 t2 :
   n <= m -> share_prefix m t1 t2 -> share_prefix n t1 t2.
-Proof. 
+Proof.
 move=> nm + r rn; apply; move: nm; rewrite leq_eqVlt => /orP.
 by case=>[/eqP <- //|/(ltn_trans rn)]; exact.
 Qed.
@@ -47,10 +47,10 @@ Qed.
 Lemma share_prefix_refl n x : share_prefix n x x.
 Proof. by move=> ? ?. Qed.
 
-Lemma share_prefix_trans n x y z : 
-  share_prefix n x y -> 
-  share_prefix n y z -> 
-  share_prefix n x z. 
+Lemma share_prefix_trans n x y z :
+  share_prefix n x y ->
+  share_prefix n y z ->
+  share_prefix n x z.
 Proof. by move=> + + m mn => /(_ _ mn) ->; apply. Qed.
 
 Definition first_diff (t1 t2: forall n, K n) : option nat :=
@@ -63,7 +63,7 @@ by rewrite /first_diff /=; congr (_ _ _); rewrite eqEsubset; split => z /=;
   rewrite // share_prefixC.
 Qed.
 
-Lemma first_diff_unique (x y : forall n, K n) : forall (n m : nat), 
+Lemma first_diff_unique (x y : forall n, K n) : forall (n m : nat),
   (share_prefix n x y /\ x n <> y n) ->
   (share_prefix m x y /\ x m <> y m) ->
   n = m.
@@ -73,17 +73,17 @@ apply: contrapT; move/negP; rewrite neq_ltn => /orP; case => RN.
   by move: xyn; have -> := mPfx _ RN.
 by move: xym; have -> := nPfx _ RN.
 Qed.
- 
-Lemma first_diff_SomeP x y n : 
+
+Lemma first_diff_SomeP x y n :
   first_diff x y = Some n <-> share_prefix n x y /\ x n <> y n.
 Proof.
 split.
-  rewrite /first_diff; case: xgetP=> // ? -> []? [+ + <-/Some_inj nE]. 
+  rewrite /first_diff; case: xgetP=> // ? -> []? [+ + <-/Some_inj nE].
   by rewrite {}nE /= => ? ?; split.
 case=> pfx xNy; rewrite /first_diff; case: xgetP => //=; first last.
   by move/(_ (Some n)); apply: absurd; exists n.
 case; last by move => ? [].
-by move=> m -> [o] [? ?] <-; congr(_ _); apply: (@first_diff_unique x y). 
+by move=> m -> [o] [? ?] <-; congr(_ _); apply: (@first_diff_unique x y).
 Qed.
 
 Lemma first_diff_NoneP t1 t2 : t1 = t2 <-> first_diff t1 t2 = None.
@@ -101,22 +101,22 @@ case; first by case/existsNP=> m /not_implyP [//] mx; apply: absurd; apply/IH.
 by move/contrapT ->.
 Qed.
 
-Lemma first_diff_lt a x y n m : 
+Lemma first_diff_lt a x y n m :
   n < m ->
   first_diff a x = Some n ->
   first_diff a y = Some m ->
   first_diff x y = Some n.
 Proof.
-move=> nm /first_diff_SomeP [xpfx xE] /first_diff_SomeP [ypfx yE]. 
+move=> nm /first_diff_SomeP [xpfx xE] /first_diff_SomeP [ypfx yE].
 apply/first_diff_SomeP; split.
   by move=> o /[dup] on /xpfx <-; apply: ypfx; apply: (ltn_trans on).
 by have <- := ypfx _ nm; exact/nesym.
 Qed.
 
-Lemma first_diff_eq a x y n m: 
+Lemma first_diff_eq a x y n m :
   first_diff a x = Some n ->
   first_diff a y = Some n ->
-  first_diff x y = Some m -> 
+  first_diff x y = Some m ->
   n <= m.
 Proof.
 case/first_diff_SomeP => axPfx axn /first_diff_SomeP [ayPfx ayn].
@@ -124,7 +124,7 @@ case/first_diff_SomeP => xyPfx; rewrite leqNgt; apply: contra_notN => mn.
 by have <- := ayPfx _ mn; have <- := axPfx _ mn.
 Qed.
 
-Lemma first_diff_dfwith x i b : 
+Lemma first_diff_dfwith x i b :
   (x i) <> b <-> first_diff x (@dfwith _ K x i b) = Some i.
 Proof.
 split; first last.
@@ -134,8 +134,8 @@ move=> n ni; apply/eqP; rewrite dfwithout //.
 by apply/negP => /eqP E; move: ni; rewrite E ltexx.
 Qed.
 
-Definition lexi_bigprod  (R : forall n, K n -> K n -> bool) (t1 t2 : forall n, K n) :=
-  match first_diff t1 t2 with  
+Definition lexi_bigprod (R : forall n, K n -> K n -> bool) (t1 t2 : forall n, K n) :=
+  match first_diff t1 t2 with
   | Some n => R n (t1 n) (t2 n)
   | None => true
   end.
@@ -156,15 +156,15 @@ case/first_diff_SomeP: E => _; apply: contra_notP => _.
 by apply: antiR; apply/andP; split.
 Qed.
 
-Lemma lexi_bigprod_trans R : 
-  (forall n, transitive (R n)) -> 
-  (forall n, antisymmetric (R n)) -> 
+Lemma lexi_bigprod_trans R :
+  (forall n, transitive (R n)) ->
+  (forall n, antisymmetric (R n)) ->
   transitive (lexi_bigprod R).
 move=> Rtrans Ranti y x z; rewrite /lexi_bigprod /=.
 case Ep: (first_diff x y) => [p|]; last by move/first_diff_NoneP: Ep ->.
 case Er: (first_diff x z) => [r|]; last by move/first_diff_NoneP: Er ->.
 case Eq: (first_diff y z) => [q|]; first last.
-  by move: Ep Er; move/first_diff_NoneP: Eq => -> -> /Some_inj ->. 
+  by move: Ep Er; move/first_diff_NoneP: Eq => -> -> /Some_inj ->.
 have := leqVgt p q; rewrite leq_eqVlt => /orP [/orP[]|].
 - move=> /eqP pqE; move: Ep Eq; rewrite pqE => Eqx Eqz.
   rewrite first_diffC in Eqx; have := first_diff_eq Eqx Eqz Er.
@@ -188,7 +188,7 @@ case E : (first_diff x y) => [n|]; first last.
 rewrite /lexi_bigprod E first_diffC E; exact: Rtotal.
 Qed.
 
-Definition start_with n (t1 t2: forall n, K n) (i : nat) : K i := 
+Definition start_with n (t1 t2: forall n, K n) (i : nat) : K i :=
   if (i < n)%O then t1 i else t2 i.
 
 Lemma start_with_prefix n x y : share_prefix n x (start_with n x y).
@@ -197,13 +197,13 @@ Proof. by move=> r rn; rewrite /start_with rn. Qed.
 End big_lexi_order.
 
 Definition big_lexi_order {I : Type} (T : I -> Type) : Type := forall i, T i.
-HB.instance Definition _ (I : Type) (K : I -> choiceType) := 
+HB.instance Definition _ (I : Type) (K : I -> choiceType) :=
   Choice.on (big_lexi_order K).
 
 Section big_lexi_porder.
 Context {d} {K : nat -> porderType d}.
 
-Definition big_lexi_ord : rel (big_lexi_order K) := 
+Definition big_lexi_ord : rel (big_lexi_order K) :=
   lexi_bigprod (fun n k1 k2 => k1 <= k2)%O.
 
 Local Lemma big_lexi_ord_reflexive : reflexive big_lexi_ord.
@@ -225,7 +225,7 @@ Context {d} {K : nat -> orderType d}.
 Local Lemma big_lexi_ord_total : total (@big_lexi_ord _ K).
 Proof. by apply: lexi_bigprod_total => ?; exact: le_total. Qed.
 
-HB.instance Definition _ := Order.POrder_isTotal.Build _ 
+HB.instance Definition _ := Order.POrder_isTotal.Build _
   (big_lexi_order K) big_lexi_ord_total.
 
 End big_lexi_total.
@@ -234,12 +234,12 @@ Section big_lexi_bottom.
 Context {d} {K : nat -> bPOrderType d}.
 
 Local Lemma big_lex_bot x : (@big_lexi_ord _ K) (fun=> \bot)%O x.
-Proof. 
+Proof.
 rewrite /big_lexi_ord/lexi_bigprod.
 by case E: (first_diff _ _); [exact: Order.le0x | done].
 Qed.
 
-HB.instance Definition _ := @Order.hasBottom.Build _ 
+HB.instance Definition _ := @Order.hasBottom.Build _
   (big_lexi_order K) (fun=> \bot)%O big_lex_bot.
 
 End big_lexi_bottom.
@@ -248,20 +248,20 @@ Section big_lexi_top.
 Context {d} {K : nat -> tPOrderType d}.
 
 Local Lemma big_lex_top x : (@big_lexi_ord _ K) x (fun=> \top)%O.
-Proof. 
+Proof.
 rewrite /big_lexi_ord/lexi_bigprod.
 by case E: (first_diff _ _); [exact: Order.lex1 | done].
 Qed.
 
-HB.instance Definition _ := @Order.hasTop.Build _ 
+HB.instance Definition _ := @Order.hasTop.Build _
   (big_lexi_order K) (fun=> \top)%O big_lex_top.
 
 End big_lexi_top.
 
 Section big_lexi_intervals.
 Context {d} {K : nat -> orderType d}.
-Lemma lexi_bigprod_prefix_lt (b a x: big_lexi_order K) n: 
-  (a < b)%O -> 
+Lemma lexi_bigprod_prefix_lt (b a x: big_lexi_order K) n :
+  (a < b)%O ->
   first_diff a b = Some n ->
   share_prefix n.+1 x b ->
   (a < x)%O.
@@ -272,15 +272,15 @@ case E1 : (first_diff a x) => [m|]; first last.
 move=> ab pfx; apply/andP; split.
   by apply/negP => /eqP/first_diff_NoneP; rewrite first_diffC E1.
 move: ab; rewrite /Order.lt/= => /andP [?].
-rewrite /big_lexi_ord /lexi_bigprod E1 abD; suff : n = m. 
+rewrite /big_lexi_ord /lexi_bigprod E1 abD; suff : n = m.
   by have := pfx n (ltnSn _) => /[swap] -> ->.
 apply: (@first_diff_unique _ a x) => //=; last by case/first_diff_SomeP:E1.
 split; last by by have -> := pfx n (ltnSn _).
 by apply: (share_prefix_trans pfa); rewrite share_prefixC; exact: share_prefixS.
 Qed.
 
-Lemma lexi_bigprod_prefix_gt (b a x: big_lexi_order K) n:
-  (b < a)%O -> 
+Lemma lexi_bigprod_prefix_gt (b a x: big_lexi_order K) n :
+  (b < a)%O ->
   first_diff a b = Some n ->
   share_prefix n.+1 x b ->
   (x < a)%O.
@@ -291,17 +291,17 @@ case E1 : (first_diff x a) => [m|]; first last.
 move=> ab pfx; apply/andP; split.
   by apply/negP => /eqP/first_diff_NoneP; rewrite first_diffC E1.
 move: ab; rewrite /Order.lt/= => /andP [?].
-rewrite /big_lexi_ord /lexi_bigprod [_ b a]first_diffC E1 abD; suff : n = m. 
+rewrite /big_lexi_ord /lexi_bigprod [_ b a]first_diffC E1 abD; suff : n = m.
   by have := pfx n (ltnSn _) => /[swap] -> ->.
 apply: (@first_diff_unique _ x a) => //=; last by case/first_diff_SomeP:E1.
 rewrite share_prefixC; split; last by have -> := pfx n (ltnSn _); apply/nesym.
 by apply: (share_prefix_trans pfa); rewrite share_prefixC; exact: share_prefixS.
 Qed.
 
-Lemma lexi_bigprod_between (a x b: big_lexi_order K) n:
-  (a <= x <= b)%O -> 
-  share_prefix n a b -> 
-  share_prefix n x a. 
+Lemma lexi_bigprod_between (a x b: big_lexi_order K) n :
+  (a <= x <= b)%O ->
+  share_prefix n a b ->
+  share_prefix n x a.
 Proof.
 move=> axb; elim: n => // n IH.
 move=> pfxSn m mSn; have pfxA : share_prefix n a x.
@@ -315,47 +315,47 @@ move/eqP ->; apply: le_anti; apply/andP; split.
   case/andP:axb => ? +; rewrite {1}/Order.le/=/big_lexi_ord/lexi_bigprod.
   have -> := pfxSn n (ltnSn _).
   case E : (first_diff x b) => [r|]; last by move/first_diff_NoneP:E ->.
-  move=> xrb; have : n <= r. 
+  move=> xrb; have : n <= r.
     rewrite leqNgt; apply/negP=> /[dup] /pfxB xbE.
-    by case/first_diff_SomeP:E => _; rewrite xbE. 
+    by case/first_diff_SomeP:E => _; rewrite xbE.
   rewrite leq_eqVlt => /orP [/eqP -> //|] => nr.
-  by case/first_diff_SomeP:E => /(_ n nr) ->. 
+  by case/first_diff_SomeP:E => /(_ n nr) ->.
 case/andP:axb => + ?; rewrite {1}/Order.le/=/big_lexi_ord/lexi_bigprod.
-case E : (first_diff a x) => [r|]; last by move/first_diff_NoneP:E <-. 
-move=> xrb; have : n <= r. 
+case E : (first_diff a x) => [r|]; last by move/first_diff_NoneP:E <-.
+move=> xrb; have : n <= r.
   rewrite leqNgt; apply/negP=> /[dup] /pfxA xbE.
-  by case/first_diff_SomeP:E => _; rewrite xbE. 
+  by case/first_diff_SomeP:E => _; rewrite xbE.
 rewrite leq_eqVlt => /orP [/eqP -> //|] => nr.
-by case/first_diff_SomeP:E => /(_ n nr) ->. 
+by case/first_diff_SomeP:E => /(_ n nr) ->.
 Qed.
 
 Lemma big_lexi_interval_prefix (i : interval (big_lexi_order K))
-    (x : big_lexi_order K) : 
+    (x : big_lexi_order K) :
   itv_open_ends i -> x \in i ->
   exists n, (share_prefix n x `<=` [set` i]).
 Proof.
 move: i; case=> [][[]l|[]] [[]r|[]] [][]; rewrite ?in_itv /= ?andbT.
-- move=> /andP [] lx xr. 
+- move=> /andP [] lx xr.
   case E1 : (first_diff l x) => [m|]; first last.
     by move: lx; move/first_diff_NoneP: E1 ->; rewrite bnd_simp.
   case E2 : (first_diff x r) => [n|]; first last.
     by move: xr; move/first_diff_NoneP: E2 ->; rewrite bnd_simp.
-  exists (Order.max n m).+1 => p xppfx; rewrite set_itvE. 
-  apply/andP; split. 
+  exists (Order.max n m).+1 => p xppfx; rewrite set_itvE.
+  apply/andP; split.
     apply: (lexi_bigprod_prefix_lt lx E1) => w wm; apply/sym_equal/xppfx.
     by move/ltnSE/leq_ltn_trans: wm; apply; rewrite ltnS leq_max leqnn orbT.
   rewrite first_diffC in E2.
   apply: (lexi_bigprod_prefix_gt xr E2) => w wm; apply/sym_equal/xppfx.
   by move/ltnSE/leq_ltn_trans: wm; apply; rewrite ltnS leq_max leqnn.
-- move=> lx. 
+- move=> lx.
   case E1 : (first_diff l x) => [m|]; first last.
     by move: lx; move/first_diff_NoneP: E1 ->; rewrite bnd_simp.
   exists m.+1 => p xppfx; rewrite set_itvE /=.
   by apply: (lexi_bigprod_prefix_lt lx E1) => w wm; apply/sym_equal/xppfx.
-- move=> xr. 
+- move=> xr.
   case E2 : (first_diff x r) => [n|]; first last.
     by move: xr; move/first_diff_NoneP: E2 ->; rewrite bnd_simp.
-  exists n.+1; rewrite first_diffC in E2 => p xppfx. 
+  exists n.+1; rewrite first_diffC in E2 => p xppfx.
   rewrite set_itvE /=.
   by apply: (lexi_bigprod_prefix_gt xr E2) => w wm; apply/sym_equal/xppfx.
 by move=> _; exists 0=> ? ?; rewrite set_itvE.
@@ -363,9 +363,9 @@ Qed.
 End big_lexi_intervals.
 
 (** TODO: generalize to tbOrderType when that's available in mathcomp*)
-Lemma shared_prefix_closed_itv {d} {K : nat -> finOrderType d} n  
+Lemma shared_prefix_closed_itv {d} {K : nat -> finOrderType d} n
   (x : big_lexi_order K) :
-  share_prefix n x = 
+  share_prefix n x =
     `[(start_with n x (fun=>\bot):big_lexi_order K)%O, (start_with n x (fun=>\top))%O].
 Proof.
 rewrite eqEsubset; split=> z; first last.
@@ -374,7 +374,7 @@ rewrite eqEsubset; split=> z; first last.
   rewrite share_prefixC; apply: (lexi_bigprod_between xbt).
   apply:share_prefix_trans; last by apply: @start_with_prefix.
   by rewrite share_prefixC; apply: start_with_prefix.
-move=> pfxz; rewrite set_itvE /= /Order.le /= /big_lexi_ord /= /lexi_bigprod. 
+move=> pfxz; rewrite set_itvE /= /Order.le /= /big_lexi_ord /= /lexi_bigprod.
 apply/andP; split.
   case E : (first_diff _ _ ) => [m|] //; rewrite /start_with /=.
   case mn : (_ < _)%O => //; last by rewrite le0x.

--- a/classical/classical_orders.v
+++ b/classical/classical_orders.v
@@ -9,10 +9,10 @@ From mathcomp Require Import functions set_interval.
 (* This file provides some additional order theory that requires stronger     *)
 (* axioms than mathcomp's own orders expect.                                  *)
 (* ```                                                                        *)
-(*    same_prefix n == two elements in a product space agree up n             *)
+(*     same_prefix n == two elements in a product space agree up n            *)
 (*    first_diff x y == the first occurrence where x n != y n, or None        *)
-(*      lexi_bigprod == the (countably) infinite lexicographical ordering     *)
-(*    big_lexi_order == an alias for attack this order type                   *)
+(*       big_lexi_le == the (countably) infinite lexicographical ordering     *)
+(*    big_lexi_order == an alias for attaching this order type                *)
 (*  start_with n x y == x for the first n values, then switches to y          *)
 (* ```                                                                        *)
 (*                                                                            *)
@@ -25,7 +25,11 @@ Import Order.TTheory GRing.Theory Num.Def Num.Theory.
 
 Local Open Scope classical_set_scope.
 
-Section big_lexi_order.
+Definition big_lexi_order {I : Type} (T : I -> Type) : Type := forall i, T i.
+HB.instance Definition _ (I : Type) (K : I -> choiceType) :=
+  Choice.on (big_lexi_order K).
+
+Section big_lexi_le.
 Context {K : nat -> eqType}.
 
 Definition same_prefix n (t1 t2 : forall n, K n) :=
@@ -123,32 +127,32 @@ apply/first_diff_SomeP; split; last by rewrite dfwithin.
 by move=> n ni; rewrite dfwithout// gt_eqF.
 Qed.
 
-Definition lexi_bigprod
+Definition big_lexi_le
     (R : forall n, K n -> K n -> bool) (t1 t2 : forall n, K n) :=
   if first_diff t1 t2 is Some n then R n (t1 n) (t2 n) else true.
 
-Lemma lexi_bigprod_reflexive R : reflexive (lexi_bigprod R).
+Lemma big_lexi_le_reflexive R : reflexive (big_lexi_le R).
 Proof.
-move=> x; rewrite /lexi_bigprod /= /first_diff.
+move=> x; rewrite /big_lexi_le /= /first_diff.
 by case: xgetP => //= -[n _|//] [m []]; rewrite eqxx.
 Qed.
 
-Lemma lexi_bigprod_anti R : (forall n, antisymmetric (R n)) ->
-  antisymmetric (lexi_bigprod R).
+Lemma big_lexi_le_anti R : (forall n, antisymmetric (R n)) ->
+  antisymmetric (big_lexi_le R).
 Proof.
 move=> antiR x y /andP[xy yx]; apply/first_diff_NoneP; move: xy yx.
-rewrite /lexi_bigprod first_diff_sym.
+rewrite /big_lexi_le first_diff_sym.
 case E : (first_diff y x) => [n|]// Rxy Ryx.
 case/first_diff_SomeP : E => _.
 by apply: contra_neqP => _; apply/antiR; rewrite Ryx.
 Qed.
 
-Lemma lexi_bigprod_trans R :
+Lemma big_lexi_le_trans R :
   (forall n, transitive (R n)) ->
   (forall n, antisymmetric (R n)) ->
-  transitive (lexi_bigprod R).
+  transitive (big_lexi_le R).
 Proof.
-move=> Rtrans Ranti y x z; rewrite /lexi_bigprod /=.
+move=> Rtrans Ranti y x z; rewrite /big_lexi_le /=.
 case Ep : (first_diff x y) => [p|]; last by move/first_diff_NoneP : Ep ->.
 case Er : (first_diff x z) => [r|]; last by move/first_diff_NoneP : Er ->.
 case Eq : (first_diff y z) => [q|]; first last.
@@ -168,12 +172,12 @@ have [pq|qp|pqE]:= ltgtP p q.
   by apply/Ranti/andP; split.
 Qed.
 
-Lemma lexi_bigprod_total R : (forall n, total (R n)) -> total (lexi_bigprod R).
+Lemma big_lexi_le_total R : (forall n, total (R n)) -> total (big_lexi_le R).
 Proof.
 move=> Rtotal x y.
 case E : (first_diff x y) => [n|]; first last.
-  by move/first_diff_NoneP : E ->; rewrite lexi_bigprod_reflexive.
-by rewrite /lexi_bigprod E first_diff_sym E; exact: Rtotal.
+  by move/first_diff_NoneP : E ->; rewrite big_lexi_le_reflexive.
+by rewrite /big_lexi_le E first_diff_sym E; exact: Rtotal.
 Qed.
 
 Definition start_with n (t1 t2 : forall n, K n) (i : nat) : K i :=
@@ -182,79 +186,75 @@ Definition start_with n (t1 t2 : forall n, K n) (i : nat) : K i :=
 Lemma start_with_prefix n x y : same_prefix n x (start_with n x y).
 Proof. by move=> r rn; rewrite /start_with rn. Qed.
 
-End big_lexi_order.
-
-Definition big_lexi_order {I : Type} (T : I -> Type) : Type := forall i, T i.
-HB.instance Definition _ (I : Type) (K : I -> choiceType) :=
-  Choice.on (big_lexi_order K).
+End big_lexi_le.
 
 Section big_lexi_porder.
 Context {d} {K : nat -> porderType d}.
 
-Definition big_lexi_ord : rel (big_lexi_order K) :=
-  lexi_bigprod (fun n k1 k2 => k1 <= k2)%O.
+Let Rn n (k1 k2 : K n) := (k1 <= k2)%O.
 
-Local Lemma big_lexi_ord_reflexive : reflexive big_lexi_ord.
-Proof. exact: lexi_bigprod_reflexive. Qed.
+Local Lemma big_lexi_ord_reflexive : reflexive (big_lexi_le Rn).
+Proof. exact: big_lexi_le_reflexive. Qed.
 
-Local Lemma big_lexi_ord_anti : antisymmetric big_lexi_ord.
-Proof. by apply: lexi_bigprod_anti => n; exact: le_anti. Qed.
+Local Lemma big_lexi_ord_anti : antisymmetric (big_lexi_le Rn).
+Proof. by apply: big_lexi_le_anti => n; exact: le_anti. Qed.
 
-Local Lemma big_lexi_ord_trans : transitive big_lexi_ord.
-Proof. by apply: lexi_bigprod_trans=> n; [exact: le_trans|exact: le_anti]. Qed.
+Local Lemma big_lexi_ord_trans : transitive (big_lexi_le Rn).
+Proof. by apply: big_lexi_le_trans => n; [exact: le_trans|exact: le_anti]. Qed.
 
 HB.instance Definition _ := Order.Le_isPOrder.Build d (big_lexi_order K)
   big_lexi_ord_reflexive big_lexi_ord_anti big_lexi_ord_trans.
+
+Lemma leEbig_lexi_order (a b : big_lexi_order K) :
+  (a <= b)%O = if first_diff a b is Some n then (a n <= b n)%O else true.
+
+Proof. by []. Qed.
 
 End big_lexi_porder.
 
 Section big_lexi_total.
 Context {d} {K : nat -> orderType d}.
 
-Local Lemma big_lexi_ord_total : total (@big_lexi_ord _ K).
-Proof. by apply: lexi_bigprod_total => ?; exact: le_total. Qed.
+Local Lemma big_lexi_ord_total : total (@Order.le _ (big_lexi_order K)).
+Proof. by apply: big_lexi_le_total => ?; exact: le_total. Qed.
 
 HB.instance Definition _ := Order.POrder_isTotal.Build _
   (big_lexi_order K) big_lexi_ord_total.
-
-Lemma leEbig_lexi_order (a b : big_lexi_order K) :
-  (a <= b)%O = if first_diff a b is Some n then (a n <= b n)%O else true.
-Proof. by []. Qed.
 
 End big_lexi_total.
 
 Section big_lexi_bottom.
 Context {d} {K : nat -> bPOrderType d}.
 
-Local Lemma big_lex_bot x : (@big_lexi_ord _ K) (fun=> \bot)%O x.
+Let b : big_lexi_order K := (fun=> \bot)%O.
+Local Lemma big_lex_bot (x : big_lexi_order K) : (b <= x)%O.
 Proof.
-rewrite /big_lexi_ord /lexi_bigprod.
-by case: first_diff => // ?; exact: Order.le0x.
+by rewrite leEbig_lexi_order; case: first_diff => // ?; exact: Order.le0x.
 Qed.
 
 HB.instance Definition _ := @Order.hasBottom.Build _
-  (big_lexi_order K) (fun=> \bot)%O big_lex_bot.
+  (big_lexi_order K) b big_lex_bot.
 
 End big_lexi_bottom.
 
 Section big_lexi_top.
 Context {d} {K : nat -> tPOrderType d}.
 
-Local Lemma big_lex_top x : (@big_lexi_ord _ K) x (fun=> \top)%O.
+Let t : big_lexi_order K := (fun=> \top)%O.
+Local Lemma big_lex_top (x : big_lexi_order K) : (x <= t)%O.
 Proof.
-rewrite /big_lexi_ord /lexi_bigprod.
-by case: first_diff => // ?; exact: Order.lex1.
+by rewrite leEbig_lexi_order; case: first_diff => // ?; exact: Order.lex1.
 Qed.
 
 HB.instance Definition _ := @Order.hasTop.Build _
-  (big_lexi_order K) (fun=> \top)%O big_lex_top.
+  (big_lexi_order K) t big_lex_top.
 
 End big_lexi_top.
 
 Section big_lexi_intervals.
 Context {d} {K : nat -> orderType d}.
 
-Lemma lexi_bigprod_prefix_lt (b a x: big_lexi_order K) n :
+Lemma big_lexi_order_prefix_lt (b a x: big_lexi_order K) n :
   (a < b)%O ->
   first_diff a b = Some n ->
   same_prefix n.+1 x b ->
@@ -273,7 +273,7 @@ apply: (@first_diff_unique _ a x) => //=; [| |by case/first_diff_SomeP : E1..].
 - by rewrite (pfx n (ltnSn _)).
 Qed.
 
-Lemma lexi_bigprod_prefix_gt (b a x : big_lexi_order K) n :
+Lemma big_lexi_order_prefix_gt (b a x : big_lexi_order K) n :
   (b < a)%O ->
   first_diff a b = Some n ->
   same_prefix n.+1 x b ->
@@ -293,7 +293,7 @@ apply: (@first_diff_unique _ x a) => //=; [| |by case/first_diff_SomeP : E1..].
 - by rewrite (pfx n (ltnSn _)) eq_sym; exact/eqP.
 Qed.
 
-Lemma lexi_bigprod_between (a x b : big_lexi_order K) n :
+Lemma big_lexi_order_between (a x b : big_lexi_order K) n :
   (a <= x <= b)%O ->
   same_prefix n a b ->
   same_prefix n x a.
@@ -324,7 +324,7 @@ rewrite leq_eqVlt => /predU1P[->//|nr].
 by case/first_diff_SomeP : E => /(_ n nr) ->.
 Qed.
 
-Lemma big_lexi_interval_prefix (i : interval (big_lexi_order K))
+Lemma big_lexi_order_interval_prefix (i : interval (big_lexi_order K))
     (x : big_lexi_order K) :
   itv_open_ends i -> x \in i ->
   exists n, same_prefix n x `<=` [set` i].
@@ -337,28 +337,28 @@ move: i; case=> [][[]l|[]] [[]r|[]] [][]; rewrite ?in_itv /= ?andbT.
     by move: xr; move/first_diff_NoneP : E2 ->; rewrite bnd_simp.
   exists (Order.max n m).+1 => p xppfx; rewrite set_itvE.
   apply/andP; split.
-    apply: (lexi_bigprod_prefix_lt lx E1) => w wm; apply/esym/xppfx.
+    apply: (big_lexi_order_prefix_lt lx E1) => w wm; apply/esym/xppfx.
     by move/ltnSE/leq_ltn_trans : wm; apply; rewrite ltnS leq_max leqnn orbT.
   rewrite first_diff_sym in E2.
-  apply: (lexi_bigprod_prefix_gt xr E2) => w wm; apply/esym/xppfx.
+  apply: (big_lexi_order_prefix_gt xr E2) => w wm; apply/esym/xppfx.
   by move/ltnSE/leq_ltn_trans : wm; apply; rewrite ltnS leq_max leqnn.
 - move=> lx.
   case E1 : (first_diff l x) => [m|]; first last.
     by move: lx; move/first_diff_NoneP : E1 ->; rewrite bnd_simp.
   exists m.+1 => p xppfx; rewrite set_itvE /=.
-  by apply: (lexi_bigprod_prefix_lt lx E1) => w wm; exact/esym/xppfx.
+  by apply: (big_lexi_order_prefix_lt lx E1) => w wm; exact/esym/xppfx.
 - move=> xr.
   case E2 : (first_diff x r) => [n|]; first last.
     by move: xr; move/first_diff_NoneP : E2 ->; rewrite bnd_simp.
   exists n.+1; rewrite first_diff_sym in E2 => p xppfx.
   rewrite set_itvE /=.
-  by apply: (lexi_bigprod_prefix_gt xr E2) => w wm; exact/esym/xppfx.
+  by apply: (big_lexi_order_prefix_gt xr E2) => w wm; exact/esym/xppfx.
 by move=> _; exists 0 => ? ?; rewrite set_itvE.
 Qed.
 End big_lexi_intervals.
 
 (** TODO: generalize to tbOrderType when that's available in mathcomp *)
-Lemma same_prefix_closed_itv {d} {K : nat -> finOrderType d} n
+Lemma big_lexi_order_prefix_closed_itv {d} {K : nat -> finOrderType d} n
   (x : big_lexi_order K) :
   same_prefix n x = `[
     (start_with n x (fun=>\bot):big_lexi_order K)%O,
@@ -367,7 +367,7 @@ Proof.
 rewrite eqEsubset; split=> [z pfxz|z]; first last.
   rewrite set_itvE /= => xbt; apply: same_prefix_trans.
     exact: (start_with_prefix _ (fun=> \bot)%O).
-  apply/same_prefix_sym/(lexi_bigprod_between xbt).
+  apply/same_prefix_sym/(big_lexi_order_between xbt).
   apply: same_prefix_trans (start_with_prefix _ _).
   exact/same_prefix_sym/start_with_prefix.
 rewrite set_itvE /= !leEbig_lexi_order; apply/andP; split;


### PR DESCRIPTION
lexical ordering over nats, uses more axioms than mathcomp's order, so it makes sense to put it in classical. This topology is mostly useful for finitely branching trees, where the product and this order topology agree. Such proofs are coming next. 

This PR slightly depends on the order topology PR for some definitions in `set_interval`, so review that one first. 
<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Checklist

- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
