### PR TITLE
Adapt to rocq#19987

### DIFF
--- a/classical/functions.v
+++ b/classical/functions.v
@@ -1734,7 +1734,7 @@ Lemma reindex_bigcup {aT rT I} (f : aT -> I) (P : set aT) (Q : set I)
     (F : I -> set rT) : set_fun P Q f -> set_surj P Q f ->
   \bigcup_(x in Q) F x = \bigcup_(x in P) F (f x).
 Proof.
-by move=> /image_subP fPQ /(surj_image_eq fPQ)<-; rewrite bigcup_image.
+by move=> /image_subP fPQ /(surj_image_eq fPQ) QE; rewrite -[Q]QE bigcup_image.
 Qed.
 Arguments reindex_bigcup {aT rT I} f P Q.
 
@@ -1742,7 +1742,7 @@ Lemma reindex_bigcap {aT rT I} (f : aT -> I) (P : set aT) (Q : set I)
     (F : I -> set rT) : set_fun P Q f -> set_surj P Q f ->
   \bigcap_(x in Q) F x = \bigcap_(x in P) F (f x).
 Proof.
-by move=> /image_subP fPQ /(surj_image_eq fPQ)<-; rewrite bigcap_image.
+by move=> /image_subP fPQ /(surj_image_eq fPQ) QE; rewrite -[Q]QE bigcap_image.
 Qed.
 Arguments reindex_bigcap {aT rT I} f P Q.
 

--- a/theories/function_spaces.v
+++ b/theories/function_spaces.v
@@ -1426,7 +1426,7 @@ Lemma continuous_curry (f : U * V -> W) :
     continuous (curry f) /\ forall u, continuous (curry f u).
 Proof.
 move=> ctsf; split; first last.
-  move=> u z; apply: continuous_comp; last exact: ctsf.
+  move=> u z; apply: (continuous_comp _ (ctsf (u, z))).
   by apply: cvg_pair => //=; exact: cvg_cst.
 move=> x; apply/compact_open_cvgP => K O /= cptK oO fKO.
 near=> z => w /= [+ + <-]; near: z.


### PR DESCRIPTION
##### Motivation for this change

https://github.com/coq/coq/pull/19987 refolds terms before using them to instantiate evars. In `classical/functions.v`, there is a lemma (`image_subP`) that uses `homomorphism_1`, which introduces eta-expansions. Due to unfoldings in the previous algorithm, these eta-expansions were removed, whereas they are not now, which makes `rewrite`'s matching algorithm fail. In `theories/function_spaces`, there is a second order unification problem which is solved differently.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Checklist

- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
