### PR TITLE
equivalence between exponential funcitons in stdlib and mca

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -9,7 +9,7 @@
 
 - file `Rstruct.v`
   + lemma `Pos_to_natE` (from `mathcomp_extra.v`)
-  + lemmas `RabsE`, `RdistE`, `sum_f_R0E`, `factE`, `RexpE`
+  + lemmas `RabsE`, `RdistE`, `sum_f_R0E`, `factE`
 
 - new file `internal_Eqdep_dec.v` (don't use, internal, to be removed)
 
@@ -29,6 +29,9 @@
 - in `measure.v`:
   + lemmas `preimage_set_system0`, `preimage_set_systemU`, `preimage_set_system_comp`
   + lemma `preimage_set_system_id`
+
+- in `Rstruct_topology.v`:
+  + lemma `RexpE`
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -9,6 +9,7 @@
 
 - file `Rstruct.v`
   + lemma `Pos_to_natE` (from `mathcomp_extra.v`)
+  + lemmas `RabsE`, `RdistE`, `sum_f_R0E`, `factE`, `RexpE`
 
 - new file `internal_Eqdep_dec.v` (don't use, internal, to be removed)
 

--- a/analysis_stdlib/Rstruct_topology.v
+++ b/analysis_stdlib/Rstruct_topology.v
@@ -90,7 +90,7 @@ Proof. by move=> Lf /continuity_pt_cvg; apply. Qed.
 End analysis_struct.
 
 Module RexpE.
-Import topology normedtype sequences.
+Import normedtype sequences.
 
 (* proof by comparing the defining power series *)
 Lemma RexpE (x : R) : Rtrigo_def.exp x = expR x.

--- a/analysis_stdlib/Rstruct_topology.v
+++ b/analysis_stdlib/Rstruct_topology.v
@@ -10,11 +10,12 @@ Require Import Rtrigo1 Reals.
 From mathcomp Require Import all_ssreflect ssralg poly mxpoly ssrnum.
 From mathcomp Require Import archimedean.
 From HB Require Import structures.
-From mathcomp Require Import mathcomp_extra.
-From mathcomp Require Import boolp classical_sets.
+From mathcomp Require Import mathcomp_extra boolp classical_sets.
 From mathcomp Require Import reals interval_inference.
-From mathcomp Require Import topology.
 From mathcomp Require Export Rstruct.
+From mathcomp Require Import topology.
+(* The following line is for RexpE. *)
+From mathcomp Require normedtype sequences.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
@@ -87,3 +88,24 @@ Lemma nbhs_pt_comp (P : R -> Prop) (f : R -> R) (x : R) :
 Proof. by move=> Lf /continuity_pt_cvg; apply. Qed.
 
 End analysis_struct.
+
+Module RexpE.
+Import topology normedtype sequences.
+
+(* proof by comparing the defining power series *)
+Lemma RexpE (x : R) : Rtrigo_def.exp x = expR x.
+Proof.
+apply/esym; rewrite /exp /exist_exp; case: Alembert_C3 => y.
+rewrite /Pser /infinite_sum /= => exp_ub.
+rewrite /expR /exp_coeff /series/=; apply: (@cvg_lim R^o) => //.
+rewrite -cvg_shiftS /=; apply/cvgrPdist_lt => /= e /RltP /exp_ub[N Nexp_ub].
+near=> n.
+have nN : (n >= N)%coq_nat by apply/ssrnat.leP; near: n; exact: nbhs_infty_ge.
+move: Nexp_ub => /(_ _ nN) /[!RdistE] /RltP /=.
+rewrite distrC sum_f_R0E; congr (`| _ - _ | < e).
+by apply: eq_bigr=> k _; rewrite RinvE RpowE mulrC factE INRE.
+Unshelve. all: by end_near. Qed.
+
+End RexpE.
+
+Definition RexpE := RexpE.RexpE.

--- a/reals_stdlib/Rstruct.v
+++ b/reals_stdlib/Rstruct.v
@@ -32,8 +32,6 @@ From mathcomp Require Import all_ssreflect ssralg poly mxpoly ssrnum.
 From mathcomp Require Import archimedean.
 From HB Require Import structures.
 From mathcomp Require Import mathcomp_extra.
-(* The following line is for RexpE. *)
-From mathcomp Require topology normedtype sequences.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
@@ -739,24 +737,3 @@ Qed.
 End bigmaxr.
 
 End ssreal_struct_contd.
-
-Module RexpE.
-Import topology normedtype sequences.
-
-(* proof by comparing the defining power series *)
-Lemma RexpE (x : R) : Rtrigo_def.exp x = expR x.
-Proof.
-apply/esym; rewrite /exp /exist_exp; case: Alembert_C3 => y.
-rewrite /Pser /infinite_sum /= => exp_ub.
-rewrite /expR /exp_coeff /series/=; apply: (@cvg_lim R^o) => //.
-rewrite -cvg_shiftS /=; apply/cvgrPdist_lt => /= e /RltP /exp_ub[N Nexp_ub].
-near=> n.
-have nN : (n >= N)%coq_nat by apply/ssrnat.leP; near: n; exact: nbhs_infty_ge.
-move: Nexp_ub => /(_ _ nN) /[!RdistE] /RltP /=.
-rewrite distrC sum_f_R0E; congr (`| _ - _ | < e).
-by apply: eq_bigr=> k _; rewrite RinvE RpowE mulrC factE INRE.
-Unshelve. all: by end_near. Qed.
-
-End RexpE.
-
-Definition RexpE := RexpE.RexpE.


### PR DESCRIPTION
##### Motivation for this change

`Rtrigo_def.exp` in stdlib and `expR` are equal.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
