### PR TITLE
minor generalization

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -33,7 +33,10 @@
   + lemma `integral_measure_add`
 
 - in `probability.v`
-  + lemma `integral_distribution` (existsing lemma `integral_distribution` has been renamed)
+  + lemma `integral_distribution` (existing lemma `integral_distribution` has been renamed)
+
+- in `measure.v`:
+  + lemma `countable_bigcupT_measurable`
 
 ### Changed
 

--- a/classical/classical_sets.v
+++ b/classical/classical_sets.v
@@ -2602,6 +2602,7 @@ Proof.
 by apply: qcanon; elim/eqPchoice; elim/choicePpointed => [[T F]|T];
    [left; exists (Empty.Pack F) | right; exists T].
 Qed.
+
 Lemma Ppointed : quasi_canonical Type pointedType.
 Proof.
 by apply: qcanon; elim/Peq; elim/eqPpointed => [[T F]|T];

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -1390,11 +1390,22 @@ Qed.
 
 End sigma_ring_lambda_system.
 
+Lemma countable_bigcupT_measurable d (T : sigmaRingType d) (U : choiceType)
+    (F : U -> set T) : countable [set: U] ->
+  (forall i, measurable (F i)) -> measurable (\bigcup_i F i).
+Proof.
+elim/choicePpointed: U => U in F *.
+  by move=> _ _; rewrite empty_eq0 bigcup0.
+move=> /countable_bijP[B] /ppcard_eqP[f] Fm.
+rewrite (reindex_bigcup f^-1%FUN setT)//=; first exact: bigcupT_measurable.
+exact: (@subl_surj _ _ B).
+Qed.
+
 Lemma bigcupT_measurable_rat d (T : sigmaRingType d) (F : rat -> set T) :
   (forall i, measurable (F i)) -> measurable (\bigcup_i F i).
 Proof.
-move=> Fm; have /ppcard_eqP[f] := card_rat.
-by rewrite (reindex_bigcup f^-1%FUN setT)//=; exact: bigcupT_measurable.
+apply: countable_bigcupT_measurable.
+by apply/countable_bijP; exists setT; exact: card_rat.
 Qed.
 
 Section measurable_lemmas.

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -1390,12 +1390,11 @@ Qed.
 
 End sigma_ring_lambda_system.
 
-Lemma countable_bigcupT_measurable d (T : sigmaRingType d) (U : choiceType)
+Lemma countable_bigcupT_measurable d (T : sigmaRingType d) U
     (F : U -> set T) : countable [set: U] ->
   (forall i, measurable (F i)) -> measurable (\bigcup_i F i).
 Proof.
-elim/choicePpointed: U => U in F *.
-  by move=> _ _; rewrite empty_eq0 bigcup0.
+elim/Ppointed: U => U in F *; first by move=> *; rewrite empty_eq0 bigcup0.
 move=> /countable_bijP[B] /ppcard_eqP[f] Fm.
 rewrite (reindex_bigcup f^-1%FUN setT)//=; first exact: bigcupT_measurable.
 exact: (@subl_surj _ _ B).
@@ -1403,10 +1402,7 @@ Qed.
 
 Lemma bigcupT_measurable_rat d (T : sigmaRingType d) (F : rat -> set T) :
   (forall i, measurable (F i)) -> measurable (\bigcup_i F i).
-Proof.
-apply: countable_bigcupT_measurable.
-by apply/countable_bijP; exists setT; exact: card_rat.
-Qed.
+Proof. exact/countable_bigcupT_measurable. Qed.
 
 Section measurable_lemmas.
 Context d (T : measurableType d).


### PR DESCRIPTION
##### Motivation for this change

This generalizes `bigcupT_measurable_rat`to any `choiceType` whose whole set is countable.
I didn't prove a version with `countType` because I didn't manage to generalize the
`quasi_canonical` machinery. Anyway, that doesn't make the lemma less general. @CohenCyril 

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
