### PR TITLE
generalize the return type of RVs

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -24,6 +24,8 @@
 - in `constructive_ereal.v`:
   + notations `\prod` in scope ereal_scope
   + lemmas `prode_ge0`, `prode_fin_num`
+- in `probability.v`:
+  + lemma `expectation_def`
 
 ### Changed
 
@@ -37,6 +39,8 @@
   + `emeasurable_fun_sum` -> `emeasurable_sum`
   + `emeasurable_fun_fsum` -> `emeasurable_fsum`
   + `ge0_emeasurable_fun_sum` -> `ge0_emeasurable_sum`
+- in `probability.v`:
+  + `expectationM` -> `expectationMl`
 
 - in `classical_sets.v`:
   + `preimage_itv_o_infty` -> `preimage_itvoy`
@@ -51,6 +55,18 @@
   + `mineMl` -> `mine_pMl`
 
 ### Generalized
+
+- in `probability.v`:
+  + definition `random_variable`
+  + lemmas `notin_range_measure`, `probability_range`
+  + definition `distribution`
+  + lemma `probability_distribution`, `integral_distribution`
+  + mixin `MeasurableFun_isDiscrete`
+  + structure `discreteMeasurableFun`
+  + definition `discrete_random_variable`
+  + lemma `dRV_dom_enum`
+  + definitions `dRV_dom`, `dRV_enum`, `enum_prob`
+  + lemmas `distribution_dRV`, `sum_enum_prob`
 
 ### Deprecated
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -26,6 +26,7 @@
   + lemmas `prode_ge0`, `prode_fin_num`
 - in `probability.v`:
   + lemma `expectation_def`
+  + notation `'M_`
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -41,7 +41,7 @@
   + `emeasurable_fun_fsum` -> `emeasurable_fsum`
   + `ge0_emeasurable_fun_sum` -> `ge0_emeasurable_sum`
 - in `probability.v`:
-  + `expectationM` -> `expectationMl`
+  + `expectationM` -> `expectationZl`
 
 - in `classical_sets.v`:
   + `preimage_itv_o_infty` -> `preimage_itvoy`

--- a/theories/probability.v
+++ b/theories/probability.v
@@ -16,23 +16,24 @@ From mathcomp Require Import lebesgue_integral kernel.
 (* the type probability T R (a measure that sums to 1).                       *)
 (*                                                                            *)
 (* ```                                                                        *)
-(*         {RV P >-> R} == real random variable: a measurable function from   *)
-(*                         the measurableType of the probability P to R       *)
+(*        {RV P >-> T'} == random variable: a measurable function to the      *)
+(*                         measurableType T' from the measured space          *)
+(*                         characterized by the probability P                 *)
 (*     distribution P X == measure image of the probability measure P by the  *)
-(*                         random variable X : {RV P -> R}                    *)
+(*                         random variable X : {RV P -> T'}                   *)
 (*                         P as type probability T R with T of type           *)
 (*                         measurableType.                                    *)
 (*                         Declared as an instance of probability measure.    *)
 (*              'E_P[X] == expectation of the real measurable function X      *)
 (*       covariance X Y == covariance between real random variable X and Y    *)
 (*              'V_P[X] == variance of the real random variable X             *)
-(*        mmt_gen_fun X == moment generating function of the random variable  *)
+(*                'M_ X == moment generating function of the random variable  *)
 (*                         X                                                  *)
 (*      {dmfun T >-> R} == type of discrete real-valued measurable functions  *)
 (*        {dRV P >-> R} == real-valued discrete random variable               *)
 (*            dRV_dom X == domain of the discrete random variable X           *)
 (*           dRV_enum X == bijection between the domain and the range of X    *)
-(*             pmf X r := fine (P (X @^-1` [set r]))                          *)
+(*              pmf X r := fine (P (X @^-1` [set r]))                         *)
 (*        enum_prob X k == probability of the kth value in the range of X     *)
 (* ```                                                                        *)
 (*                                                                            *)
@@ -57,6 +58,8 @@ Reserved Notation "'{' 'RV' P >-> R '}'"
   (at level 0, format "'{' 'RV'  P  '>->'  R '}'").
 Reserved Notation "''E_' P [ X ]" (format "''E_' P [ X ]", at level 5).
 Reserved Notation "''V_' P [ X ]" (format "''V_' P [ X ]", at level 5).
+Reserved Notation "'M_ X t" (format "''M_' X  t",
+  at level 5, t, X at next level).
 Reserved Notation "{ 'dmfun' aT >-> T }"
   (at level 0, format "{ 'dmfun'  aT  >->  T }").
 Reserved Notation "'{' 'dRV' P >-> R '}'"
@@ -556,9 +559,10 @@ apply: (le_trans (@le_integral_comp_abse _ _ _ P _ measurableT (EFin \o X)
 Qed.
 
 Definition mmt_gen_fun (X : {RV P >-> R}) (t : R) := 'E_P[expR \o t \o* X].
+Local Notation "'M_ X t" := (mmt_gen_fun X t).
 
 Lemma chernoff (X : {RV P >-> R}) (r a : R) : (0 < r)%R ->
-  P [set x | X x >= a]%R <= mmt_gen_fun X r * (expR (- (r * a)))%:E.
+  P [set x | X x >= a]%R <= 'M_X r * (expR (- (r * a)))%:E.
 Proof.
 move=> t0.
 rewrite /mmt_gen_fun; have -> : expR \o r \o* X =

--- a/theories/probability.v
+++ b/theories/probability.v
@@ -167,7 +167,7 @@ move: iX => /integrableP[? Xoo]; rewrite (le_lt_trans _ Xoo)// unlock.
 exact: le_trans (le_abse_integral _ _ _).
 Qed.
 
-Lemma expectationMl (X : {RV P >-> R}) (iX : P.-integrable [set: T] (EFin \o X))
+Lemma expectationZl (X : {RV P >-> R}) (iX : P.-integrable [set: T] (EFin \o X))
   (k : R) : 'E_P[k \o* X] = k%:E * 'E_P [X].
 Proof. by rewrite unlock muleC -integralZr. Qed.
 
@@ -217,8 +217,8 @@ by apply/funext => t/=; rewrite big_map sumEFin mfun_sum.
 Qed.
 
 End expectation_lemmas.
-#[deprecated(since="mathcomp-analysis 1.8.0", note="renamed to `expectationMl`")]
-Notation expectationM := expectationMl (only parsing).
+#[deprecated(since="mathcomp-analysis 1.8.0", note="renamed to `expectationZl`")]
+Notation expectationM := expectationZl (only parsing).
 
 HB.lock Definition covariance {d} {T : measurableType d} {R : realType}
     (P : probability T R) (X Y : T -> R) :=
@@ -249,7 +249,7 @@ rewrite expectationD/=; last 2 first.
   - by rewrite compreBr// integrableB// compre_scale ?integrableZl.
   - by rewrite compre_scale// integrableZl// finite_measure_integrable_cst.
 rewrite 2?expectationB//= ?compre_scale// ?integrableZl//.
-rewrite 3?expectationMl//= ?finite_measure_integrable_cst//.
+rewrite 3?expectationZl//= ?finite_measure_integrable_cst//.
 by rewrite expectation_cst mule1 fineM// EFinM !fineK// muleC subeK ?fin_numM.
 Qed.
 
@@ -289,7 +289,7 @@ have aXY : (a \o* X * Y = a \o* (X * Y))%R.
 rewrite [LHS]covarianceE => [||//|] /=; last 2 first.
 - by rewrite compre_scale ?integrableZl.
 - by rewrite aXY compre_scale ?integrableZl.
-rewrite covarianceE// aXY !expectationMl//.
+rewrite covarianceE// aXY !expectationZl//.
 by rewrite -muleA -muleBr// fin_num_adde_defr// expectation_fin_num.
 Qed.
 


### PR DESCRIPTION
##### Motivation for this change

This is an uncontroversial part of the PR on sampling: it just generalizes the type of random variables. This has been made possible by the recent generalization of measurable functions defined as a type in `lebesgue_measure.v`.

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
