### PR TITLE
l'hopital's rule

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -4,11 +4,6 @@
 
 ### Added
 
-### Changed
-
-- in `Rstruct.v`
-  + instantiate `GRinv.inv` by `Rinv` instead of `Rinvx`
-
 - in `mathcomp_extra.v`:
   + lemmas `prodr_ile1`, `nat_int`
 
@@ -257,6 +252,15 @@
 - in `normedtype.v`:
   + lemmas `gt0_cvgMlNy`, `gt0_cvgMly`
 
+- in `set_interval.v`:
+  + lemma `set_itv_splitU`
+
+- in `normedtype.v`:
+  + lemma `lt_nbhsr`
+
+- in `realfun.v`:
+  + lemmas `lhopital_at_left`, `lhopital_at_left`, `lhopital`,
+
 ### Changed
 
 - in `lebesgue_integral.v`
@@ -291,6 +295,8 @@
 - in `measure.v`:
   + `content_snum` -> `content_inum`
   + `measure_snum` -> `measure_inum`
+- in `Rstruct.v`
+  + instantiate `GRinv.inv` by `Rinv` instead of `Rinvx`
 
 ### Renamed
 
@@ -382,6 +388,10 @@
 - in `set_interval.v`:
   + `opp_itv_bnd_infty` -> `opp_itv_bndy`
   + `opp_itv_infty_bnd` -> `opp_itvNy_bnd`
+
+- in `normedtype.v`:
+  + `nbhs_lt` -> `lt_nbhsl_lt`
+  + `nbhs_le` -> `lt_nbhsl_le`
 
 ### Generalized
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -255,7 +255,7 @@
 - in `set_interval.v`:
   + lemma `set_itv_splitU`
 
-- in `normedtype.v`:
+- in `num_topology.v`:
   + lemma `lt_nbhsr`
 
 - in `realfun.v`:
@@ -297,6 +297,10 @@
   + `measure_snum` -> `measure_inum`
 - in `Rstruct.v`
   + instantiate `GRinv.inv` by `Rinv` instead of `Rinvx`
+
+- moved from `normedtype.v` to `num_topology.v` and renamed:
+  + `nbhs_lt` -> `lt_nbhsl_lt`
+  + `nbhs_le` -> `lt_nbhsl_le`
 
 ### Renamed
 
@@ -388,10 +392,6 @@
 - in `set_interval.v`:
   + `opp_itv_bnd_infty` -> `opp_itv_bndy`
   + `opp_itv_infty_bnd` -> `opp_itvNy_bnd`
-
-- in `normedtype.v`:
-  + `nbhs_lt` -> `lt_nbhsl_lt`
-  + `nbhs_le` -> `lt_nbhsl_le`
 
 ### Generalized
 

--- a/classical/set_interval.v
+++ b/classical/set_interval.v
@@ -234,7 +234,7 @@ Notation subset_itvS := subset_itvScc (only parsing).
 
 Section set_itv_orderType.
 Variables (d : Order.disp_t) (T : orderType d).
-Implicit Types a x y : itv_bound T.
+Implicit Types a b x y : itv_bound T.
 
 Lemma itv_bndbnd_setU a x y : (a <= x)%O -> (x <= y)%O ->
   ([set` Interval a y] = [set` Interval a x] `|` [set` Interval x y])%classic.
@@ -291,6 +291,26 @@ move: a ax => [b t /= tx| [/= oox|/= oox]].
     by move=> /le_trans; apply; exact/ltW.
   + by move=> /andP[].
 - by move: x => [[|] x|[|]//]/= in xy oox *.
+Qed.
+
+Lemma set_itv_splitU a b (c : T) : c \in Interval a b ->
+  [set` Interval a b] `\ c =
+    [set` Interval a (BLeft c)] `|` [set` Interval (BRight c) b].
+Proof.
+move=> cab; apply/seteqP; split => [x /= [xab /eqP]|x[|]]/=.
+- rewrite neq_lt => /orP[xc|cx]; [left|right].
+  + move: cab xab; rewrite !itv_boundlr => /andP[ac cb] /andP[ax xb].
+    by rewrite ax/= bnd_simp.
+  + move: cab xab; rewrite !itv_boundlr => /andP[ac cb] /andP[ax xb].
+    by rewrite xb andbT bnd_simp.
+- move: cab; rewrite !itv_boundlr => /andP[ac cb] /andP[ax].
+  rewrite bnd_simp => xc.
+  rewrite ax/= (le_trans _ cb) ?bnd_simp ?(ltW xc)//; split => //.
+  by apply/eqP; rewrite lt_eqF.
+- move: cab; rewrite !itv_boundlr => /andP[ac cb] /andP[+ xb].
+  rewrite bnd_simp => cx.
+  rewrite xb/= andbT (le_trans ac)/= ?bnd_simp ?(ltW cx)//; split => //.
+  by apply/eqP; rewrite gt_eqF.
 Qed.
 
 End set_itv_orderType.

--- a/theories/ftc.v
+++ b/theories/ftc.v
@@ -533,7 +533,8 @@ have /ifab : (mu `[a, c] < d%:E)%E.
 move=> /(_ (measurable_itv _)) {ifab}.
 apply: le_lt_trans.
 have acbc : `[a, c] `<=` `[a, b].
-  by apply: subset_itvl; rewrite bnd_simp; move: ac; near: c; exact: nbhs_le.
+  apply: subset_itvl; rewrite bnd_simp; move: ac; near: c.
+  exact: lt_nbhsl_le.
 rewrite -lee_fin fineK; last first.
   apply: integral_fune_fin_num => //=.
   rewrite (_ : (fun _ => _) = abse \o ((EFin \o f) \_ `[a, b])); last first.

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -1290,41 +1290,6 @@ Arguments cvgr0_norm_le {_ _ _ F FF}.
 #[global] Hint Extern 0 (is_true (`|?x| <= _)) => match goal with
   H : x \is_near _ |- _ => near: x; exact: cvgr0_norm_le end : core.
 
-Section nbhs_lt_le.
-Context {R : numFieldType}.
-Implicit Types x z : R.
-
-Lemma lt_nbhsl_lt x z : x < z -> \forall y \near x, x <= y -> y < z.
-Proof.
-move=> xz; near=> y.
-rewrite le_eqVlt => /predU1P[<-//|].
-near: y; exists (z - x) => /=; first by rewrite subr_gt0.
-move=> y/= /[swap] xy; rewrite ltr0_norm ?subr_lt0//.
-by rewrite opprD addrC ltrBlDr subrK opprK.
-Unshelve. all: by end_near. Qed.
-
-Lemma lt_nbhsl_le x z : x < z -> \forall y \near x, x <= y -> y <= z.
-Proof.
-by move=> xz; apply: filterS (lt_nbhsl_lt xz) => y /[apply] /ltW.
-Qed.
-
-End nbhs_lt_le.
-(*#[deprecated(since="mathcomp-analysis 1.9.0", note="use `lt_nbhsl_lt` instead")]
-Notation nbhs_lt := lt_nbhsl_lt (only parsing).
-#[deprecated(since="mathcomp-analysis 1.9.0", note="use `lt_nbhsl_le` instead")]
-Notation nbhs_le := lt_nbhsl_le (only parsing).*)
-
-Lemma lt_nbhsr {R : realFieldType} (a z : R) : a < z ->
-  \forall x \near z, a < x.
-Proof.
-rewrite -subr_gt0 => za0; exists (z - a) => //= u/=.
-rewrite ltrBrDl addrC -ltrBrDl => /lt_le_trans; apply.
-rewrite lerBlDl.
-have [uz|uz] := leP u z.
-  by rewrite ger0_norm ?subr_ge0// subrK.
-by rewrite ltr0_norm ?subr_lt0// opprB addrAC -lerBlDr opprK lerD// ?ltW.
-Qed.
-
 Section open_closed_sets.
 (* TODO: duplicate theory within the subspace topology of Num.real
          in a numDomainType *)

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -1291,10 +1291,10 @@ Arguments cvgr0_norm_le {_ _ _ F FF}.
   H : x \is_near _ |- _ => near: x; exact: cvgr0_norm_le end : core.
 
 Section nbhs_lt_le.
-Context {R : realType}.
+Context {R : numFieldType}.
 Implicit Types x z : R.
 
-Lemma nbhs_lt x z : x < z -> \forall y \near x, x <= y -> y < z.
+Lemma lt_nbhsl_lt x z : x < z -> \forall y \near x, x <= y -> y < z.
 Proof.
 move=> xz; near=> y.
 rewrite le_eqVlt => /predU1P[<-//|].
@@ -1303,12 +1303,27 @@ move=> y/= /[swap] xy; rewrite ltr0_norm ?subr_lt0//.
 by rewrite opprD addrC ltrBlDr subrK opprK.
 Unshelve. all: by end_near. Qed.
 
-Lemma nbhs_le x z : x < z -> \forall y \near x, x <= y -> y <= z.
+Lemma lt_nbhsl_le x z : x < z -> \forall y \near x, x <= y -> y <= z.
 Proof.
-by move=> xz; apply: filterS (nbhs_lt xz) => y /[apply] /ltW.
+by move=> xz; apply: filterS (lt_nbhsl_lt xz) => y /[apply] /ltW.
 Qed.
 
 End nbhs_lt_le.
+(*#[deprecated(since="mathcomp-analysis 1.9.0", note="use `lt_nbhsl_lt` instead")]
+Notation nbhs_lt := lt_nbhsl_lt (only parsing).
+#[deprecated(since="mathcomp-analysis 1.9.0", note="use `lt_nbhsl_le` instead")]
+Notation nbhs_le := lt_nbhsl_le (only parsing).*)
+
+Lemma lt_nbhsr {R : realFieldType} (a z : R) : a < z ->
+  \forall x \near z, a < x.
+Proof.
+rewrite -subr_gt0 => za0; exists (z - a) => //= u/=.
+rewrite ltrBrDl addrC -ltrBrDl => /lt_le_trans; apply.
+rewrite lerBlDl.
+have [uz|uz] := leP u z.
+  by rewrite ger0_norm ?subr_ge0// subrK.
+by rewrite ltr0_norm ?subr_lt0// opprB addrAC -lerBlDr opprK lerD// ?ltW.
+Qed.
 
 Section open_closed_sets.
 (* TODO: duplicate theory within the subspace topology of Num.real

--- a/theories/topology_theory/num_topology.v
+++ b/theories/topology_theory/num_topology.v
@@ -127,6 +127,7 @@ move=> xb; exists ((a + x) / 2) => /=.
   by rewrite divr_gt0// -(opprK x) subr_gt0.
 move=> r/=; rewrite ltr_pdivlMr// -ltrBlDr; apply: le_lt_trans.
 by rewrite -lerBlDr opprK addrC (le_trans (ler_norm _))// ler_peMr// ler1n.
+Qed.
 
 Section nbhs_lt_le.
 Context {R : numFieldType}.

--- a/theories/topology_theory/num_topology.v
+++ b/theories/topology_theory/num_topology.v
@@ -127,6 +127,40 @@ move=> xb; exists ((a + x) / 2) => /=.
   by rewrite divr_gt0// -(opprK x) subr_gt0.
 move=> r/=; rewrite ltr_pdivlMr// -ltrBlDr; apply: le_lt_trans.
 by rewrite -lerBlDr opprK addrC (le_trans (ler_norm _))// ler_peMr// ler1n.
+
+Section nbhs_lt_le.
+Context {R : numFieldType}.
+Implicit Types x z : R.
+
+Lemma lt_nbhsl_lt x z : x < z -> \forall y \near x, x <= y -> y < z.
+Proof.
+move=> xz; near=> y.
+rewrite le_eqVlt => /predU1P[<-//|].
+near: y; exists (z - x) => /=; first by rewrite subr_gt0.
+move=> y/= /[swap] xy; rewrite ltr0_norm ?subr_lt0//.
+by rewrite opprD addrC ltrBlDr subrK opprK.
+Unshelve. all: by end_near. Qed.
+
+Lemma lt_nbhsl_le x z : x < z -> \forall y \near x, x <= y -> y <= z.
+Proof.
+by move=> xz; apply: filterS (lt_nbhsl_lt xz) => y /[apply] /ltW.
+Qed.
+
+End nbhs_lt_le.
+#[deprecated(since="mathcomp-analysis 1.9.0", note="use `lt_nbhsl_lt` instead")]
+Notation nbhs_lt := lt_nbhsl_lt (only parsing).
+#[deprecated(since="mathcomp-analysis 1.9.0", note="use `lt_nbhsl_le` instead")]
+Notation nbhs_le := lt_nbhsl_le (only parsing).
+
+Lemma lt_nbhsr {R : realFieldType} (a z : R) : a < z ->
+  \forall x \near z, a < x.
+Proof.
+rewrite -subr_gt0 => za0; exists (z - a) => //= u/=.
+rewrite ltrBrDl addrC -ltrBrDl => /lt_le_trans; apply.
+rewrite lerBlDl.
+have [uz|uz] := leP u z.
+  by rewrite ger0_norm ?subr_ge0// subrK.
+by rewrite ltr0_norm ?subr_lt0// opprB addrAC -lerBlDr opprK lerD// ?ltW.
 Qed.
 
 Global Instance Proper_dnbhs_regular_numFieldType (R : numFieldType) (x : R^o) :

--- a/theories/trigo.v
+++ b/theories/trigo.v
@@ -1231,3 +1231,21 @@ by rewrite ltrNl oppr0 divr_gt0// pi_gt0.
 Qed.
 
 End Atan.
+
+Section lhopital_examples.
+Variable R : realType.
+
+Example cvg_mulsinV0 : sin x / x @[x --> 0^'] --> (1:R).
+Proof.
+apply: (@lhopital _ sin cos id 1 (-1) 1 0 1).
+- by rewrite in_itv/= ltrN10 ltr01.
+- rewrite -[X in _ --> X]sin0.
+  exact: continuous_sin.
+- exact: cvg_id.
+- by move=> ? _; exact: oner_neq0.
+- rewrite -[X in _ --> X]cos0.
+  under eq_fun do rewrite invr1 mulr1.
+  exact: continuous_cos.
+Qed.
+
+End lhopital_examples.

--- a/theories/trigo.v
+++ b/theories/trigo.v
@@ -1231,21 +1231,3 @@ by rewrite ltrNl oppr0 divr_gt0// pi_gt0.
 Qed.
 
 End Atan.
-
-Section lhopital_examples.
-Variable R : realType.
-
-Example cvg_mulsinV0 : sin x / x @[x --> 0^'] --> (1:R).
-Proof.
-apply: (@lhopital _ sin cos id 1 (-1) 1 0 1).
-- by rewrite in_itv/= ltrN10 ltr01.
-- rewrite -[X in _ --> X]sin0.
-  exact: continuous_sin.
-- exact: cvg_id.
-- by move=> ? _; exact: oner_neq0.
-- rewrite -[X in _ --> X]cos0.
-  under eq_fun do rewrite invr1 mulr1.
-  exact: continuous_cos.
-Qed.
-
-End lhopital_examples.


### PR DESCRIPTION
##### Motivation for this change

This PR provides a proof of L'Hopital's rule which is more general
than PR #1371  (I did not add a commit to this PR whose log is too complicated
for a proper rebase).

@ndslusarz I kept the previous versions of the lemmas in sections
lhopital0 and lhopital1, you can use them in your development but
it would be much better if you can use instead the lemmas lhopital_at_right and
lhopital_at_left instead.
Can you check that so that we remove them and your development
still stays compatible with the next version of MathComp-Analysis?

(thanks @zstone1)

closes PR #1371

better to merge PR #1477 before this one (fyi @t6s)

##### Checklist

- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
