### PR TITLE
Rintegral atan expR

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -24,6 +24,9 @@
 - in `lebesgue_measure.v`:
   + lemmas `RintegralZl`, `RintegralZr`, `Rintegral_ge0`
 
+- in `trigo.v`:
+  + lemmas `derive1_atan`, `lt_atan`, `le_atan`, `cvgy_atan`
+
 ### Changed
 
 - The file `topology.v` has been split into several files in the directory 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -27,6 +27,9 @@
 - in `trigo.v`:
   + lemmas `derive1_atan`, `lt_atan`, `le_atan`, `cvgy_atan`
 
+- in `exp.v`:
+  + lemmas `cvgr_expR`, `cvgn_expR`
+
 ### Changed
 
 - The file `topology.v` has been split into several files in the directory 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -21,6 +21,8 @@
   + `weak_topology.v`
   + `num_topology.v`
   + `quotient_topology.v`
+- in `lebesgue_measure.v`:
+  + lemmas `RintegralZl`, `RintegralZr`, `Rintegral_ge0`
 
 ### Changed
 

--- a/theories/exp.v
+++ b/theories/exp.v
@@ -479,6 +479,21 @@ Proof.
 by have [->|/expR_gt1Dx/ltW//] := eqVneq x 0; rewrite expR0 addr0.
 Qed.
 
+Lemma cvgr_expR : @expR R (- x) @[x --> +oo] --> 0.
+Proof.
+apply/cvgrPdist_le => e e0; near=> x.
+rewrite sub0r normrN ger0_norm; last exact: expR_ge0.
+rewrite expRN -[leRHS]invrK lef_pV2 ?posrE ?expR_gt0 ?invr_gt0//.
+rewrite (le_trans _ (expR_ge1Dx _))// -lerBlDl.
+by near: x; apply: nbhs_pinfty_ge; exact: num_real.
+Unshelve. end_near. Qed.
+
+Lemma cvgn_expR : @expR R (- n%:R) @[n --> \oo] --> 0%R.
+Proof.
+under eq_cvg do rewrite -mulNrn -mulr_natr expRM_natr; apply: cvg_expr.
+by rewrite ger0_norm ?expR_ge0// expRN invf_lt1 ?expR_gt1// expR_gt0.
+Qed.
+
 Lemma expR_inj : injective (@expR R).
 Proof.
 move=> x y exE.

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -4347,13 +4347,11 @@ End dominated_convergence_theorem.
 Section Rintegral.
 Context d {T : measurableType d} {R : realType}.
 Variable mu : {measure set T -> \bar R}.
+Implicit Types (D A B : set T) (f : T -> R).
 
 Lemma eq_Rintegral D g f : {in D, f =1 g} ->
   \int[mu]_(x in D) f x = \int[mu]_(x in D) g x.
-Proof.
-move=> fg; rewrite /Rintegral; congr fine.
-by apply: eq_integral => /= x xD; rewrite fg.
-Qed.
+Proof. by move=> fg; congr fine; apply: eq_integral => /= x xD; rewrite fg. Qed.
 
 Lemma Rintegral_mkcond D f : \int[mu]_(x in D) f x = \int[mu]_x (f \_ D) x.
 Proof.
@@ -4372,14 +4370,33 @@ Lemma Rintegral_mkcondl D P f :
   \int[mu]_(x in P `&` D) f x = \int[mu]_(x in D) (f \_ P) x.
 Proof. by rewrite setIC Rintegral_mkcondr. Qed.
 
-Lemma le_normr_integral A f : measurable A -> mu.-integrable A (EFin \o f) ->
-  (`|\int[mu]_(t in A) f t| <= \int[mu]_(t in A) `|f t|)%R.
+Lemma RintegralZl D f r : measurable D -> mu.-integrable D (EFin \o f) ->
+  \int[mu]_(x in D) (r * f x) = r * \int[mu]_(x in D) f x.
+Proof.
+move=> mD intf; rewrite (_ : r = fine r%:E)// -fineM//; last first.
+  exact: integral_fune_fin_num.
+by congr fine; under eq_integral do rewrite EFinM; exact: integralZl.
+Qed.
+
+Lemma RintegralZr D f r : measurable D -> mu.-integrable D (EFin \o f) ->
+  \int[mu]_(x in D) (f x * r) = \int[mu]_(x in D) f x * r.
+Proof.
+move=> mD intf; rewrite mulrC -RintegralZl//.
+by under eq_Rintegral do rewrite mulrC.
+Qed.
+
+Lemma Rintegral_ge0 D f : (forall x, D x -> 0 <= f x) ->
+  0 <= \int[mu]_(x in D) f x.
+Proof. by move=> f0; rewrite fine_ge0// integral_ge0. Qed.
+
+Lemma le_normr_integral D f : measurable D -> mu.-integrable D (EFin \o f) ->
+  `|\int[mu]_(t in D) f t| <= \int[mu]_(t in D) `|f t|.
 Proof.
 move=> mA /integrableP[mf ifoo].
 rewrite -lee_fin; apply: le_trans.
   apply: (le_trans _ (le_abse_integral mu mA mf)).
   rewrite /abse.
-  have [/fineK <-//|] := boolP (\int[mu]_(x in A) (EFin \o f) x \is a fin_num)%E.
+  have [/fineK <-//|] := boolP (\int[mu]_(x in D) (EFin \o f) x \is a fin_num)%E.
   by rewrite fin_numEn => /orP[|] /eqP ->; rewrite leey.
 rewrite /Rintegral.
 move: ifoo.
@@ -4407,7 +4424,7 @@ rewrite fineD//.
 - by rewrite fin_num_abs (le_lt_trans _ itBfoo)//; exact: le_abse_integral.
 Qed.
 
-Lemma Rintegral_set0 (f : T -> R) : (\int[mu]_(x in set0) f x = 0)%R.
+Lemma Rintegral_set0 f : \int[mu]_(x in set0) f x = 0.
 Proof. by rewrite /Rintegral integral_set0. Qed.
 
 End Rintegral.

--- a/theories/trigo.v
+++ b/theories/trigo.v
@@ -1239,7 +1239,7 @@ move: cos_gt0; rewrite cosE ltNge; case/negP.
 by rewrite oppr_le0 invr_ge0 sqrtr_ge0.
 Qed.
 
-Global Instance is_derive1_atan x : is_derive x 1 (@atan R) (1 + x ^+ 2)^-1.
+Global Instance is_derive1_atan x : is_derive x 1 atan (1 + x ^+ 2)^-1.
 Proof.
 rewrite -{1}[x]atanK.
 have cosD0 : cos (atan x) != 0.
@@ -1253,5 +1253,44 @@ apply: (@is_derive_inverse R tan).
 - by rewrite -[X in 1 + X ^+ 2]atanK -cos2_tan2 //; exact: is_derive_tan.
 by apply/lt0r_neq0/(@lt_le_trans _ _ 1) => //; rewrite lerDl sqr_ge0.
 Unshelve. all: by end_near. Qed.
+
+Lemma derive1_atan : atan^`() =1 (fun x => (1 + x ^+ 2)^-1).
+Proof. by move=> x; rewrite derive1E derive_val. Qed.
+
+Lemma lt_atan : {homo (@atan R) : x y / x < y}.
+Proof.
+move=> x y xy; rewrite -subr_gt0.
+have datan z : z \in `]x, y[ -> is_derive z 1 atan (1 + z ^+ 2)^-1.
+  by move=> _; exact: is_derive1_atan.
+have catan : {within `[x, y], continuous atan}.
+  by apply: derivable_within_continuous => z _; exact: ex_derive.
+have [c _ ->] := MVT xy datan catan.
+by rewrite mulr_gt0// ?subr_gt0// invr_gt0// ltr_wpDr// sqr_ge0.
+Qed.
+
+Lemma le_atan : {homo @atan R : x y / x <= y}.
+Proof.
+by move=> x y; rewrite le_eqVlt => /predU1P[-> //|xy]; exact/ltW/lt_atan.
+Qed.
+
+Lemma cvgy_atan : (@atan R) x @[x --> +oo] --> pi / 2.
+Proof.
+have ? : ubound (range (@atan R)) (pi / 2).
+  by move=> _ /= [x _ <-]; exact/ltW/atan_ltpi2.
+rewrite (_ : pi / 2 = sup (range atan)).
+  by apply/(nondecreasing_cvgr le_atan); exists (pi / 2).
+apply/eqP; rewrite eq_le; apply/andP; split; last first.
+  by apply: sup_le_ub => //; exists 0, 0 => //; exact: atan0.
+have -> : pi / 2 = sup `[0, pi / 2[ :> R.
+  by rewrite real_interval.sup_itv// bnd_simp divr_gt0// pi_gt0.
+apply: le_sup; last 2 first.
+- by exists 0; rewrite /= in_itv/= lexx/= divr_gt0// pi_gt0.
+- split; first by exists 0, 0 => //; rewrite atan0.
+  by exists (pi / 2) => _ [x _ <-]; exact/ltW/atan_ltpi2.
+move=> x/= /[!in_itv]/= /andP[x0 xpi2].
+apply/downP; exists (atan (tan x)) => /=; first by exists (tan x).
+rewrite tanK// in_itv/= xpi2 andbT (lt_le_trans _ x0)//.
+by rewrite ltrNl oppr0 divr_gt0// pi_gt0.
+Qed.
 
 End Atan.


### PR DESCRIPTION
##### Motivation for this change

A few lemmas about `Rintegral`, `atan`, and `expR` that have found their use in an on-going development about the Gauss integral.

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [ ] added corresponding documentation in the headers~~

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
