### PR TITLE
add in_nearW

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -17,7 +17,7 @@
   + lemmas `cvg_pinftyP`, `cvg_ninftyP`
 
 - in `topology.v`:
-  + lemma `in_nearW`
+  + lemmas `in_nearW`, `open_in_nearW`
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -16,6 +16,9 @@
 - in `realfun.v`:
   + lemmas `cvg_pinftyP`, `cvg_ninftyP`
 
+- in `topology.v`:
+  + lemma `in_nearW`
+
 ### Changed
 
 ### Renamed

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -7176,3 +7176,13 @@ Qed.
 Local Close Scope relation_scope.
 
 #[global] Hint Resolve uniform_regular : core.
+
+Lemma in_nearW (R : topologicalType) (P : R -> Prop) (S : set R) :
+  @open R^o S ->
+ {in S, forall x, P x} ->
+ {in S, forall x, \near x, P x}.
+Proof.
+move=> oS HP z /set_mem Sz.
+rewrite -nbhs_nearE nbhsE/=.
+by exists S; last move=> x /mem_set/HP.
+Qed.

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -782,6 +782,13 @@ Arguments filter_not_empty {T} F {_}.
 
 Notation ProperFilter := ProperFilter'.
 
+Lemma in_nearW {T : Type} (F : set_system T) (P : T -> Prop) (S : set T) :
+  Filter F -> F S -> {in S, forall x, P x} -> \near F, P F.
+Proof.
+move=> FF FS SP; rewrite -nbhs_nearE.
+by apply: (@filterS _ F _ S) => // x /mem_set /SP.
+Qed.
+
 Lemma filter_setT (T' : Type) : Filter [set: set T'].
 Proof. by constructor. Qed.
 
@@ -980,7 +987,7 @@ Arguments near {T F P} FP x Px.
 
 Lemma nearW {T : Type} {F : set_system T} (P : T -> Prop) :
   Filter F -> (forall x, P x) -> (\forall x \near F, P x).
-Proof. by move=> FF FP; apply: filterS filterT. Qed.
+Proof. by move=> FF FP; exact: (in_nearW _ filterT). Qed.
 
 Lemma filterE {T : Type} {F : set_system T} :
   Filter F -> forall P : set T, (forall x, P x) -> F P.
@@ -1799,16 +1806,22 @@ Qed.
 
 End Topological1.
 
+Lemma open_in_nearW {T : topologicalType} (P : T -> Prop) (S : set T) :
+  open S -> {in S, forall x, P x} -> {in S, forall x, \near x, P x}.
+Proof.
+by move=> oS SP z /set_mem Sz; apply: in_nearW SP => //=; exact: open_nbhs_nbhs.
+Qed.
+
 #[global] Hint Extern 0 (Filter (nbhs _)) =>
   solve [apply: nbhs_filter] : typeclass_instances.
 #[global] Hint Extern 0 (ProperFilter (nbhs _)) =>
   solve [apply: nbhs_pfilter] : typeclass_instances.
 
-Global Instance alias_nbhs_filter {T : topologicalType} x : 
+Global Instance alias_nbhs_filter {T : topologicalType} x :
   @Filter T^o (@nbhs T^o T x).
 Proof. apply: @nbhs_filter T x. Qed.
 
-Global Instance alias_nbhs_pfilter {T : topologicalType} x : 
+Global Instance alias_nbhs_pfilter {T : topologicalType} x :
   @ProperFilter T^o (@nbhs T^o T x).
 Proof. exact: @nbhs_pfilter T x. Qed.
 
@@ -7176,27 +7189,3 @@ Qed.
 Local Close Scope relation_scope.
 
 #[global] Hint Resolve uniform_regular : core.
-
-Lemma in_nearW (U : Type) (T : filteredType U) (F : set_system T)
- (P : T -> Prop) (S : set T) :
-  Filter F ->
-  F S ->
- {in S, forall x, P x} ->
- \near F, P F.
-Proof.
-move=> filF FS HP.
-rewrite -nbhs_nearE.
-apply: (@filterS _ F _ S) => //.
-by move=> x /mem_set/HP.
-Qed.
-
-Lemma open_in_nearW (R : topologicalType) (P : R -> Prop) (S : set R) :
-  open S ->
- {in S, forall x, P x} ->
- {in S, forall x, \near x, P x}.
-Proof.
-move=> oS HP z /set_mem Sz.
-apply: in_nearW HP.
-rewrite /=.
-by apply: open_nbhs_nbhs; split.
-Qed.

--- a/theories/topology.v
+++ b/theories/topology.v
@@ -7177,12 +7177,26 @@ Local Close Scope relation_scope.
 
 #[global] Hint Resolve uniform_regular : core.
 
-Lemma in_nearW (R : topologicalType) (P : R -> Prop) (S : set R) :
-  @open R^o S ->
+Lemma in_nearW (U : Type) (T : filteredType U) (F : set_system T)
+ (P : T -> Prop) (S : set T) :
+  Filter F ->
+  F S ->
+ {in S, forall x, P x} ->
+ \near F, P F.
+Proof.
+move=> filF FS HP.
+rewrite -nbhs_nearE.
+apply: (@filterS _ F _ S) => //.
+by move=> x /mem_set/HP.
+Qed.
+
+Lemma open_in_nearW (R : topologicalType) (P : R -> Prop) (S : set R) :
+  open S ->
  {in S, forall x, P x} ->
  {in S, forall x, \near x, P x}.
 Proof.
 move=> oS HP z /set_mem Sz.
-rewrite -nbhs_nearE nbhsE/=.
-by exists S; last move=> x /mem_set/HP.
+apply: in_nearW HP.
+rewrite /=.
+by apply: open_nbhs_nbhs; split.
 Qed.


### PR DESCRIPTION
##### Motivation for this change
add lemma which is `{in S, ...}` version of `nearW` for topologicalType and open set `S`.

this lemma is used in other my work (#1294 )
<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
