### PR TITLE
Lemmas `fiberwise_{finite,countable}_preimage`

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- in file `cardinality.v`,
+  + lemmas `fiberwise_finite_preimage`, `fiberwise_countable_preimage`
+
 - file `Rstruct_topology.v`
 
 - package `coq-mathcomp-reals` depending on `coq-mathcomp-classical`

--- a/classical/cardinality.v
+++ b/classical/cardinality.v
@@ -840,6 +840,15 @@ have Gy : y \in G k by rewrite in_fset_set ?inE//; apply: Ffin.
 by exists (Tagged G [` Gy]%fset).
 Qed.
 
+Lemma fiberwise_finite_preimage {T U} (B : set U) (f : T -> U) :
+  finite_set B -> (forall b, B b -> finite_set (f @^-1` [set b])) ->
+  finite_set (f @^-1` B).
+Proof.
+move=> *.
+rewrite -(image_id B) -bigcup_imset1 preimage_bigcup.
+exact: bigcup_finite.
+Qed.
+
 Lemma trivIset_sum_card (T : choiceType) (F : nat -> set T) n :
   (forall n, finite_set (F n)) -> trivIset [set: nat] F ->
   (\sum_(i < n) #|` fset_set (F i)| =
@@ -1141,6 +1150,15 @@ suff: (\bigcup_i G i #<= [set: {i & G i}])%card.
   by move=> /sub_countable->//; rewrite (eq_fun GE).
 apply/pcard_geP/surjPex; exists (fun (k : {i & G i}) => val (projT2 k)).
 by move=> x [i _] Gix/=; exists (Tagged G (SigSub (mem_set Gix))).
+Qed.
+
+Lemma fiberwise_countable_preimage {T U} (B : set U) (f : T -> U) :
+  countable B -> (forall b, B b -> countable (f @^-1` [set b])) ->
+  countable (f @^-1` B).
+Proof.
+move=> *.
+rewrite -(image_id B) -bigcup_imset1 preimage_bigcup.
+exact: bigcup_countable.
 Qed.
 
 Lemma countableXR T T' (A : set T) (B : T -> set T') :


### PR DESCRIPTION
##### Motivation for this change
Add lemmas stating that the preimage of a set along a function is finite / countable if every pointwise preimage is so.

NB: there is already `finite_preimage` which is similar but for injective preimages.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
