### PR TITLE
Complete the set of trunc/floor/ceil lemmas

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -56,6 +56,9 @@
   + lemmas `num_spec_sin`, `num_spec_cos`
   + canonical instances `sin_inum`, `cos_inum`
 
+- in `mathcomp_extra.v`:
+  + lemmas `intrN`, `real_floor_itv`, `real_ge_floor`, `real_ceil_itv`
+
 ### Changed
 
 - file `nsatz_realtype.v` moved from `reals` to `reals-stdlib` package

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -126,6 +126,9 @@
     to new file `unstable.v` that shouldn't be used outside of
     Analysis)
 
+- in `reals.v`:
+  + lemmas `floor_le`, `le_floor` (deprecated since 1.3.0)
+
 ### Infrastructure
 
 ### Misc

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -4,9 +4,6 @@
 
 ### Added
 
-- file `mathcomp_extra.v`
-  + lemmas `ge_trunc`, `lt_succ_trunc`, `trunc_ge_nat`, `trunc_lt_nat`
-
 - file `Rstruct.v`
   + lemma `Pos_to_natE` (from `mathcomp_extra.v`)
   + lemmas `RabsE`, `RdistE`, `sum_f_R0E`, `factE`
@@ -120,8 +117,7 @@
     `onem_le1`, `onem_lt1`, `onemX_ge0`, `onemX_lt1`, `onemD`,
     `onemMr`, `onemM`, `onemV`, `lez_abs2`, `ler_gtP`, `ler_ltP`,
     `real_ltr_distlC`, `prodAK`, `prodArK`, `swapK`, `lt_min_lt`,
-    `intrD1`, `intr1D`, `ge_trunc`, `lt_succ_trunc`, `trunc_ge_nat`,
-    `trunc_lt_nat`, `floor_lt_int`, `floor_ge0`, `floor_le0`,
+    `intrD1`, `intr1D`, `floor_lt_int`, `floor_ge0`, `floor_le0`,
     `floor_lt0`, `floor_eq`, `floor_neq0`, `ceil_gt_int`, `ceil_ge0`,
     `ceil_gt0`, `ceil_le0`, `abs_ceil_ge`, `nat_int`, `bij_forall`,
     `and_prop_in`, `mem_inc_segment`, `mem_dec_segment`,

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -97,6 +97,9 @@
   + lemmas `measurable_funP`, `ge0_integral_pushforward`,
     `integrable_pushforward`, `integral_pushforward`
 
+- in `real_interval.v`:
+  + lemmas `bigcup_itvT`, `itv_bndy_bigcup_BRight`, `itv_bndy_bigcup_BLeft_shift`
+
 ### Deprecated
 
 ### Removed

--- a/classical/mathcomp_extra.v
+++ b/classical/mathcomp_extra.v
@@ -109,7 +109,37 @@ Arguments dfwith {I T} f i x.
 
 Definition idempotent_fun (U : Type) (f : U -> U) := f \o f =1 f.
 
+Section intrN.
+
+Variable R : ringType.
+
+Implicit Types n : int.
+
+Lemma intrN n : (- n)%:~R = - n%:~R :> R. Proof. exact: mulrNz. Qed.
+
+End intrN.
+
 From mathcomp Require Import archimedean.
+Import Num.Theory.
+
+Section num_floor_ceil.
+Context {R : archiNumDomainType}.
+Implicit Type x : R.
+
+Lemma real_floor_itv x : x \is Num.real ->
+  (Num.floor x)%:~R <= x < (Num.floor x + 1)%:~R.
+Proof. by case: (x \is _) (archimedean.Num.Theory.floorP x). Qed.
+
+Lemma real_ge_floor x : x \is Num.real -> (Num.floor x)%:~R <= x.
+Proof. by move=> /real_floor_itv /andP[]. Qed.
+
+Lemma real_ceil_itv x : x \is Num.real ->
+  (Num.ceil x - 1)%:~R < x <= (Num.ceil x)%:~R.
+Proof.
+by move=> Rx; rewrite -opprD !mulrNz ltrNl lerNr andbC real_floor_itv ?realN.
+Qed.
+
+End num_floor_ceil.
 
 Section floor_ceil.
 Context {R : archiDomainType}.

--- a/classical/unstable.v
+++ b/classical/unstable.v
@@ -320,71 +320,241 @@ Proof. by rewrite intrD. Qed.
 Lemma intr1D {R : ringType} (i : int) : 1 + i%:~R = (1 + i)%:~R :> R.
 Proof. by rewrite intrD. Qed.
 
-Section floor_ceil.
-Context {R : archiDomainType}.
+Section num_trunc_floor_ceil.
+Context {R : archiNumDomainType}.
 Implicit Type x : R.
 
 Lemma ge_trunc x : ((Num.trunc x)%:R <= x) = (0 <= x).
 Proof.
-by have [/Num.Theory.trunc_itv/andP[]//|] := leP 0 x; exact/contra_ltF/le_trans.
+by have := trunc_floor x; case: ifP => [/trunc_itv/andP[] | _ -> //].
+(* simplify proof when backporting:
+by have := Def.truncP x; case: ifP => [+ /andP[] | + /eqP->//]. *)
 Qed.
 
-Lemma lt_succ_trunc x : x < (Num.trunc x).+1%:R.
-Proof. by have [/Num.Theory.trunc_itv/andP[]|/lt_le_trans->] := leP 0 x. Qed.
+Lemma real_ltStrunc x : x \is Num.real -> x < (Num.trunc x).+1%:R.
+Proof. by move/real_ge0P => [/trunc_itv/andP[]|/lt_le_trans->]. Qed.
 
-Lemma trunc_ge_nat x (n : nat) : 0 <= x -> (n%:R <= x) = (n <= Num.trunc x)%N.
+Lemma trunc_ge_nat x n : 0 <= x -> (n <= Num.trunc x)%N = (n%:R <= x).
 Proof.
-move=> /Num.Theory.trunc_itv /andP[letx ltxt1]; apply/idP/idP => lenx.
-  by rewrite -ltnS -(ltr_nat R); apply: le_lt_trans ltxt1.
-by apply: le_trans letx; rewrite ler_nat.
+move=> /trunc_itv /andP[letx ltxt1]; apply/idP/idP => lenx.
+  by apply: le_trans letx; rewrite ler_nat.
+by rewrite -ltnS -(ltr_nat R); apply: le_lt_trans ltxt1.
 Qed.
 
-Lemma trunc_lt_nat x (n : nat) : 0 <= x -> (x < n%:R) = (Num.trunc x < n)%N.
-Proof. by rewrite ltNge ltnNge => /trunc_ge_nat ->. Qed.
-
-Lemma floor_lt_int x (z : int) : (x < z%:~R) = (Num.floor x < z).
-Proof. by rewrite ltNge mathcomp_extra.floor_ge_int -ltNge. Qed.
-
-Lemma floor_ge0 x : (0 <= Num.floor x) = (0 <= x).
-Proof. by rewrite -floor_ge_int. Qed.
-
-Lemma floor_le0 x : (x < 1) = (Num.floor x <= 0).
-Proof. by rewrite -ltzD1 add0r -floor_lt_int. Qed.
-
-Lemma floor_lt0 x : (x < 0) = (Num.floor x < 0).
-Proof. by rewrite -floor_lt_int. Qed.
-
-Lemma floor_eq x m : (Num.floor x == m) = (m%:~R <= x < (m + 1)%:~R).
+Lemma trunc_gt_nat x n : (n < Num.trunc x)%N = (n.+1%:R <= x).
 Proof.
-apply/eqP/idP; [move=> <-|by move=> /Num.Theory.floor_def ->].
-by rewrite Num.Theory.ge_floor//= Num.Theory.lt_succ_floor.
+have := trunc_floor x; case: ifP => [x0 _ | x0 ->].
+  by rewrite trunc_ge_nat.
+by rewrite ltn0; apply/esym/(contraFF _ x0)/le_trans.
+(* simplify proof when backporting
+have := archimedean.Num.Def.truncP x; case: ifP => [x0 _ | x0 /eqP->].
+  by rewrite trunc_ge_nat.
+by rewrite ltn0; apply/esym/(contraFF _ x0)/le_trans. *)
+Qed.
+
+Lemma trunc_lt_nat x n : 0 <= x -> (Num.trunc x < n)%N = (x < n%:R).
+Proof. by move=> ?; rewrite real_ltNge ?ger0_real// ltnNge trunc_ge_nat. Qed.
+
+Lemma real_trunc_le_nat x n : x \is Num.real ->
+  (Num.trunc x <= n)%N = (x < n.+1%:R).
+Proof. by move=> ?; rewrite real_ltNge// leqNgt trunc_gt_nat. Qed.
+
+Lemma trunc_eq x n : 0 <= x -> (Num.trunc x == n) = (n%:R <= x < n.+1%:R).
+Proof.
+by move=> xr; apply/eqP/idP => [<-|]; [exact: trunc_itv|exact: trunc_def].
+Qed.
+
+Lemma le_trunc : {homo Num.trunc : x y / x <= y :> R >-> (x <= y)%N}.
+Proof.
+move=> x y lexy.
+move: (trunc_floor x) (trunc_floor y).
+case: ifP => [x0 _ | x0->//].
+case: ifP => [y0 _ | + ->]; [|by rewrite (le_trans x0 lexy)].
+move: (trunc_itv y0) => /andP[_ /(le_lt_trans lexy)].
+move: (trunc_itv x0) => /andP[+ _] => /le_lt_trans/[apply].
+by rewrite ltr_nat ltnS.
+(* simplify proof when backporting:
+move: (archimedean.Num.Def.truncP x) (archimedean.Num.Def.truncP y).
+case: ifP => [x0 /andP[letx _] | x0 /eqP->//].
+case: ifP => [y0 /andP[_] | + /eqP->]; [|by rewrite (le_trans x0 lexy)].
+by move=> /(le_lt_trans lexy) /(le_lt_trans letx); rewrite ltr_nat ltnS. *)
+Qed.
+
+Lemma real_lt_floorD1 x : x \is Num.real -> x < (Num.floor x + 1)%:~R.
+Proof. by move=> /real_floor_itv /andP[]. Qed.
+
+(* TODO: rename to real_floor_ge_int,
+   once the currently deprecated one has been removed *)
+Lemma real_floor_ge_int_tmp x n : x \is Num.real ->
+  (n <= Num.floor x) = (n%:~R <= x).
+Proof.
+move=> /real_floor_itv /andP[lefx ltxf1]; apply/idP/idP => lenx.
+  by apply: le_trans lefx; rewrite ler_int.
+by rewrite -ltzD1 -(ltr_int R); apply: le_lt_trans ltxf1.
+Qed.
+
+#[deprecated(since="mathcomp-analysis 1.10.0",
+  note="Use real_floor_ge_int_tmp instead.")]
+Lemma real_floor_ge_int x n : x \is Num.real -> (n%:~R <= x) = (n <= Num.floor x).
+Proof. by move=> ?; rewrite real_floor_ge_int_tmp. Qed.
+
+Lemma real_floor_lt_int x n : x \is Num.real -> (Num.floor x < n) = (x < n%:~R).
+Proof.
+by move=> ?; rewrite [RHS]real_ltNge ?realz -?real_floor_ge_int_tmp -?ltNge.
+Qed.
+
+Lemma le_floor : {homo (@Num.floor R) : x y / x <= y}.
+Proof. exact: floor_le. Qed.
+
+Lemma real_floor_eq x n : x \is Num.real ->
+  (Num.floor x == n) = (n%:~R <= x < (n + 1)%:~R).
+Proof.
+by move=> xr; apply/eqP/idP => [<-|]; [exact: real_floor_itv|exact: floor_def].
+Qed.
+
+Lemma real_floor_ge0 x : x \is Num.real -> (0 <= Num.floor x) = (0 <= x).
+Proof. by move=> ?; rewrite real_floor_ge_int_tmp. Qed.
+
+Lemma floor_lt0 x : (Num.floor x < 0) = (x < 0).
+Proof.
+have := archimedean.Num.Theory.floorP x; case: ifP => [xr _ | xr /eqP].
+  by rewrite real_floor_lt_int.
+rewrite -?[0%Z]/(@GRing.zero int) => <-.
+by rewrite ltxx; apply/esym/(contraFF _ xr)/ltr0_real.
+(* simpler proof when backporting:
+have := archimedean.Num.Theory.floorP x; case: ifP => [xr _ | xr /eqP<-].
+  by rewrite real_floor_lt_int.
+by rewrite ltxx; apply/esym/(contraFF _ xr)/ltr0_real. *)
+Qed.
+
+Lemma real_floor_le0 x : x \is Num.real -> (Num.floor x <= 0) = (x < 1).
+Proof. by move=> ?; rewrite -ltzD1 add0r real_floor_lt_int. Qed.
+
+Lemma floor_gt0 x : (Num.floor x > 0) = (x >= 1).
+Proof.
+have := archimedean.Num.Theory.floorP x; case: ifP => [xr _ | xr /eqP->].
+  by rewrite gtz0_ge1 real_floor_ge_int_tmp.
+by rewrite ltxx; apply/esym/(contraFF _ xr)/ger1_real.
 Qed.
 
 Lemma floor_neq0 x : (Num.floor x != 0) = (x < 0) || (x >= 1).
-Proof. by rewrite floor_eq negb_and -ltNge -leNgt. Qed.
+Proof.
+have := archimedean.Num.Theory.floorP x.
+case: ifP => [xr _ | xr /eqP->]; rewrite ?eqxx/=.
+  by rewrite neq_lt floor_lt0 floor_gt0.
+by apply/esym/(contraFF _ xr) => /orP[]; [exact: ltr0_real|exact: ger1_real].
+Qed.
 
-Lemma ceil_gt_int x (z : int) : (z%:~R < x) = (z < Num.ceil x).
-Proof. by rewrite ltNge Num.Theory.ceil_le_int// -ltNge. Qed.
+(* TODO: rename to real_ceil_le_int,
+   once the currently deprecated one has been removed *)
+Lemma real_ceil_le_int_tmp x n : x \is Num.real ->
+  (Num.ceil x <= n) = (x <= n%:~R).
+Proof.
+rewrite -realN; move=> /(real_floor_ge_int_tmp (- n)).
+by rewrite mulrNz lerNl => ->; rewrite lerN2.
+Qed.
 
-Lemma ceil_ge0 x : (- 1 < x) = (0 <= Num.ceil x).
-Proof. by rewrite ltrNl floor_le0 lerNr oppr0. Qed.
+#[deprecated(since="mathcomp-analyss 1.10.0",
+  note="Use real_ceil_le_int_tmp instead.")]
+Lemma real_ceil_le_int x n : x \is Num.real -> (x <= n%:~R) = (Num.ceil x <= n).
+Proof. by move=> ?; rewrite real_ceil_le_int_tmp. Qed.
 
-Lemma ceil_gt0 x : (0 < x) = (0 < Num.ceil x).
-Proof. by rewrite -ceil_gt_int. Qed.
+Lemma real_ceil_gt_int x n : x \is Num.real -> (n < Num.ceil x) = (n%:~R < x).
+Proof.
+by move=> ?; rewrite [RHS]real_ltNge ?realz -?real_ceil_le_int_tmp ?ltNge.
+Qed.
 
-Lemma ceil_le0 x : (x <= 0) = (Num.ceil x <= 0).
-Proof. by rewrite -Num.Theory.ceil_le_int. Qed.
+Lemma le_ceil : {homo (@Num.ceil R) : x y / x <= y}.
+Proof. exact: ceil_le. Qed.
+
+Lemma real_ceil_eq x n : x \is Num.real ->
+  (Num.ceil x == n) = ((n - 1)%:~R < x <= n%:~R).
+Proof.
+by move=> xr; apply/eqP/idP => [<-|]; [exact: real_ceil_itv|exact: ceil_def].
+Qed.
+
+Lemma real_ceil_ge0 x : x \is Num.real -> (0 <= Num.ceil x) = (-1 < x).
+Proof. by move=> ?; rewrite oppr_ge0 real_floor_le0 ?realN// ltrNl. Qed.
+
+Lemma ceil_lt0 x : Num.ceil x < 0 = (x <= -1).
+Proof. by rewrite oppr_lt0 floor_gt0 lerNr. Qed.
+
+Lemma real_ceil_le0 x : x \is Num.real -> (Num.ceil x <= 0) = (x <= 0).
+Proof. by move=> ?; rewrite real_ceil_le_int_tmp. Qed.
+
+Lemma ceil_gt0 x : (Num.ceil x > 0) = (x > 0).
+Proof. by rewrite oppr_gt0 floor_lt0 oppr_lt0. Qed.
+
+Lemma ceil_neq0 x : (Num.ceil x != 0) = (x <= -1) || (x > 0).
+Proof. by rewrite oppr_eq0 floor_neq0 oppr_lt0 lerNr orbC. Qed.
+
+End num_trunc_floor_ceil.
+
+Section trunc_floor_ceil.
+Context {R : archiDomainType}.
+Implicit Type x : R.
+
+Lemma ltStrunc x : x < (Num.trunc x).+1%:R.
+Proof. exact: real_ltStrunc. Qed.
+
+Lemma trunc_le_nat x n : (Num.trunc x <= n)%N = (x < n.+1%:R).
+Proof. exact: real_trunc_le_nat. Qed.
+
+Lemma lt_floorD1 x : x < (Num.floor x + 1)%:~R.
+Proof. exact: real_lt_floorD1. Qed.
+
+#[deprecated(since="mathcomp-analysis 1.10.0", note="Use floor_ge_int_tmp instead.")]
+Lemma floor_ge_int x n : (n%:~R <= x) = (n <= Num.floor x).
+Proof. exact: real_floor_ge_int. Qed.
+
+(* TODO: rename to floor_ge_int,
+   once the currently deprecated one has been removed *)
+Lemma floor_ge_int_tmp x n : (n <= Num.floor x) = (n%:~R <= x).
+Proof. exact: real_floor_ge_int_tmp. Qed.
+
+Lemma floor_lt_int x n : (Num.floor x < n) = (x < n%:~R).
+Proof. exact: real_floor_lt_int. Qed.
+
+Lemma floor_eq x n : (Num.floor x == n) = (n%:~R <= x < (n + 1)%:~R).
+Proof. exact: real_floor_eq. Qed.
+
+Lemma floor_ge0 x : (0 <= Num.floor x) = (0 <= x).
+Proof. exact: real_floor_ge0. Qed.
+
+Lemma floor_le0 x : (Num.floor x <= 0) = (x < 1).
+Proof. exact: real_floor_le0. Qed.
+
+#[deprecated(since="mathcomp-analysis 1.10.0", note="Use ceil_le_int_tmp instead.")]
+Lemma ceil_le_int x n : x <= n%:~R = (Num.ceil x <= n).
+Proof. exact: real_ceil_le_int. Qed.
+
+(* TODO: rename to ceil_le_int,
+   once the currently deprecated one has been removed *)
+Lemma ceil_le_int_tmp x n : (Num.ceil x <= n) = (x <= n%:~R).
+Proof. exact: real_ceil_le_int_tmp. Qed.
+
+Lemma ceil_gt_int x n : (n < Num.ceil x) = (n%:~R < x).
+Proof. exact: real_ceil_gt_int. Qed.
+
+Lemma ceil_eq x n : (Num.ceil x == n) = ((n - 1)%:~R < x <= n%:~R).
+Proof. exact: real_ceil_eq. Qed.
+
+Lemma ceil_ge0 x : (0 <= Num.ceil x) = (-1 < x).
+Proof. exact: real_ceil_ge0. Qed.
+
+Lemma ceil_le0 x : (Num.ceil x <= 0) = (x <= 0).
+Proof. exact: real_ceil_le0. Qed.
 
 Lemma abs_ceil_ge x : `|x| <= `|Num.ceil x|.+1%:R.
 Proof.
 rewrite -natr1 natr_absz; have [x0|x0] := ltP 0 x.
-  by rewrite !gtr0_norm// -?ceil_gt0// (le_trans (Num.Theory.le_ceil _))// lerDl.
-by rewrite !ler0_norm -?ceil_le0// opprK intrD1 ltW// lt_succ_floor.
+  by rewrite !gtr0_norm ?ceil_gt0// (le_trans (Num.Theory.le_ceil _))// lerDl.
+by rewrite !ler0_norm ?ceil_le0// opprK intrD1 ltW// lt_floorD1.
 Qed.
 
-End floor_ceil.
+End trunc_floor_ceil.
 
-#[deprecated(since="mathcomp-analysis 1.3.0", note="renamed to `ceil_gt_int`")]
+#[deprecated(since="mathcomp-analysis 1.3.0", note="Use ceil_gt_int instead.")]
 Notation ceil_lt_int := ceil_gt_int (only parsing).
 
 Lemma natr_int {R : archiNumDomainType} n : n%:R \is a @Num.int R.

--- a/classical/unstable.v
+++ b/classical/unstable.v
@@ -387,7 +387,7 @@ End floor_ceil.
 #[deprecated(since="mathcomp-analysis 1.3.0", note="renamed to `ceil_gt_int`")]
 Notation ceil_lt_int := ceil_gt_int (only parsing).
 
-Lemma nat_int {R : archiNumDomainType} n : n%:R \is a @Num.int R.
+Lemma natr_int {R : archiNumDomainType} n : n%:R \is a @Num.int R.
 Proof. by rewrite Num.Theory.intrEge0. Qed.
 
 Section bijection_forall.

--- a/reals/real_interval.v
+++ b/reals/real_interval.v
@@ -68,7 +68,7 @@ Qed.
 
 Let inf_itv_bnd_infty x b : inf [set` Interval (BSide b x) +oo%O] = x.
 Proof.
-case: b; last by rewrite /inf opp_itv_bnd_infty sup_itv_infty_bnd opprK.
+case: b; last by rewrite /inf opp_itv_bndy sup_itv_infty_bnd opprK.
 rewrite -setU1itv// inf_setU ?inf1// => _ b ->.
 by rewrite !set_itvE => /ltW.
 Qed.
@@ -227,9 +227,9 @@ Section set_ereal.
 Context (R : realType) T (f g : T -> \bar R).
 Local Open Scope ereal_scope.
 
-Let E j := [set x | f x - g x >= j.+1%:R^-1%:E].
+Let E n := [set x | f x - g x >= n.+1%:R^-1%:E].
 
-Lemma set_lte_bigcup : [set x | f x > g x] = \bigcup_j E j.
+Lemma set_lte_bigcup : [set x | f x > g x] = \bigcup_n E n.
 Proof.
 apply/seteqP; split => [x/=|x [n _]]; last first.
   by rewrite /E/= -sube_gt0; apply: lt_le_trans.
@@ -259,17 +259,12 @@ Lemma itv_bnd_open_bigcup (R : realType) b (r s : R) :
   [set` Interval (BSide b r) (BLeft s)] =
   \bigcup_n [set` Interval (BSide b r) (BRight (s - n.+1%:R^-1))].
 Proof.
-apply/seteqP; split => [x/=|]; last first.
+apply/seteqP; split => [|]; last first.
   move=> x [n _ /=] /[!in_itv] /andP[-> /le_lt_trans]; apply.
   by rewrite ltrBlDr ltrDl invr_gt0 ltr0n.
-rewrite in_itv/= => /andP[sx xs]; exists `|ceil (s - x)^-1|%N => //=.
-rewrite in_itv/= sx/= lerBrDl addrC -lerBrDl.
-rewrite -[in X in _ <= X](invrK (s - x)) ler_pV2.
-- rewrite -natr1 natr_absz ger0_norm; last first.
-    by rewrite -(ceil0 R) ceil_le// invr_ge0 subr_ge0 ltW.
-  by rewrite (@le_trans _ _ (ceil (s - x)^-1)%:~R)// ?lerDl// ceil_ge.
-- by rewrite inE unitfE ltr0n andbT pnatr_eq0.
-- by rewrite inE invr_gt0 subr_gt0 xs andbT unitfE invr_eq0 subr_eq0 gt_eqF.
+move=> x/= /[!in_itv]/= /andP[sx xs]; exists (trunc (s - x)^-1) => //=.
+rewrite in_itv/= sx/= lerBrDl addrC -lerBrDl -[leRHS]invrK.
+by rewrite lef_pV2 ?posrE ?ltr0n// ?invr_gt0 ?subr_gt0// ltW// ltStrunc.
 Qed.
 
 Lemma itv_open_bnd_bigcup (R : realType) b (r s : R) :
@@ -283,42 +278,35 @@ apply eq_bigcupr => k _; apply/seteqP; split=> [_/= [y ysr] <-|x/= xsr].
 by exists (- x); rewrite ?oppr_itv//= opprK// negbK opprB opprK addrC.
 Qed.
 
-Lemma itv_bndy_bigcup_BLeft_shift {R : realType} (b : bool) (x : R) (n : nat):
+Lemma itv_bndy_bigcup_BLeft_shift {R : archiDomainType} b (x : R) n:
   [set` Interval (BSide b x) +oo%O] =
   \bigcup_i [set` Interval (BSide b x) (BLeft (x + (i + n)%:R))].
 Proof.
 apply/seteqP; split=> y; rewrite /= !in_itv/= andbT; last first.
   by move=> [k _ /=]; move: b => [|] /=; rewrite in_itv/= => /andP[//] /ltW.
-move=> xy; exists `|Num.ceil (y - x)|.+1 => //=.
-rewrite in_itv/= xy/= natrD -natr1 natr_absz intr_norm -addrA nat1r addrA.
-apply: ltr_pwDr; first by rewrite ltr0n.
-rewrite -lterBDl (le_trans (le_ceil _)) //= le_eqVlt; apply/predU1P; left.
-apply/esym/normr_idP.
-rewrite ler0z ceil_ge0 (lt_le_trans (@ltrN10 R))// subr_ge0.
-by case: b xy => //= /ltW.
+move=> xy; exists (trunc (y - x)).+1 => //=.
+by rewrite in_itv/= xy/= natrD addrA ltr_wpDr// -ltrBDl ltStrunc.
 Qed.
 
-Lemma itv_bndy_bigcup_BRight (R : realType) b (x : R) :
+Lemma itv_bndy_bigcup_BRight (R : archiDomainType) b (x : R) :
   [set` Interval (BSide b x) +oo%O] =
-  \bigcup_i [set` Interval (BSide b x) (BRight (x + i%:R))].
+  \bigcup_n [set` Interval (BSide b x) (BRight (x + n%:R))].
 Proof.
 apply/seteqP; split=> y; rewrite /= !in_itv/= andbT; last first.
   by move=> [k _ /=]; move: b => [|] /=; rewrite in_itv/= => /andP[//] /ltW.
-move=> xy; exists `|ceil (y - x)|%N => //=; rewrite in_itv/= xy/= -lerBlDl.
-rewrite natr_absz ger0_norm ?ceil_ge//.
-by rewrite -(ceil0 R) ceil_le// subr_ge0 (lteifW xy).
+move=> xy; exists (trunc (y - x)).+1 => //=; rewrite in_itv/= xy/= -lerBlDl.
+by rewrite ltW// ltStrunc.
 Qed.
 #[deprecated(since="mathcomp-analysis 1.9.0", note="renamed to `itv_bndy_bigcup_BRight`")]
 Notation itv_bnd_infty_bigcup := itv_bndy_bigcup_BRight (only parsing).
 
 Lemma itv0y_bigcup0S (R : realType) :
-  `[0%R, +oo[%classic = \bigcup_i `[0%R, i.+1%:R]%classic :> set R.
+  `[0, +oo[%classic = \bigcup_n `[0, n.+1%:R]%classic :> set R.
 Proof.
 rewrite eqEsubset; split; last first.
   by move=> /= x [n _]/=; rewrite !in_itv/= => /andP[->].
-rewrite itv_bndy_bigcup_BRight => z [i _ /= zi].
-exists i => //=.
-apply: subset_itvl zi.
+rewrite itv_bndy_bigcup_BRight => z [n _ /= zn].
+exists n => //=; apply: subset_itvl zn.
 by rewrite bnd_simp/= add0r ler_nat.
 Qed.
 #[deprecated(since="mathcomp-analysis 1.9.0", note="renamed to `itv0y_bigcup0S`")]
@@ -329,7 +317,7 @@ Lemma itvNy_bnd_bigcup_BLeft (R : realType) b (x : R) :
   \bigcup_i [set` Interval (BLeft (x - i%:R)) (BSide b x)].
 Proof.
 have /(congr1 (fun x => -%R @` x)) := itv_bndy_bigcup_BRight (~~ b) (- x).
-rewrite opp_itv_bnd_infty negbK opprK => ->; rewrite image_bigcup.
+rewrite opp_itv_bndy negbK opprK => ->; rewrite image_bigcup.
 apply eq_bigcupr => k _; apply/seteqP; split=> [_ /= -[r rbxk <-]|y/= yxkb].
   by rewrite oppr_itv/= opprB addrC.
 by exists (- y); [rewrite oppr_itv/= negbK opprD opprK|rewrite opprK].
@@ -337,14 +325,13 @@ Qed.
 #[deprecated(since="mathcomp-analysis 1.9.0", note="renamed to `itvNy_bnd_bigcup_BLeft`")]
 Notation itv_infty_bnd_bigcup := itvNy_bnd_bigcup_BLeft (only parsing).
 
-Lemma bigcup_itvT {R : realType} b :
-  \bigcup_i [set` Interval (BSide b (- i%:R)) (BRight i%:R)] = [set: R].
+Lemma bigcup_itvT {R : archiDomainType} b1 b2 :
+  \bigcup_n [set` Interval (BSide b1 (- n%:R)) (BSide b2 n%:R)] = [set: R].
 Proof.
-rewrite -subTset => x _ /=; exists `|(floor `|x| + 1)%R|%N => //=.
-rewrite in_itv/= !natr_absz intr_norm intrD.
-have : `|x| < `|(floor `|x|)%:~R + 1|.
-  by rewrite [ltRHS]ger0_norm ?intrD1 ?lt_succ_floor// ler0z addr_ge0 ?floor_ge0.
-case: b => /=.
+rewrite -subTset => x _ /=; exists (trunc `|x|).+1 => //=.
+have := ltStrunc `|x|; rewrite in_itv/=; move: b1 b2 => [] []/=.
+- by rewrite ltr_norml => /andP[/ltW ->].
 - by move/ltW; rewrite ler_norml => /andP[-> ->].
-- by rewrite ltr_norml => /andP[-> /ltW->].
+- by rewrite ltr_norml => /andP[-> ->].
+- by rewrite ltr_norml => /andP[-> /ltW].
 Qed.

--- a/reals/real_interval.v
+++ b/reals/real_interval.v
@@ -151,7 +151,7 @@ Proof.
 rewrite predeqE => y; split=> /=; last first.
   by move=> [n _]/=; rewrite in_itv => /andP[xy yn]; rewrite in_itv /= xy.
 rewrite in_itv /= andbT => xy; exists (trunc y).+1 => //=.
-by rewrite in_itv /= xy /= lt_succ_trunc.
+by rewrite in_itv /= xy /= ltStrunc.
 Qed.
 
 Lemma itv_o_inftyEbigcup x :
@@ -239,7 +239,7 @@ move gxE : (g x) => gx; case: gx gxE => [gx| |gxoo fxoo]; last 2 first.
 move fxE : (f x) => fx; case: fx fxE => [fx fxE gxE|fxoo gxE _|//]; last first.
   by exists 0%N => //; rewrite /E/= fxoo gxE// addye// leey.
 rewrite lte_fin -subr_gt0 => fgx; exists (trunc (fx - gx)^-1) => //.
-by rewrite /E/= fxE gxE lee_fin invf_ple ?posrE//; apply/ltW/lt_succ_trunc.
+by rewrite /E/= fxE gxE lee_fin invf_ple ?posrE//; apply/ltW/ltStrunc.
 Qed.
 
 End set_ereal.
@@ -252,7 +252,7 @@ apply/seteqP; split=> [x ->|].
 move=> x rx; apply/esym/eqP; rewrite eq_le (itvP (rx 0%N _))// andbT.
 apply/ler_addgt0Pl => e e_gt0; rewrite -lerBlDl ltW//.
 have := rx (trunc e^-1) I; rewrite /= in_itv => /andP[/le_lt_trans->]//.
-by rewrite lerB// invf_ple ?posrE//; apply/ltW/lt_succ_trunc.
+by rewrite lerB// invf_ple ?posrE//; apply/ltW/ltStrunc.
 Qed.
 
 Lemma itv_bnd_open_bigcup (R : realType) b (r s : R) :
@@ -294,7 +294,7 @@ rewrite in_itv/= xy/= natrD -natr1 natr_absz intr_norm -addrA nat1r addrA.
 apply: ltr_pwDr; first by rewrite ltr0n.
 rewrite -lterBDl (le_trans (le_ceil _)) //= le_eqVlt; apply/predU1P; left.
 apply/esym/normr_idP.
-rewrite ler0z -ceil_ge0 (lt_le_trans (@ltrN10 R))// subr_ge0.
+rewrite ler0z ceil_ge0 (lt_le_trans (@ltrN10 R))// subr_ge0.
 by case: b xy => //= /ltW.
 Qed.
 

--- a/reals/reals.v
+++ b/reals/reals.v
@@ -474,10 +474,6 @@ Proof. exact: mem_rg1_floor. Qed.
 Lemma Rfloor_le x : Rfloor x <= x.
 Proof. by case/andP: (mem_rg1_Rfloor x). Qed.
 
-#[deprecated(since="mathcomp-analysis 1.3.0", note="use `ge_floor` instead")]
-Lemma floor_le x : (floor x)%:~R <= x.
-Proof. by rewrite ge_floor. Qed.
-
 Lemma lt_succ_Rfloor x : x < Rfloor x + 1.
 Proof. by case/andP: (mem_rg1_Rfloor x). Qed.
 
@@ -521,10 +517,6 @@ Proof. by move=> ?; rewrite -Rfloor0 le_Rfloor. Qed.
 
 Lemma Rfloor_lt0 x : x < 0 -> Rfloor x < 0.
 Proof. by move=> x0; rewrite (le_lt_trans _ x0) // Rfloor_le. Qed.
-
-#[deprecated(since="mathcomp-analysis 1.3.0", note="use `Num.Theory.floor_le` instead")]
-Lemma le_floor : {homo @Num.floor R : x y / x <= y}.
-Proof. exact: Num.Theory.floor_le. Qed.
 
 Lemma ltr_add_invr (y x : R) : y < x -> exists k, y + k.+1%:R^-1 < x.
 Proof.

--- a/reals/reals.v
+++ b/reals/reals.v
@@ -466,7 +466,7 @@ Lemma RfloorE x : Rfloor x = (floor x)%:~R.
 Proof. by []. Qed.
 
 Lemma mem_rg1_floor x : (range1 (floor x)%:~R) x.
-Proof. by rewrite /range1 /mkset intrD1 ge_floor lt_succ_floor. Qed.
+Proof. by rewrite /range1 /mkset intrD1 ge_floor lt_floorD1. Qed.
 
 Lemma mem_rg1_Rfloor x : (range1 (Rfloor x)) x.
 Proof. exact: mem_rg1_floor. Qed.
@@ -510,7 +510,7 @@ Lemma Rfloor_ge_int x (n : int) : (n%:~R <= x)= (n%:~R <= Rfloor x).
 Proof. by rewrite ler_int floor_ge_int. Qed.
 
 Lemma Rfloor_lt_int x (z : int) : (x < z%:~R) = (Rfloor x < z%:~R).
-Proof. by rewrite ltr_int floor_lt_int. Qed.
+Proof. by rewrite ltr_int -floor_lt_int. Qed.
 
 Lemma Rfloor_le0 x : x <= 0 -> Rfloor x <= 0.
 Proof. by move=> ?; rewrite -Rfloor0 le_Rfloor. Qed.
@@ -521,7 +521,7 @@ Proof. by move=> x0; rewrite (le_lt_trans _ x0) // Rfloor_le. Qed.
 Lemma ltr_add_invr (y x : R) : y < x -> exists k, y + k.+1%:R^-1 < x.
 Proof.
 move=> yx; exists (trunc (x - y)^-1).
-by rewrite -ltrBrDl invf_plt 1?posrE 1?subr_gt0// lt_succ_trunc.
+by rewrite -ltrBrDl invf_plt 1?posrE 1?subr_gt0// ltStrunc.
 Qed.
 
 End FloorTheory.
@@ -538,7 +538,7 @@ Lemma Rceil0 : Rceil 0 = 0 :> R.
 Proof. by rewrite /Rceil ceil0. Qed.
 
 Lemma Rceil_ge x : x <= Rceil x.
-Proof. by rewrite /Rceil le_ceil// num_real. Qed.
+Proof. by rewrite Num.Theory.le_ceil ?num_real. Qed.
 
 Lemma le_Rceil : {homo (@Rceil R) : x y / x <= y}.
 Proof. by move=> x y ?; rewrite /Rceil ler_int ceil_le. Qed.

--- a/theories/ereal.v
+++ b/theories/ereal.v
@@ -1421,13 +1421,13 @@ case: x => /= [x [_/posnumP[d] dP] |[d [dreal dP]] |[d [dreal dP]]]; last 2 firs
       by rewrite Znat_def floor_ge0 le_max lexx orbC.
     exists N.+1 => // n ltNn; apply: dP; rewrite lte_fin.
     have /le_lt_trans : (d <= Num.max d 0)%R by rewrite le_max lexx.
-    apply; rewrite (lt_le_trans (lt_succ_floor _))// Nfloor.
+    apply; rewrite (lt_le_trans (lt_floorD1 _))// Nfloor.
     by rewrite natr1 mulrz_nat ler_nat.
   have /natrP[N Nfloor] : Num.floor (Num.max (- d)%R 0%R) \is a Num.nat.
     by rewrite Znat_def floor_ge0 le_max lexx orbC.
   exists N.+1 => // n ltNn; apply: dP; rewrite lte_fin ltrNl.
   have /le_lt_trans : (- d <= Num.max (- d) 0)%R by rewrite le_max lexx.
-  apply; rewrite (lt_le_trans (lt_succ_floor _))// Nfloor.
+  apply; rewrite (lt_le_trans (lt_floorD1 _))// Nfloor.
   by rewrite natr1 mulrz_nat ler_nat.
 have /natrP[N Nfloor] : Num.floor d%:num^-1 \is a Num.nat.
   by rewrite Znat_def floor_ge0.
@@ -1435,5 +1435,5 @@ exists N => // n leNn; apply: dP; last first.
   by rewrite eq_sym addrC -subr_eq subrr eq_sym; exact/invr_neq0/lt0r_neq0.
 rewrite /= opprD addrA subrr distrC subr0 gtr0_norm; last by rewrite invr_gt0.
 rewrite -[ltLHS]mulr1 ltr_pdivrMl // -ltr_pdivrMr // div1r.
-by rewrite (lt_le_trans (lt_succ_floor _))// Nfloor !natr1 mulrz_nat ler_nat.
+by rewrite (lt_le_trans (lt_floorD1 _))// Nfloor !natr1 mulrz_nat ler_nat.
 Qed.

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -1273,10 +1273,10 @@ rewrite predeqE => r; split => [/= /[!in_itv]/= /andP[nr rn1]|]; last first.
   by rewrite -natrX -2!natrM 2!ler_nat.
 have ?: 0 <= r * 2 ^+ n.+1 by rewrite mulr_ge0// (le_trans _ nr).
 rewrite -bigcup_seq /=; exists (trunc (r * 2 ^+ n.+1)).
-  rewrite /= mem_index_iota -trunc_ge_nat// -trunc_lt_nat//.
+  rewrite /= mem_index_iota trunc_ge_nat// trunc_lt_nat//.
   by rewrite !natrM natrX ler_pM2r// ltr_pM2r// nr.
 rewrite /= in_itv/= ler_pdivrMr// ltr_pdivlMr//.
-by rewrite trunc_ge_nat// trunc_lt_nat// !leqnn.
+by rewrite -trunc_ge_nat// -trunc_lt_nat// !leqnn.
 Qed.
 
 Lemma dyadic_itv_image n T (f : T -> \bar R) x :
@@ -1394,7 +1394,7 @@ apply/negP => /andP[/allP An0]; rewrite mulf_eq0 => /orP[|].
 rewrite pnatr_eq0 eqb0 notin_setE /B => /not_andP[] // /negP.
 rewrite -ltNge => fxn.
 have K : (trunc (fine (f x) * 2 ^+ n) < n * 2 ^ n)%N.
-  rewrite -trunc_lt_nat; last by rewrite mulr_ge0// ltW.
+  rewrite trunc_lt_nat; last by rewrite mulr_ge0// ltW.
   by rewrite natrM natrX ltr_pM2r// -lte_fin (fineK fxfin).
 have /[!mem_index_enum]/(_ isT) := An0 (Ordinal K).
 rewrite implyTb indicE mem_set ?mulr1; last first.
@@ -1536,12 +1536,12 @@ case/cvg_ex => /= l; have [l0|l0] := leP 0%R l.
   move=> /(_ (`|ceil l|.+1 + n)%N) /= /(_ (leq_addl _ _)); apply/negP.
   rewrite -leNgt approx_x distrC (le_trans _ (lerB_normD _ _))// normrN.
   rewrite lerBrDl addSnnS natrD [leRHS]ger0_norm// lerD ?ler1n// natr_absz.
-  by rewrite !ger0_norm ?le_ceil// -ceil_ge0; apply: lt_le_trans l0.
+  by rewrite !ger0_norm ?le_ceil// ceil_ge0; apply: lt_le_trans l0.
 - move=> /cvgrPdist_lt/(_ _ ltr01)[n _].
   move=> /(_ (`|floor l|.+1 + n)%N)/(_ (leq_addl _ _)); apply/negP.
   rewrite approx_x -leNgt distrC (le_trans _ (lerB_normD _ _))// normrN.
   rewrite lerBrDl addSnnS natrD [leRHS]ger0_norm// lerD ?ler1n// natr_absz.
-  by rewrite !ltr0_norm -?floor_lt0// mulrNz lerN2 ge_floor.
+  by rewrite !ltr0_norm ?floor_lt0// mulrNz lerN2 ge_floor.
 Qed.
 
 Lemma ecvg_approx (f0 : forall x, D x -> (0 <= f x)%E) x :
@@ -3602,7 +3602,7 @@ apply/negP; rewrite -ltNge.
 rewrite -[X in _ * X](@fineK _ (mu (E `&` D))); last first.
   by rewrite fin_numElt muEDoo (lt_le_trans _ (measure_ge0 _ _)).
 rewrite lte_fin -ltr_pdivrMr.
-  rewrite pmulrn floor_lt_int intS ltz1D abszE.
+  rewrite pmulrn -floor_lt_int intS ltz1D abszE.
   by apply: le_trans (ler_norm _); rewrite ceil_floor//= lerDl.
 rewrite -lte_fin fineK.
   rewrite lt0e measure_ge0 andbT.

--- a/theories/lebesgue_integral.v
+++ b/theories/lebesgue_integral.v
@@ -1492,12 +1492,8 @@ have /(fpos_approx_neq0 Dx)[m _ Hm] : (0 < f x < +oo)%E by rewrite lt0e fx0 f0.
 near=> n.
 have mn : (m <= n)%N by near: n; exists m.
 have : fine (f x) < n%:R.
-  near: n.
-  exists `|floor (fine (f x))|.+1%N => //= p /=.
-  rewrite -(@ler_nat R); apply: lt_le_trans.
-  rewrite -natr1 (_ : `| _ |%:R  = (floor (fine (f x)))%:~R); last first.
-    by rewrite -[in RHS](@gez0_abs (floor _))// floor_ge0//; exact/fine_ge0/f0.
-  by rewrite intrD1 lt_succ_floor.
+  near: n; exists (trunc (fine (f x))).+2 => //= p /= fxp.
+  by rewrite (lt_trans (ltStrunc _))// ltr_nat.
 rewrite -lte_fin (fineK fxfin) => fxn.
 have [approx_nx0|[k [/andP[k0 kn2n] ? ->]]] := f_ub_approx fxn.
   by have := Hm _ mn; rewrite approx_nx0.
@@ -1533,15 +1529,15 @@ move=> Dx fxoo; have approx_x n : approx n x = n%:R.
   by rewrite fgen_A0 // ?mulr0 // fxoo leey.
 case/cvg_ex => /= l; have [l0|l0] := leP 0%R l.
 - move=> /cvgrPdist_lt/(_ _ ltr01) -[n _].
-  move=> /(_ (`|ceil l|.+1 + n)%N) /= /(_ (leq_addl _ _)); apply/negP.
-  rewrite -leNgt approx_x distrC (le_trans _ (lerB_normD _ _))// normrN.
-  rewrite lerBrDl addSnnS natrD [leRHS]ger0_norm// lerD ?ler1n// natr_absz.
-  by rewrite !ger0_norm ?le_ceil// ceil_ge0; apply: lt_le_trans l0.
+  move=> /(_ ((trunc l).+2 + n)%N) /= /(_ (leq_addl _ _)); apply/negP.
+  rewrite -leNgt approx_x distrC addSnnS natrD ger0_norm//; last first.
+    by rewrite subr_ge0 ltW// (lt_le_trans (ltStrunc _))// lerDl.
+  by rewrite lerBrDl lerD ?ler1n// ltW// ltStrunc.
 - move=> /cvgrPdist_lt/(_ _ ltr01)[n _].
-  move=> /(_ (`|floor l|.+1 + n)%N)/(_ (leq_addl _ _)); apply/negP.
-  rewrite approx_x -leNgt distrC (le_trans _ (lerB_normD _ _))// normrN.
-  rewrite lerBrDl addSnnS natrD [leRHS]ger0_norm// lerD ?ler1n// natr_absz.
-  by rewrite !ltr0_norm ?floor_lt0// mulrNz lerN2 ge_floor.
+  move=> /(_ ((trunc l).+2 + n))/(_ (leq_addl _ _)); apply/negP.
+  rewrite approx_x -leNgt distrC natrD ger0_norm; last first.
+    by rewrite subr_ge0 -natr1 -addrA ler_wpDr// ltW// ltStrunc.
+  by rewrite lerBrDl -natr1 -addrA nat1r lerD ?ler1n// ltW// ltStrunc.
 Qed.
 
 Lemma ecvg_approx (f0 : forall x, D x -> (0 <= f x)%E) x :
@@ -2340,18 +2336,15 @@ transitivity (\int[mu]_(x in D) limn (g^~ x)).
     rewrite /g; case: (f x) fx0 => [r r0|_|//]; last first.
       by exists 1%N => // m /= m0; rewrite mulry gtr0_sg// ?ltr0n// mul1e leey.
     near=> n; rewrite lee_fin -ler_pdivrMr//.
-    near: n; exists `|ceil (M / r)|%N => // m /=.
-    rewrite -(ler_nat R); apply: le_trans.
-    rewrite natr_absz ger0_norm ?ceil_ge//.
-    by rewrite -(ceil0 R) ceil_le// divr_ge0// ltW.
+    near: n; exists (trunc (M / r)).+1 => // m /= Mrm.
+    by rewrite (le_trans (ltW (ltStrunc _)))// ler_nat.
   - rewrite lt0_mulye//; apply/cvgeNyPleNy; near=> M;
     have M0 : (M <= 0)%R by [].
     rewrite /g; case: (f x) fx0 => [r r0|//|_]; last first.
       by exists 1%N => // m /= m0; rewrite mulrNy gtr0_sg// ?ltr0n// mul1e leNye.
     near=> n; rewrite lee_fin -ler_ndivrMr//.
-    near: n; exists `|ceil (M / r)|%N => // m /=.
-    rewrite -(ler_nat R); apply: le_trans.
-    by rewrite pmulrn abszE ceil_ge_int ler_norm.
+    near: n; exists (trunc (M / r)).+1 => // m /= Mrm.
+    by rewrite (le_trans (ltW (ltStrunc _)))// ler_nat.
   - rewrite -fx0 mule0 /g -fx0.
     under eq_fun do rewrite mule0/=. (*TODO: notation broken*)
     exact: cvg_cst.
@@ -2370,10 +2363,9 @@ rewrite -(@fineK _ (\int[mu]_(x in D) f x)); last first.
 rewrite -lee_pdivrMr//; last first.
   by move: if_gt0 ifoo; case: (\int[mu]_(x in D) f x).
 near: n.
-exists `|ceil (M * (fine (\int[mu]_(x in D) f x))^-1)|%N => //.
+exists (trunc (M * (fine (\int[mu]_(x in D) f x))^-1)).+1 => //.
 move=> n /=; rewrite -(@ler_nat R) -lee_fin; apply: le_trans.
-rewrite lee_fin natr_absz ger0_norm ?ceil_ge//.
-by rewrite -(ceil0 R) ceil_le// divr_ge0//; exact/fine_ge0/integral_ge0.
+by rewrite lee_fin ltW// ltStrunc.
 Unshelve. all: by end_near. Qed.
 
 Lemma ge0_integralZr k : (forall x, D x -> 0 <= f x) ->
@@ -2609,18 +2601,18 @@ Proof.
 move=> muD0; pose g : (T -> \bar R)^nat := fun n => cst n%:R%:E.
 have <- : (fun t => limn (g^~ t)) = cst +oo.
   rewrite funeqE => t; apply/cvg_lim => //=.
-  apply/cvgeryP/cvgryPge => M; exists `|ceil M|%N => //= m.
-  by rewrite /= pmulrn ceil_ge_int// -lez_nat abszE; apply/le_trans/ler_norm.
+  apply/cvgeryP/cvgryPge => M; exists (trunc M).+1 => //= m/= Mn.
+  by rewrite (le_trans (ltW (ltStrunc _)))// ler_nat.
 rewrite monotone_convergence //.
 - under [in LHS]eq_fun do rewrite integral_cstr.
   apply/cvg_lim => //; apply/cvgeyPge => M.
   have [muDoo|muDoo] := ltP (mu D) +oo; last first.
     exists 1%N => // m /= m0; move: muDoo; rewrite leye_eq => /eqP ->.
     by rewrite mulry gtr0_sg ?mul1e ?leey// ltr0n.
-  exists `|ceil (M / fine (mu D))|%N => // m /=.
-  rewrite -lez_nat abszE => MDm; rewrite -(@fineK _ (mu D)) ?ge0_fin_numE//.
+  exists (trunc (M / fine (mu D))).+1 => // m /=.
+  rewrite -lez_nat => MDm; rewrite -(@fineK _ (mu D)) ?ge0_fin_numE//.
   rewrite -lee_pdivrMr; last by rewrite fine_gt0// lt0e muD0 measure_ge0.
-  by rewrite lee_fin pmulrn ceil_ge_int// (le_trans _ MDm)// ler_norm.
+  by rewrite lee_fin (le_trans (ltW (ltStrunc _)))// ler_nat.
 - by move=> n; exact: measurable_cst.
 - by move=> n x Dx; rewrite lee_fin.
 - by move=> t Dt n m nm; rewrite /g lee_fin ler_nat.
@@ -3597,13 +3589,11 @@ have [M M0 muM] : exists2 M, (0 <= M)%R &
 apply/eqP/negPn/negP => /eqP muED0; move/not_forallP : muM; apply.
 have [muEDoo|] := ltP (mu (E `&` D)) +oo; last first.
   by rewrite leye_eq => /eqP ->; exists 1%N; rewrite mul1e leye_eq.
-exists `|ceil (M * (fine (mu (E `&` D)))^-1)|%N.+1.
+exists (trunc (M * (fine (mu (E `&` D)))^-1)).+1.
 apply/negP; rewrite -ltNge.
 rewrite -[X in _ * X](@fineK _ (mu (E `&` D))); last first.
   by rewrite fin_numElt muEDoo (lt_le_trans _ (measure_ge0 _ _)).
-rewrite lte_fin -ltr_pdivrMr.
-  rewrite pmulrn -floor_lt_int intS ltz1D abszE.
-  by apply: le_trans (ler_norm _); rewrite ceil_floor//= lerDl.
+rewrite lte_fin -ltr_pdivrMr; first by rewrite ltStrunc.
 rewrite -lte_fin fineK.
   rewrite lt0e measure_ge0 andbT.
   suff: E `&` D = E by move=> ->; exact/eqP.
@@ -3866,15 +3856,13 @@ move=> mf; split=> [iDf0|Df0].
     rewrite predeqE => t; split=> [[Dt ft0]|[n _ /= [Dt nft]]].
       have [ftoo|ftoo] := eqVneq `|f t| +oo.
         by exists 0%N => //; split => //=; rewrite ftoo /= leey.
-      pose m := `|ceil (fine `|f t|)^-1|%N.
+      pose m := (trunc (fine `|f t|)^-1).
       have ftfin : `|f t|%E \is a fin_num by rewrite ge0_fin_numE// ltey.
       exists m => //; split => //=.
       rewrite -(@fineK _ `|f t|) // lee_fin invf_ple; last 2 first.
-      - exact: ltr0n.
-      - by apply/fine_gt0; rewrite lt0e abse_ge0 abse_eq0 ft0 ltey.
-      rewrite /m -natr1 natr_absz ger0_norm; last first.
-        by rewrite -(ceil0 R) ceil_le.
-      by rewrite intrD1 ceil_ge_int lerDl.
+        exact: ltr0n.
+        by apply/fine_gt0; rewrite lt0e abse_ge0 abse_eq0 ft0 ltey.
+      by rewrite (le_trans (ltW (ltStrunc _))).
     by split => //; apply: contraTN nft => /eqP ->; rewrite abse0 -ltNge.
   transitivity (limn (fun n => mu (D `&` [set x | `|f x| >= n.+1%:R^-1%:E]))).
     apply/esym/cvg_lim => //; apply: nondecreasing_cvg_mu.
@@ -6966,9 +6954,8 @@ move=> Ef; have {Ef} : mu.-negligible (E `&` [set x | 0 < f^* x]).
   near \oo => m; exists m => //=.
   rewrite -(@fineK _ (f^* x)) ?gt0_fin_numE ?ltey// lte_fin.
   rewrite invf_plt ?posrE//; last by rewrite fine_gt0// ltey fx0.
-  set r := _^-1; rewrite (@le_lt_trans _ _ `|ceil r|.+1%:R)//.
-    by rewrite (le_trans _ (abs_ceil_ge _))// ler_norm.
-  by rewrite ltr_nat ltnS; near: m; exact: nbhs_infty_gt.
+  set r := _^-1; rewrite (lt_le_trans (ltStrunc _))//.
+  by rewrite ler_nat ltnS; near: m; exact: nbhs_infty_ge.
 apply: negligibleS => z /= /not_implyP[Ez H]; split => //.
 rewrite ltNge; apply: contra_notN H.
 rewrite le_eqVlt ltNge limf_esup_ge0/= ?orbF//; last first.

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -1170,7 +1170,7 @@ have finite_set_F i : finite_set (F i).
   apply/negP; rewrite -ltNge lebesgue_measure_ball// lte_fin.
   rewrite -[M%:R]natr1 natr_absz ger0_norm; last first.
     by rewrite -[leLHS](ceil0 R) ceil_le.
-  by rewrite -ltr_pdivrMr// intrD1 floor_lt_int ltzD1 ceil_floor// lerDl.
+  by rewrite -ltr_pdivrMr// intrD1 -floor_lt_int ltzD1 ceil_floor// lerDl.
 have mur2_fin_num_ : mu (ball (0:R) (r%:num + 2))%R < +oo.
   by rewrite lebesgue_measure_ball// ltry.
 have FE : \sum_(n <oo) \esum_(i in F n) mu (closure (B i)) =
@@ -1505,7 +1505,7 @@ have bigBG_fin (r : {posnum R}) : finite_set (bigB G r%:num).
           by rewrite ge0_fin_numE//; case/andP: OAoo => ?; exact: lt_trans.
         rewrite -EFinM /M lte_fin (le_lt_trans (ceil_ge _))//.
         rewrite -natr1 natr_absz ger0_norm ?ltrDl//.
-        by rewrite -ceil_ge0// (@lt_le_trans _ _ 0%R)// divr_ge0// fine_ge0.
+        by rewrite ceil_ge0// (@lt_le_trans _ _ 0%R)// divr_ge0// fine_ge0.
       rewrite big_seq [in leRHS]big_seq.
       apply: lee_sum => //= i /G0G'r [iG rBi].
       rewrite -[leRHS]fineK//; last first.

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -1128,7 +1128,7 @@ have {}EBr2 : \esum_(i in E) mu (closure (B i)) <=
   by apply: bigcup_measurable => *; exact: measurable_closure.
 have finite_set_F i : finite_set (F i).
   apply: contrapT.
-  pose M := `|ceil ((r%:num + 2) *+ 2 / (1 / (2 ^ i.+1)%:R))|.+1.
+  pose M := (trunc ((r%:num + 2) *+ 2 / (1 / (2 ^ i.+1)%:R))).+1.
   move/(infinite_set_fset M) => [/= C CsubFi McardC].
   have MC : (M%:R * (1 / (2 ^ i.+1)%:R))%:E <=
             mu (\bigcup_(j in [set` C]) closure (B j)).
@@ -1168,9 +1168,7 @@ have finite_set_F i : finite_set (F i).
     - by move=> /= x [n Fni Bnx]; exists n => //; exists i.
   have {CFi Fir2} := le_trans MC (le_trans CFi Fir2).
   apply/negP; rewrite -ltNge lebesgue_measure_ball// lte_fin.
-  rewrite -[M%:R]natr1 natr_absz ger0_norm; last first.
-    by rewrite -[leLHS](ceil0 R) ceil_le.
-  by rewrite -ltr_pdivrMr// intrD1 -floor_lt_int ltzD1 ceil_floor// lerDl.
+  by rewrite -ltr_pdivrMr// /M ltStrunc.
 have mur2_fin_num_ : mu (ball (0:R) (r%:num + 2))%R < +oo.
   by rewrite lebesgue_measure_ball// ltry.
 have FE : \sum_(n <oo) \esum_(i in F n) mu (closure (B i)) =
@@ -1490,7 +1488,7 @@ have {}Hc : mu (\bigcup_(k in G) closure (B k) `\`
   rewrite setIidr; last exact: bigcup_subset.
   by rewrite lteBlDr-?lteBlDl//; exact: muGSfin.
 have bigBG_fin (r : {posnum R}) : finite_set (bigB G r%:num).
-  pose M := `|ceil (fine (mu O) / r%:num)|.+1.
+  pose M := (trunc (fine (mu O) / r%:num)).+1.
   apply: contrapT => /infinite_set_fset /= /(_ M)[G0 G0G'r MG0].
   have : mu O < mu (\bigcup_(k in bigB G r%:num) closure (B k)).
     apply: (@lt_le_trans _ _ (mu (\bigcup_(k in [set` G0]) closure (B k)))).
@@ -1503,9 +1501,7 @@ have bigBG_fin (r : {posnum R}) : finite_set (bigB G r%:num).
           by rewrite lee_fin ler_wpM2l// ler_nat count_predT.
         rewrite EFinM -lte_pdivrMl// muleC -(@fineK _ (mu O)); last first.
           by rewrite ge0_fin_numE//; case/andP: OAoo => ?; exact: lt_trans.
-        rewrite -EFinM /M lte_fin (le_lt_trans (ceil_ge _))//.
-        rewrite -natr1 natr_absz ger0_norm ?ltrDl//.
-        by rewrite ceil_ge0// (@lt_le_trans _ _ 0%R)// divr_ge0// fine_ge0.
+        by rewrite -EFinM /M lte_fin ltStrunc.
       rewrite big_seq [in leRHS]big_seq.
       apply: lee_sum => //= i /G0G'r [iG rBi].
       rewrite -[leRHS]fineK//; last first.

--- a/theories/lebesgue_stieltjes_measure.v
+++ b/theories/lebesgue_stieltjes_measure.v
@@ -481,12 +481,8 @@ Lemma wlength_sigma_finite (f : R -> R) :
 Proof.
 exists (fun k => `](- k%:R), k%:R]%classic).
   apply/esym; rewrite -subTset => /= x _ /=.
-  exists `|(floor `|x| + 1)%R|%N; rewrite //= in_itv/=.
-  rewrite !natr_absz intr_norm intrD.
-  suff: `|x| < `|(floor `|x|)%:~R + 1| by rewrite ltr_norml => /andP[-> /ltW->].
-  rewrite [ltRHS]ger0_norm//.
-    by rewrite intrD1 (le_lt_trans _ (lt_succ_floor _))// ?ler_norm.
-  by rewrite addr_ge0// ler0z floor_ge0.
+  exists (trunc `|x|).+1; rewrite //= in_itv/=.
+  by have := ltStrunc `|x|; rewrite ltr_norml => /andP[-> /ltW->].
 move=> k; split => //; rewrite wlength_itv /= -EFinB.
 by case: ifP; rewrite ltey.
 Qed.

--- a/theories/measurable_realfun.v
+++ b/theories/measurable_realfun.v
@@ -694,7 +694,7 @@ move=> /(_ `|floor r|%N Logic.I); rewrite /= in_itv/= ltNge.
 rewrite lee_fin; have [r0|r0] := leP 0%R r.
   by rewrite (le_trans _ r0) // lerNl oppr0 ler0n.
 rewrite lerNl -abszN natr_absz gtr0_norm; last first.
-  by rewrite ltrNr oppr0 -floor_lt0.
+  by rewrite ltrNr oppr0 floor_lt0.
 by rewrite mulrNz lerNl opprK ge_floor.
 Qed.
 
@@ -704,7 +704,7 @@ rewrite eqEsubset; split=> [_ -> i _/=|]; first by rewrite in_itv /= ltry.
 move=> [r| |/(_ O Logic.I)] // /(_ `|ceil r|%N Logic.I); rewrite /= in_itv /=.
 rewrite andbT lte_fin ltNge.
 have [r0|r0] := ltP 0%R r; last by rewrite (le_trans r0).
-by rewrite natr_absz gtr0_norm// ?le_ceil// -ceil_gt0.
+by rewrite natr_absz gtr0_norm// ?le_ceil// ceil_gt0.
 Qed.
 
 End erealwithrays.

--- a/theories/measurable_realfun.v
+++ b/theories/measurable_realfun.v
@@ -442,13 +442,11 @@ rewrite [X in measurable X](_ : _ =
   apply: bigcupT_measurable => k; rewrite -(setIid D) setIACA.
   exact/measurableI/emeasurable_fun_infty_c/emeasurable_fun_c_infty.
 rewrite predeqE => t; split => [/= [Dt ft]|].
-  exists `|ceil `|fine (f t)| |%N => //=; split=> //; split.
-    rewrite -[leRHS](fineK ft) lee_fin lerNl pmulrn abszE ceil_ge_int ger0_norm.
-      by rewrite ceil_le// -normrN ler_norm.
-    by rewrite -(ceil0 R) ceil_le.
-  rewrite -[leLHS](fineK ft) lee_fin pmulrn abszE ceil_ge_int ger0_norm.
-    by rewrite ceil_le// ler_norm.
-  by rewrite -(ceil0 R) ceil_le.
+  exists (trunc `|fine (f t)|).+1 => //=; split=> //; split.
+    rewrite -[leRHS](fineK ft) lee_fin lerNl.
+    by rewrite (le_trans (ler_norm _))// normrN ltW// ltStrunc.
+  rewrite -[leLHS](fineK ft) lee_fin (le_trans (ler_norm _))//.
+  by rewrite ltW// ltStrunc.
 move=> [n _] [/= Dt [nft fnt]]; split => //; rewrite fin_numElt.
 by rewrite (lt_le_trans _ nft) ?ltNyr//= (le_lt_trans fnt)// ltry.
 Qed.
@@ -693,8 +691,7 @@ move=> [r|/(_ O Logic.I)|]//.
 move=> /(_ `|floor r|%N Logic.I); rewrite /= in_itv/= ltNge.
 rewrite lee_fin; have [r0|r0] := leP 0%R r.
   by rewrite (le_trans _ r0) // lerNl oppr0 ler0n.
-rewrite lerNl -abszN natr_absz gtr0_norm; last first.
-  by rewrite ltrNr oppr0 floor_lt0.
+rewrite lerNl -abszN natr_absz gtr0_norm; last by rewrite ltrNr oppr0 floor_lt0.
 by rewrite mulrNz lerNl opprK ge_floor.
 Qed.
 

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -2329,9 +2329,10 @@ Lemma infinite_card_dirac (A : set T) : infinite_set A ->
   \esum_(i in A) \d_ i A = +oo :> \bar R.
 Proof.
 move=> infA; apply/eqyP => r r0.
-have [B BA Br] := infinite_set_fset `|ceil r| infA.
-apply: esum_ge; exists [set` B] => //; apply: (@le_trans _ _ `|ceil r|%:R%:E).
-  by rewrite lee_fin natr_absz gtr0_norm ?ceil_gt0// ceil_ge.
+have [B BA Br] := infinite_set_fset (trunc r).+1 infA.
+apply: esum_ge; exists [set` B] => //.
+apply: (@le_trans _ _ (trunc r).+1%:R%:E).
+  by rewrite lee_fin ltW// ltStrunc.
 move: Br; rewrite -(@ler_nat R) -lee_fin => /le_trans; apply.
 rewrite (eq_fsbigr (cst 1))/=; last first.
   by move=> i /[!inE] /BA /mem_set iA; rewrite diracE iA.

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -2331,7 +2331,7 @@ Proof.
 move=> infA; apply/eqyP => r r0.
 have [B BA Br] := infinite_set_fset `|ceil r| infA.
 apply: esum_ge; exists [set` B] => //; apply: (@le_trans _ _ `|ceil r|%:R%:E).
-  by rewrite lee_fin natr_absz gtr0_norm -?ceil_gt0// ceil_ge.
+  by rewrite lee_fin natr_absz gtr0_norm ?ceil_gt0// ceil_ge.
 move: Br; rewrite -(@ler_nat R) -lee_fin => /le_trans; apply.
 rewrite (eq_fsbigr (cst 1))/=; last first.
   by move=> i /[!inE] /BA /mem_set iA; rewrite diracE iA.

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -284,14 +284,8 @@ End pseudoMetricnormedzmodule_lemmas.
 
 Lemma bigcup_ballT {R : realType} : \bigcup_n ball (0%R : R) n%:R = setT.
 Proof.
-apply/seteqP; split => // x _; have [x0|x0] := ltP 0%R x.
-  exists `|ceil x|.+1 => //.
-  rewrite /ball /= sub0r normrN gtr0_norm// (le_lt_trans (ceil_ge _))//.
-  by rewrite -natr1 natr_absz -abszE gtz0_abs// ?ceil_gt0// ltr_pwDr.
-exists `|ceil (- x)|.+1 => //.
-rewrite /ball /= sub0r normrN ler0_norm// (le_lt_trans (ceil_ge _))//.
-rewrite -natr1 natr_absz -abszE gez0_abs ?ltr_pwDr// ceil_ge0 ltrNl opprK.
-by rewrite (le_lt_trans x0).
+rewrite -[RHS](bigcup_itvT false true); apply: eq_bigcup => //= n _.
+by apply/seteqP; split=> [?|?]; rewrite /ball/= sub0r normrN in_itv/= ltr_norml.
 Qed.
 
 Section lower_semicontinuous.
@@ -679,10 +673,7 @@ move=> dF nyF; rewrite itvNy_bnd_bigcup_BLeft eqEsubset; split.
   have [i iFan] : exists i, F (a + i.+1%:R) < F a - n%:R.
     move/cvgrNy_lt : nyF.
     move/(_ (F a - n%:R)) => [z [zreal zFan]].
-    exists `|ceil (z - a)|%N.
-    rewrite zFan// -ltrBlDl.
-    rewrite (le_lt_trans (Num.Theory.le_ceil _))  ?num_real//.
-    by rewrite (le_lt_trans (ler_norm _))// -natr1 -intr_norm ltrDl.
+    by exists (trunc (z - a)); rewrite zFan// -ltrBlDl ltStrunc.
   by exists i => //=; rewrite in_itv/= yFa (lt_le_trans _ Fany).
 - move=> z/= [n _ /=]; rewrite in_itv/= => /andP[Fanz zFa].
   exists `|ceil (F (a + n.+1%:R) - F a)%R|.+1 => //=.
@@ -710,15 +701,14 @@ Proof.
 move=> dF nyF; rewrite itvNy_bnd_bigcup_BLeft eqEsubset; split.
 - move=> y/= [n _]/=; rewrite in_itv/= => /andP[Fany yFa].
   have [i iFan] : exists i, F (a - i.+1%:R) < F a - n%:R.
-    move/cvgrNy_lt : nyF.
-    move/(_ (F a - n%:R)) => [z [zreal zFan]].
+    move/cvgrNy_lt : nyF => /(_ (F a - n%:R))[z [zreal zFan]].
     exists `|ceil (a - z)|%N.
     rewrite zFan// ltrBlDr -ltrBlDl.
     rewrite (le_lt_trans (Num.Theory.le_ceil _)) ?num_real//.
     by rewrite (le_lt_trans (ler_norm _))// -natr1 -intr_norm ltrDl.
   by exists i => //=; rewrite in_itv/= yFa andbT (lt_le_trans _ Fany).
 - move=> z/= [n _ /=]; rewrite in_itv/= => /andP[Fanz zFa].
-  exists `| ceil (F (a - n.+1%:R) - F a)%R |.+1 => //=.
+  exists `|ceil (F (a - n.+1%:R) - F a)|.+1 => //=.
   rewrite in_itv/= zFa andbT lerBlDr -lerBlDl (le_trans _ (abs_ceil_ge _))//.
   by rewrite ler_normr orbC opprB lerB// ltW.
 Qed.
@@ -6145,23 +6135,23 @@ Notation r_gt0 := vitali_collection_partition_ub_gt0.
 Lemma ex_vitali_collection_partition i :
   V i -> exists n, vitali_collection_partition n i.
 Proof.
-move=> Vi; pose f := floor (r / (radius (B i))%:num).
-have f_ge0 : 0 <= f by rewrite floor_ge0// divr_ge0// ltW// (r_gt0 Vi).
-have [m /andP[mf fm]] := leq_ltn_expn `|f|.-1.
+move=> Vi; pose f := trunc (r / (radius (B i))%:num).
+have f_ge0 : (0 <= f)%N.
+  by rewrite trunc_ge_nat// divr_ge0// (le_trans _ (VBr Vi)).
+have [m /andP[mf fm]] := leq_ltn_expn f.-1.
 exists m; split => //; apply/andP; split => [{mf}|{fm}].
-  rewrite -(@ler_nat R) in fm.
+- rewrite -(@ler_nat R) in fm.
   rewrite ltr_pdivrMr// mulrC -ltr_pdivrMr// (lt_le_trans _ fm)//.
-  rewrite (lt_le_trans (lt_succ_floor _))//= -/f intrD -natr1 lerD2r//.
-  have [<-|f0] := eqVneq 0 f; first by rewrite /= ler0n.
-  rewrite prednK//; last by rewrite absz_gt0 eq_sym.
-  by rewrite natr_absz// ger0_norm.
-move: m => [|m] in mf *; first by rewrite expn0 divr1 VBr.
-rewrite -(@ler_nat R) in mf.
-rewrite ler_pdivlMr// mulrC -ler_pdivlMr//.
-have [f0|f0] := eqVneq 0 f.
-  by move: mf; rewrite -f0 absz0 leNgt expnS ltr_nat leq_pmulr// expn_gt0.
-rewrite (le_trans mf)// prednK//; last by rewrite absz_gt0 eq_sym.
-by rewrite natr_absz// ger0_norm// ge_floor.
+  rewrite (lt_le_trans (ltStrunc _))//= -/f.
+  have [<-|f0] := eqVneq 0 f; first by rewrite /= ler_nat.
+  by rewrite prednK// lt0n eq_sym.
+- move: m => [|m] in mf *; first by rewrite expn0 divr1 VBr.
+  rewrite ler_pdivlMr// mulrC -ler_pdivlMr//.
+  rewrite -(@ler_nat R) in mf.
+  have [f0|f0] := eqVneq 0 f.
+    by move: mf; rewrite -f0 leNgt expnS ltr_nat leq_pmulr// expn_gt0.
+  rewrite (le_trans mf)// prednK//; last by rewrite lt0n eq_sym.
+  by rewrite /f ge_trunc// divr_ge0// (le_trans _ (VBr Vi)).
 Qed.
 
 Lemma cover_vitali_collection_partition :

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -287,10 +287,10 @@ Proof.
 apply/seteqP; split => // x _; have [x0|x0] := ltP 0%R x.
   exists `|ceil x|.+1 => //.
   rewrite /ball /= sub0r normrN gtr0_norm// (le_lt_trans (ceil_ge _))//.
-  by rewrite -natr1 natr_absz -abszE gtz0_abs// -?ceil_gt0// ltr_pwDr.
+  by rewrite -natr1 natr_absz -abszE gtz0_abs// ?ceil_gt0// ltr_pwDr.
 exists `|ceil (- x)|.+1 => //.
 rewrite /ball /= sub0r normrN ler0_norm// (le_lt_trans (ceil_ge _))//.
-rewrite -natr1 natr_absz -abszE gez0_abs ?ltr_pwDr// -ceil_ge0 ltrNl opprK.
+rewrite -natr1 natr_absz -abszE gez0_abs ?ltr_pwDr// ceil_ge0 ltrNl opprK.
 by rewrite (le_lt_trans x0).
 Qed.
 
@@ -662,7 +662,7 @@ split=> [/cvgryPge|/cvgnyPge] Foo.
   by apply/cvgnyPge => A; near do rewrite -(@ler_nat R); apply: Foo.
 apply/cvgryPgey; near=> A; near=> n.
 rewrite pmulrn ceil_le_int// [ceil _]intEsign.
-by rewrite le_gtF ?expr0 ?mul1r ?lez_nat -?ceil_ge0//; near: n; apply: Foo.
+by rewrite le_gtF ?expr0 ?mul1r ?lez_nat ?ceil_ge0//; near: n; apply: Foo.
 Unshelve. all: by end_near. Qed.
 
 Section monotonic_itv_bigcup.
@@ -5282,7 +5282,7 @@ Lemma compact_bounded (K : realType) (V : normedModType K) (A : set V) :
 Proof.
 rewrite compact_cover => Aco.
 have covA : A `<=` \bigcup_(n : int) [set p | `|p| < n%:~R].
-  by move=> p _; exists (floor `|p| + 1) => //=; rewrite lt_succ_floor.
+  by move=> p _; exists (floor `|p| + 1) => //=; rewrite lt_floorD1.
 have /Aco [] := covA.
   move=> n _; rewrite openE => p; rewrite /= -subr_gt0 => ltpn.
   apply/nbhs_ballP; exists (n%:~R - `|p|) => // q.

--- a/theories/pi_irrational.v
+++ b/theories/pi_irrational.v
@@ -86,7 +86,7 @@ Let f_int i : n`!%:R * f`_i \is a Num.int.
 Proof.
 rewrite /f coefZ mulrA divff ?mul1r ?pnatr_eq0 ?gtn_eqF ?fact_gt0//.
 apply/polyOverP => /=; rewrite rpredM ?rpredX ?polyOverX//=.
-by rewrite rpredB ?polyOverC ?polyOverZ ?polyOverX//= nat_int.
+by rewrite rpredB ?polyOverC ?polyOverZ ?polyOverX//= natr_int.
 Qed.
 
 Let f_small_coef0 i : (i < n)%N -> f`_i = 0.
@@ -97,7 +97,7 @@ Proof.
 rewrite horner_coef0 coef_derivn addn0 ffactnn.
 have [/f_small_coef0 ->|/bin_fact <-] := ltnP i n.
   by rewrite mul0rn // int_Qint.
-by rewrite mulnCA -mulr_natl natrM mulrAC rpredM ?f_int ?nat_int.
+by rewrite mulnCA -mulr_natl natrM mulrAC rpredM ?f_int ?natr_int.
 Qed.
 
 Lemma F0_int : F.[0] \is a Num.int.

--- a/theories/realfun.v
+++ b/theories/realfun.v
@@ -200,9 +200,8 @@ exists (fun n => sval (cid (He (PosNum (invn n))))).
   apply/cvgrPdist_lt => r r0; near=> t.
   rewrite /sval/=; case: cid => x [px xpt _].
   rewrite distrC (lt_le_trans xpt)// -(@invrK _ r) lef_pV2 ?posrE ?invr_gt0//.
-  near: t; exists `|ceil r^-1|%N => // s /=.
-  rewrite -ltnS -(@ltr_nat R) => /ltW; apply: le_trans.
-  by rewrite natr_absz gtr0_norm ?ceil_gt0 ?invr_gt0// ceil_ge.
+  near: t; exists (trunc r^-1) => // s /= rs.
+  by rewrite (le_trans (ltW (ltStrunc _)))// ler_nat.
 move=> /cvgrPdist_lt/(_ e%:num (ltac:(by [])))[] n _ /(_ _ (leqnn _)).
 rewrite /sval/=; case: cid => // x [px xpn].
 by rewrite leNgt distrC => /negP.
@@ -258,9 +257,8 @@ exists (fun n => sval (cid (He (PosNum (invn n))))).
   apply/cvgrPdist_lt => r r0; near=> t.
   rewrite /sval/=; case: cid => x [xpt _].
   rewrite distrC (lt_le_trans xpt)// -[leRHS]invrK lef_pV2 ?posrE ?invr_gt0//.
-  near: t; exists `|ceil r^-1|%N => // s /=.
-  rewrite -ltnS -(@ltr_nat R) => /ltW; apply: le_trans.
-  by rewrite natr_absz gtr0_norm ?ceil_gt0 ?invr_gt0 ?le_ceil ?num_real.
+  near: t; exists (trunc r^-1) => // s /= rs.
+  by rewrite (le_trans (ltW (ltStrunc _)))// ler_nat.
 move=> /cvgrPdist_lt/(_ e%:num (ltac:(by [])))[] n _ /(_ _ (leqnn _)).
 rewrite /sval/=; case: cid => // x [px xpn].
 by rewrite ltNge distrC => /negP.
@@ -293,9 +291,8 @@ have y_p : y_ n @[n --> \oo] --> p.
   rewrite /y_ /sval/=; case: cid2 => //= x /andP[_ + _].
   rewrite -ltrBlDl => /lt_le_trans; apply.
   rewrite -(invrK e) lef_pV2// ?posrE ?invr_gt0//.
-  near: t.
-  exists `|ceil e^-1|%N => // k /=; rewrite pmulrn ceil_ge_int// -lez_nat abszE.
-  by move=> /(le_trans (ler_norm _)) /le_trans; apply; rewrite lez_nat leqnSn.
+  near: t; exists (trunc e^-1) => // s /= es.
+  by rewrite (le_trans (ltW (ltStrunc _)))// ler_nat.
 have /fine_cvgP[[m _ mfy_] /= _] := h _ (conj py_ y_p).
 near \oo => n.
 have mn : (m <= n)%N by near: n; exists m.
@@ -2797,10 +2794,8 @@ have FrBFl (x : elt_type) : exists m, m.+1%:R ^-1 < Fr (sval x) - Fl (sval x).
     apply: (@nondecreasing_at_left_at_right _ _ a b) => //.
     by case: x {Fc Fd cd} => x/= /[1!inE] -[].
   have {}FlFr : Fl (sval x) < Fr (sval x) by rewrite lt_neqAle FlFr andbT.
-  exists (`|floor (Fr (sval x) - Fl (sval x))^-1|)%N.
-  rewrite invf_plt ?posrE ?subr_gt0// -natr1 natr_absz ger0_norm; last first.
-    by rewrite floor_ge0 invr_ge0// subr_ge0 ltW.
-  by rewrite intrD1 mathcomp_extra.lt_succ_floor// realE.
+  exists (trunc (Fr (sval x) - Fl (sval x))^-1).
+  by rewrite invf_plt ?posrE ?subr_gt0// ltStrunc.
 pose S m := [set x | x \in `]a, b[ /\ m.+1%:R ^-1 < Fr x - Fl x].
 have jumpfafb m (s : seq R) : (forall i, (i < size s)%N -> nth b s i \in S m) ->
   path <%R a s ->
@@ -2826,7 +2821,7 @@ have jumpfafb m (s : seq R) : (forall i, (i < size s)%N -> nth b s i \in S m) ->
   by rewrite -big_nat.
 have fin_S m : finite_set (S m).
   apply: contrapT => /infinite_set_fset.
-  move=> /(_ (m.+1 * `|ceil (F b - F a)|).+1)[B BSm mFbFaB].
+  move=> /(_ (m.+1 * (trunc (F b - F a)).+1).+1)[B BSm mFbFaB].
   set s := sort <=%R B.
   have := jumpfafb m s.
   have HsSm n : (n < size s)%N -> nth b s n \in S m.
@@ -2841,18 +2836,16 @@ have fin_S m : finite_set (S m).
     by rewrite sort_lt_sorted; exact: fset_uniq.
   move/(_ Hpas){Hpas}.
   contra; rewrite -ltNge => _.
-  apply: (@le_lt_trans _ _`|ceil (F b - F a)|%:R).
-    by rewrite natr_absz intr_norm ler_normr ceil_ge.
-  apply: (@lt_trans _ _ (m.+1%:R^-1 * #|` B|%:R)).
-    by rewrite ltr_pdivlMl// -natrM ltr_nat.
+  rewrite (lt_le_trans (ltStrunc _))//.
+  apply: (@le_trans _ _ (m.+1%:R^-1 * #|` B|%:R)).
+    by rewrite ler_pdivlMl// -natrM ler_nat ltnW.
   rewrite card_fset_sum1 natr_sum mulr_sumr mulr1 big_tnth cardfE.
   rewrite -(big_mkord xpredT (fun=> m.+1%:R^-1)) size_sort cardfE.
-  rewrite ltr_sum_nat//; first by rewrite -cardfE (leq_trans _ mFbFaB).
-  move=> k; rewrite leq0n/= => kB.
+  rewrite ler_sum_nat// => k /[!leq0n]/= kB.
   have : nth b s k \in S m.
     apply/mem_set/BSm => /=; rewrite -(@mem_sort _ <=%R).
     by apply/mem_nth; rewrite size_sort cardfE.
-  by rewrite inE => -[].
+  by rewrite /S inE/= => -[_ /ltW].
 suff -> : A = \bigcup_m S m.
   by apply: bigcup_countable => // n _; exact: finite_set_countable.
 rewrite eqEsubset; split.

--- a/theories/realfun.v
+++ b/theories/realfun.v
@@ -202,7 +202,7 @@ exists (fun n => sval (cid (He (PosNum (invn n))))).
   rewrite distrC (lt_le_trans xpt)// -(@invrK _ r) lef_pV2 ?posrE ?invr_gt0//.
   near: t; exists `|ceil r^-1|%N => // s /=.
   rewrite -ltnS -(@ltr_nat R) => /ltW; apply: le_trans.
-  by rewrite natr_absz gtr0_norm -?ceil_gt0 ?invr_gt0// ceil_ge.
+  by rewrite natr_absz gtr0_norm ?ceil_gt0 ?invr_gt0// ceil_ge.
 move=> /cvgrPdist_lt/(_ e%:num (ltac:(by [])))[] n _ /(_ _ (leqnn _)).
 rewrite /sval/=; case: cid => // x [px xpn].
 by rewrite leNgt distrC => /negP.
@@ -260,7 +260,7 @@ exists (fun n => sval (cid (He (PosNum (invn n))))).
   rewrite distrC (lt_le_trans xpt)// -[leRHS]invrK lef_pV2 ?posrE ?invr_gt0//.
   near: t; exists `|ceil r^-1|%N => // s /=.
   rewrite -ltnS -(@ltr_nat R) => /ltW; apply: le_trans.
-  by rewrite natr_absz gtr0_norm -?ceil_gt0 ?invr_gt0 ?le_ceil ?num_real.
+  by rewrite natr_absz gtr0_norm ?ceil_gt0 ?invr_gt0 ?le_ceil ?num_real.
 move=> /cvgrPdist_lt/(_ e%:num (ltac:(by [])))[] n _ /(_ _ (leqnn _)).
 rewrite /sval/=; case: cid => // x [px xpn].
 by rewrite ltNge distrC => /negP.

--- a/theories/separation_axioms.v
+++ b/theories/separation_axioms.v
@@ -741,23 +741,20 @@ Qed.
 Local Open Scope classical_set_scope.
 Local Open Scope ring_scope.
 
-Local Definition distN (e : R) : nat := `|Num.floor e^-1|%N.
+Local Definition distN (e : R) : nat := Num.trunc e^-1.
 
 Local Lemma distN0 : distN 0 = 0%N.
-Proof. by rewrite /distN invr0 floor0. Qed.
+Proof. by rewrite /distN invr0 trunc0. Qed.
 
 Local Lemma distN_nat (n : nat) : distN n%:R^-1 = n.
 Proof.
-rewrite /distN invrK.
-apply/eqP; rewrite -(@eqr_nat R) natr_absz ger0_norm ?floor_ge0//.
-by rewrite -intrEfloor intrEge0.
+by rewrite /distN invrK; apply/eqP; rewrite -(@eqr_nat R) -natrE.
 Qed.
 
 Local Lemma distN_le e1 e2 : e1 > 0 -> e1 <= e2 -> (distN e2 <= distN e1)%N.
 Proof.
-move=> e1pos e1e2; rewrite /distN; apply: lez_abs2.
-  by rewrite floor_ge0 ltW// invr_gt0 (lt_le_trans _ e1e2).
-by rewrite floor_le// lef_pV2 ?invrK ?invr_gt0//; exact: (lt_le_trans _ e1e2).
+move=> e1pos e1e2; rewrite /distN le_trunc// lef_pV2// posrE.
+by rewrite (lt_le_trans e1pos).
 Qed.
 
 Local Fixpoint n_step_ball n x e z :=
@@ -960,9 +957,8 @@ Definition type : Type := let _ := countableBase in let _ := entF in T.
 Lemma countable_uniform_bounded (x y : T) : @ball _ type x 2 y.
 Proof.
 rewrite /ball; exists O%N; rewrite /n_step_ball; split; rewrite // /distN.
-rewrite [X in `|X|%N](_ : _ = 0) ?absz0//.
-apply/eqP; rewrite -[_ == _]negbK; rewrite floor_neq0 negb_or -?ltNge -?leNgt.
-by apply/andP; split => //; rewrite invf_lt1 //= ltrDl.
+rewrite (_ : Num.trunc _ = 0)//.
+by apply/eqP; rewrite trunc_eq// invr_ge0// ler0n/= invf_lt1// ltr1n.
 Qed.
 
 End countable_uniform.

--- a/theories/sequences.v
+++ b/theories/sequences.v
@@ -1190,12 +1190,11 @@ Qed.
 
 Lemma is_cvg_series_exp_coeff_pos : cvgn (series (exp x)).
 Proof.
-rewrite /series; near \oo => N; have xN : x < N%:R; last first.
-  rewrite -(@is_cvg_series_restrict N.+1).
-  by apply: (nondecreasing_is_cvgn (incr_S1 N)); eexists; apply: S1_sup.
-near: N; exists `|floor x|.+1 => // m; rewrite /mkset -(@ler_nat R).
-move/lt_le_trans => -> //; rewrite (lt_le_trans (mathcomp_extra.lt_succ_floor x))//.
-by rewrite -intrD1 -natr1 lerD2r -(@gez0_abs (floor x)) ?floor_ge0// ltW.
+rewrite /series; near \oo => N; have xN : x < N%:R.
+  near: N; exists (trunc x).+2 => // m/= xm.
+  by rewrite (lt_trans (ltStrunc _))// ltr_nat.
+rewrite -(@is_cvg_series_restrict N.+1).
+by apply: (nondecreasing_is_cvgn (incr_S1 N)); eexists; exact: S1_sup.
 Unshelve. all: by end_near. Qed.
 
 End exponential_series_cvg.
@@ -2767,11 +2766,8 @@ have : cvg (a @ \oo).
   have [n rne] : exists n, 2 * (r n)%:num < e.
     pose eps := e / 2.
     have [n n1e] : exists n, n.+1%:R^-1 < eps.
-      exists `|ceil eps^-1|%N.
-      rewrite -ltf_pV2 ?(posrE,divr_gt0)// invrK -addn1 natrD.
-      rewrite natr_absz gtr0_norm.
-        by rewrite (le_lt_trans (ceil_ge _)) // ltrDl.
-      by rewrite ceil_gt0 invr_gt0 divr_gt0.
+      exists (trunc eps^-1).
+      by rewrite -ltf_pV2 ?(posrE,divr_gt0)// invrK ltStrunc.
     exists n.+1; rewrite -ltr_pdivlMl //.
     have /lt_trans : (r n.+1)%:num < n.+1%:R^-1.
       have [_ ] : P n.+1 (a n, r n) (a n.+1, r n.+1) by apply: (Pf (n, ar n)).
@@ -2872,16 +2868,16 @@ set O_inf := \bigcap_i (O i).
 have O_infempty : O_inf = set0.
   rewrite -subset0 => x.
   have [M FxM] := BoundedF x; rewrite /O_inf /O /=.
-  move=> /(_ `|ceil M|%N Logic.I)[f Ff]; apply/negP; rewrite -leNgt.
-  rewrite (le_trans (FxM _ Ff))// (le_trans (ceil_ge _))//.
-  by have := lez_abs (ceil M); rewrite -(@ler_int K).
+  move=> /(_ (trunc M).+1 Logic.I)[f Ff]; apply/negP; rewrite -leNgt.
+  by rewrite (le_trans (FxM _ Ff))// ltW// ltStrunc.
 have ContraBaire : exists i, not (dense (O i)).
   have dOinf : ~ dense O_inf.
     rewrite /dense O_infempty ; apply /existsNP; exists setT; elim.
     - by move=> x; rewrite setI0.
     - by exists point.
     - exact: openT.
-  have /contra_not/(_ dOinf) : (forall i, open (O i) /\ dense (O i)) -> dense (O_inf).
+  have /contra_not/(_ dOinf) :
+      (forall i, open (O i) /\ dense (O i)) -> dense (O_inf).
     exact: Baire.
   move=> /asboolPn /existsp_asboolPn[n /and_asboolP /nandP Hn].
   by exists n; case: Hn => /asboolPn.
@@ -2895,11 +2891,11 @@ exists ((n + n)%:R * k * 2 / r%:num)=> f Ff y Hx; move: (Propf f Ff) => [ _ linf
 case: (eqVneq y 0) => [-> | Zeroy].
   move: (linear0 (pack_linear linf)) => /= ->.
   by rewrite normr0 !mulr_ge0 // (le_trans _ Hx).
-have majballi : forall f x, F f -> (ball x0 r%:num) x -> `|f x | <= n%:R.
-  move=> g x Fg /(H x); rewrite leNgt.
+have majballi g x : F g -> (ball x0 r%:num) x -> `|g x| <= n%:R.
+  move=> Fg /(H x); rewrite leNgt.
   by rewrite /O setC_bigcup /= => /(_ _ Fg)/negP.
-have majball : forall f x, F f -> (ball x0 r%:num) x -> `|f (x - x0)| <= n%:R + n%:R.
-  move=> g x Fg; move: (Propf g Fg) => [Bg Lg].
+have majball g x : F g -> (ball x0 r%:num) x -> `|g (x - x0)| <= n%:R + n%:R.
+  move=> Fg; have [Bg Lg] := Propf g Fg.
   move: (linearB (pack_linear Lg)) => /= -> Ballx.
   apply/(le_trans (ler_normB _ _))/lerD; first exact: majballi.
   by apply: majballi => //; exact/ball_center.

--- a/theories/sequences.v
+++ b/theories/sequences.v
@@ -2771,7 +2771,7 @@ have : cvg (a @ \oo).
       rewrite -ltf_pV2 ?(posrE,divr_gt0)// invrK -addn1 natrD.
       rewrite natr_absz gtr0_norm.
         by rewrite (le_lt_trans (ceil_ge _)) // ltrDl.
-      by rewrite -ceil_gt0 invr_gt0 divr_gt0.
+      by rewrite ceil_gt0 invr_gt0 divr_gt0.
     exists n.+1; rewrite -ltr_pdivlMl //.
     have /lt_trans : (r n.+1)%:num < n.+1%:R^-1.
       have [_ ] : P n.+1 (a n, r n) (a n.+1, r n.+1) by apply: (Pf (n, ar n)).

--- a/theories/topology_theory/pseudometric_structure.v
+++ b/theories/topology_theory/pseudometric_structure.v
@@ -338,7 +338,7 @@ exists `|Num.floor e^-1|%N; apply: subset_trans subE => xy; apply: le_ball.
 rewrite /= -[leRHS]invrK lef_pV2 ?posrE ?invr_gt0// -natr1.
 rewrite natr_absz ger0_norm; last first.
   by rewrite -floor_ge_int ?invr_ge0 ?num_real // ltW.
-by rewrite intrD1 ltW// lt_succ_floor ?num_real.
+by rewrite intrD1 ltW// lt_floorD1 ?num_real.
 Qed.
 
 (** Specific pseudoMetric spaces *)


### PR DESCRIPTION
##### Motivation for this change

Complete the set of lemmas about trunc/ceil/floor before backporting them to MathComp (c.f. https://github.com/math-comp/math-comp/pull/1359 )

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] ~added corresponding documentation in the headers~

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
