### PR TITLE
duality between `closure` and `interior`

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -99,7 +99,7 @@
 
 - in `topology_structure.v`:
   + definitions `regopen`, `regclosed`
-  + lemmas `interiorC`, `closureU`, `interiorU`,
+  + lemmas `closure_setC`, `interiorC`, `closureU`, `interiorU`,
            `closureEbigcap`, `interiorEbigcup`,
 	   `closure_open_regclosed`, `interior_closed_regopen`,
 	   `closure_interior_idem`, `interior_closure_idem`

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -106,9 +106,6 @@
 
 ### Changed
 
-- in `topology_structure.v`:
-  + lemma `closureC`
-
 ### Renamed
 
 ### Generalized
@@ -121,6 +118,9 @@
     * lemmas `mfun_rect`, `mfun_valP`, `mfuneqP`
 
 ### Deprecated
+
+- in `topology_structure.v`:
+  + lemma `closureC`
 
 ### Removed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -94,10 +94,14 @@
   + structure `NonNegSimpleFun` now inside a module `HBNNSimple`
   + lemma `cst_nnfun_subproof` has now a different statement
   + lemma `indic_nnfun_subproof` has now a different statement
+- in `mathcomp_extra.v`:
+  + definition `idempotent_fun`
 
 - in `topology_structure.v`:
+  + definitions `regopen`, `regclosed`
   + lemmas `interiorC`, `closureU`, `interiorU`,
            `closureEbigcap`, `interiorEbigcup`,
+	   `closure_open_regclosed`, `interior_closed_regopen`,
 	   `closure_interior_idem`, `interior_closure_idem`
 
 ### Changed

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -95,6 +95,15 @@
   + lemma `cst_nnfun_subproof` has now a different statement
   + lemma `indic_nnfun_subproof` has now a different statement
 
+- in `topology_structure.v`:
+  + lemmas `interiorC`, `closureU`, `interiorU`,
+           `closureEbigcap`, `interiorEbigcup`,
+	   `closure_interior_idem`, `interior_closure_idem`
+
+### Changed
+
+- in `topology_structure.v`:
+  + lemma `closureC`
 
 ### Renamed
 

--- a/classical/mathcomp_extra.v
+++ b/classical/mathcomp_extra.v
@@ -117,6 +117,8 @@ Arguments dfwith {I T} f i x.
 (* not yet backported *)
 (**********************)
 
+Definition idempotent_fun (U : Type) (f : U -> U) := f \o f =1 f.
+
 From mathcomp Require Import poly.
 
 Lemma deg_le2_ge0 (F : rcfType) (a b c : F) :

--- a/theories/function_spaces.v
+++ b/theories/function_spaces.v
@@ -341,7 +341,7 @@ apply: (wiFx i); have /= -> := @nbhsE (weak_topology (f_ i)) x.
 exists (f_ i @^-1` (~` closure [set f_ i x | x in ~` B])); [split=>//|].
   apply: open_comp; last by rewrite ?openC//; exact: closed_closure.
   by move=> + _; exact: (@weak_continuous _ _ (f_ i)).
-rewrite closureC preimage_bigcup => z [V [oV]] VnB => /VnB.
+rewrite -interiorC interiorEbigcup preimage_bigcup => z [V [oV]] VnB => /VnB.
 by move/forall2NP => /(_ z) [] // /contrapT.
 Qed.
 
@@ -382,7 +382,8 @@ have [// | i nAfiy] := @sepf (~` A) x (open_closedC oA).
 pose B : set PU := proj i @^-1` (~` closure (f_ i @` ~` A)).
 apply: (@filterS _ _ _ (range join_product `&` B)).
   move=> z [[w ?]] wzE Bz; exists w => //.
-  move: Bz; rewrite /B -wzE closureC; case=> K [oK KsubA] /KsubA.
+  move: Bz; rewrite /B -wzE -interiorC interiorEbigcup.
+  case=> K [oK KsubA] /KsubA.
   have -> : proj i (join_product w) = f_ i w by [].
   by move=> /exists2P/forallNP/(_ w)/not_andP [] // /contrapT.
 apply: open_nbhs_nbhs; split; last by rewrite -jxy.

--- a/theories/topology_theory/connected.v
+++ b/theories/topology_theory/connected.v
@@ -69,7 +69,8 @@ exists (fun i => if i is false then A `\` C else A `&` C); split.
   by apply: AF; rewrite BAC; exact/setIidPl.
 - by rewrite setDE -setIUr setUCl setIT.
 - split.
-  + rewrite setIC; apply/disjoints_subset; rewrite closureC => x [? ?].
+  + rewrite setIC; apply/disjoints_subset.
+    rewrite -interiorC interiorEbigcup => x [? ?].
     by exists C => //; split=> //; rewrite setDE setCI setCK; right.
   + apply/disjoints_subset => y -[Ay Cy].
     rewrite -BAC BAD => /closureI[_]; move/closure_id : cD => <- Dy.

--- a/theories/topology_theory/topology_structure.v
+++ b/theories/topology_theory/topology_structure.v
@@ -30,8 +30,10 @@ From mathcomp Require Export filter.
 (*               interior U == all of the points which are locally in U       *)
 (*                             i.e. the largest open set contained in U       *)
 (*                closure U == the smallest closed set containing U           *)
-(*                regopen U == U is equal to the interior of its closure      *)
-(*              regclosed U == U is equal to the closure of its interior      *)
+(*                regopen U == U is regular open                              *)
+(*                             i.e. equal to the interior of its closure      *)
+(*              regclosed U == U is regular closed                            *)
+(*                             i.e. equal to the closure of its interior      *)
 (*           open_of_nbhs B == the open sets induced by neighborhoods         *)
 (*           nbhs_of_open B == the neighborhoods induced by open sets         *)
 (*                      x^' == set of neighbourhoods of x where x is          *)
@@ -829,7 +831,7 @@ exists U=> //; apply/(subset_trans UX)/disjoints_subset; rewrite setIC.
 by apply/eqP/negbNE/negP; rewrite set0P.
 Qed.
 
-Lemma closureC (A : set T) : closure (~` A) = ~` A^°.
+Let _to_be_closureC (A : set T) : closure (~` A) = ~` A^°.
 Proof. by apply: setC_inj; rewrite -interiorC !setCK. Qed.
 
 Lemma closureU (A B : set T) : closure (A `|` B) = closure A `|` closure B.
@@ -837,7 +839,7 @@ Proof. by apply: setC_inj; rewrite setCU -!interiorC -interiorI setCU. Qed.
 
 Lemma interiorU (A B : set T) : A^° `|` B^° `<=` (A `|` B)^°.
 Proof.
-by apply: subsetC2; rewrite setCU -!closureC setCU; exact: closureI.
+by apply: subsetC2; rewrite setCU -!_to_be_closureC setCU; exact: closureI.
 Qed.
 
 Lemma closureEbigcap (A : set T) :
@@ -847,7 +849,7 @@ Proof. exact: closureE. Qed.
 Lemma interiorEbigcup (A : set T) :
   A^° = \bigcup_(x in [set U | open U /\ U `<=` A]) x.
 Proof.
-apply: setC_inj; rewrite -closureC closureEbigcap setC_bigcup.
+apply: setC_inj; rewrite -_to_be_closureC closureEbigcap setC_bigcup.
 rewrite -[RHS](bigcap_image _ setC idfun) /=.
 apply: eq_bigcapl; split=> X /=.
   by rewrite -openC -setCS setCK; exists (~` X)=> //; rewrite setCK.
@@ -875,8 +877,8 @@ Qed.
 Lemma closure_open_regclosed (A : set T) : open A -> regclosed (closure A).
 Proof.
 rewrite /regclosed -(setCK A) openC=> ?.
-rewrite closureC -[in RHS]interior_closed_regopen //.
-by rewrite !(closureC, interiorC).
+rewrite _to_be_closureC -[in RHS]interior_closed_regopen //.
+by rewrite !(_to_be_closureC, interiorC).
 Qed.
 
 Lemma interior_closure_idem : @idempotent_fun (set T) (interior \o closure).  
@@ -886,6 +888,12 @@ Lemma closure_interior_idem : @idempotent_fun (set T) (closure \o interior).
 Proof. move=> ?; exact/closure_open_regclosed/open_interior. Qed.
 
 End closure_interior_lemmas.
+
+Lemma closureC_deprecated (T : topologicalType) (E : set T) :
+  ~` closure E = \bigcup_(x in [set U | open U /\ U `<=` ~` E]) x.
+Proof. by rewrite -interiorC interiorEbigcup. Qed.
+#[deprecated(since="mathcomp-analysis 1.6.1", note="use `interiorC` and `interiorEbigcup` instead")]
+Notation closureC := closureC_deprecated (only parsing).
 
 Section DiscreteTopology.
 Section DiscreteMixin.

--- a/theories/topology_theory/topology_structure.v
+++ b/theories/topology_theory/topology_structure.v
@@ -27,13 +27,13 @@ From mathcomp Require Export filter.
 (*                             is convertible to G (globally A)               *)
 (*            finI_from D f == set of \bigcap_(i in E) f i where E is a       *)
 (*                             finite subset of D                             *)
-(*               interior U == all of the points which are locally in U       *)
-(*                             i.e. the largest open set contained in U       *)
+(*               interior U == all of the points which are locally in U,      *)
+(*                             i.e., the largest open set contained in U      *)
 (*                closure U == the smallest closed set containing U           *)
-(*                regopen U == U is regular open                              *)
-(*                             i.e. equal to the interior of its closure      *)
-(*              regclosed U == U is regular closed                            *)
-(*                             i.e. equal to the closure of its interior      *)
+(*                regopen U == U is regular open,                             *)
+(*                             i.e., equal to the interior of its closure     *)
+(*              regclosed U == U is regular closed,                           *)
+(*                             i.e., equal to the closure of its interior     *)
 (*           open_of_nbhs B == the open sets induced by neighborhoods         *)
 (*           nbhs_of_open B == the neighborhoods induced by open sets         *)
 (*                      x^' == set of neighbourhoods of x where x is          *)
@@ -44,7 +44,6 @@ From mathcomp Require Export filter.
 (*                             type topologicalType                           *)
 (*      discrete_space dscT == the discrete topology on T, provided           *)
 (*                             a (dscT : discrete_space T)                    *)
-(*                                                                            *)
 (* ```                                                                        *)
 (* ### Factories                                                              *)
 (* ```                                                                        *)
@@ -835,9 +834,9 @@ rewrite eqEsubset; split=> x; rewrite /closure /interior nbhsE /= -existsNE.
   case=> U ? /disjoints_subset UA; exists U; rewrite not_implyE.
   split; first exact/open_nbhs_nbhs.
   by rewrite setIC UA; apply/set0P; rewrite eqxx.
-case=> X; rewrite not_implyE nbhsE=> -[] -[] U ? UX ?.
-exists U=> //; apply/(subset_trans UX)/disjoints_subset; rewrite setIC.
-by apply/eqP/negbNE/negP; rewrite set0P.
+case=> X; rewrite not_implyE nbhsE=> -[] -[] U xU UX AX0.
+exists U => //; apply/(subset_trans UX)/disjoints_subset; rewrite setIC.
+exact/eqP/negbNE/negP/set0P.
 Qed.
 
 (* TODO: rename to closureC after removing the deprecated one *)
@@ -861,7 +860,7 @@ Lemma interiorEbigcup (A : set T) :
 Proof.
 apply: setC_inj; rewrite -closure_setC closureEbigcap setC_bigcup.
 rewrite -[RHS](bigcap_image _ setC idfun) /=.
-apply: eq_bigcapl; split=> X /=.
+apply: eq_bigcapl; split => X /=.
   by rewrite -openC -setCS setCK; exists (~` X)=> //; rewrite setCK.
 by case=> Y + <-; rewrite closedC setCS.
 Qed.
@@ -869,26 +868,25 @@ Qed.
 Lemma interior_closed_regopen (A : set T) : closed A -> regopen A^°.
 Proof.
 move=> cA; rewrite /regopen eqEsubset; split=> x.
-  rewrite {1}/closure {1}/interior nbhsE=> -[] U oxU UciA.
-  rewrite /interior nbhsE /=.
-  exists U=> //; apply: (subset_trans UciA) => y /= H.
-  apply: cA; rewrite /closure /= => B /H; apply:subset_nonempty; apply: setSI.
+  rewrite /closure [X in X -> _]/interior nbhsE => -[] U oxU UciA.
+  rewrite /interior nbhsE /=; exists U => //.
+  apply: (subset_trans UciA) => y /= yA.
+  apply: cA => B /yA; apply/subset_nonempty; apply: setSI.
   exact: interior_subset.
 rewrite {1}/interior nbhsE=> -[] U [] oU Ux UA.
-rewrite {1}/interior nbhsE /=.
-exists U=> //.
-have:= UA; rewrite open_subsetE//; move/subset_trans; apply.
+rewrite {1}/interior nbhsE /=; exists U=> //.
+have:= UA; rewrite open_subsetE// => /subset_trans; apply.
 exact: subset_closure.
 Qed.
 
 Lemma closure_open_regclosed (A : set T) : open A -> regclosed (closure A).
 Proof.
-rewrite /regclosed -(setCK A) openC=> ?.
-rewrite closure_setC -[in RHS]interior_closed_regopen //.
+rewrite /regclosed -(setCK A) openC => cCA.
+rewrite closure_setC -[in RHS]interior_closed_regopen//.
 by rewrite !(closure_setC, interiorC).
 Qed.
 
-Lemma interior_closure_idem : @idempotent_fun (set T) (interior \o closure).  
+Lemma interior_closure_idem : @idempotent_fun (set T) (interior \o closure).
 Proof. move=> ?; exact/interior_closed_regopen/closed_closure. Qed.
 
 Lemma closure_interior_idem : @idempotent_fun (set T) (closure \o interior).

--- a/theories/topology_theory/topology_structure.v
+++ b/theories/topology_theory/topology_structure.v
@@ -818,7 +818,7 @@ End closure_lemmas.
 Section closure_interior_lemmas.
 Variable T : topologicalType.
 
-Lemma interiorC (A : set T) : interior (~` A) = ~` closure A.
+Lemma interiorC (A : set T) : (~` A)^° = ~` closure A.
 Proof.
 rewrite eqEsubset; split=> x; rewrite /closure /interior nbhsE /= -existsNE.
   case=> U ? /disjoints_subset UA; exists U; rewrite not_implyE.
@@ -829,14 +829,13 @@ exists U=> //; apply/(subset_trans UX)/disjoints_subset; rewrite setIC.
 by apply/eqP/negbNE/negP; rewrite set0P.
 Qed.
 
-Lemma closureC (A : set T) : closure (~` A) = ~` interior A.
+Lemma closureC (A : set T) : closure (~` A) = ~` A^°.
 Proof. by apply: setC_inj; rewrite -interiorC !setCK. Qed.
 
 Lemma closureU (A B : set T) : closure (A `|` B) = closure A `|` closure B.
 Proof. by apply: setC_inj; rewrite setCU -!interiorC -interiorI setCU. Qed.
 
-Lemma interiorU (A B : set T) :
-  interior A `|` interior B `<=` interior (A `|` B).
+Lemma interiorU (A B : set T) : A^° `|` B^° `<=` (A `|` B)^°.
 Proof.
 by apply: subsetC2; rewrite setCU -!closureC setCU; exact: closureI.
 Qed.
@@ -846,7 +845,7 @@ Lemma closureEbigcap (A : set T) :
 Proof. exact: closureE. Qed.
 
 Lemma interiorEbigcup (A : set T) :
-  interior A = \bigcup_(x in [set U | open U /\ U `<=` A]) x.
+  A^° = \bigcup_(x in [set U | open U /\ U `<=` A]) x.
 Proof.
 apply: setC_inj; rewrite -closureC closureEbigcap setC_bigcup.
 rewrite -[RHS](bigcap_image _ setC idfun) /=.
@@ -855,10 +854,10 @@ apply: eq_bigcapl; split=> X /=.
 by case=> Y + <-; rewrite closedC setCS.
 Qed.
 
-Definition regopen (A : set T) := interior (closure A) = A.
-Definition regclosed (A : set T) := closure (interior A) = A.
+Definition regopen (A : set T) := (closure A)^° = A.
+Definition regclosed (A : set T) := closure (A^°) = A.
 
-Lemma interior_closed_regopen (A : set T) : closed A -> regopen (interior A).
+Lemma interior_closed_regopen (A : set T) : closed A -> regopen A^°.
 Proof.
 move=> cA; rewrite /regopen eqEsubset; split=> x.
   rewrite {1}/closure {1}/interior nbhsE=> -[] U oxU UciA.

--- a/theories/topology_theory/topology_structure.v
+++ b/theories/topology_theory/topology_structure.v
@@ -899,7 +899,7 @@ End closure_interior_lemmas.
 Lemma closureC_deprecated (T : topologicalType) (E : set T) :
   ~` closure E = \bigcup_(x in [set U | open U /\ U `<=` ~` E]) x.
 Proof. by rewrite -interiorC interiorEbigcup. Qed.
-#[deprecated(since="mathcomp-analysis 1.6.1", note="use `interiorC` and `interiorEbigcup` instead")]
+#[deprecated(since="mathcomp-analysis 1.7.0", note="use `interiorC` and `interiorEbigcup` instead")]
 Notation closureC := closureC_deprecated (only parsing).
 
 Section DiscreteTopology.

--- a/theories/topology_theory/topology_structure.v
+++ b/theories/topology_theory/topology_structure.v
@@ -817,6 +817,15 @@ Qed.
 
 End closure_lemmas.
 
+Section regular_open_closed.
+Variable T : topologicalType.
+
+Definition regopen (A : set T) := (closure A)^° = A.
+
+Definition regclosed (A : set T) := closure (A^°) = A.
+
+End regular_open_closed.
+
 Section closure_interior_lemmas.
 Variable T : topologicalType.
 
@@ -831,7 +840,8 @@ exists U=> //; apply/(subset_trans UX)/disjoints_subset; rewrite setIC.
 by apply/eqP/negbNE/negP; rewrite set0P.
 Qed.
 
-Let _to_be_closureC (A : set T) : closure (~` A) = ~` A^°.
+(* TODO: rename to closureC after removing the deprecated one *)
+Lemma closure_setC (A : set T) : closure (~` A) = ~` A^°.
 Proof. by apply: setC_inj; rewrite -interiorC !setCK. Qed.
 
 Lemma closureU (A B : set T) : closure (A `|` B) = closure A `|` closure B.
@@ -839,7 +849,7 @@ Proof. by apply: setC_inj; rewrite setCU -!interiorC -interiorI setCU. Qed.
 
 Lemma interiorU (A B : set T) : A^° `|` B^° `<=` (A `|` B)^°.
 Proof.
-by apply: subsetC2; rewrite setCU -!_to_be_closureC setCU; exact: closureI.
+by apply: subsetC2; rewrite setCU -!closure_setC setCU; exact: closureI.
 Qed.
 
 Lemma closureEbigcap (A : set T) :
@@ -849,15 +859,12 @@ Proof. exact: closureE. Qed.
 Lemma interiorEbigcup (A : set T) :
   A^° = \bigcup_(x in [set U | open U /\ U `<=` A]) x.
 Proof.
-apply: setC_inj; rewrite -_to_be_closureC closureEbigcap setC_bigcup.
+apply: setC_inj; rewrite -closure_setC closureEbigcap setC_bigcup.
 rewrite -[RHS](bigcap_image _ setC idfun) /=.
 apply: eq_bigcapl; split=> X /=.
   by rewrite -openC -setCS setCK; exists (~` X)=> //; rewrite setCK.
 by case=> Y + <-; rewrite closedC setCS.
 Qed.
-
-Definition regopen (A : set T) := (closure A)^° = A.
-Definition regclosed (A : set T) := closure (A^°) = A.
 
 Lemma interior_closed_regopen (A : set T) : closed A -> regopen A^°.
 Proof.
@@ -877,8 +884,8 @@ Qed.
 Lemma closure_open_regclosed (A : set T) : open A -> regclosed (closure A).
 Proof.
 rewrite /regclosed -(setCK A) openC=> ?.
-rewrite _to_be_closureC -[in RHS]interior_closed_regopen //.
-by rewrite !(_to_be_closureC, interiorC).
+rewrite closure_setC -[in RHS]interior_closed_regopen //.
+by rewrite !(closure_setC, interiorC).
 Qed.
 
 Lemma interior_closure_idem : @idempotent_fun (set T) (interior \o closure).  


### PR DESCRIPTION
##### Motivation for this change

This PR adds some lemmas for the closure and interior operators that
are a basic part of the duality between these.  This addition will serve
as an initial step towards the theory of regular open/closed sets.

Lemma `closureC` is modified since its original statement seemed not
conforming to the name.

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
