### PR TITLE
Instances for dependent function types

### DIFF
--- a/classical/boolp.v
+++ b/classical/boolp.v
@@ -106,8 +106,11 @@ Proof. by have [propext _] := extensionality; apply: propext. Qed.
 
 Ltac eqProp := apply: propext; split.
 
+Lemma funext_dep {T} {U : T -> Type} (f g : forall t, U t) : (forall t, f t = g t) -> f = g.
+Proof. exact/functional_extensionality_dep. Qed.
+
 Lemma funext {T U : Type} (f g : T -> U) : (f =1 g) -> f = g.
-Proof. by case: extensionality=> _; apply. Qed.
+Proof. exact/funext_dep. Qed.
 
 Lemma propeqE (P Q : Prop) : (P = Q) = (P <-> Q).
 Proof. by apply: propext; split=> [->|/propext]. Qed.

--- a/classical/cardinality.v
+++ b/classical/cardinality.v
@@ -1340,7 +1340,7 @@ Section zmod.
 Context (aT : Type) (rT : zmodType).
 Lemma fimfun_zmod_closed : zmod_closed (@fimfun aT rT).
 Proof.
-split=> [|f g]; rewrite !inE/=; first exact: finite_image_cst.
+split=> [|f g]; rewrite !inE/=; first exact: (finite_image_cst 0).
 by move=> fA gA; apply: (finite_image11 (fun x y => x - y)).
 Qed.
 HB.instance Definition _ :=

--- a/theories/esum.v
+++ b/theories/esum.v
@@ -587,9 +587,10 @@ move=> /cvgrPdist_lt cvgAB; apply/cvgrPdist_lt => e e0.
 move: cvgAB => /(_ _ e0) [N _/= hN] /=.
 near=> n.
 rewrite distrC subr0.
-have -> : (C_ = A_ \- B_)%R.
+have -> : (C_ = A_ - B_)%R.
   apply/funext => k.
-  rewrite /= /A_ /C_ /B_ -sumrN -big_split/= -summable_fine_sum//.
+  rewrite /= /A_ /C_ /B_ sub_funE/=.
+  rewrite -sumrN -big_split/= -summable_fine_sum//.
   apply eq_bigr => i Pi; rewrite -fineB//.
   - by rewrite [in LHS](funeposneg f).
   - by rewrite fin_num_abs (@summable_pinfty _ _ P) //; exact/summable_funepos.

--- a/theories/ftc.v
+++ b/theories/ftc.v
@@ -839,7 +839,8 @@ set f  := fun x => if x == a then r else if x == b then l else F^`() x.
 have fE : {in `]a, b[, F^`() =1 f}.
   by move=> x; rewrite in_itv/= => /andP[ax xb]; rewrite /f gt_eqF// lt_eqF.
 have DPGFE : {in `]a, b[, (- (PG \o F))%R^`() =1 ((G \o F) * (- f))%R}.
-  move=> x /[dup]xab /andP[ax xb]; rewrite derive1_comp //; last first.
+  move=> x /[dup]xab /andP[ax xb].
+  rewrite (@derive1_comp _ _ (@GRing.opp R)) //; last first.
     apply: diff_derivable; apply: differentiable_comp; apply/derivable1_diffP.
       by case: Fab => + _ _; exact.
     by case: PGFbFa => + _ _; apply; exact: decreasing_image_oo.
@@ -886,7 +887,8 @@ rewrite oppeD//= -(continuous_FTC2 ab _ _ DPGFE); last 2 first.
 - have [/= dF rF lF] := Fab.
   have := derivable_oo_continuous_bnd_within PGFbFa.
   move=> /(continuous_within_itvP _ FbFa)[_ PGFb PGFa]; split => /=.
-  - move=> x xab; apply/derivable1_diffP; apply: differentiable_comp => //.
+- move=> x xab; apply/derivable1_diffP.
+  apply: (differentiable_comp (g:=@GRing.opp R)) => //.
     apply: differentiable_comp; apply/derivable1_diffP.
       by case: Fab => + _ _; exact.
     by case: PGFbFa => + _ _; apply; exact: decreasing_image_oo.
@@ -909,7 +911,7 @@ rewrite oppeD//= -(continuous_FTC2 ab _ _ DPGFE); last 2 first.
     rewrite gtr0_norm// ?subr_gt0//.
     by near: t; exact: nbhs_left_ltBl.
 apply: eq_integral_itv_bounded.
-- rewrite mulrN; apply: measurableT_comp => //.
+  - rewrite mulrN; apply: (measurableT_comp (f:=@GRing.opp R)) => //.
   apply: (eq_measurable_fun ((G \o F) * F^`())%R) => //.
     by move=> x; rewrite inE/= => xab; rewrite !fctE fE.
   by move: mGFF'; apply: measurable_funS => //; exact: subset_itv_oo_cc.
@@ -994,13 +996,14 @@ have mF' : measurable_fun `]a, b[ F^`().
   apply: subspace_continuous_measurable_fun => //.
   by apply: continuous_in_subspaceT => x /[!inE] xab; exact: cF'.
 rewrite integral_itv_bndoo//; last first.
-  rewrite compA -(compA G -%R) (_ : -%R \o -%R = id); last first.
+  rewrite (compA _ -%R) -(compA G -%R) (_ : -%R \o -%R = id); last first.
     by apply/funext => y; rewrite /= opprK.
-  apply: measurable_funM => //; apply: measurableT_comp => //.
+  apply: measurable_funM => //.
+  apply: (measurableT_comp (f:=@GRing.opp R)) => //.
   apply: (@eq_measurable_fun _ _ _ _ _ (- F^`())%R).
     move=> x /[!inE] xab; rewrite [in RHS]derive1E deriveN -?derive1E//.
     by case: Fab => + _ _; apply.
-  exact: measurableT_comp.
+  exact: (measurableT_comp (f:=@GRing.opp R)).
 rewrite [in RHS]integral_itv_bndoo//; last exact: measurable_funM.
 apply: eq_integral => x /[!inE] xab; rewrite !fctE !opprK derive1E deriveN.
 - by rewrite opprK -derive1E.

--- a/theories/landau.v
+++ b/theories/landau.v
@@ -414,7 +414,7 @@ Proof. by rewrite [RHS]littleoE. Qed.
 
 Lemma oppox (F : filter_on T) (f : T -> V) e x :
   - [o_F e of f] x = [o_F e of - [o_F e of f]] x.
-Proof. by move: x; rewrite -/(- _ =1 _) {1}oppo. Qed.
+Proof. by move: x; rewrite -/(- [o_F e of f] =1 _) {1}oppo. Qed.
 
 Lemma eqadd_some_oP (F : filter_on T) (f g : T -> V) (e : T -> W) h :
   f = g + [o_F e of h] -> littleo_def F (f - g) e.
@@ -596,7 +596,7 @@ Proof. by rewrite [RHS]bigOE. Qed.
 
 Lemma oppOx (F : filter_on T) (f : T -> V) e x :
   - [O_F e of f] x = [O_F e of - [O_F e of f]] x.
-Proof. by move: x; rewrite -/(- _ =1 _) {1}oppO. Qed.
+Proof. by move: x; rewrite -/(- [O_F e of f] =1 _) {1}oppO. Qed.
 
 Lemma add_bigO_subproof (F : filter_on T) e (df dg : {O_F e}) :
   bigO_def F (df \+ dg) e.
@@ -618,7 +618,7 @@ Proof. by rewrite [RHS]bigOE. Qed.
 Lemma addOx (F : filter_on T) (f g: T -> V) e x :
   [O_F e of f] x + [O_F e of g] x =
   [O_F e of [O_F e of f] + [O_F e of g]] x.
-Proof. by move: x; rewrite -/(_ + _ =1 _) {1}addO. Qed.
+Proof. by move: x; rewrite -/([O_F e of f] + _ =1 _) {1}addO. Qed.
 
 Lemma eqadd_some_OP (F : filter_on T) (f g : T -> V) (e : T -> W) h :
   f = g + [O_F e of h] -> bigO_def F (f - g) e.
@@ -848,7 +848,7 @@ Proof. by rewrite [RHS]littleoE. Qed.
 Lemma addox (F : filter_on T) (f g: T -> V) (e : _ -> W) x :
   [o_F e of f] x + [o_F e of g] x =
   [o_F e of [o_F e of f] + [o_F e of g]] x.
-Proof. by move: x; rewrite -/(_ + _ =1 _) {1}addo. Qed.
+Proof. by move: x; rewrite -/([o_F e of f] + _ =1 _) {1}addo. Qed.
 
 (* duplicate from Section Domination *)
 Hint Extern 0 (littleo_def _ _ _) => solve[apply: littleoP] : core.
@@ -871,7 +871,7 @@ Proof. by rewrite [RHS]littleoE. Qed.
 
 Lemma scaleox (F : filter_on T) a (f : T -> V) (e : _ -> W) x :
   a *: ([o_F e of f] x) = [o_F e of a *: [o_F e of f]] x.
-Proof. by move: x; rewrite -/(_ *: _ =1 _) {1}scaleo. Qed.
+Proof. by move: x; rewrite -/(_ *: [o_F e of f] =1 _) {1}scaleo. Qed.
 
 End Domination_numFieldType.
 

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -251,7 +251,7 @@ Context d (aT : measurableType d) (rT : realType).
 Lemma mfun_subring_closed : subring_closed (@mfun _ _ aT rT).
 Proof.
 split=> [|f g|f g]; rewrite !inE/=.
-- exact: measurable_cst.
+- exact: measurable_cst (1 : rT).
 - exact: measurable_funB.
 - exact: measurable_funM.
 Qed.
@@ -5991,7 +5991,8 @@ Qed.
 Lemma locally_integrableN D f :
   locally_integrable D f -> locally_integrable D (\- f)%R.
 Proof.
-move=> [mf oD foo]; split => //; first exact: measurableT_comp.
+move=> [mf oD foo]; split => //.
+  exact: (measurableT_comp (f:=@GRing.opp R)).
 by move=> K KD cK; under eq_integral do rewrite normrN; exact: foo.
 Qed.
 
@@ -6482,10 +6483,10 @@ Proof.
 move=> xU mU mUf cg locg; apply/eqP; rewrite eq_le; apply/andP; split.
 - rewrite [leRHS](_ : _ = f^* x + (\- g)%R^* x).
     apply: (lim_sup_davg_le xU) => //.
-    apply/(measurable_comp measurableT) => //.
+    apply/(measurable_comp (f:=@GRing.opp R) measurableT) => //.
     by case: locg => + _ _; exact: measurable_funS.
   rewrite (@continuous_lim_sup_davg (- g)%R _ _ xU mU); first by rewrite adde0.
-  - apply/(measurable_comp measurableT) => //.
+  - apply/(measurable_comp (f:=@GRing.opp R) measurableT) => //.
     by case: locg => + _ _; apply: measurable_funS.
   + by move=> y; exact/continuousN/cg.
 - rewrite [leRHS](_ : _ = ((f \- g)%R^* \+ g^*) x)//.

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -1002,7 +1002,9 @@ Qed.
 
 Lemma measurable_funB D f g : measurable_fun D f ->
   measurable_fun D g -> measurable_fun D (f \- g).
-Proof. by move=> ? ?; apply: measurable_funD =>//; exact: measurableT_comp. Qed.
+Proof.
+by move=> ? ?; apply: measurable_funD =>//; exact: measurableT_comp.
+Qed.
 
 Lemma measurable_funM D f g :
   measurable_fun D f -> measurable_fun D g -> measurable_fun D (f \* g).

--- a/theories/numfun.v
+++ b/theories/numfun.v
@@ -409,13 +409,15 @@ Context (aT : pointedType) (rT : ringType).
 
 Lemma fimfun_mulr_closed : mulr_closed (@fimfun aT rT).
 Proof.
-split=> [|f g]; rewrite !inE/=; first exact: finite_image_cst.
+split=> [|f g]; rewrite !inE/=; first exact: finite_image_cst 1.
 by move=> fA gA; exact: (finite_image11 (fun x y => x * y)).
 Qed.
 
 HB.instance Definition _ :=
    @GRing.isMulClosed.Build _ (@fimfun aT rT) fimfun_mulr_closed.
-HB.instance Definition _ := [SubZmodule_isSubRing of {fimfun aT >-> rT} by <:].
+(* TODO: Why is this not known to HB? *)
+HB.instance Definition _ := @GRing.ZmodClosed.on (@fimfun aT rT).
+HB.instance Definition  _ := [SubZmodule_isSubRing of {fimfun aT >-> rT} by <:].
 
 Implicit Types f g : {fimfun aT >-> rT}.
 
@@ -575,7 +577,7 @@ have g_cts n : continuous (g_ n).
 have g_bd n : forall x, `|g_ n x| <= geometric ((1/3) * M%:num) (2/3) n.
   have [ctsN bdfN] := f_geo n; rewrite /geometric /= -[_ * M%:num * _]mulrA.
   by have [_ _] := projT2 (tietze_step (f_ n) _) ctsN (MN0 n) bdfN.
-pose h_ : nat -> arrow_uniform_type X R^o := @series {uniform X -> _} g_.
+pose h_ : nat -> arrow_uniform_type X R^o := @series {uniform X -> R^o} g_.
 have cvgh' : cvg (h_ @ \oo).
   apply/cauchy_cvgP/cauchy_ballP => eps epos; near_simpl.
   suff : \forall x & x' \near \oo, (x' <= x)%N -> ball (h_ x) eps (h_ x').

--- a/theories/probability.v
+++ b/theories/probability.v
@@ -196,7 +196,7 @@ Lemma expectation_sum (X : seq {RV P >-> R}) :
     (forall Xi, Xi \in X -> P.-integrable [set: T] (EFin \o Xi)) ->
   'E_P[\sum_(Xi <- X) Xi] = \sum_(Xi <- X) 'E_P[Xi].
 Proof.
-elim: X => [|X0 X IHX] intX; first by rewrite !big_nil expectation_cst.
+elim: X => [|X0 X IHX] intX; first by rewrite !big_nil (expectation_cst 0).
 have intX0 : P.-integrable [set: T] (EFin \o X0).
   by apply: intX; rewrite in_cons eqxx.
 have {}intX Xi : Xi \in X -> P.-integrable [set: T] (EFin \o Xi).
@@ -331,7 +331,7 @@ Lemma covarianceDl (X Y Z : {RV P >-> R}) :
 Proof.
 move=> X1 X2 Y1 Y2 Z1 Z2 XZ1 YZ1.
 rewrite [LHS]covarianceE//= ?mulrDl ?compreDr// ?integrableD//.
-rewrite 2?expectationD//=.
+rewrite add_funE 2?expectationD//=.
 rewrite muleDl ?fin_num_adde_defr ?expectation_fin_num//.
 rewrite oppeD ?fin_num_adde_defr ?fin_numM ?expectation_fin_num//.
 by rewrite addeACA 2?covarianceE.
@@ -397,7 +397,7 @@ Proof. by move=> /[dup]; apply: covariance_fin_num. Qed.
 
 Lemma variance_ge0 (X : {RV P >-> R}) : (0 <= 'V_P[X])%E.
 Proof.
-by rewrite /variance unlock; apply: expectation_ge0 => x; apply: sqr_ge0.
+by rewrite /variance unlock mul_funE; apply: expectation_ge0 => x; apply: sqr_ge0.
 Qed.
 
 Lemma variance_cst r : 'V_P[cst r] = 0%E.
@@ -459,7 +459,7 @@ rewrite varianceD/= ?varianceN ?covarianceNr ?muleN//.
 - by rewrite mulrN compreN ?integrableN.
 Qed.
 
-Lemma varianceD_cst_l c (X : {RV P >-> R}) :
+Lemma varianceD_cst_l (c : R) (X : {RV P >-> R}) :
     P.-integrable setT (EFin \o X) -> P.-integrable setT (EFin \o (X ^+ 2)%R) ->
   'V_P[(cst c \+ X)%R] = 'V_P[X].
 Proof.
@@ -480,7 +480,7 @@ have -> : (X \+ cst c = cst c \+ X)%R by apply/funeqP => x /=; rewrite addrC.
 exact: varianceD_cst_l.
 Qed.
 
-Lemma varianceB_cst_l c (X : {RV P >-> R}) :
+Lemma varianceB_cst_l (c : R) (X : {RV P >-> R}) :
     P.-integrable setT (EFin \o X) -> P.-integrable setT (EFin \o (X ^+ 2)%R) ->
   'V_P[(cst c \- X)%R] = 'V_P[X].
 Proof.


### PR DESCRIPTION
##### Motivation for this change

Generalizes the instances on function types to dependent function types. The same generalization is happening in mathcomp (see https://github.com/math-comp/math-comp/pull/1256) and it needs to be done here first for backwards compatibility.
EDIT: WIP because we are waiting for unification features in Coq that make unifying dependent functions work.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Checklist

- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
