### PR TITLE
weaken expR_ge1Dx

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -40,6 +40,9 @@
     `big_lexi_order_between`, `big_lexi_order_interval_prefix`, and
     `big_lexi_order_prefix_closed_itv`.
 
+- in `exp.v`:
+  + lemma `expR_gt1Dx`
+
 ### Changed
 
 - in `numfun.v`:
@@ -180,6 +183,10 @@
   + lemma `integral_setD1_EFin`
   + lemmas `integral_itv_bndo_bndc`, `integral_itv_obnd_cbnd`
   + lemmas `Rintegral_itv_bndo_bndc`, `Rintegral_itv_obnd_cbnd`
+
+- in `exp.v`:
+  + lemmas `expR_ge1Dx` and `expeR_ge1Dx` (remove hypothesis)
+  + lemma `le_ln1Dx` (weaken hypothesis)
 
 ### Deprecated
 


### PR DESCRIPTION
##### Motivation for this change

This is needed in infotheo to prove partition inequality

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [ ] added corresponding documentation in the headers~~

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
