### PR TITLE
near lemmas about derivation

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -119,6 +119,9 @@
 - new file `measurable_realfun.v`
   + with as contents the first half of the file `lebesgue_measure.v`
 
+- in `derive.v`:
+  + lemmas `near_derive`, `near_eq_derivable`, `near_eq_derive`, `near_eq_is_derive`
+
 ### Changed
 
 - in `lebesgue_integral.v`

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -120,7 +120,7 @@
   + with as contents the first half of the file `lebesgue_measure.v`
 
 - in `derive.v`:
-  + lemmas `near_derive`, `near_eq_derivable`, `near_eq_derive`, `near_eq_is_derive`
+  + lemmas `near_eq_derivable`, `near_eq_derive`, `near_eq_is_derive`
 
 ### Changed
 

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -1861,14 +1861,17 @@ rewrite diff_comp // !derive1E' //= -[X in 'd  _ _ X = _]mulr1.
 by rewrite [LHS]linearZ mulrC.
 Qed.
 
-Lemma near_derive (R : numFieldType) (V W : normedModType R)
-    (f g : V -> W) (a v : V) : v != 0 -> {near a, f =1 g} ->
+Section near_derive.
+Context (R : numFieldType) (V W : normedModType R).
+Variables (f g : V -> W) (a v : V).
+Hypotheses (v0 : v != 0) (afg : {near a, f =1 g}).
+
+Let near_derive :
   {near 0^', (fun h => h^-1 *: (f (h *: v + a) - f a)) =1
              (fun h => h^-1 *: (g (h *: v + a) - g a))}.
 Proof.
-move=> v0 nfg; near=> t; congr (_ *: _).
-near: t.
-move: nfg; rewrite {1}/prop_near1/= nbhsE/= => -[B [oB Ba] /[dup] Bfg Bfg'].
+near do congr (_ *: _).
+move: afg; rewrite {1}/prop_near1/= nbhsE/= => -[B [oB Ba] /[dup] Bfg Bfg'].
 have [e /= e0 eB] := open_subball oB Ba.
 have vv0 : 0 < `|2 *: v| by rewrite normrZ mulr_gt0 ?normr_gt0.
 near=> x.
@@ -1882,31 +1885,27 @@ apply: Bfg; apply: (eB (`|x| * `|2 *: v|)).
   by rewrite normrZ ltr_pMl ?normr_gt0// gtr0_norm ?ltr1n.
 Unshelve. all: by end_near. Qed.
 
-Lemma near_eq_derivable (R : numFieldType) (V W : normedModType R)
-    (f g : V -> W) (a v : V) : v != 0 ->
-  {near a, f =1 g} -> derivable f a v -> derivable g a v.
+Lemma near_eq_derivable : derivable f a v -> derivable g a v.
 Proof.
-move=> vn0 nfg /cvg_ex[/= l fl]; apply/cvg_ex; exists l => /=.
+move=> /cvg_ex[/= l fl]; apply/cvg_ex; exists l => /=.
 by apply: cvg_trans fl; apply: near_eq_cvg; exact: near_derive.
 Qed.
 
-Lemma near_eq_derive (R : numFieldType) (V W : normedModType R)
-  (f g : V -> W) (a v : V) :
-  v != 0 -> (\near a, f a = g a) -> 'D_v f a = 'D_v g a.
+Lemma near_eq_derive : 'D_v f a = 'D_v g a.
 Proof.
-move=> v0 fg; rewrite /derive; congr (lim _).
-have {}fg := near_derive v0 fg.
+rewrite /derive; congr (lim _).
+have {}fg := near_derive.
 rewrite eqEsubset; split; apply: near_eq_cvg=> //.
 by move/filterS : fg; apply => ? /esym.
 Qed.
 
-Lemma near_eq_is_derive (R : numFieldType) (V W : normedModType R)
-    (f g : V -> W) (a v : V) (df : W) : v != 0 ->
-  (\near a, f a = g a) -> is_derive a v f df -> is_derive a v g df.
+Lemma near_eq_is_derive (df : W) : is_derive a v f df -> is_derive a v g df.
 Proof.
-move=> v0 fg [fav <-]; rewrite (near_eq_derive v0 fg).
+move=> [fav <-]; rewrite near_eq_derive.
 by apply: DeriveDef => //; exact: near_eq_derivable fav.
 Qed.
+
+End near_derive.
 
 (* Trick to trigger type class resolution *)
 Lemma trigger_derive (R : realType) (f : R -> R) x x1 y1 :

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -1861,6 +1861,53 @@ rewrite diff_comp // !derive1E' //= -[X in 'd  _ _ X = _]mulr1.
 by rewrite [LHS]linearZ mulrC.
 Qed.
 
+Lemma near_derive (R : numFieldType) (V W : normedModType R)
+    (f g : V -> W) (a v : V) : v != 0 -> {near a, f =1 g} ->
+  {near 0^', (fun h => h^-1 *: (f (h *: v + a) - f a)) =1
+             (fun h => h^-1 *: (g (h *: v + a) - g a))}.
+Proof.
+move=> v0 nfg; near=> t; congr (_ *: _).
+near: t.
+move: nfg; rewrite {1}/prop_near1/= nbhsE/= => -[B [oB Ba] /[dup] Bfg Bfg'].
+have [e /= e0 eB] := open_subball oB Ba.
+have vv0 : 0 < `|2 *: v| by rewrite normrZ mulr_gt0 ?normr_gt0.
+near=> x.
+have x0 : 0 < `|x| by rewrite normr_gt0//; near: x; exact: nbhs_dnbhs_neq.
+congr (_ - _); last exact: Bfg'.
+apply: Bfg; apply: (eB (`|x| * `|2 *: v|)).
+- rewrite /ball_/= sub0r normrN normrM !normr_id -ltr_pdivlMr//.
+  by near: x; apply: dnbhs0_lt; rewrite divr_gt0.
+- by rewrite mulr_gt0.
+- rewrite -ball_normE/= opprD addrCA subrr addr0 normrN normrZ ltr_pM2l//.
+  by rewrite normrZ ltr_pMl ?normr_gt0// gtr0_norm ?ltr1n.
+Unshelve. all: by end_near. Qed.
+
+Lemma near_eq_derivable (R : numFieldType) (V W : normedModType R)
+    (f g : V -> W) (a v : V) : v != 0 ->
+  {near a, f =1 g} -> derivable f a v -> derivable g a v.
+Proof.
+move=> vn0 nfg /cvg_ex[/= l fl]; apply/cvg_ex; exists l => /=.
+by apply: cvg_trans fl; apply: near_eq_cvg; exact: near_derive.
+Qed.
+
+Lemma near_eq_derive (R : numFieldType) (V W : normedModType R)
+  (f g : V -> W) (a v : V) :
+  v != 0 -> (\near a, f a = g a) -> 'D_v f a = 'D_v g a.
+Proof.
+move=> v0 fg; rewrite /derive; congr (lim _).
+have {}fg := near_derive v0 fg.
+rewrite eqEsubset; split; apply: near_eq_cvg=> //.
+by move/filterS : fg; apply => ? /esym.
+Qed.
+
+Lemma near_eq_is_derive (R : numFieldType) (V W : normedModType R)
+    (f g : V -> W) (a v : V) (df : W) : v != 0 ->
+  (\near a, f a = g a) -> is_derive a v f df -> is_derive a v g df.
+Proof.
+move=> v0 fg [fav <-]; rewrite (near_eq_derive v0 fg).
+by apply: DeriveDef => //; exact: near_eq_derivable fav.
+Qed.
+
 (* Trick to trigger type class resolution *)
 Lemma trigger_derive (R : realType) (f : R -> R) x x1 y1 :
   is_derive x (1 : R) f x1 -> x1 = y1 -> is_derive x 1 f y1.

--- a/theories/topology_theory/topology_structure.v
+++ b/theories/topology_theory/topology_structure.v
@@ -104,7 +104,7 @@ HB.structure Definition PointedTopological :=
   {T of PointedNbhs T & Nbhs_isTopological T}.
 
 #[short(type="bpTopologicalType")]
-HB.structure Definition BiPointedTopological := 
+HB.structure Definition BiPointedTopological :=
   { X of BiPointed X & Topological X }.
 
 Section Topological1.


### PR DESCRIPTION
##### Motivation for this change

This PR provides four lemmas about derivation and `near`
that have been useful in InfoTheo
(https://github.com/affeldt-aist/infotheo/blob/8ac29a2e5cd8096b927daf38a00519af063f8d71/lib/derive_ext.v#L96) and also in the proof of L'Hopital's rule
(https://github.com/math-comp/analysis/pull/1371).

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [ ] added corresponding documentation in the headers~~

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
