### PR TITLE
composition is continuous

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -98,7 +98,7 @@
 - in file `weak_topology.v`,
   + new lemma `continuous_comp_weak`.
 - in file `function_spaces.v`,
-  + new definitions `eval`, and `comp_cts`.
+  + new definitions `eval`.
   + new lemmas `continuous_curry_fun`, `continuous_curry_joint_cvg`, 
     `eval_continuous`, and `compose_continuous`.
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -93,6 +93,15 @@
   + new lemmas `min_continuous`, `min_fun_continuous`, `max_continuous`, and
     `max_fun_continuous`.
 
+- in file `functions.v`,
+  + new lemmas `uncurryK`, and `curryK`.
+- in file `weak_topology.v`,
+  + new lemma `continuous_comp_weak`.
+- in file `function_spaces.v`,
+  + new definitions `eval`, and `comp_cts`.
+  + new lemmas `continuous_curry_fun`, `continuous_curry_joint_cvg`, 
+    `eval_continuous`, and `compose_continuous`.
+
 ### Changed
 
 - in file `normedtype.v`,

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -93,14 +93,14 @@
   + new lemmas `min_continuous`, `min_fun_continuous`, `max_continuous`, and
     `max_fun_continuous`.
 
-- in file `functions.v`,
-  + new lemmas `uncurryK`, and `curryK`.
+- in file `boolp.v`,
+  + new lemmas `uncurryK`, and `curryK`
 - in file `weak_topology.v`,
-  + new lemma `continuous_comp_weak`.
+  + new lemma `continuous_comp_weak`
 - in file `function_spaces.v`,
-  + new definitions `eval`.
+  + new definition `eval`
   + new lemmas `continuous_curry_fun`, `continuous_curry_joint_cvg`, 
-    `eval_continuous`, and `compose_continuous`.
+    `eval_continuous`, and `compose_continuous`
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -99,7 +99,7 @@
   + new lemma `continuous_comp_weak`
 - in file `function_spaces.v`,
   + new definition `eval`
-  + new lemmas `continuous_curry_fun`, `continuous_curry_joint_cvg`, 
+  + new lemmas `continuous_curry_fun`, `continuous_curry_cvg`, 
     `eval_continuous`, and `compose_continuous`
 
 ### Changed

--- a/classical/boolp.v
+++ b/classical/boolp.v
@@ -969,3 +969,9 @@ Lemma inhabited_witness: inhabited T -> T.
 Proof. by rewrite inhabitedE => /cid[]. Qed.
 
 End Inhabited.
+
+Lemma uncurryK {X Y Z : Type} : cancel (@uncurry X Y Z) curry.
+Proof. by move=> f; rewrite funeq2E. Qed.
+
+Lemma curryK {X Y Z : Type} : cancel curry (@uncurry X Y Z).
+Proof. by move=> f; rewrite funeqE=> -[]. Qed.

--- a/classical/functions.v
+++ b/classical/functions.v
@@ -2665,3 +2665,9 @@ End function_space_lemmas.
 
 Lemma inv_funK T (R : unitRingType) (f : T -> R) : f\^-1\^-1%R = f.
 Proof. by apply/funeqP => x; rewrite /inv_fun/= GRing.invrK. Qed.
+
+Lemma uncurryK  {X Y Z : Type} : cancel (@uncurry X Y Z) curry.
+Proof. by move=> f; rewrite funeq2E => ? ?. Qed.
+
+Lemma curryK  {X Y Z : Type} : cancel curry (@uncurry X Y Z).
+Proof. by move=> f; rewrite funeqE; case=> ? ?. Qed.

--- a/classical/functions.v
+++ b/classical/functions.v
@@ -2665,9 +2665,3 @@ End function_space_lemmas.
 
 Lemma inv_funK T (R : unitRingType) (f : T -> R) : f\^-1\^-1%R = f.
 Proof. by apply/funeqP => x; rewrite /inv_fun/= GRing.invrK. Qed.
-
-Lemma uncurryK  {X Y Z : Type} : cancel (@uncurry X Y Z) curry.
-Proof. by move=> f; rewrite funeq2E => ? ?. Qed.
-
-Lemma curryK  {X Y Z : Type} : cancel curry (@uncurry X Y Z).
-Proof. by move=> f; rewrite funeqE; case=> ? ?. Qed.

--- a/theories/function_spaces.v
+++ b/theories/function_spaces.v
@@ -71,7 +71,6 @@ From mathcomp Require Import reals signed topology separation_axioms.
 (*  {compact_open, U -> V} == compact-open topology                           *)
 (* {compact_open, F --> f} == F converges to f in {compact_open, U -> V}      *)
 (*                    eval == the evaluation map for continuous functions     *)
-(*                comp_cts == composition for continuous functions            *)
 (* ```                                                                        *)
 (*                                                                            *)
 (* ## Ascoli's theorem notations                                              *)
@@ -1561,10 +1560,6 @@ End currying.
 Definition eval {X Y : topologicalType} : continuousType X Y * X -> Y  := 
   uncurry (id : continuousType X Y -> (X -> Y)).
 
-Definition comp_cts {X Y Z : topologicalType} (g : continuousType Y Z)
-    (f : continuousType X Y) : continuousType X Z :=
-  g \o f.
-
 Section composition.
 
 Local Import ArrowAsCompactOpen.
@@ -1580,7 +1575,8 @@ Qed.
 Lemma compose_continuous {X Y Z : topologicalType} : 
   locally_compact [set: X] -> @regular_space X ->
   locally_compact [set: Y] -> @regular_space Y ->
-  continuous (uncurry (@comp_cts X Y Z)).
+  continuous (uncurry 
+    (comp : continuousType Y Z -> continuousType X Y -> continuousType X Z)).
 Proof.
 move=> ? ? lY rY; apply: continuous_comp_weak.
 set F := _ \o _.

--- a/theories/function_spaces.v
+++ b/theories/function_spaces.v
@@ -70,6 +70,8 @@ From mathcomp Require Import reals signed topology separation_axioms.
 (*   {family fam, F --> f} == F converges to f in {family fam, U -> V}        *)
 (*  {compact_open, U -> V} == compact-open topology                           *)
 (* {compact_open, F --> f} == F converges to f in {compact_open, U -> V}      *)
+(*                    eval == the evaluation map for continuous functions     *)
+(*                comp_cts == composition for continuous functions            *)
 (* ```                                                                        *)
 (*                                                                            *)
 (* ## Ascoli's theorem notations                                              *)
@@ -1436,6 +1438,17 @@ move=> v Kv; have [[P Q] [Px Qv] PQfO] : nbhs (x, v) (f @^-1` O).
 by exists (Q, P) => // -[b a] /= [Qb Pa] Kb; exact: PQfO.
 Unshelve. all: by end_near. Qed.
 
+Lemma continuous_curry_fun (f : U * V -> W) :
+  continuous f -> continuous (curry f).
+Proof. by case/continuous_curry. Qed.
+
+Lemma continuous_curry_joint_cvg (f : U * V -> W) (u : U) (v : V) : 
+  continuous f -> curry f z.1 z.2 @[z --> (u,v)] --> curry f u v.
+Proof. 
+move=> cf D /cf; rewrite ?nbhs_simpl /curry /=; apply: filterS => z.
+by move=> ?; rewrite /= -surjective_pairing.
+Qed.
+
 Lemma continuous_uncurry_regular (f : U -> V -> W) :
   locally_compact [set: V] -> @regular_space V -> continuous f ->
   (forall u, continuous (f u)) -> continuous (uncurry f).
@@ -1544,3 +1557,51 @@ Unshelve. all: by end_near. Qed.
 End cartesian_closed.
 
 End currying.
+
+Definition eval {X Y : topologicalType} : continuousType X Y * X -> Y  := 
+  uncurry (id : continuousType X Y -> (X -> Y)).
+
+Definition comp_cts {X Y Z : topologicalType} (g : continuousType Y Z)
+    (f : continuousType X Y) : continuousType X Z :=
+  g \o f.
+
+Section composition.
+
+Local Import ArrowAsCompactOpen.
+
+Lemma eval_continuous {X Y : topologicalType} : 
+  locally_compact [set: X] -> regular_space X -> continuous (@eval X Y).
+Proof.
+move=> ? ?; apply: continuous_uncurry_regular => //.
+  exact: weak_continuous.
+by move=> ?; exact: cts_fun.
+Qed.
+
+Lemma compose_continuous {X Y Z : topologicalType} : 
+  locally_compact [set: X] -> @regular_space X ->
+  locally_compact [set: Y] -> @regular_space Y ->
+  continuous (uncurry (@comp_cts X Y Z)).
+Proof.
+move=> ? ? lY rY; apply: continuous_comp_weak.
+set F := _ \o _.
+rewrite -[F]uncurryK; apply: continuous_curry_fun.
+pose g := uncurry F \o prodAr \o (@swap _ _); simpl in *.
+have -> : uncurry F = uncurry F \o prodAr \o prodA.
+  by rewrite funeqE; case; case.
+move=> z; apply: continuous_comp; first exact: prodA_continuous.
+have -> : uncurry F \o prodAr = 
+    uncurry F \o prodAr \o (@swap _ _) \o (@swap _ _).
+  by rewrite funeqE; case; case.
+apply: continuous_comp; first exact: swap_continuous.
+pose h (fxg : continuousType X Y * X * continuousType Y Z) : Z := 
+  eval (fxg.2, ((eval fxg.1))).
+have <- : h = uncurry F \o prodAr \o (@swap _ _).
+  by rewrite /h/g/uncurry/swap/F funeqE; case; case.
+rewrite /h.
+apply: (@continuous2_cvg _ _ _ _ _ _ (snd) (eval \o fst) (curry eval)).
+- by apply: continuous_curry_joint_cvg; exact: eval_continuous.
+- exact: cvg_snd.
+- by apply: cvg_comp; [exact: cvg_fst | exact: eval_continuous].
+Qed.
+
+End composition.

--- a/theories/function_spaces.v
+++ b/theories/function_spaces.v
@@ -1441,11 +1441,11 @@ Lemma continuous_curry_fun (f : U * V -> W) :
   continuous f -> continuous (curry f).
 Proof. by case/continuous_curry. Qed.
 
-Lemma continuous_curry_joint_cvg (f : U * V -> W) (u : U) (v : V) : 
-  continuous f -> curry f z.1 z.2 @[z --> (u,v)] --> curry f u v.
-Proof. 
-move=> cf D /cf; rewrite ?nbhs_simpl /curry /=; apply: filterS => z.
-by move=> ?; rewrite /= -surjective_pairing.
+Lemma continuous_curry_joint_cvg (f : U * V -> W) (u : U) (v : V) :
+  continuous f -> curry f z.1 z.2 @[z --> (u, v)] --> curry f u v.
+Proof.
+move=> cf D /cf; rewrite !nbhs_simpl /curry /=; apply: filterS => z ? /=.
+by rewrite -surjective_pairing.
 Qed.
 
 Lemma continuous_uncurry_regular (f : U -> V -> W) :
@@ -1557,44 +1557,42 @@ End cartesian_closed.
 
 End currying.
 
-Definition eval {X Y : topologicalType} : continuousType X Y * X -> Y  := 
+Definition eval {X Y : topologicalType} : continuousType X Y * X -> Y :=
   uncurry (id : continuousType X Y -> (X -> Y)).
 
 Section composition.
 
 Local Import ArrowAsCompactOpen.
 
-Lemma eval_continuous {X Y : topologicalType} : 
+Lemma eval_continuous {X Y : topologicalType} :
   locally_compact [set: X] -> regular_space X -> continuous (@eval X Y).
 Proof.
-move=> ? ?; apply: continuous_uncurry_regular => //.
+move=> lcX rsX; apply: continuous_uncurry_regular => //.
   exact: weak_continuous.
 by move=> ?; exact: cts_fun.
 Qed.
 
-Lemma compose_continuous {X Y Z : topologicalType} : 
+Lemma compose_continuous {X Y Z : topologicalType} :
   locally_compact [set: X] -> @regular_space X ->
   locally_compact [set: Y] -> @regular_space Y ->
-  continuous (uncurry 
+  continuous (uncurry
     (comp : continuousType Y Z -> continuousType X Y -> continuousType X Z)).
 Proof.
-move=> ? ? lY rY; apply: continuous_comp_weak.
+move=> lX rX lY rY; apply: continuous_comp_weak.
 set F := _ \o _.
 rewrite -[F]uncurryK; apply: continuous_curry_fun.
-pose g := uncurry F \o prodAr \o (@swap _ _); simpl in *.
-have -> : uncurry F = uncurry F \o prodAr \o prodA.
-  by rewrite funeqE; case; case.
+pose g := uncurry F \o prodAr \o swap; rewrite /= in g *.
+have -> : uncurry F = uncurry F \o prodAr \o prodA by rewrite funeqE => -[[]].
 move=> z; apply: continuous_comp; first exact: prodA_continuous.
-have -> : uncurry F \o prodAr = 
-    uncurry F \o prodAr \o (@swap _ _) \o (@swap _ _).
-  by rewrite funeqE; case; case.
+have -> : uncurry F \o prodAr = uncurry F \o prodAr \o swap \o swap.
+  by rewrite funeqE => -[[]].
 apply: continuous_comp; first exact: swap_continuous.
-pose h (fxg : continuousType X Y * X * continuousType Y Z) : Z := 
-  eval (fxg.2, ((eval fxg.1))).
-have <- : h = uncurry F \o prodAr \o (@swap _ _).
-  by rewrite /h/g/uncurry/swap/F funeqE; case; case.
+pose h (fxg : continuousType X Y * X * continuousType Y Z) : Z :=
+  eval (fxg.2, (eval fxg.1)).
+have <- : h = uncurry F \o prodAr \o swap.
+  by rewrite /h/g/uncurry/swap/F funeqE => -[[]].
 rewrite /h.
-apply: (@continuous2_cvg _ _ _ _ _ _ (snd) (eval \o fst) (curry eval)).
+apply: (@continuous2_cvg _ _ _ _ _ _ snd (eval \o fst) (curry eval)).
 - by apply: continuous_curry_joint_cvg; exact: eval_continuous.
 - exact: cvg_snd.
 - by apply: cvg_comp; [exact: cvg_fst | exact: eval_continuous].

--- a/theories/function_spaces.v
+++ b/theories/function_spaces.v
@@ -1441,7 +1441,7 @@ Lemma continuous_curry_fun (f : U * V -> W) :
   continuous f -> continuous (curry f).
 Proof. by case/continuous_curry. Qed.
 
-Lemma continuous_curry_joint_cvg (f : U * V -> W) (u : U) (v : V) :
+Lemma continuous_curry_cvg (f : U * V -> W) (u : U) (v : V) :
   continuous f -> curry f z.1 z.2 @[z --> (u, v)] --> curry f u v.
 Proof.
 move=> cf D /cf; rewrite !nbhs_simpl /curry /=; apply: filterS => z ? /=.
@@ -1593,7 +1593,7 @@ have <- : h = uncurry F \o prodAr \o swap.
   by rewrite /h/g/uncurry/swap/F funeqE => -[[]].
 rewrite /h.
 apply: (@continuous2_cvg _ _ _ _ _ _ snd (eval \o fst) (curry eval)).
-- by apply: continuous_curry_joint_cvg; exact: eval_continuous.
+- by apply: continuous_curry_cvg; exact: eval_continuous.
 - exact: cvg_snd.
 - by apply: cvg_comp; [exact: cvg_fst | exact: eval_continuous].
 Qed.

--- a/theories/topology_theory/weak_topology.v
+++ b/theories/topology_theory/weak_topology.v
@@ -211,3 +211,11 @@ move=> [][][[]l|[]] [[]r|[]][][]//= _ xlr /filterS; apply.
 Qed.
 
 End weak_order_refine.
+
+Lemma continuous_comp_weak {Y : choiceType} {X Z : topologicalType} (w : Y -> Z) 
+  (f : X -> (weak_topology w)) :
+  continuous (w \o f) -> continuous f.
+Proof.
+move=> cf z U [?/= [[W oW <-]]] /= Wsfz /filterS; apply; apply: cf.
+by apply: open_nbhs_nbhs; split.
+Qed.

--- a/theories/topology_theory/weak_topology.v
+++ b/theories/topology_theory/weak_topology.v
@@ -212,10 +212,10 @@ Qed.
 
 End weak_order_refine.
 
-Lemma continuous_comp_weak {Y : choiceType} {X Z : topologicalType} (w : Y -> Z) 
-  (f : X -> (weak_topology w)) :
+Lemma continuous_comp_weak {Y : choiceType} {X Z : topologicalType} (w : Y -> Z)
+  (f : X -> weak_topology w) :
   continuous (w \o f) -> continuous f.
 Proof.
 move=> cf z U [?/= [[W oW <-]]] /= Wsfz /filterS; apply; apply: cf.
-by apply: open_nbhs_nbhs; split.
+exact: open_nbhs_nbhs.
 Qed.


### PR DESCRIPTION
The last of the foundational bits for homotopy. The idea is simply that for nice spaces (E.G. locally compact) in the compact-open topology, composition itself is continuous. A couple small notes 
- Apparently the condition of local compactness of `X` is unnecessary (munrkes $46, ex. 7). But the proof here is much easier, and it shouldn't matter too much for us in the near future.
- The `regular_space` condition is redundant due to `locally_compact_completely_regular + completely_regular_regular`. But those proofs sit in `normed_type.v` and need to be moved to `separation_axioms.v` before they can be used. Can be cleaned up later (or as a prerequisite if you think that's more important)

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
