### PR TITLE
gen fset lemma for partitions

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -10,6 +10,9 @@
 - in `normedtype.v`:
   + lemmas `continuous_within_itvcyP`, `continuous_within_itvNycP`
 
+- in `mathcomp_extra.v`:
+  + lemma `partition_disjoint_bigfcup`
+
 ### Changed
   
 ### Renamed


### PR DESCRIPTION
##### Motivation for this change

this PR adds a lemma to `mathcomp_extra.v` that generalizes a lemma of `finmap`,
the same lemma has also been PRed to `finmap` but we need a local copy in the meantime,
this is used to prove properties of independence of random variables and it is
better to have it in master asap to avoid recompilation from `classical` when switching branches

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
