### PR TITLE
Remove duplicated lemmas and dependency to Rstruct

### DIFF
--- a/theories/numfun.v
+++ b/theories/numfun.v
@@ -480,7 +480,7 @@ Lemma urysohn_ext_itv A B x y :
     f @` A `<=` [set x], f @` B `<=` [set y] & range f `<=` `[x, y]].
 Proof.
 move=> cA cB A0 xy; move/normal_separatorP : normalX => urysohn_ext.
-have /(@uniform_separatorP _ R)[f [cf f01 f0 f1]] := urysohn_ext _ _ cA cB A0.
+have /(@uniform_separatorP _ R)[f [cf f01 f0 f1]] := urysohn_ext R _ _ cA cB A0.
 pose g : X -> R := line_path x y \o f; exists g; split; rewrite /g /=.
   move=> t; apply: continuous_comp; first exact: cf.
   apply: (@continuousD R R^o).


### PR DESCRIPTION
##### Motivation for this change

This both removes copy/pasted lemmas (the removed lemmas are still in Rstruct.v) and an undue dependency to Rstruct.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Checklist

- ~[ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`~

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- ~[ ] added corresponding documentation in the headers~

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
