### PR TITLE
generalize measurable_funP, integral_pushforward and similar lemmas

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -28,7 +28,7 @@
 - in `lebesgue_integral.v`:
   + `fubini1a` -> `integrable12ltyP`
   + `fubini1b` -> `integrable21ltyP`
-  + (original) `measurable_funP` -> `measurable_funPT`
+  + `measurable_funP` -> `measurable_funPT` (field of `isMeasurableFun` mixin)
 
 - in `mathcomp_extra.v`
   + `comparable_min_le_min` -> `comparable_le_min2`
@@ -44,7 +44,8 @@
 
 - in `lebesgue_integral.v`
   + lemmas `measurable_funP`, `ge0_integral_pushforward`,
-           `integrable_pushforward`, `integral_pushforward`
+    `integrable_pushforward`, `integral_pushforward`
+
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -28,6 +28,7 @@
 - in `lebesgue_integral.v`:
   + `fubini1a` -> `integrable12ltyP`
   + `fubini1b` -> `integrable21ltyP`
+  + (original) `measurable_funP` -> `measurable_funPT`
 
 - in `mathcomp_extra.v`
   + `comparable_min_le_min` -> `comparable_le_min2`
@@ -41,6 +42,9 @@
 - in `constructive_ereal.v`:
   + lemma `EFin_natmul`
 
+- in `lebesgue_integral.v`
+  + lemmas `measurable_funP`, `ge0_integral_pushforward`,
+           `integrable_pushforward`, `integral_pushforward`
 ### Deprecated
 
 ### Removed

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -127,8 +127,6 @@ HB.structure Definition MeasurableFun d d' aT rT :=
   {f of @isMeasurableFun d d' aT rT f}.
 Arguments measurable_funPT {d d' aT rT} s.
 
-(* #[global] Hint Resolve fimfun_inP : core. *)
-
 Reserved Notation "{ 'mfun' aT >-> T }"
   (at level 0, format "{ 'mfun'  aT  >->  T }").
 Reserved Notation "[ 'mfun' 'of' f ]"
@@ -147,8 +145,8 @@ Lemma measurable_funP {d d' : measure_display}
   {aT : measurableType d} {rT : sigmaRingType d'}
   (D : set aT) (s : {mfun aT >-> rT}) : measurable_fun D s.
 Proof.
-move=> mD Y mY; apply: measurableI=> //.
-by rewrite -[X in measurable X]setTI; exact: measurable_funPT.
+move=> mD Y mY; apply: measurableI => //.
+by rewrite -(setTI (_ @^-1` _)); exact: measurable_funPT.
 Qed.
 Arguments measurable_funP {d d' aT rT D} s.
 (*#[global] Hint Extern 0 (measurable_fun _ _) =>
@@ -2667,7 +2665,7 @@ Context d1 d2 (X : measurableType d1) (Y : measurableType d2) (R : realType).
 Variables (phi : X -> Y) (mphi : measurable_fun setT phi).
 Variables (mu : {measure set X -> \bar R}).
 Let mphi_mixin := isMeasurableFun.Build _ _ _ _ _ mphi.
-Let mphi_pack := MeasurableFun.Pack (MeasurableFun.Class mphi_mixin).
+Let mphi_pack : {mfun _ >-> _} := HB.pack phi mphi_mixin.
 
 Import HBNNSimple.
 
@@ -2677,8 +2675,8 @@ Lemma ge0_integral_pushforward D (f : Y -> \bar R) :
   \int[mu]_(x in phi @^-1` D) (f \o phi) x.
 Proof.
 move=> mD mf f0.
-have mphiD: measurable (phi @^-1` D).
-  by rewrite -[X in measurable X]setTI; exact: (measurable_funP mphi_pack).
+have mphiD : measurable (phi @^-1` D).
+  by rewrite -(setTI (_ @^-1` _)); exact: (measurable_funP mphi_pack).
 pose f_ := nnsfun_approx mD mf.
 transitivity (limn (fun n => \int[pushforward mu mphi]_(x in D) (f_ n x)%:E)).
   rewrite -monotone_convergence//.
@@ -2687,16 +2685,15 @@ transitivity (limn (fun n => \int[pushforward mu mphi]_(x in D) (f_ n x)%:E)).
   - by move=> n; apply/measurable_EFinP; exact: measurable_funP.
   - by move=> n y _; rewrite lee_fin.
   - by move=> y _ m n mn; rewrite lee_fin; exact/lefP/nd_nnsfun_approx.
-rewrite (_ : (fun _ => _) =
-             (fun n => \int[mu]_(x in phi @^-1` D) (EFin \o f_ n \o phi) x)).
+rewrite [X in limn X](_ : _ =
+    (fun n => \int[mu]_(x in phi @^-1` D) (EFin \o f_ n \o phi) x)).
   rewrite -monotone_convergence//; last 3 first.
-    - move=> n /=; apply: measurableT_comp=> //; apply: measurableT_comp=> //.
+    - move=> n /=; do 2 apply: measurableT_comp=> //.
       exact: (measurable_funP mphi_pack).
     - by move=> n x _ /=; rewrite lee_fin.
     - by move=> x _ m n mn; rewrite lee_fin; exact/lefP/nd_nnsfun_approx.
   apply: eq_integral => x /[!inE] phiDx /=; apply/cvg_lim => //.
-  apply: cvg_nnsfun_approx=> //.
-  by move=> *; apply: f0; rewrite inE.
+  by apply: cvg_nnsfun_approx=> // y Dy; apply: f0; rewrite inE.
 apply/funext => n.
 have mfnphi r : measurable (f_ n @^-1` [set r] \o phi).
   rewrite -[_ \o _]/(phi @^-1` (f_ n @^-1` [set r])) -(setTI (_ @^-1` _)).
@@ -2709,7 +2706,7 @@ transitivity (\sum_(k \in range (f_ n))
     - by move=> y x _; rewrite nnfun_muleindic_ge0.
   apply: eq_fsbigr => r _; rewrite integralZl_indic_nnsfun// integral_indic//=.
   rewrite (integralZl_indic _ (fun r => f_ n @^-1` [set r] \o phi))//.
-    congr (_ * _); rewrite [RHS](@integral_indic)//.
+    by congr (_ * _); rewrite [RHS]integral_indic.
   by move=> r0; rewrite preimage_nnfun0.
 rewrite -ge0_integral_fsum//; last 2 first.
   - by move=> r; apply/measurable_EFinP; exact: measurable_funM.
@@ -4246,14 +4243,12 @@ Proof.
 move=> mD; apply/integrableP; split; first exact: (measurable_funP mf_pack).
 move/integrableP : (intf) => [_]; apply: le_lt_trans.
 rewrite ge0_integral_pushforward//.
-apply: measurableT_comp=> //.
-exact: (measurable_funS measurableT).
+by apply: measurableT_comp => //; exact: measurable_funTS.
 Qed.
 
 Local Open Scope ereal_scope.
 
-Lemma integral_pushforward :
-  measurable D ->
+Lemma integral_pushforward : measurable D ->
   \int[pushforward mu mphi]_(y in D) f y =
   \int[mu]_(x in phi @^-1` D) (f \o phi) x.
 Proof.
@@ -4262,9 +4257,9 @@ rewrite integralE.
 under [X in X - _]eq_integral do rewrite funepos_comp.
 under [X in _ - X]eq_integral do rewrite funeneg_comp.
 rewrite -[X in _ = X - _]ge0_integral_pushforward//; last first.
-  exact/measurable_funepos/(measurable_funS measurableT).
+  exact/measurable_funepos/measurable_funTS.
 rewrite -[X in _ = _ - X]ge0_integral_pushforward//; last first.
-  exact/measurable_funeneg/(measurable_funS measurableT).
+  exact/measurable_funeneg/measurable_funTS.
 rewrite -integralB//=; last first.
 - by apply: integrable_funeneg => //=; exact: integrable_pushforward.
 - by apply: integrable_funepos => //=; exact: integrable_pushforward.

--- a/theories/probability.v
+++ b/theories/probability.v
@@ -96,7 +96,7 @@ Proof. by rewrite preimage_range probability_setT. Qed.
 
 Definition distribution d d' (T : measurableType d) (T' : measurableType d')
     (R : realType) (P : probability T R) (X : {mfun T >-> T'}) :=
-  pushforward P (@measurable_funP _ _ _ _ X).
+  pushforward P (@measurable_funP _ _ _ _ _ X).
 
 Section distribution_is_probability.
 Context d d' {T : measurableType d} {T' : measurableType d'} {R : realType}


### PR DESCRIPTION
##### Motivation for this change

Some lemmas in `lebesgue_integral.v` have their domain unnecessarily restricted to `setT`,
including `measurable_funP` and those related to `pushforward`.
This PR generalizes them to take an arbitrary set as the domain.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->
Answers #1519 


<!-- you may also explain what remains to do if the fix is incomplete -->

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
