### PR TITLE
Homeomorphisms for (X*Y)*Z -> X*(Y*Z) and X*Y -> Y*X

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -71,6 +71,11 @@
   + lemma `countable_measurable`
 - in `realfun.v`:
   + lemma `cvgr_dnbhsP`
+  + new definitions `left_assoc_prod`, and `right_assoc_prod`.
+  + new lemmas `left_assoc_prodK`, `right_assoc_prodK`, and `swapK`.
+- in file `product_topology.v`,
+  + new lemmas `swap_continuous`, `left_assoc_prod_continuous`, and 
+    `right_assoc_prod_continuous`.
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -71,8 +71,6 @@
   + lemma `countable_measurable`
 - in `realfun.v`:
   + lemma `cvgr_dnbhsP`
-  + new definitions `left_assoc_prod`, and `right_assoc_prod`.
-  + new lemmas `left_assoc_prodK`, `right_assoc_prodK`, and `swapK`.
   + new definitions `prodA`, and `prodAr`.
   + new lemmas `prodAK`, `prodArK`, and `swapK`.
 - in file `product_topology.v`,

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -73,9 +73,11 @@
   + lemma `cvgr_dnbhsP`
   + new definitions `left_assoc_prod`, and `right_assoc_prod`.
   + new lemmas `left_assoc_prodK`, `right_assoc_prodK`, and `swapK`.
+  + new definitions `prodA`, and `prodAr`.
+  + new lemmas `prodAK`, `prodArK`, and `swapK`.
 - in file `product_topology.v`,
-  + new lemmas `swap_continuous`, `left_assoc_prod_continuous`, and 
-    `right_assoc_prod_continuous`.
+  + new lemmas `swap_continuous`, `prodA_continuous`, and 
+    `prodAr_continuous`.
 
 ### Changed
 

--- a/classical/mathcomp_extra.v
+++ b/classical/mathcomp_extra.v
@@ -379,17 +379,19 @@ Definition swap {T1 T2 : Type} (x : T1 * T2) := (x.2, x.1).
 
 Section reassociate_products.
 Context {X Y Z : Type}.
-Definition left_assoc_prod (xyz : (X * Y) * Z) : X * (Y * Z) := 
-  (xyz.1.1,(xyz.1.2,xyz.2)).
 
-Definition right_assoc_prod (xyz : X * (Y * Z)) : (X * Y) * Z := 
-  ((xyz.1,xyz.2.1),xyz.2.2).
+Definition left_assoc_prod (xyz : (X * Y) * Z) : X * (Y * Z) :=
+  (xyz.1.1, (xyz.1.2, xyz.2)).
+
+Definition right_assoc_prod (xyz : X * (Y * Z)) : (X * Y) * Z :=
+  ((xyz.1, xyz.2.1), xyz.2.2).
 
 Lemma left_assoc_prodK : cancel left_assoc_prod right_assoc_prod.
-Proof. by case;case. Qed.
+Proof. by case; case. Qed.
 
 Lemma right_assoc_prodK : cancel right_assoc_prod left_assoc_prod.
 Proof. by case => ? []. Qed.
+
 End reassociate_products.
 
 Lemma swapK {T1 T2 : Type} : cancel (@swap T1 T2) (@swap T2 T1).

--- a/classical/mathcomp_extra.v
+++ b/classical/mathcomp_extra.v
@@ -18,6 +18,8 @@ From mathcomp Require Import finset interval.
 (*                           {in A &, {mono f : x y /~ x <= y}}               *)
 (*             sigT_fun f := lifts a family of functions f into a function on *)
 (*                           the dependent sum                                *)
+(*      left_assoc_prod x := sends (X * Y) * Z to X * (Y * Z)                 *)
+(*     right_assoc_prod x := sends X * (Y * Z) to (X * Y) * Z                 *)
 (* ```                                                                        *)
 (*                                                                            *)
 (******************************************************************************)
@@ -373,7 +375,25 @@ Lemma real_ltr_distlC [R : numDomainType] [x y : R] (e : R) :
   x - y \is Num.real -> (`|x - y| < e) = (x - e < y < x + e).
 Proof. by move=> ?; rewrite distrC real_ltr_distl// -rpredN opprB. Qed.
 
-Definition swap (T1 T2 : Type) (x : T1 * T2) := (x.2, x.1).
+Definition swap {T1 T2 : Type} (x : T1 * T2) := (x.2, x.1).
+
+Section reassociate_products.
+Context {X Y Z : Type}.
+Definition left_assoc_prod (xyz : (X * Y) * Z) : X * (Y * Z) := 
+  (xyz.1.1,(xyz.1.2,xyz.2)).
+
+Definition right_assoc_prod (xyz : X * (Y * Z)) : (X * Y) * Z := 
+  ((xyz.1,xyz.2.1),xyz.2.2).
+
+Lemma left_assoc_prodK : cancel left_assoc_prod right_assoc_prod.
+Proof. by case;case. Qed.
+
+Lemma right_assoc_prodK : cancel right_assoc_prod left_assoc_prod.
+Proof. by case => ? []. Qed.
+End reassociate_products.
+
+Lemma swapK {T1 T2 : Type} : cancel (@swap T1 T2) (@swap T2 T1).
+Proof. by case=> ? ?. Qed.
 
 Definition map_pair {S U : Type} (f : S -> U) (x : (S * S)) : (U * U) :=
   (f x.1, f x.2).

--- a/classical/mathcomp_extra.v
+++ b/classical/mathcomp_extra.v
@@ -18,8 +18,8 @@ From mathcomp Require Import finset interval.
 (*                           {in A &, {mono f : x y /~ x <= y}}               *)
 (*             sigT_fun f := lifts a family of functions f into a function on *)
 (*                           the dependent sum                                *)
-(*      left_assoc_prod x := sends (X * Y) * Z to X * (Y * Z)                 *)
-(*     right_assoc_prod x := sends X * (Y * Z) to (X * Y) * Z                 *)
+(*                prodA x := sends (X * Y) * Z to X * (Y * Z)                 *)
+(*               prodAr x := sends X * (Y * Z) to (X * Y) * Z                 *)
 (* ```                                                                        *)
 (*                                                                            *)
 (******************************************************************************)
@@ -380,16 +380,16 @@ Definition swap {T1 T2 : Type} (x : T1 * T2) := (x.2, x.1).
 Section reassociate_products.
 Context {X Y Z : Type}.
 
-Definition left_assoc_prod (xyz : (X * Y) * Z) : X * (Y * Z) :=
+Definition prodA (xyz : (X * Y) * Z) : X * (Y * Z) :=
   (xyz.1.1, (xyz.1.2, xyz.2)).
 
-Definition right_assoc_prod (xyz : X * (Y * Z)) : (X * Y) * Z :=
+Definition prodAr (xyz : X * (Y * Z)) : (X * Y) * Z :=
   ((xyz.1, xyz.2.1), xyz.2.2).
 
-Lemma left_assoc_prodK : cancel left_assoc_prod right_assoc_prod.
+Lemma prodAK : cancel prodA prodAr.
 Proof. by case; case. Qed.
 
-Lemma right_assoc_prodK : cancel right_assoc_prod left_assoc_prod.
+Lemma prodArK : cancel prodAr prodA.
 Proof. by case => ? []. Qed.
 
 End reassociate_products.

--- a/theories/topology_theory/product_topology.v
+++ b/theories/topology_theory/product_topology.v
@@ -241,7 +241,7 @@ Qed.
 Section reassociate_continuous.
 Context {X Y Z : topologicalType}.
 
-Lemma left_assoc_prod_continuous : continuous (@left_assoc_prod X Y Z).
+Lemma prodA_continuous : continuous (@prodA X Y Z).
 Proof.
 move=> [] [a b] c U [[/= P V]] [Pa] [][/= Q R][ Qb Rc] QRV PVU.
 exists ((P `*` Q), R); first split.
@@ -251,7 +251,7 @@ exists ((P `*` Q), R); first split.
 - by move=> [[x y] z] [] [] ? ? ?; apply: PVU; split => //; exact: QRV.
 Qed.
 
-Lemma right_assoc_prod_continuous : continuous (@right_assoc_prod X Y Z).
+Lemma prodAr_continuous : continuous (@prodAr X Y Z).
 Proof.
 case=> a [b c] U [[V R]] [/= [[P Q /=]]] [Pa Qb] PQV Rc VRU.
 exists (P, (Q `*` R)); first split => //.

--- a/theories/topology_theory/product_topology.v
+++ b/theories/topology_theory/product_topology.v
@@ -234,35 +234,30 @@ Notation compact_setM := compact_setX (only parsing).
 
 Lemma swap_continuous {X Y : topologicalType} : continuous (@swap X Y).
 Proof.
-case=> a b W /=[[U V]][] /= Ua Vb UVW; exists (V, U); first by split.
-by case => //= ? ? [] ? ?; apply: UVW.
+case=> a b W /= [[U V]][] /= Ub Va UVW; exists (V, U); first by split.
+by case => //= ? ? [] ? ?; exact: UVW.
 Qed.
 
 Section reassociate_continuous.
 Context {X Y Z : topologicalType}.
 
-Lemma left_assoc_prod_continuous : continuous (@left_assoc_prod X Y Z). 
+Lemma left_assoc_prod_continuous : continuous (@left_assoc_prod X Y Z).
 Proof.
-case;case=> a b c U [[/= P V]] [Pa] [][/= Q R][ Qb Rc] QRV PVU.
+move=> [] [a b] c U [[/= P V]] [Pa] [][/= Q R][ Qb Rc] QRV PVU.
 exists ((P `*` Q), R); first split.
-- exists (P, Q); first split => //=.
-  by case=> x y /= [Px Qy]; split => //.
-- done.
-- case; case=> x y z /= [][] ? ? ?; apply: PVU; split => //.
-  exact: QRV.
+- exists (P, Q); first by [].
+  by case=> x y /= [Px Qy].
+- by [].
+- by move=> [[x y] z] [] [] ? ? ?; apply: PVU; split => //; exact: QRV.
 Qed.
 
-Lemma right_assoc_prod_continuous : continuous (@right_assoc_prod X Y Z). 
+Lemma right_assoc_prod_continuous : continuous (@right_assoc_prod X Y Z).
 Proof.
 case=> a [b c] U [[V R]] [/= [[P Q /=]]] [Pa Qb] PQV Rc VRU.
-exists (P, (Q `*` R)); first split.
-- done. 
-- exists (Q, R); first split => //=.
-  by case=> ? ? /= [? ?]; split.
-- case=> x [y z] [? [? ?]]; apply: VRU; split => //.
-  exact: PQV.
+exists (P, (Q `*` R)); first split => //.
+- exists (Q, R); first by [].
+  by case=> ? ? /= [].
+- by case=> x [y z] [? [? ?]]; apply: VRU; split => //; exact: PQV.
 Qed.
 
 End reassociate_continuous.
-
-

--- a/theories/topology_theory/product_topology.v
+++ b/theories/topology_theory/product_topology.v
@@ -231,3 +231,38 @@ by apply: (ngPr (b, a, i)); split => //; exact: N1N2N.
 Unshelve. all: by end_near. Qed.
 #[deprecated(since="mathcomp-analysis 0.6.0", note="renamed to `compact_setX`")]
 Notation compact_setM := compact_setX (only parsing).
+
+Lemma swap_continuous {X Y : topologicalType} : continuous (@swap X Y).
+Proof.
+case=> a b W /=[[U V]][] /= Ua Vb UVW; exists (V, U); first by split.
+by case => //= ? ? [] ? ?; apply: UVW.
+Qed.
+
+Section reassociate_continuous.
+Context {X Y Z : topologicalType}.
+
+Lemma left_assoc_prod_continuous : continuous (@left_assoc_prod X Y Z). 
+Proof.
+case;case=> a b c U [[/= P V]] [Pa] [][/= Q R][ Qb Rc] QRV PVU.
+exists ((P `*` Q), R); first split.
+- exists (P, Q); first split => //=.
+  by case=> x y /= [Px Qy]; split => //.
+- done.
+- case; case=> x y z /= [][] ? ? ?; apply: PVU; split => //.
+  exact: QRV.
+Qed.
+
+Lemma right_assoc_prod_continuous : continuous (@right_assoc_prod X Y Z). 
+Proof.
+case=> a [b c] U [[V R]] [/= [[P Q /=]]] [Pa Qb] PQV Rc VRU.
+exists (P, (Q `*` R)); first split.
+- done. 
+- exists (Q, R); first split => //=.
+  by case=> ? ? /= [? ?]; split.
+- case=> x [y z] [? [? ?]]; apply: VRU; split => //.
+  exact: PQV.
+Qed.
+
+End reassociate_continuous.
+
+


### PR DESCRIPTION
Product topologies are symmetric and associative. Useful in general, and one of many preliminary results needed for #1350 

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
