### PR TITLE
derive lemmas for shift

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -33,6 +33,9 @@
 - in `Rstruct_topology.v`:
   + lemma `RexpE`
 
+- in `derive.v`:
+  + lemmas `derive_shift`, `is_derive_shift`
+
 ### Changed
 
 - file `nsatz_realtype.v` moved from `reals` to `reals-stdlib` package

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -1377,6 +1377,16 @@ Qed.
 
 End Derive_lemmasVR.
 
+Lemma derive_shift {R : numFieldType} (v k : R) :
+  'D_v (shift k : R^o -> R^o) = cst v.
+Proof.
+by apply/funext => x/=; rewrite deriveD// derive_id derive_cst addr0.
+Qed.
+
+Lemma is_derive_shift {R : numFieldType} x v (k : R) :
+  is_derive x v (shift k : R^o -> R^o) v.
+Proof. by apply: DeriveDef => //; rewrite derive_val addr0. Qed.
+
 Lemma derive1_cst {R : numFieldType} (k : R) t : (cst k)^`() t = 0.
 Proof. by rewrite derive1E derive_cst. Qed.
 


### PR DESCRIPTION
##### Motivation for this change

two easy lemmas about derivation and `shift` that found their use when proving a measurability property of the normal distribution (PR to come)

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
