### PR TITLE
Mark things as backported

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -29,6 +29,13 @@
   + `fubini1a` -> `integrable12ltyP`
   + `fubini1b` -> `integrable21ltyP`
 
+- in `mathcomp_extra.v`
+  + `comparable_min_le_min` -> `comparable_le_min2`
+  + `comparable_max_le_max` -> `comparable_le_max2`
+  + `min_le_min` -> `le_min2`
+  + `max_le_max` -> `le_max2`
+  + `real_sqrtC` -> `sqrtC_real`
+
 ### Generalized
 
 - in `constructive_ereal.v`:

--- a/classical/mathcomp_extra.v
+++ b/classical/mathcomp_extra.v
@@ -114,6 +114,88 @@ Proof. by move=> z; rewrite /proj dfwithin. Qed.
 End DFunWith.
 Arguments dfwith {I T} f i x.
 
+(**************************)
+(* MathComp 2.4 additions *)
+(**************************)
+
+Lemma comparable_BSide_min d (T : porderType d) b (x y : T) : (x >=< y)%O ->
+  BSide b (Order.min x y) = Order.min (BSide b x) (BSide b y).
+Proof. by rewrite !minEle bnd_simp => /comparable_leP[]. Qed.
+
+Lemma comparable_BSide_max d (T : porderType d) b (x y : T) : (x >=< y)%O ->
+  BSide b (Order.max x y) = Order.max (BSide b x) (BSide b y).
+Proof. by rewrite !maxEle bnd_simp => /comparable_leP[]. Qed.
+
+Lemma BSide_min d (T : orderType d) b (x y : T) : (x >=< y)%O ->
+  BSide b (Order.min x y) = Order.min (BSide b x) (BSide b y).
+Proof. exact: comparable_BSide_min. Qed.
+
+Lemma BSide_max d (T : orderType d) b (x y : T) : (x >=< y)%O ->
+  BSide b (Order.max x y) = Order.max (BSide b x) (BSide b y).
+Proof. exact: comparable_BSide_max. Qed.
+
+Section NumDomainType.
+
+Variable (R : numDomainType).
+
+Lemma real_BSide_min b (x y : R) : x \in Num.real -> y \in Num.real ->
+  BSide b (Order.min x y) = Order.min (BSide b x) (BSide b y).
+Proof. by move=> xr yr; apply/comparable_BSide_min/real_comparable. Qed.
+
+Lemma real_BSide_max b (x y : R) : x \in Num.real -> y \in Num.real ->
+  BSide b (Order.max x y) = Order.max (BSide b x) (BSide b y).
+Proof. by move=> xr yr; apply/comparable_BSide_max/real_comparable. Qed.
+
+Lemma natr_min (m n : nat) : (Order.min m n)%:R = Order.min m%:R n%:R :> R.
+Proof. by rewrite !minElt ltr_nat /Order.lt/= -fun_if. Qed.
+
+Lemma natr_max (m n : nat) : (Order.max m n)%:R = Order.max m%:R n%:R :> R.
+Proof. by rewrite !maxElt ltr_nat /Order.lt/= -fun_if. Qed.
+
+End NumDomainType.
+
+Lemma comparable_le_min2 d (T : porderType d) (x y z t : T) :
+    (x >=< y)%O -> (z >=< t)%O ->
+  (x <= z)%O -> (y <= t)%O -> (Order.min x y <= Order.min z t)%O.
+Proof.
+move=> + + xz yt => /comparable_leP[] xy /comparable_leP[] zt //.
+- exact: le_trans xy yt.
+- exact: le_trans (ltW xy) xz.
+Qed.
+#[deprecated(since="mathcomp-analysis 1.10.0",
+  note="use `comparable_le_min2` instead")]
+Notation comparable_min_le_min := comparable_le_min2.
+
+Lemma comparable_le_max2 d (T : porderType d) (x y z t : T) :
+    (x >=< y)%O -> (z >=< t)%O ->
+  (x <= z)%O -> (y <= t)%O -> (Order.max x y <= Order.max z t)%O.
+Proof.
+move=> + + xz yt => /comparable_leP[] xy /comparable_leP[] zt //.
+- exact: le_trans yt (ltW zt).
+- exact: le_trans xz zt.
+Qed.
+#[deprecated(since="mathcomp-analysis 1.10.0",
+  note="use `comparable_le_max2` instead")]
+Notation comparable_max_le_max := comparable_le_max2.
+
+Lemma le_min2 d (T : orderType d) (x y z t : T) :
+  (x <= z)%O -> (y <= t)%O -> (Order.min x y <= Order.min z t)%O.
+Proof. exact: comparable_min_le_min. Qed.
+#[deprecated(since="mathcomp-analysis 1.10.0", note="use `le_min2` instead")]
+Notation min_le_min := le_min2.
+
+Lemma le_max2 d (T : orderType d) (x y z t : T) :
+  (x <= z)%O -> (y <= t)%O -> (Order.max x y <= Order.max z t)%O.
+Proof. exact: comparable_max_le_max. Qed.
+#[deprecated(since="mathcomp-analysis 1.10.0", note="use `le_max2` instead")]
+Notation max_le_max := le_max2.
+
+Lemma sqrtC_real {R : numClosedFieldType} (x : R) : 0 <= x ->
+  sqrtC x \in Num.real.
+Proof. by rewrite -sqrtC_ge0; apply: ger0_real. Qed.
+#[deprecated(since="mathcomp-analysis 1.10.0", note="use `sqrtC_real` instead")]
+Notation real_sqrtC := sqrtC_real.
+
 (**********************)
 (* not yet backported *)
 (**********************)
@@ -602,82 +684,3 @@ Proof.
 move=> lt_mn i; rewrite big_nat [ltRHS]big_nat ltr_sum//.
 by apply/hasP; exists m; rewrite ?mem_index_iota leqnn lt_mn.
 Qed.
-
-(* To backport to interval *)
-Lemma comparable_BSide_min d (T : porderType d) b (x y : T) : (x >=< y)%O ->
-  BSide b (Order.min x y) = Order.min (BSide b x) (BSide b y).
-Proof. by rewrite !minEle bnd_simp => /comparable_leP[]. Qed.
-
-(* To backport to interval *)
-Lemma comparable_BSide_max d (T : porderType d) b (x y : T) : (x >=< y)%O ->
-  BSide b (Order.max x y) = Order.max (BSide b x) (BSide b y).
-Proof. by rewrite !maxEle bnd_simp => /comparable_leP[]. Qed.
-
-(* To backport to interval *)
-Lemma BSide_min d (T : orderType d) b (x y : T) : (x >=< y)%O ->
-  BSide b (Order.min x y) = Order.min (BSide b x) (BSide b y).
-Proof. exact: comparable_BSide_min. Qed.
-
-(* To backport to interval *)
-Lemma BSide_max d (T : orderType d) b (x y : T) : (x >=< y)%O ->
-  BSide b (Order.max x y) = Order.max (BSide b x) (BSide b y).
-Proof. exact: comparable_BSide_max. Qed.
-
-Section NumDomainType.
-
-Variable (R : numDomainType).
-
-(* To backport to interval *)
-Lemma real_BSide_min b (x y : R) : x \in Num.real -> y \in Num.real ->
-  BSide b (Order.min x y) = Order.min (BSide b x) (BSide b y).
-Proof. by move=> xr yr; apply/comparable_BSide_min/real_comparable. Qed.
-
-(* To backport to interval *)
-Lemma real_BSide_max b (x y : R) : x \in Num.real -> y \in Num.real ->
-  BSide b (Order.max x y) = Order.max (BSide b x) (BSide b y).
-Proof. by move=> xr yr; apply/comparable_BSide_max/real_comparable. Qed.
-
-(* To backport to ssralg.v *)
-Lemma natr_min (m n : nat) : (Order.min m n)%:R = Order.min m%:R n%:R :> R.
-Proof. by rewrite !minElt ltr_nat /Order.lt/= -fun_if. Qed.
-
-(* To backport to ssralg.v *)
-Lemma natr_max (m n : nat) : (Order.max m n)%:R = Order.max m%:R n%:R :> R.
-Proof. by rewrite !maxElt ltr_nat /Order.lt/= -fun_if. Qed.
-
-End NumDomainType.
-
-(* To backport to order.v *)
-Lemma comparable_min_le_min d (T : porderType d) (x y z t : T) :
-    (x >=< y)%O -> (z >=< t)%O ->
-  (x <= z)%O -> (y <= t)%O -> (Order.min x y <= Order.min z t)%O.
-Proof.
-move=> + + xz yt => /comparable_leP[] xy /comparable_leP[] zt //.
-- exact: le_trans xy yt.
-- exact: le_trans (ltW xy) xz.
-Qed.
-
-(* To backport to order.v *)
-Lemma comparable_max_le_max d (T : porderType d) (x y z t : T) :
-    (x >=< y)%O -> (z >=< t)%O ->
-  (x <= z)%O -> (y <= t)%O -> (Order.max x y <= Order.max z t)%O.
-Proof.
-move=> + + xz yt => /comparable_leP[] xy /comparable_leP[] zt //.
-- exact: le_trans yt (ltW zt).
-- exact: le_trans xz zt.
-Qed.
-
-(* To backport to order.v *)
-Lemma min_le_min d (T : orderType d) (x y z t : T) :
-  (x <= z)%O -> (y <= t)%O -> (Order.min x y <= Order.min z t)%O.
-Proof. exact: comparable_min_le_min. Qed.
-
-(* To backport to order.v *)
-Lemma max_le_max d (T : orderType d) (x y z t : T) :
-  (x <= z)%O -> (y <= t)%O -> (Order.max x y <= Order.max z t)%O.
-Proof. exact: comparable_max_le_max. Qed.
-
-(* To backport to ssrnum.v *)
-Lemma real_sqrtC {R : numClosedFieldType} (x : R) : 0 <= x ->
-  sqrtC x \in Num.real.
-Proof. by rewrite -sqrtC_ge0; apply: ger0_real. Qed.


### PR DESCRIPTION
Following the merge of https://github.com/math-comp/math-comp/pull/1351

##### Motivation for this change

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] ~added corresponding documentation in the headers~

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
