### PR TITLE
convergence of functions wrt deleted nbhs

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -69,6 +69,8 @@
 
 - in `measure.v`:
   + lemma `countable_measurable`
+- in `realfun.v`:
+  + lemma `cvg_dnbhsP`
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -70,7 +70,7 @@
 - in `measure.v`:
   + lemma `countable_measurable`
 - in `realfun.v`:
-  + lemma `cvg_dnbhsP`
+  + lemma `cvgr_dnbhsP`
 
 ### Changed
 

--- a/theories/realfun.v
+++ b/theories/realfun.v
@@ -207,6 +207,20 @@ apply: pfl.
 by split; [move=> k; rewrite ltrNl//|apply/cvgNP => /=; rewrite opprK].
 Qed.
 
+Lemma cvg_dnbhsP (f : R -> R) (p l : R) :
+  f x @[x --> p^'] --> l <->
+  (forall u : R^nat, (forall n, u n != p) /\ (u n @[n --> \oo] --> p) ->
+    f (u n) @[n --> \oo] --> l).
+Proof.
+split=> [/cvgrPdist_le fpl u [up /cvgrPdist_lt put]|pfl].
+  apply/cvgrPdist_le => e /fpl [r /=] /put[n _ {}put] {}fpl.
+  near=> t; apply: fpl => //=; apply: put.
+  by near: t; exact: nbhs_infty_ge.
+apply: cvg_at_right_left_dnbhs.
+- by apply/cvg_at_rightP => u [pu ?]; apply: pfl; split => // n; rewrite gt_eqF.
+- by apply/cvg_at_leftP => u [pu ?]; apply: pfl; split => // n; rewrite lt_eqF.
+Unshelve. all: end_near. Qed.
+
 End cvgr_fun_cvg_seq.
 
 Section cvge_fun_cvg_seq.

--- a/theories/realfun.v
+++ b/theories/realfun.v
@@ -207,7 +207,7 @@ apply: pfl.
 by split; [move=> k; rewrite ltrNl//|apply/cvgNP => /=; rewrite opprK].
 Qed.
 
-Lemma cvg_dnbhsP (f : R -> R) (p l : R) :
+Lemma cvgr_dnbhsP (f : R -> R) (p l : R) :
   f x @[x --> p^'] --> l <->
   (forall u : R^nat, (forall n, u n != p) /\ (u n @[n --> \oo] --> p) ->
     f (u n) @[n --> \oo] --> l).


### PR DESCRIPTION
##### Motivation for this change

Easy lemma about convergence of real functions w.r.t. deleted neighborhoods used in the proof of the Gauss integral.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [ ] added corresponding documentation in the headers~~

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
