### PR TITLE
generalizations of derive incr/decr lemmas

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -169,10 +169,13 @@
 - in `derive.v`:
   + lemmas `ger0_derive1_le`, `ger0_derive1_le_cc`, `ger0_derive1_le_co`,
     `ger0_derive1_le_oc`, `ger0_derive1_le_oo`
+  + lemmas `gtr0_derive1_lt`, `gtr0_derive1_lt_cc`, `gtr0_derive1_lt_co`,
+    `gtr0_derive1_lt_oc`, `gtr0_derive1_lt_oo`
   + lemmas `ler0_derive1_le`, `ler0_derive1_le_cc`, `ler0_derive1_le_co`,
     `ler0_derive1_le_oc`, `ler0_derive1_le_oo`
   + lemmas `ltr0_derive1_lt`, `ltr0_derive1_lt_cc`, `ltr0_derive1_lt_co`,
     `ltr0_derive1_lt_oc`, `ltr0_derive1_lt_oo`
+
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -166,6 +166,13 @@
 
 - in `derive.v`:
   + lemmas `derive1Mr`, `derive1Ml`
+- in `derive.v`:
+  + lemmas `ger0_derive1_le`, `ger0_derive1_le_cc`, `ger0_derive1_le_co`,
+    `ger0_derive1_le_oc`, `ger0_derive1_le_oo`
+  + lemmas `ler0_derive1_le`, `ler0_derive1_le_cc`, `ler0_derive1_le_co`,
+    `ler0_derive1_le_oc`, `ler0_derive1_le_oo`
+  + lemmas `ltr0_derive1_lt`, `ltr0_derive1_lt_cc`, `ltr0_derive1_lt_co`,
+    `ltr0_derive1_lt_oc`, `ltr0_derive1_lt_oo`
 
 ### Changed
 
@@ -294,6 +301,9 @@
 
 - in `normed_theory` (was in `normedtype.v` before the split)
   + `pseudoMetricNormedZModType_hausdorff` (use `norm_hausdorff` instead)
+- in `derive.v`:
+  + `ler0_derive1_nincr` (use `ler0_derive1_le_cc`)
+  + `gtr0_derive1_incr` (use `gtr0_le_derive1`)
 
 ### Removed
 

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -1598,13 +1598,17 @@ have [c cab D] := MVT altb fdrvbl fcont.
 by exists c => //; rewrite in_itv /= ltW (itvP cab).
 Qed.
 
-Lemma ger0_derive1_homo (R : realType) (f : R^o -> R^o) (a b : R) (sa sb : bool) :
-  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
-  (forall x : R, x \in `]a, b[%R -> 0 <= (f^`())%classic x) ->
+Section ger0_derive1_le.
+Context {R : realType}.
+Variables (f : R -> R) (a b : R).
+Hypothesis df : forall x, x \in `]a, b[%R -> derivable f x 1.
+Hypothesis dfge0 : forall x, x \in `]a, b[%R -> 0 <= (f^`())%classic x.
+
+Lemma ger0_derive1_le (sa sb : bool) :
   {within [set` (Interval (BSide sa a) (BSide sb b))], continuous f} ->
-  {in (Interval (BSide sa a) (BSide sb b)) &, {homo f : x y / x <= y >-> x <= y}}.
+  {in Interval (BSide sa a) (BSide sb b) &, {homo f : x y / x <= y >-> x <= y}}.
 Proof.
-move=> df dfge0 cf x y + + xy.
+move=> cf x y + + xy.
 rewrite !itv_boundlr /= => /andP [] ax ? /andP [] ? yb.
 have HMVT1: {within `[x, y], continuous f}.
   exact/(continuous_subspaceW _ cf)/subset_itv.
@@ -1620,42 +1624,36 @@ have[z zxy ->]:= MVT xy' HMVT0 HMVT1.
 by rewrite mulr_ge0// ?subr_ge0// dfge0// zab.
 Qed.
 
-Lemma ger0_derive1_homo_cc (R : realType) (f : R^o -> R^o) (a b : R) :
-  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
-  (forall x : R, x \in `]a, b[%R -> 0 <= (f^`())%classic x) ->
-  {within [set` `[a, b]]%R , continuous f} ->
+Lemma ger0_derive1_le_cc : {within `[a, b] , continuous f} ->
   {in `[a, b]%R &, {homo f : x y / x <= y >-> x <= y}}.
-Proof. exact: ger0_derive1_homo. Qed.
+Proof. exact: ger0_derive1_le. Qed.
 
-Lemma ger0_derive1_homo_co (R : realType) (f : R^o -> R^o) (a b : R) :
-  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
-  (forall x : R, x \in `]a, b[%R -> 0 <= (f^`())%classic x) ->
-  {within [set` `[a, b[]%R , continuous f} ->
+Lemma ger0_derive1_le_co : {within `[a, b[ , continuous f} ->
   {in `[a, b[%R &, {homo f : x y / x <= y >-> x <= y}}.
-Proof. exact: ger0_derive1_homo. Qed.
+Proof. exact: ger0_derive1_le. Qed.
 
-Lemma ger0_derive1_homo_oc (R : realType) (f : R^o -> R^o) (a b : R) :
-  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
-  (forall x : R, x \in `]a, b[%R -> 0 <= (f^`())%classic x) ->
-  {within [set` `]a, b]]%R , continuous f} ->
+Lemma ger0_derive1_le_oc : {within `]a, b], continuous f} ->
   {in `]a, b]%R &, {homo f : x y / x <= y >-> x <= y}}.
-Proof. exact: ger0_derive1_homo. Qed.
+Proof. exact: ger0_derive1_le. Qed.
 
-Lemma ger0_derive1_homo_oo (R : realType) (f : R^o -> R^o) (a b : R) :
-  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
-  (forall x : R, x \in `]a, b[%R -> 0 <= (f^`())%classic x) ->
-  {in `]a, b[, continuous f} ->
+Lemma ger0_derive1_le_oo : {in `]a, b[, continuous f} ->
   {in `]a, b[%R &, {homo f : x y / x <= y >-> x <= y}}.
-Proof. by rewrite -continuous_open_subspace//; exact: ger0_derive1_homo. Qed.
+Proof. by rewrite -continuous_open_subspace//; exact: ger0_derive1_le. Qed.
+
+End ger0_derive1_le.
+
+Section ler0_derive1_le.
+Context {R : realType}.
+Variables (f : R -> R) (a b : R).
+Hypothesis df : forall x, x \in `]a, b[%R -> derivable f x 1.
+Hypothesis dfle0 : forall x, x \in `]a, b[%R -> f^`() x <= 0.
 
 (* TODO: check that this can be proved in terms of ger0_derive1_homo *)
-Lemma ler0_derive1_homo (R : realType) (f : R^o -> R^o) (a b : R) (sa sb : bool) :
-  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
-  (forall x : R, x \in `]a, b[%R -> f^`() x <= 0) ->
+Lemma ler0_derive1_le (sa sb : bool) :
   {within [set` (Interval (BSide sa a) (BSide sb b))], continuous f} ->
-  {in (Interval (BSide sa a) (BSide sb b)) &, {homo f : x y / x <= y >-> y <= x}}.
+  {in Interval (BSide sa a) (BSide sb b) &, {homo f : x y / x <= y >-> y <= x}}.
 Proof.
-move=> df dfle0 cf x y + + xy.
+move=> cf x y + + xy.
 rewrite !itv_boundlr /= => /andP [] ax xb /andP [] ay yb.
 have HMVT1: {within `[x, y], continuous f}.
   exact/(continuous_subspaceW _ cf)/subset_itv.
@@ -1671,34 +1669,26 @@ have[z zxy ->]:= MVT xy' HMVT0 HMVT1.
 by rewrite mulr_le0_ge0// ?subr_ge0// dfle0// zab.
 Qed.
 
-Lemma ler0_derive1_homo_cc (R : realType) (f : R^o -> R^o) (a b : R) :
-  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
-  (forall x : R, x \in `]a, b[%R -> f^`() x <= 0) ->
-  {within [set` `[a, b]%R], continuous f} ->
+Lemma ler0_derive1_le_cc :{within `[a, b], continuous f} ->
   {in `[a, b]%R &, {homo f : x y / x <= y >-> y <= x}}.
-Proof. exact: ler0_derive1_homo. Qed.
+Proof. exact: ler0_derive1_le. Qed.
 
-Lemma ler0_derive1_homo_co (R : realType) (f : R^o -> R^o) (a b : R) :
-  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
-  (forall x : R, x \in `]a, b[%R -> f^`() x <= 0) ->
-  {within [set` `[a, b[%R], continuous f} ->
+Lemma ler0_derive1_le_co : {within `[a, b[, continuous f} ->
   {in `[a, b[%R &, {homo f : x y / x <= y >-> y <= x}}.
-Proof. exact: ler0_derive1_homo. Qed.
+Proof. exact: ler0_derive1_le. Qed.
 
-Lemma ler0_derive1_homo_oc (R : realType) (f : R^o -> R^o) (a b : R) :
-  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
-  (forall x : R, x \in `]a, b[%R -> f^`() x <= 0) ->
-  {within [set` `]a, b]%R], continuous f} ->
+Lemma ler0_derive1_le_oc : {within `]a, b], continuous f} ->
   {in `]a, b]%R &, {homo f : x y / x <= y >-> y <= x}}.
-Proof. exact: ler0_derive1_homo. Qed.
+Proof. exact: ler0_derive1_le. Qed.
 
-Lemma ler0_derive1_homo_oo (R : realType) (f : R^o -> R^o) (a b : R) :
-  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
-  (forall x : R, x \in `]a, b[%R -> f^`() x <= 0) ->
-  {in `]a, b[, continuous f} ->
+Lemma ler0_derive1_le_oo : {in `]a, b[, continuous f} ->
   {in `]a, b[%R &, {homo f : x y / x <= y >-> y <= x}}.
-Proof. by rewrite -continuous_open_subspace//; exact: ler0_derive1_homo. Qed.
+Proof. by rewrite -continuous_open_subspace//; exact: ler0_derive1_le. Qed.
 
+End ler0_derive1_le.
+
+#[deprecated(since="mathcomp-analysis 1.10.0",
+  note="use `ler0_derive1_le_cc` instead")]
 Lemma ler0_derive1_nincr (R : realType) (f : R -> R) (a b : R) :
   (forall x, x \in `]a, b[%R -> derivable f x 1) ->
   (forall x, x \in `]a, b[%R -> f^`() x <= 0) ->
@@ -1706,18 +1696,22 @@ Lemma ler0_derive1_nincr (R : realType) (f : R -> R) (a b : R) :
   forall x y, a <= x -> x <= y -> y <= b -> f y <= f x.
 Proof.
 move=> fdrvbl dfle0 ctsf x y leax lexy leyb.
-apply: ler0_derive1_homo_cc; [ exact: fdrvbl | exact: dfle0 | by [] | | | by [] ].
+apply: ler0_derive1_le_cc; [ exact: fdrvbl | exact: dfle0 | by [] | | | by [] ].
   by rewrite in_itv/= leax (le_trans lexy leyb).
 by rewrite in_itv/= (le_trans leax lexy) leyb.
 Qed.
 
-Lemma ltr0_derive1_homo (R : realType) (f : R^o -> R^o) (a b : R) (sa sb : bool) :
-  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
-  (forall x : R, x \in `]a, b[%R -> f^`() x < 0) ->
+Section ltr0_derive1_lt.
+Context {R : realType}.
+Variables (f : R -> R) (a b : R).
+Hypothesis df : forall x, x \in `]a, b[%R -> derivable f x 1.
+Hypothesis dfgt0 : forall x, x \in `]a, b[%R -> f^`() x < 0.
+
+Lemma ltr0_derive1_lt (sa sb : bool) :
   {within [set` (Interval (BSide sa a) (BSide sb b))], continuous f} ->
-  {in (Interval (BSide sa a) (BSide sb b)) &, {homo f : x y / x < y >-> y < x}}.
+  {in Interval (BSide sa a) (BSide sb b) &, {homo f : x y / x < y >-> y < x}}.
 Proof.
-move=> df dfgt0 cf x y + + xy.
+move=> cf x y + + xy.
 rewrite !itv_boundlr /= => /andP [] ax ? /andP [] ? yb.
 have HMVT1: {within `[x, y], continuous f}.
   exact/(continuous_subspaceW _ cf)/subset_itv.
@@ -1732,33 +1726,25 @@ have[z zxy ->]:= MVT xy HMVT0 HMVT1.
 by rewrite nmulr_rlt0// ?subr_gt0// dfgt0// zab.
 Qed.
 
-Lemma ltr0_derive1_homo_cc (R : realType) (f : R^o -> R^o) (a b : R) :
-  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
-  (forall x : R, x \in `]a, b[%R -> f^`() x < 0) ->
-  {within [set` `[a, b]%R], continuous f} ->
+Lemma ltr0_derive1_lt_cc : {within `[a, b], continuous f} ->
   {in `[a, b]%R &, {homo f : x y / x < y >-> y < x}}.
-Proof. exact: ltr0_derive1_homo. Qed.
+Proof. exact: ltr0_derive1_lt. Qed.
 
-Lemma ltr0_derive1_homo_co (R : realType) (f : R^o -> R^o) (a b : R) :
-  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
-  (forall x : R, x \in `]a, b[%R -> f^`() x < 0) ->
-  {within [set` `[a, b[%R], continuous f} ->
+Lemma ltr0_derive1_lt_co : {within `[a, b[, continuous f} ->
   {in `[a, b[%R &, {homo f : x y / x < y >-> y < x}}.
-Proof. exact: ltr0_derive1_homo. Qed.
+Proof. exact: ltr0_derive1_lt. Qed.
 
-Lemma ltr0_derive1_homo_oc (R : realType) (f : R^o -> R^o) (a b : R) :
-  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
-  (forall x : R, x \in `]a, b[%R -> f^`() x < 0) ->
-  {within [set` `]a, b]%R], continuous f} ->
+Lemma ltr0_derive1_lt_oc : {within `]a, b], continuous f} ->
   {in `]a, b]%R &, {homo f : x y / x < y >-> y < x}}.
-Proof. exact: ltr0_derive1_homo. Qed.
+Proof. exact: ltr0_derive1_lt. Qed.
 
-Lemma ltr0_derive1_homo_oo (R : realType) (f : R^o -> R^o) (a b : R) :
-  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
-  (forall x : R, x \in `]a, b[%R -> f^`() x < 0) ->
-  {in `]a, b[, continuous f} ->
+Lemma ltr0_derive1_lt_oo : {in `]a, b[, continuous f} ->
   {in `]a, b[%R &, {homo f : x y / x < y >-> y < x}}.
-Proof. by rewrite -continuous_open_subspace//; exact: ltr0_derive1_homo. Qed.
+Proof. by rewrite -continuous_open_subspace//; exact: ltr0_derive1_lt. Qed.
+
+End ltr0_derive1_lt.
+
+(* wip *)
 
 Lemma ltr0_derive1_decr (R : realType) (f : R -> R) (a b : R) :
   (forall x, x \in `]a, b[%R -> derivable f x 1) ->
@@ -1767,7 +1753,7 @@ Lemma ltr0_derive1_decr (R : realType) (f : R -> R) (a b : R) :
   forall x y, a <= x -> x < y -> y <= b -> f y < f x.
 Proof.
 move=> fdrvbl dflt0 ctsf x y leax ltxy leyb.
-apply: ltr0_derive1_homo; [ exact: fdrvbl | exact: dflt0 | by [] | | | by [] ].
+apply: ltr0_derive1_lt; [ exact: fdrvbl | exact: dflt0 | by [] | | | by [] ].
   by rewrite in_itv/= leax (ltW (lt_le_trans ltxy leyb)).
 by rewrite in_itv/= (ltW (le_lt_trans leax ltxy)) leyb.
 Qed.
@@ -1821,16 +1807,18 @@ Lemma gtr0_derive1_homo_oo (R : realType) (f : R^o -> R^o) (a b : R) :
   {in `]a, b[%R &, {homo f : x y / x < y >-> x < y}}.
 Proof. by rewrite -continuous_open_subspace//; exact: gtr0_derive1_homo. Qed.
 
+#[deprecated(since="mathcomp-analysis 1.10.0",
+  note="use `gtr0_le_derive1` instead")]
 Lemma gtr0_derive1_incr (R : realType) (f : R -> R) (a b : R) :
   (forall x, x \in `]a, b[%R -> derivable f x 1) ->
   (forall x, x \in `]a, b[%R -> 0 < f^`() x) ->
   {within `[a, b], continuous f}%classic ->
   forall x y, a <= x -> x < y -> y <= b -> f x < f y.
 Proof.
-move=> fdrvbl dfgt0 ctsf x y leax ltxy leyb.
-apply: gtr0_derive1_homo; [ exact: fdrvbl | exact: dfgt0 | by [] | | | by [] ].
-  by rewrite in_itv/= leax (ltW (lt_le_trans ltxy leyb)).
-by rewrite in_itv/= (ltW (le_lt_trans leax ltxy)) leyb.
+move=> abf abf' cf x y ax xy yb; apply: (@gtr0_derive1_homo_cc _ _ a b) => //;
+  rewrite in_itv/= ?ax ?yb ?andbT/=.
+- by rewrite (le_trans (ltW xy)).
+- by rewrite (le_trans _ (ltW xy)).
 Qed.
 
 Lemma ler0_derive1_nincry {R : realType} (f : R -> R) (a : R) :

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -97,7 +97,7 @@ Lemma diff_continuous (x : filter_on V) (f : V -> W) :
   differentiable f x -> continuous ('d f x).
 Proof. by move=> /diffP []. Qed.
 (* We should have a continuous class or structure *)
-Hint Extern 0 (continuous _) => exact: diff_continuous : core.
+Hint Extern 0 (continuous _) => solve[apply: diff_continuous] : core.
 
 Lemma diffE (F : filter_on V) (f : V -> W) :
   differentiable f F ->
@@ -124,7 +124,7 @@ Context {K : numFieldType (*TODO: to numDomainType?*)} {V W : normedModType K}.
 Local Notation differentiable f F :=
   (@differentiable_def _ _ _ f _ (Phantom _ (nbhs F))).
 Local Notation "''d' f x" := (@diff _ _ _ _ (Phantom _ (nbhs x)) f).
-Hint Extern 0 (continuous _) => exact: diff_continuous : core.
+Hint Extern 0 (continuous _) => solve[now apply: diff_continuous] : core.
 
 Lemma diff_locallyxP (x : V) (f : V -> W) :
   differentiable f x <-> continuous ('d f x) /\
@@ -164,7 +164,8 @@ Notation differentiable f F := (@differentiable_def _ _ _ f _ (Phantom _ (nbhs F
 
 Notation "'is_diff' F" := (is_diff_def (Phantom _ (nbhs F))).
 #[global] Hint Extern 0 (differentiable _ _) => solve[apply: ex_diff] : core.
-#[global] Hint Extern 0 ({for _, continuous _}) => exact: diff_continuous : core.
+#[global] Hint Extern 0 ({for _, continuous _}) =>
+  solve[now apply: diff_continuous] : core.
 
 Lemma differentiableP (R : numDomainType) (V W : normedModType R) (f : V -> W) x :
   differentiable f x -> is_diff x f ('d f x).

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -1801,10 +1801,12 @@ apply: ltr0_derive1_lt_cc; [ exact: df | exact: f'0 | by [] | | | by [] ];
 by rewrite (le_trans (ltW xy)).
 Qed.
 
-#[global] Hint Extern 0 (is_true (_ <= ?x)) => match goal with
-  H : x \is_near _ |- _ => near: x; apply: nbhs_pinfty_ge; exact: num_real end : core.
-#[global] Hint Extern 0 (is_true (?x <= _)) => match goal with
-  H : x \is_near _ |- _ => near: x; apply: nbhs_ninfty_le; exact: num_real end : core.
+#[global] Hint Extern 0 (is_true (_ <= ?x)) => solve[match goal with
+    H : x \is_near _ |- _ => near: x; apply: nbhs_pinfty_ge; apply: num_real
+  end] : core.
+#[global] Hint Extern 0 (is_true (?x <= _)) => solve[match goal with
+    H : x \is_near _ |- _ => near: x; apply: nbhs_ninfty_le; apply: num_real
+  end] : core.
 
 Lemma ler0_derive1_nincry {R : realType} (f : R -> R) (a : R) :
   (forall x, x \in `]a, +oo[%R -> derivable f x 1) ->

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -1801,12 +1801,14 @@ apply: ltr0_derive1_lt_cc; [ exact: df | exact: f'0 | by [] | | | by [] ];
 by rewrite (le_trans (ltW xy)).
 Qed.
 
-#[global] Hint Extern 0 (is_true (_ <= ?x)) => solve[match goal with
-    H : x \is_near _ |- _ => near: x; apply: nbhs_pinfty_ge; apply: num_real
-  end] : core.
-#[global] Hint Extern 0 (is_true (?x <= _)) => solve[match goal with
-    H : x \is_near _ |- _ => near: x; apply: nbhs_ninfty_le; apply: num_real
-  end] : core.
+#[global] Hint Extern 0 (is_true (_ <= ?x)) => match goal with
+    H : x \is_near _ |- _ =>
+      solve[near: x; apply: nbhs_pinfty_ge; apply: num_real]
+  end : core.
+#[global] Hint Extern 0 (is_true (?x <= _)) => match goal with
+    H : x \is_near _ |- _ =>
+      solve[near: x; apply: nbhs_ninfty_le; apply: num_real]
+  end : core.
 
 Lemma ler0_derive1_nincry {R : realType} (f : R -> R) (a : R) :
   (forall x, x \in `]a, +oo[%R -> derivable f x 1) ->

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -1802,9 +1802,9 @@ by rewrite (le_trans (ltW xy)).
 Qed.
 
 #[global] Hint Extern 0 (is_true (_ <= ?x)) => match goal with
-  H : x \is_near _ |- _ => by near: x; apply: nbhs_pinfty_ge; rewrite num_real end : core.
+  H : x \is_near _ |- _ => near: x; apply: nbhs_pinfty_ge; exact: num_real end : core.
 #[global] Hint Extern 0 (is_true (?x <= _)) => match goal with
-  H : x \is_near _ |- _ => by near: x; apply: nbhs_ninfty_le; rewrite num_real end : core.
+  H : x \is_near _ |- _ => near: x; apply: nbhs_ninfty_le; exact: num_real end : core.
 
 Lemma ler0_derive1_nincry {R : realType} (f : R -> R) (a : R) :
   (forall x, x \in `]a, +oo[%R -> derivable f x 1) ->

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -1598,27 +1598,167 @@ have [c cab D] := MVT altb fdrvbl fcont.
 by exists c => //; rewrite in_itv /= ltW (itvP cab).
 Qed.
 
+Lemma ger0_derive1_homo (R : realType) (f : R^o -> R^o) (a b : R) (sa sb : bool) :
+  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
+  (forall x : R, x \in `]a, b[%R -> 0 <= (f^`())%classic x) ->
+  {within [set` (Interval (BSide sa a) (BSide sb b))], continuous f} ->
+  {in (Interval (BSide sa a) (BSide sb b)) &, {homo f : x y / x <= y >-> x <= y}}.
+Proof.
+move=> df dfge0 cf x y + + xy.
+rewrite !itv_boundlr /= => /andP [] ax ? /andP [] ? yb.
+have HMVT1: {within `[x, y], continuous f}.
+  exact/(continuous_subspaceW _ cf)/subset_itv.
+have zab: forall z, z \in `]x, y[%R -> z \in `]a, b[%R.
+  apply/subset_itv.
+    by move: ax; clear; case: sa; rewrite !bnd_simp// => /ltW.
+  by move: yb; clear; case: sb; rewrite !bnd_simp// => /ltW.
+have HMVT0 (z : R^o) : z \in `]x, y[%R -> is_derive z 1 f ((f^`())%classic z).
+  by move=> zxy; rewrite derive1E; exact/derivableP/df/zab.
+rewrite -subr_ge0.
+move: (xy); rewrite le_eqVlt=> /orP [/eqP-> | xy']; first by rewrite subrr.
+have[z zxy ->]:= MVT xy' HMVT0 HMVT1.
+by rewrite mulr_ge0// ?subr_ge0// dfge0// zab.
+Qed.
+
+Lemma ger0_derive1_homo_cc (R : realType) (f : R^o -> R^o) (a b : R) :
+  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
+  (forall x : R, x \in `]a, b[%R -> 0 <= (f^`())%classic x) ->
+  {within [set` `[a, b]]%R , continuous f} ->
+  {in `[a, b]%R &, {homo f : x y / x <= y >-> x <= y}}.
+Proof. exact: ger0_derive1_homo. Qed.
+
+Lemma ger0_derive1_homo_co (R : realType) (f : R^o -> R^o) (a b : R) :
+  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
+  (forall x : R, x \in `]a, b[%R -> 0 <= (f^`())%classic x) ->
+  {within [set` `[a, b[]%R , continuous f} ->
+  {in `[a, b[%R &, {homo f : x y / x <= y >-> x <= y}}.
+Proof. exact: ger0_derive1_homo. Qed.
+
+Lemma ger0_derive1_homo_oc (R : realType) (f : R^o -> R^o) (a b : R) :
+  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
+  (forall x : R, x \in `]a, b[%R -> 0 <= (f^`())%classic x) ->
+  {within [set` `]a, b]]%R , continuous f} ->
+  {in `]a, b]%R &, {homo f : x y / x <= y >-> x <= y}}.
+Proof. exact: ger0_derive1_homo. Qed.
+
+Lemma ger0_derive1_homo_oo (R : realType) (f : R^o -> R^o) (a b : R) :
+  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
+  (forall x : R, x \in `]a, b[%R -> 0 <= (f^`())%classic x) ->
+  {in `]a, b[, continuous f} ->
+  {in `]a, b[%R &, {homo f : x y / x <= y >-> x <= y}}.
+Proof. by rewrite -continuous_open_subspace//; exact: ger0_derive1_homo. Qed.
+
+(* TODO: check that this can be proved in terms of ger0_derive1_homo *)
+Lemma ler0_derive1_homo (R : realType) (f : R^o -> R^o) (a b : R) (sa sb : bool) :
+  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
+  (forall x : R, x \in `]a, b[%R -> f^`() x <= 0) ->
+  {within [set` (Interval (BSide sa a) (BSide sb b))], continuous f} ->
+  {in (Interval (BSide sa a) (BSide sb b)) &, {homo f : x y / x <= y >-> y <= x}}.
+Proof.
+move=> df dfle0 cf x y + + xy.
+rewrite !itv_boundlr /= => /andP [] ax xb /andP [] ay yb.
+have HMVT1: {within `[x, y], continuous f}.
+  exact/(continuous_subspaceW _ cf)/subset_itv.
+have zab : forall z, z \in `]x, y[%R -> z \in `]a, b[%R.
+  apply/subset_itv.
+    by move: ax; clear; case: sa; rewrite !bnd_simp// => /ltW.
+  by move: yb; clear; case: sb; rewrite !bnd_simp// => /ltW.
+have HMVT0 (z : R^o) : z \in `]x, y[%R -> is_derive z 1 f (f^`() z).
+  by move=> zxy; rewrite derive1E; exact/derivableP/df/zab.
+rewrite -subr_le0.
+move: (xy); rewrite le_eqVlt=> /orP [/eqP-> | xy']; first by rewrite subrr.
+have[z zxy ->]:= MVT xy' HMVT0 HMVT1.
+by rewrite mulr_le0_ge0// ?subr_ge0// dfle0// zab.
+Qed.
+
+Lemma ler0_derive1_homo_cc (R : realType) (f : R^o -> R^o) (a b : R) :
+  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
+  (forall x : R, x \in `]a, b[%R -> f^`() x <= 0) ->
+  {within [set` `[a, b]%R], continuous f} ->
+  {in `[a, b]%R &, {homo f : x y / x <= y >-> y <= x}}.
+Proof. exact: ler0_derive1_homo. Qed.
+
+Lemma ler0_derive1_homo_co (R : realType) (f : R^o -> R^o) (a b : R) :
+  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
+  (forall x : R, x \in `]a, b[%R -> f^`() x <= 0) ->
+  {within [set` `[a, b[%R], continuous f} ->
+  {in `[a, b[%R &, {homo f : x y / x <= y >-> y <= x}}.
+Proof. exact: ler0_derive1_homo. Qed.
+
+Lemma ler0_derive1_homo_oc (R : realType) (f : R^o -> R^o) (a b : R) :
+  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
+  (forall x : R, x \in `]a, b[%R -> f^`() x <= 0) ->
+  {within [set` `]a, b]%R], continuous f} ->
+  {in `]a, b]%R &, {homo f : x y / x <= y >-> y <= x}}.
+Proof. exact: ler0_derive1_homo. Qed.
+
+Lemma ler0_derive1_homo_oo (R : realType) (f : R^o -> R^o) (a b : R) :
+  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
+  (forall x : R, x \in `]a, b[%R -> f^`() x <= 0) ->
+  {in `]a, b[, continuous f} ->
+  {in `]a, b[%R &, {homo f : x y / x <= y >-> y <= x}}.
+Proof. by rewrite -continuous_open_subspace//; exact: ler0_derive1_homo. Qed.
+
 Lemma ler0_derive1_nincr (R : realType) (f : R -> R) (a b : R) :
   (forall x, x \in `]a, b[%R -> derivable f x 1) ->
   (forall x, x \in `]a, b[%R -> f^`() x <= 0) ->
   {within `[a, b], continuous f} ->
   forall x y, a <= x -> x <= y -> y <= b -> f y <= f x.
 Proof.
-move=> fdrvbl dfle0 ctsf x y leax lexy leyb; rewrite -subr_ge0.
-case: ltgtP lexy => // [xlty|->]; last by rewrite subrr.
-have itvW : {subset `[x, y]%R <= `[a, b]%R}.
-  by apply/subitvP; rewrite /<=%O /= /<=%O /= leyb leax.
-have itvWlt : {subset `]x, y[%R <= `]a, b[%R}.
-  by apply subitvP; rewrite /<=%O /= /<=%O /= leyb leax.
-have fdrv z : z \in `]x, y[%R -> is_derive z 1 f (f^`()z).
-  rewrite in_itv/= => /andP[xz zy]; apply: DeriveDef; last by rewrite derive1E.
-  by apply: fdrvbl; rewrite in_itv/= (le_lt_trans _ xz)// (lt_le_trans zy).
-have [] := @MVT _ f (f^`()) x y xlty fdrv.
-  apply: (@continuous_subspaceW _ _ _ `[a, b]); first exact: itvW.
-  by rewrite continuous_subspace_in.
-move=> t /itvWlt dft dftxy _; rewrite -oppr_le0 opprB dftxy.
-by apply: mulr_le0_ge0 => //; [exact: dfle0|by rewrite subr_ge0 ltW].
+move=> fdrvbl dfle0 ctsf x y leax lexy leyb.
+apply: ler0_derive1_homo_cc; [ exact: fdrvbl | exact: dfle0 | by [] | | | by [] ].
+  by rewrite in_itv/= leax (le_trans lexy leyb).
+by rewrite in_itv/= (le_trans leax lexy) leyb.
 Qed.
+
+Lemma ltr0_derive1_homo (R : realType) (f : R^o -> R^o) (a b : R) (sa sb : bool) :
+  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
+  (forall x : R, x \in `]a, b[%R -> f^`() x < 0) ->
+  {within [set` (Interval (BSide sa a) (BSide sb b))], continuous f} ->
+  {in (Interval (BSide sa a) (BSide sb b)) &, {homo f : x y / x < y >-> y < x}}.
+Proof.
+move=> df dfgt0 cf x y + + xy.
+rewrite !itv_boundlr /= => /andP [] ax ? /andP [] ? yb.
+have HMVT1: {within `[x, y], continuous f}.
+  exact/(continuous_subspaceW _ cf)/subset_itv.
+have zab: forall z, z \in `]x, y[%R -> z \in `]a, b[%R.
+  apply/subset_itv.
+    by move: ax; clear; case: sa; rewrite !bnd_simp// => /ltW.
+  by move: yb; clear; case: sb; rewrite !bnd_simp// => /ltW.
+have HMVT0 (z : R^o) : z \in `]x, y[%R -> is_derive z 1 f (f^`() z).
+  by move=> zxy; rewrite derive1E; exact/derivableP/df/zab.
+rewrite -subr_lt0.
+have[z zxy ->]:= MVT xy HMVT0 HMVT1.
+by rewrite nmulr_rlt0// ?subr_gt0// dfgt0// zab.
+Qed.
+
+Lemma ltr0_derive1_homo_cc (R : realType) (f : R^o -> R^o) (a b : R) :
+  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
+  (forall x : R, x \in `]a, b[%R -> f^`() x < 0) ->
+  {within [set` `[a, b]%R], continuous f} ->
+  {in `[a, b]%R &, {homo f : x y / x < y >-> y < x}}.
+Proof. exact: ltr0_derive1_homo. Qed.
+
+Lemma ltr0_derive1_homo_co (R : realType) (f : R^o -> R^o) (a b : R) :
+  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
+  (forall x : R, x \in `]a, b[%R -> f^`() x < 0) ->
+  {within [set` `[a, b[%R], continuous f} ->
+  {in `[a, b[%R &, {homo f : x y / x < y >-> y < x}}.
+Proof. exact: ltr0_derive1_homo. Qed.
+
+Lemma ltr0_derive1_homo_oc (R : realType) (f : R^o -> R^o) (a b : R) :
+  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
+  (forall x : R, x \in `]a, b[%R -> f^`() x < 0) ->
+  {within [set` `]a, b]%R], continuous f} ->
+  {in `]a, b]%R &, {homo f : x y / x < y >-> y < x}}.
+Proof. exact: ltr0_derive1_homo. Qed.
+
+Lemma ltr0_derive1_homo_oo (R : realType) (f : R^o -> R^o) (a b : R) :
+  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
+  (forall x : R, x \in `]a, b[%R -> f^`() x < 0) ->
+  {in `]a, b[, continuous f} ->
+  {in `]a, b[%R &, {homo f : x y / x < y >-> y < x}}.
+Proof. by rewrite -continuous_open_subspace//; exact: ltr0_derive1_homo. Qed.
 
 Lemma ltr0_derive1_decr (R : realType) (f : R -> R) (a b : R) :
   (forall x, x \in `]a, b[%R -> derivable f x 1) ->
@@ -1626,21 +1766,60 @@ Lemma ltr0_derive1_decr (R : realType) (f : R -> R) (a b : R) :
   {within `[a, b], continuous f}%classic ->
   forall x y, a <= x -> x < y -> y <= b -> f y < f x.
 Proof.
-move=> fdrvbl dflt0 ctsf x y leax ltxy leyb; rewrite -subr_gt0.
-case: ltgtP ltxy => // xlty _.
-have itvW : {subset `[x, y]%R <= `[a, b]%R}.
-  by apply/subitvP; rewrite /<=%O /= /<=%O /= leyb leax.
-have itvWlt : {subset `]x, y[%R <= `]a, b[%R}.
-  by apply subitvP; rewrite /<=%O /= /<=%O /= leyb leax.
-have fdrv z : z \in `]x, y[%R -> is_derive z 1 f (f^`()z).
-  rewrite in_itv/= => /andP[xz zy]; apply: DeriveDef; last by rewrite derive1E.
-  by apply: fdrvbl; rewrite in_itv/= (le_lt_trans _ xz)// (lt_le_trans zy).
-have [] := @MVT _ f (f^`()) x y xlty fdrv.
-  apply: (@continuous_subspaceW _ _ _ `[a, b]); first exact: itvW.
-  by rewrite continuous_subspace_in.
-move=> t /itvWlt dft dftxy; rewrite -oppr_lt0 opprB dftxy.
-by rewrite pmulr_llt0 ?subr_gt0// dflt0.
+move=> fdrvbl dflt0 ctsf x y leax ltxy leyb.
+apply: ltr0_derive1_homo; [ exact: fdrvbl | exact: dflt0 | by [] | | | by [] ].
+  by rewrite in_itv/= leax (ltW (lt_le_trans ltxy leyb)).
+by rewrite in_itv/= (ltW (le_lt_trans leax ltxy)) leyb.
 Qed.
+
+Lemma gtr0_derive1_homo (R : realType) (f : R^o -> R^o) (a b : R) (sa sb : bool) :
+  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
+  (forall x : R, x \in `]a, b[%R -> 0 < f^`() x) ->
+  {within [set` (Interval (BSide sa a) (BSide sb b))], continuous f} ->
+  {in (Interval (BSide sa a) (BSide sb b)) &, {homo f : x y / x < y >-> x < y}}.
+Proof.
+move=> df dfgt0 cf x y + + xy.
+rewrite !itv_boundlr /= => /andP [] ax ? /andP [] ? yb.
+have HMVT1: {within `[x, y], continuous f}.
+  exact/(continuous_subspaceW _ cf)/subset_itv.
+have zab: forall z, z \in `]x, y[%R -> z \in `]a, b[%R.
+  apply/subset_itv.
+    by move: ax; clear; case: sa; rewrite !bnd_simp// => /ltW.
+  by move: yb; clear; case: sb; rewrite !bnd_simp// => /ltW.
+have HMVT0 (z : R^o) : z \in `]x, y[%R -> is_derive z 1 f ((f^`())%classic z).
+  by move=> zxy; rewrite derive1E; exact/derivableP/df/zab.
+rewrite -subr_gt0.
+have[z zxy ->]:= MVT xy HMVT0 HMVT1.
+by rewrite mulr_gt0// ?subr_gt0// dfgt0// zab.
+Qed.
+
+Lemma gtr0_derive1_homo_cc (R : realType) (f : R^o -> R^o) (a b : R) :
+  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
+  (forall x : R, x \in `]a, b[%R -> 0 < f^`() x) ->
+  {within [set` `[a, b]%R], continuous f} ->
+  {in `[a, b]%R &, {homo f : x y / x < y >-> x < y}}.
+Proof. exact: gtr0_derive1_homo. Qed.
+
+Lemma gtr0_derive1_homo_co (R : realType) (f : R^o -> R^o) (a b : R) :
+  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
+  (forall x : R, x \in `]a, b[%R -> 0 < f^`() x) ->
+  {within [set` `[a, b[%R], continuous f} ->
+  {in `[a, b[%R &, {homo f : x y / x < y >-> x < y}}.
+Proof. exact: gtr0_derive1_homo. Qed.
+
+Lemma gtr0_derive1_homo_oc (R : realType) (f : R^o -> R^o) (a b : R) :
+  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
+  (forall x : R, x \in `]a, b[%R -> 0 < f^`() x) ->
+  {within [set` `]a, b]%R], continuous f} ->
+  {in `]a, b]%R &, {homo f : x y / x < y >-> x < y}}.
+Proof. exact: gtr0_derive1_homo. Qed.
+
+Lemma gtr0_derive1_homo_oo (R : realType) (f : R^o -> R^o) (a b : R) :
+  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
+  (forall x : R, x \in `]a, b[%R -> 0 < f^`() x) ->
+  {in `]a, b[, continuous f} ->
+  {in `]a, b[%R &, {homo f : x y / x < y >-> x < y}}.
+Proof. by rewrite -continuous_open_subspace//; exact: gtr0_derive1_homo. Qed.
 
 Lemma gtr0_derive1_incr (R : realType) (f : R -> R) (a b : R) :
   (forall x, x \in `]a, b[%R -> derivable f x 1) ->
@@ -1649,14 +1828,9 @@ Lemma gtr0_derive1_incr (R : realType) (f : R -> R) (a b : R) :
   forall x y, a <= x -> x < y -> y <= b -> f x < f y.
 Proof.
 move=> fdrvbl dfgt0 ctsf x y leax ltxy leyb.
-rewrite -ltrN2; apply: (@ltr0_derive1_decr _ (\- f) a b).
-- by move=> z zab; apply: derivableN; exact: fdrvbl.
-- move=> z zab; rewrite derive1E deriveN; last exact: fdrvbl.
-  by rewrite ltrNl oppr0 -derive1E dfgt0.
-- by move=> z; apply: continuousN; exact: ctsf.
-- exact: leax.
-- exact: ltxy.
-- exact: leyb.
+apply: gtr0_derive1_homo; [ exact: fdrvbl | exact: dfgt0 | by [] | | | by [] ].
+  by rewrite in_itv/= leax (ltW (lt_le_trans ltxy leyb)).
+by rewrite in_itv/= (ltW (le_lt_trans leax ltxy)) leyb.
 Qed.
 
 Lemma ler0_derive1_nincry {R : realType} (f : R -> R) (a : R) :

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -1602,24 +1602,23 @@ Section ger0_derive1_le.
 Context {R : realType}.
 Variables (f : R -> R) (a b : R).
 Hypothesis df : forall x, x \in `]a, b[%R -> derivable f x 1.
-Hypothesis dfge0 : forall x, x \in `]a, b[%R -> 0 <= (f^`())%classic x.
+Hypothesis dfge0 : forall x, x \in `]a, b[%R -> 0 <= f^`() x.
 
 Lemma ger0_derive1_le (sa sb : bool) :
   {within [set` (Interval (BSide sa a) (BSide sb b))], continuous f} ->
-  {in Interval (BSide sa a) (BSide sb b) &, {homo f : x y / x <= y >-> x <= y}}.
+  {in Interval (BSide sa a) (BSide sb b) &, {homo f : x y / x <= y}}.
 Proof.
 move=> cf x y + + xy.
-rewrite !itv_boundlr /= => /andP [] ax ? /andP [] ? yb.
-have HMVT1: {within `[x, y], continuous f}.
+move: (xy); rewrite le_eqVlt=> /predU1P[-> | xy']; first by rewrite lexx.
+rewrite !itv_boundlr -subr_ge0 /= => /andP[ax _] /andP[_ yb].
+have HMVT1 : {within `[x, y], continuous f}.
   exact/(continuous_subspaceW _ cf)/subset_itv.
-have zab: forall z, z \in `]x, y[%R -> z \in `]a, b[%R.
-  apply/subset_itv.
-    by move: ax; clear; case: sa; rewrite !bnd_simp// => /ltW.
-  by move: yb; clear; case: sb; rewrite !bnd_simp// => /ltW.
-have HMVT0 (z : R^o) : z \in `]x, y[%R -> is_derive z 1 f ((f^`())%classic z).
+have zab : `]x, y[ `<=` `]a, b[.
+  clear -ax yb; apply/subset_itv.
+    by move: sa ax => []; rewrite !bnd_simp// => /ltW.
+  by move: sb yb => []; rewrite !bnd_simp// => /ltW.
+have HMVT0 z : z \in `]x, y[%R -> is_derive z 1 f (f^`() z).
   by move=> zxy; rewrite derive1E; exact/derivableP/df/zab.
-rewrite -subr_ge0.
-move: (xy); rewrite le_eqVlt=> /orP [/eqP-> | xy']; first by rewrite subrr.
 have[z zxy ->]:= MVT xy' HMVT0 HMVT1.
 by rewrite mulr_ge0// ?subr_ge0// dfge0// zab.
 Qed.
@@ -1648,41 +1647,34 @@ Variables (f : R -> R) (a b : R).
 Hypothesis df : forall x, x \in `]a, b[%R -> derivable f x 1.
 Hypothesis dfle0 : forall x, x \in `]a, b[%R -> f^`() x <= 0.
 
-(* TODO: check that this can be proved in terms of ger0_derive1_homo *)
 Lemma ler0_derive1_le (sa sb : bool) :
   {within [set` (Interval (BSide sa a) (BSide sb b))], continuous f} ->
-  {in Interval (BSide sa a) (BSide sb b) &, {homo f : x y / x <= y >-> y <= x}}.
+  {in Interval (BSide sa a) (BSide sb b) &, {homo f : x y /~ x <= y}}.
 Proof.
-move=> cf x y + + xy.
-rewrite !itv_boundlr /= => /andP [] ax xb /andP [] ay yb.
-have HMVT1: {within `[x, y], continuous f}.
-  exact/(continuous_subspaceW _ cf)/subset_itv.
-have zab : forall z, z \in `]x, y[%R -> z \in `]a, b[%R.
-  apply/subset_itv.
-    by move: ax; clear; case: sa; rewrite !bnd_simp// => /ltW.
-  by move: yb; clear; case: sb; rewrite !bnd_simp// => /ltW.
-have HMVT0 (z : R^o) : z \in `]x, y[%R -> is_derive z 1 f (f^`() z).
-  by move=> zxy; rewrite derive1E; exact/derivableP/df/zab.
-rewrite -subr_le0.
-move: (xy); rewrite le_eqVlt=> /orP [/eqP-> | xy']; first by rewrite subrr.
-have[z zxy ->]:= MVT xy' HMVT0 HMVT1.
-by rewrite mulr_le0_ge0// ?subr_ge0// dfle0// zab.
+move=> cf.
+suff : {in Interval (BSide sa a) (BSide sb b) &, {homo (- f) : x y / x <= y}}.
+  by move=> h y x iy ix xy; move: (h x y ix iy xy); rewrite opprfctE lerNl opprK.
+apply: ger0_derive1_le.
+- move => x xab; exact/derivableN/df.
+- move => x xab; rewrite derive1E deriveN; last exact: df.
+  by rewrite -derive1E oppr_ge0 dfle0.
+by move=> x; exact/continuousN/cf.
 Qed.
 
 Lemma ler0_derive1_le_cc :{within `[a, b], continuous f} ->
-  {in `[a, b]%R &, {homo f : x y / x <= y >-> y <= x}}.
+  {in `[a, b]%R &, {homo f : x y /~ x <= y}}.
 Proof. exact: ler0_derive1_le. Qed.
 
 Lemma ler0_derive1_le_co : {within `[a, b[, continuous f} ->
-  {in `[a, b[%R &, {homo f : x y / x <= y >-> y <= x}}.
+  {in `[a, b[%R &, {homo f : x y /~ x <= y}}.
 Proof. exact: ler0_derive1_le. Qed.
 
 Lemma ler0_derive1_le_oc : {within `]a, b], continuous f} ->
-  {in `]a, b]%R &, {homo f : x y / x <= y >-> y <= x}}.
+  {in `]a, b]%R &, {homo f : x y /~ x <= y}}.
 Proof. exact: ler0_derive1_le. Qed.
 
 Lemma ler0_derive1_le_oo : {in `]a, b[, continuous f} ->
-  {in `]a, b[%R &, {homo f : x y / x <= y >-> y <= x}}.
+  {in `]a, b[%R &, {homo f : x y /~ x <= y}}.
 Proof. by rewrite -continuous_open_subspace//; exact: ler0_derive1_le. Qed.
 
 End ler0_derive1_le.
@@ -1695,117 +1687,52 @@ Lemma ler0_derive1_nincr (R : realType) (f : R -> R) (a b : R) :
   {within `[a, b], continuous f} ->
   forall x y, a <= x -> x <= y -> y <= b -> f y <= f x.
 Proof.
-move=> fdrvbl dfle0 ctsf x y leax lexy leyb.
-apply: ler0_derive1_le_cc; [ exact: fdrvbl | exact: dfle0 | by [] | | | by [] ].
-  by rewrite in_itv/= leax (le_trans lexy leyb).
-by rewrite in_itv/= (le_trans leax lexy) leyb.
+move=> df dfle0 cf x y ax xy yb.
+by apply: ler0_derive1_le_cc; [ exact: df | exact: dfle0 | by [] | | | by [] ];
+  rewrite in_itv/= ?ax ?yb ?andbT/= ?(le_trans ax)// (le_trans _ yb).
 Qed.
 
-Section ltr0_derive1_lt.
+Section gtr0_derive1_lt.
 Context {R : realType}.
 Variables (f : R -> R) (a b : R).
 Hypothesis df : forall x, x \in `]a, b[%R -> derivable f x 1.
-Hypothesis dfgt0 : forall x, x \in `]a, b[%R -> f^`() x < 0.
+Hypothesis dfgt0 : forall x, x \in `]a, b[%R -> 0 < f^`() x.
 
-Lemma ltr0_derive1_lt (sa sb : bool) :
+Lemma gtr0_derive1_lt (sa sb : bool) :
   {within [set` (Interval (BSide sa a) (BSide sb b))], continuous f} ->
-  {in Interval (BSide sa a) (BSide sb b) &, {homo f : x y / x < y >-> y < x}}.
+  {in Interval (BSide sa a) (BSide sb b) &, {homo f : x y / x < y}}.
 Proof.
 move=> cf x y + + xy.
-rewrite !itv_boundlr /= => /andP [] ax ? /andP [] ? yb.
+rewrite !itv_boundlr /= -subr_gt0 => /andP [] ax ? /andP [] ? yb.
 have HMVT1: {within `[x, y], continuous f}.
   exact/(continuous_subspaceW _ cf)/subset_itv.
-have zab: forall z, z \in `]x, y[%R -> z \in `]a, b[%R.
-  apply/subset_itv.
-    by move: ax; clear; case: sa; rewrite !bnd_simp// => /ltW.
-  by move: yb; clear; case: sb; rewrite !bnd_simp// => /ltW.
+have zab : `]x, y[ `<=` `]a, b[.
+  clear -ax yb; apply/subset_itv.
+    by move: sa ax => []; rewrite !bnd_simp// => /ltW.
+  by move: sb yb => []; rewrite !bnd_simp// => /ltW.
 have HMVT0 (z : R^o) : z \in `]x, y[%R -> is_derive z 1 f (f^`() z).
   by move=> zxy; rewrite derive1E; exact/derivableP/df/zab.
-rewrite -subr_lt0.
-have[z zxy ->]:= MVT xy HMVT0 HMVT1.
-by rewrite nmulr_rlt0// ?subr_gt0// dfgt0// zab.
-Qed.
-
-Lemma ltr0_derive1_lt_cc : {within `[a, b], continuous f} ->
-  {in `[a, b]%R &, {homo f : x y / x < y >-> y < x}}.
-Proof. exact: ltr0_derive1_lt. Qed.
-
-Lemma ltr0_derive1_lt_co : {within `[a, b[, continuous f} ->
-  {in `[a, b[%R &, {homo f : x y / x < y >-> y < x}}.
-Proof. exact: ltr0_derive1_lt. Qed.
-
-Lemma ltr0_derive1_lt_oc : {within `]a, b], continuous f} ->
-  {in `]a, b]%R &, {homo f : x y / x < y >-> y < x}}.
-Proof. exact: ltr0_derive1_lt. Qed.
-
-Lemma ltr0_derive1_lt_oo : {in `]a, b[, continuous f} ->
-  {in `]a, b[%R &, {homo f : x y / x < y >-> y < x}}.
-Proof. by rewrite -continuous_open_subspace//; exact: ltr0_derive1_lt. Qed.
-
-End ltr0_derive1_lt.
-
-(* wip *)
-
-Lemma ltr0_derive1_decr (R : realType) (f : R -> R) (a b : R) :
-  (forall x, x \in `]a, b[%R -> derivable f x 1) ->
-  (forall x, x \in `]a, b[%R -> f^`() x < 0) ->
-  {within `[a, b], continuous f}%classic ->
-  forall x y, a <= x -> x < y -> y <= b -> f y < f x.
-Proof.
-move=> fdrvbl dflt0 ctsf x y leax ltxy leyb.
-apply: ltr0_derive1_lt; [ exact: fdrvbl | exact: dflt0 | by [] | | | by [] ].
-  by rewrite in_itv/= leax (ltW (lt_le_trans ltxy leyb)).
-by rewrite in_itv/= (ltW (le_lt_trans leax ltxy)) leyb.
-Qed.
-
-Lemma gtr0_derive1_homo (R : realType) (f : R^o -> R^o) (a b : R) (sa sb : bool) :
-  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
-  (forall x : R, x \in `]a, b[%R -> 0 < f^`() x) ->
-  {within [set` (Interval (BSide sa a) (BSide sb b))], continuous f} ->
-  {in (Interval (BSide sa a) (BSide sb b)) &, {homo f : x y / x < y >-> x < y}}.
-Proof.
-move=> df dfgt0 cf x y + + xy.
-rewrite !itv_boundlr /= => /andP [] ax ? /andP [] ? yb.
-have HMVT1: {within `[x, y], continuous f}.
-  exact/(continuous_subspaceW _ cf)/subset_itv.
-have zab: forall z, z \in `]x, y[%R -> z \in `]a, b[%R.
-  apply/subset_itv.
-    by move: ax; clear; case: sa; rewrite !bnd_simp// => /ltW.
-  by move: yb; clear; case: sb; rewrite !bnd_simp// => /ltW.
-have HMVT0 (z : R^o) : z \in `]x, y[%R -> is_derive z 1 f ((f^`())%classic z).
-  by move=> zxy; rewrite derive1E; exact/derivableP/df/zab.
-rewrite -subr_gt0.
 have[z zxy ->]:= MVT xy HMVT0 HMVT1.
 by rewrite mulr_gt0// ?subr_gt0// dfgt0// zab.
 Qed.
 
-Lemma gtr0_derive1_homo_cc (R : realType) (f : R^o -> R^o) (a b : R) :
-  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
-  (forall x : R, x \in `]a, b[%R -> 0 < f^`() x) ->
-  {within [set` `[a, b]%R], continuous f} ->
-  {in `[a, b]%R &, {homo f : x y / x < y >-> x < y}}.
-Proof. exact: gtr0_derive1_homo. Qed.
+Lemma gtr0_derive1_lt_cc : {within `[a, b], continuous f} ->
+  {in `[a, b]%R &, {homo f : x y / x < y}}.
+Proof. exact: gtr0_derive1_lt. Qed.
 
-Lemma gtr0_derive1_homo_co (R : realType) (f : R^o -> R^o) (a b : R) :
-  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
-  (forall x : R, x \in `]a, b[%R -> 0 < f^`() x) ->
-  {within [set` `[a, b[%R], continuous f} ->
-  {in `[a, b[%R &, {homo f : x y / x < y >-> x < y}}.
-Proof. exact: gtr0_derive1_homo. Qed.
+Lemma gtr0_derive1_lt_co : {within `[a, b[, continuous f} ->
+  {in `[a, b[%R &, {homo f : x y / x < y}}.
+Proof. exact: gtr0_derive1_lt. Qed.
 
-Lemma gtr0_derive1_homo_oc (R : realType) (f : R^o -> R^o) (a b : R) :
-  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
-  (forall x : R, x \in `]a, b[%R -> 0 < f^`() x) ->
-  {within [set` `]a, b]%R], continuous f} ->
-  {in `]a, b]%R &, {homo f : x y / x < y >-> x < y}}.
-Proof. exact: gtr0_derive1_homo. Qed.
+Lemma gtr0_derive1_lt_oc : {within `]a, b], continuous f} ->
+  {in `]a, b]%R &, {homo f : x y / x < y}}.
+Proof. exact: gtr0_derive1_lt. Qed.
 
-Lemma gtr0_derive1_homo_oo (R : realType) (f : R^o -> R^o) (a b : R) :
-  (forall x : R, x \in `]a, b[%R -> derivable f x 1) ->
-  (forall x : R, x \in `]a, b[%R -> 0 < f^`() x) ->
-  {in `]a, b[, continuous f} ->
-  {in `]a, b[%R &, {homo f : x y / x < y >-> x < y}}.
-Proof. by rewrite -continuous_open_subspace//; exact: gtr0_derive1_homo. Qed.
+Lemma gtr0_derive1_lt_oo : {in `]a, b[, continuous f} ->
+  {in `]a, b[%R &, {homo f : x y / x < y}}.
+Proof. by rewrite -continuous_open_subspace//; exact: gtr0_derive1_lt. Qed.
+
+End gtr0_derive1_lt.
 
 #[deprecated(since="mathcomp-analysis 1.10.0",
   note="use `gtr0_le_derive1` instead")]
@@ -1815,11 +1742,69 @@ Lemma gtr0_derive1_incr (R : realType) (f : R -> R) (a b : R) :
   {within `[a, b], continuous f}%classic ->
   forall x y, a <= x -> x < y -> y <= b -> f x < f y.
 Proof.
-move=> abf abf' cf x y ax xy yb; apply: (@gtr0_derive1_homo_cc _ _ a b) => //;
+move=> abf abf' cf x y ax xy yb; apply: (@gtr0_derive1_lt_cc _ _ a b) => //;
   rewrite in_itv/= ?ax ?yb ?andbT/=.
 - by rewrite (le_trans (ltW xy)).
 - by rewrite (le_trans _ (ltW xy)).
 Qed.
+
+Section ltr0_derive1_lt.
+Context {R : realType}.
+Variables (f : R -> R) (a b : R).
+Hypothesis df : forall x, x \in `]a, b[%R -> derivable f x 1.
+Hypothesis dflt0 : forall x, x \in `]a, b[%R -> f^`() x < 0.
+
+Lemma ltr0_derive1_lt (sa sb : bool) :
+  {within [set` (Interval (BSide sa a) (BSide sb b))], continuous f} ->
+  {in Interval (BSide sa a) (BSide sb b) &, {homo f : x y /~ x < y}}.
+Proof.
+move=> cf.
+suff : {in Interval (BSide sa a) (BSide sb b) &, {homo (- f) : x y / x < y}}.
+  by move=> h x y ix iy xy; move: (h y x iy ix xy); rewrite opprfctE ltrNl opprK.
+apply: gtr0_derive1_lt.
+- move => x xab; exact/derivableN/df.
+- move => x xab; rewrite derive1E deriveN; last exact: df.
+  by rewrite -derive1E oppr_gt0 dflt0.
+by move=> x; exact/continuousN/cf.
+Qed.
+
+Lemma ltr0_derive1_lt_cc : {within `[a, b], continuous f} ->
+  {in `[a, b]%R &, {homo f : x y /~ x < y}}.
+Proof. exact: ltr0_derive1_lt. Qed.
+
+Lemma ltr0_derive1_lt_co : {within `[a, b[, continuous f} ->
+  {in `[a, b[%R &, {homo f : x y /~ x < y}}.
+Proof. exact: ltr0_derive1_lt. Qed.
+
+Lemma ltr0_derive1_lt_oc : {within `]a, b], continuous f} ->
+  {in `]a, b]%R &, {homo f : x y /~ x < y}}.
+Proof. exact: ltr0_derive1_lt. Qed.
+
+Lemma ltr0_derive1_lt_oo : {in `]a, b[, continuous f} ->
+  {in `]a, b[%R &, {homo f : x y /~ x < y}}.
+Proof. by rewrite -continuous_open_subspace//; exact: ltr0_derive1_lt. Qed.
+
+End ltr0_derive1_lt.
+
+#[deprecated(since="mathcomp-analysis 1.10.0",
+  note="use `ler0_derive1_lt_cc` instead")]
+Lemma ltr0_derive1_decr (R : realType) (f : R -> R) (a b : R) :
+  (forall x, x \in `]a, b[%R -> derivable f x 1) ->
+  (forall x, x \in `]a, b[%R -> f^`() x < 0) ->
+  {within `[a, b], continuous f}%classic ->
+  forall x y, a <= x -> x < y -> y <= b -> f y < f x.
+Proof.
+move=> df f'0 cf x y ax xy yb.
+apply: ltr0_derive1_lt_cc; [ exact: df | exact: f'0 | by [] | | | by [] ];
+  rewrite !in_itv/= ?ax ?yb ?andbT/=.
+  by rewrite (le_trans _ (ltW xy)).
+by rewrite (le_trans (ltW xy)).
+Qed.
+
+#[global] Hint Extern 0 (is_true (_ <= ?x)) => match goal with
+  H : x \is_near _ |- _ => by near: x; apply: nbhs_pinfty_ge; rewrite num_real end : core.
+#[global] Hint Extern 0 (is_true (?x <= _)) => match goal with
+  H : x \is_near _ |- _ => by near: x; apply: nbhs_ninfty_le; rewrite num_real end : core.
 
 Lemma ler0_derive1_nincry {R : realType} (f : R -> R) (a : R) :
   (forall x, x \in `]a, +oo[%R -> derivable f x 1) ->
@@ -1827,18 +1812,14 @@ Lemma ler0_derive1_nincry {R : realType} (f : R -> R) (a : R) :
   {within `[a, +oo[, continuous f} ->
   forall x y, a <= x -> x <= y -> f y <= f x.
 Proof.
-move=> fdrvbl dfle0 fcont x y ax xy.
+move=> df dfle0 cf x y ax xy.
 near (pinfty_nbhs R)%R => N.
-apply: (@ler0_derive1_nincr _ _ a N) => //.
-- move=> r /[!in_itv]/= /andP[ar rN].
-  by apply: fdrvbl; rewrite !in_itv/= andbT ar.
-- move=> r /[!in_itv]/= /andP[ar rN].
-  by apply: dfle0; rewrite !in_itv/= andbT ar.
-- apply: continuous_subspaceW fcont.
-  exact: subset_itvl.
-- near: N.
-  apply: nbhs_pinfty_ge.
-  by rewrite num_real.
+apply: (@ler0_derive1_le_cc _ _ a N) => [r|r| | | | // ]; rewrite ?in_itv/=.
+- by move=> /andP[ar rN]; apply: df; rewrite !in_itv/= andbT ar.
+- by move=> /andP[ar rN]; apply: dfle0; rewrite !in_itv/= andbT ar.
+- exact/continuous_subspaceW/cf/subset_itvl.
+- by rewrite (le_trans ax)/=.
+- by rewrite ax/=.
 Unshelve. all: end_near. Qed.
 
 Lemma ler0_derive1_nincrNy {R : realType} (f : R -> R) (b : R) :
@@ -1847,18 +1828,14 @@ Lemma ler0_derive1_nincrNy {R : realType} (f : R -> R) (b : R) :
   {within `]-oo, b], continuous f} ->
   forall x y, x <= y -> y <= b -> f y <= f x.
 Proof.
-move=> fdrvbl dfle0 fcont x y ax xy.
+move=> df dfle0 cf x y xy yb.
 near (ninfty_nbhs R)%R => N.
-apply: (@ler0_derive1_nincr _ _ N b) => //.
-- move=> r /[!in_itv]/= /andP[Nr rb].
-  by apply: fdrvbl; rewrite !in_itv/= rb.
-- move=> r /[!in_itv]/= /andP[Nr rb].
-  by apply: dfle0; rewrite !in_itv/= rb.
-- apply: continuous_subspaceW fcont.
-  exact: subset_itvr.
-- near: N.
-  apply: nbhs_ninfty_le.
-  by rewrite num_real.
+apply: (@ler0_derive1_le_cc _ _ N b) => [r|r| | | | // ]; rewrite ?in_itv/=.
+- by move=> /andP[Nr rb]; apply: df; rewrite !in_itv/= rb.
+- by move=> /andP[Nr rb]; apply: dfle0; rewrite !in_itv/= rb.
+- exact/continuous_subspaceW/cf/subset_itvr.
+- by rewrite yb andbT.
+by rewrite (le_trans xy)//= andbT.
 Unshelve. all: end_near. Qed.
 
 Lemma ger0_derive1_ndecr (R : realType) (f : R -> R) (a b : R) :
@@ -1867,33 +1844,29 @@ Lemma ger0_derive1_ndecr (R : realType) (f : R -> R) (a b : R) :
   {within `[a,b], continuous f} ->
   forall x y, a <= x -> x <= y -> y <= b -> f x <= f y.
 Proof.
-move=> fdrvbl dfge0 fcont x y; rewrite -[f _ <= _]lerN2.
-apply (@ler0_derive1_nincr _ (- f)) => t tab; first exact/derivableN/fdrvbl.
-  rewrite derive1E deriveN; last exact: fdrvbl.
-  by rewrite oppr_le0 -derive1E; apply: dfge0.
-by apply: continuousN; exact: fcont.
+move=> df dfge0 cf x y ax xy yb.
+by apply: (@ger0_derive1_le_cc _ _ a b) => //;
+  rewrite in_itv/= ?(le_trans _ xy)//= ?(le_trans xy) ?andbT.
 Qed.
 #[deprecated(since="mathcomp-analysis 1.9.0",
   note="renamed to `ger0_derive1_ndecr`")]
 Notation le0r_derive1_ndecr := ger0_derive1_ndecr (only parsing).
 
-Lemma ger0_derive1_ndecry {R : realType} (f : R -> R) (a b : R) :
+Lemma ger0_derive1_ndecry {R : realType} (f : R -> R) (a : R) :
   (forall x, x \in `]a, +oo[%R -> derivable f x 1) ->
   (forall x, x \in `]a, +oo[%R -> 0 <= f^`() x) ->
   {within `[a, +oo[, continuous f} ->
   forall x y, a <= x -> x <= y -> f x <= f y.
 Proof.
-move=> fdrvbl dfge0 fcont x y ax xy; rewrite -[f _ <= _]lerN2.
-apply: (@ler0_derive1_nincry _ (- f)) => //.
-- move=> r /[!in_itv]/=/[!andbT] xr; apply/derivableN.
-  by apply: fdrvbl; rewrite !in_itv/= andbT (le_lt_trans ax).
-- move=> r /[!in_itv]/=/[!andbT] /(le_lt_trans ax) xr.
-  rewrite derive1E deriveN; last by (apply: fdrvbl; rewrite in_itv/= andbT).
-  by rewrite -derive1E oppr_le0; apply: dfge0; rewrite in_itv/= andbT.
-- move=> r; apply: continuousN; move: r.
-  apply: continuous_subspaceW fcont.
-  exact: subset_itvr.
-Qed.
+move=> df dfge0 cf x y ax xy.
+near (pinfty_nbhs R)%R => N.
+apply: (@ger0_derive1_le_cc _ _ a N) => [r|r| | | | // ]; rewrite ?in_itv/=.
+- by move=> /andP[ar rN]; apply: df; rewrite !in_itv/= andbT ar.
+- by move=> /andP[ar rN]; apply: dfge0; rewrite !in_itv/= andbT ar.
+- exact/continuous_subspaceW/cf/subset_itvl.
+- by rewrite (le_trans ax)/=.
+- by rewrite (le_trans ax)/=.
+Unshelve. all: end_near. Qed.
 
 Lemma ger0_derive1_ndecrNy {R : realType} (f : R -> R) (b : R) :
   (forall x, x \in `]-oo, b[%R -> derivable f x 1) ->
@@ -1901,17 +1874,15 @@ Lemma ger0_derive1_ndecrNy {R : realType} (f : R -> R) (b : R) :
   {within `]-oo, b], continuous f} ->
   forall x y, x <= y -> y <= b -> f x <= f y.
 Proof.
-move=> fdrvbl dfge0 fcont x y xy yb; rewrite -[f _ <= _]lerN2.
-apply: (@ler0_derive1_nincrNy _ (- f)) => //.
-- move=> r /[!in_itv]/= ry; apply/derivableN.
-  by apply: fdrvbl; rewrite !in_itv/= (lt_le_trans ry).
-- move=> r /[!in_itv]/= ry; have rb := lt_le_trans ry yb.
-  rewrite derive1E deriveN; last by (apply: fdrvbl; rewrite in_itv/=).
-  by rewrite -derive1E oppr_le0; apply: dfge0; rewrite in_itv/=.
-- move=> r; apply: continuousN; move: r.
-  apply: continuous_subspaceW fcont.
-  exact: subset_itvl.
-Qed.
+move=> df dfge0 cf x y xy yb.
+near (ninfty_nbhs R)%R => N.
+apply: (@ger0_derive1_le_cc _ _ N b) => [r|r| | | | // ]; rewrite ?in_itv/=.
+- by move=> /andP[Nr rb]; apply: df; rewrite !in_itv/=.
+- by move=> /andP[Nr rb]; apply: dfge0; rewrite !in_itv/=.
+- exact/continuous_subspaceW/cf/subset_itvr.
+- by rewrite (le_trans xy)//= andbT.
+- by rewrite yb andbT.
+Unshelve. all: end_near. Qed.
 
 Lemma decr_derive1_le0 {R : realFieldType} (f : R -> R) (D : set R) (x : R) :
   {in D° : set R, forall x, derivable f x 1%R} ->

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -5303,7 +5303,7 @@ Lemma measurable_xsection (A : set (T1 * T2)) (x : T1) :
   measurable A -> measurable (xsection A x).
 Proof.
 move=> mA; pose i (y : T2) := (x, y).
-have mi : measurable_fun setT i by exact: measurable_pair1.
+have mi : measurable_fun setT i by exact: pair1_measurable.
 by rewrite xsectionE -[X in measurable X]setTI; exact: mi.
 Qed.
 
@@ -5311,7 +5311,7 @@ Lemma measurable_ysection (A : set (T1 * T2)) (y : T2) :
   measurable A -> measurable (ysection A y).
 Proof.
 move=> mA; pose i (x : T1) := (x, y).
-have mi : measurable_fun setT i by exact: measurable_pair2.
+have mi : measurable_fun setT i by exact: pair2_measurable.
 by rewrite ysectionE -[X in measurable X]setTI; exact: mi.
 Qed.
 

--- a/theories/normedtype_theory/ereal_normedtype.v
+++ b/theories/normedtype_theory/ereal_normedtype.v
@@ -115,17 +115,17 @@ Qed.
 End lower_semicontinuous.
 
 #[global] Hint Extern 0 (is_true (_ < ?x)%E) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: ereal_nbhs_pinfty_gt end : core.
+  H : x \is_near _ |- _ => solve[near: x; apply: ereal_nbhs_pinfty_gt] end : core.
 #[global] Hint Extern 0 (is_true (_ <= ?x)%E) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: ereal_nbhs_pinfty_ge end : core.
+  H : x \is_near _ |- _ => solve[near: x; apply: ereal_nbhs_pinfty_ge] end : core.
 #[global] Hint Extern 0 (is_true (_ > ?x)%E) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: ereal_nbhs_ninfty_lt end : core.
+  H : x \is_near _ |- _ => solve[near: x; apply: ereal_nbhs_ninfty_lt] end : core.
 #[global] Hint Extern 0 (is_true (_ >= ?x)%E) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: ereal_nbhs_ninfty_le end : core.
+  H : x \is_near _ |- _ => solve[near: x; apply: ereal_nbhs_ninfty_le] end : core.
 #[global] Hint Extern 0 (is_true (fine ?x \is Num.real)) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: ereal_nbhs_pinfty_real end : core.
+  H : x \is_near _ |- _ => solve[near: x; apply: ereal_nbhs_pinfty_real] end : core.
 #[global] Hint Extern 0 (is_true (fine ?x \is Num.real)) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: ereal_nbhs_ninfty_real end : core.
+  H : x \is_near _ |- _ => solve[near: x; apply: ereal_nbhs_ninfty_real] end : core.
 
 Section ecvg_infty_numField.
 Local Open Scope ereal_scope.

--- a/theories/normedtype_theory/num_normedtype.v
+++ b/theories/normedtype_theory/num_normedtype.v
@@ -218,7 +218,7 @@ by rewrite {2}(splitr e%:num) ltr_pwDl.
 Qed.
 
 #[global] Hint Extern 0 (ProperFilter _^') =>
-  (apply: Proper_dnbhs_numFieldType) : typeclass_instances.
+  solve[apply: Proper_dnbhs_numFieldType] : typeclass_instances.
 
 Definition pinfty_nbhs (R : numFieldType) : set_system R :=
   fun P => exists M, M \is Num.real /\ forall x, M < x -> P x.
@@ -338,17 +338,17 @@ Qed.
 End infty_nbhs_instances.
 
 #[global] Hint Extern 0 (is_true (_ < ?x)) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: nbhs_pinfty_gt end : core.
+  H : x \is_near _ |- _ => solve[near: x; now apply: nbhs_pinfty_gt] end : core.
 #[global] Hint Extern 0 (is_true (_ <= ?x)) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: nbhs_pinfty_ge end : core.
+  H : x \is_near _ |- _ => solve[near: x; now apply: nbhs_pinfty_ge] end : core.
 #[global] Hint Extern 0 (is_true (_ > ?x)) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: nbhs_ninfty_lt end : core.
+  H : x \is_near _ |- _ => solve[near: x; now apply: nbhs_ninfty_lt] end : core.
 #[global] Hint Extern 0 (is_true (_ >= ?x)) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: nbhs_ninfty_le end : core.
+  H : x \is_near _ |- _ => solve[near: x; now apply: nbhs_ninfty_le] end : core.
 #[global] Hint Extern 0 (is_true (?x \is Num.real)) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: nbhs_pinfty_real end : core.
+  H : x \is_near _ |- _ => solve[near: x; now apply: nbhs_pinfty_real] end : core.
 #[global] Hint Extern 0 (is_true (?x \is Num.real)) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: nbhs_ninfty_real end : core.
+  H : x \is_near _ |- _ => solve[near: x; now apply: nbhs_ninfty_real] end : core.
 
 Section cvg_infty_numField.
 Context {R : numFieldType}.

--- a/theories/normedtype_theory/pseudometric_normed_Zmodule.v
+++ b/theories/normedtype_theory/pseudometric_normed_Zmodule.v
@@ -388,17 +388,17 @@ Arguments cvgr0_norm_lt {_ _ _ F FF}.
 Arguments cvgr0_norm_le {_ _ _ F FF}.
 
 #[global] Hint Extern 0 (is_true (`|_ - ?x| < _)) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: cvgr_dist_lt end : core.
+  H : x \is_near _ |- _ => solve[near: x; now apply: cvgr_dist_lt] end : core.
 #[global] Hint Extern 0 (is_true (`|?x - _| < _)) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: cvgr_distC_lt end : core.
+  H : x \is_near _ |- _ => solve[near: x; now apply: cvgr_distC_lt] end : core.
 #[global] Hint Extern 0 (is_true (`|?x| < _)) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: cvgr0_norm_lt end : core.
+  H : x \is_near _ |- _ => solve[near: x; now apply: cvgr0_norm_lt] end : core.
 #[global] Hint Extern 0 (is_true (`|_ - ?x| <= _)) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: cvgr_dist_le end : core.
+  H : x \is_near _ |- _ => solve[near: x; now apply: cvgr_dist_le] end : core.
 #[global] Hint Extern 0 (is_true (`|?x - _| <= _)) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: cvgr_distC_le end : core.
+  H : x \is_near _ |- _ => solve[near: x; now apply: cvgr_distC_le] end : core.
 #[global] Hint Extern 0 (is_true (`|?x| <= _)) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: cvgr0_norm_le end : core.
+  H : x \is_near _ |- _ => solve[near: x; now apply: cvgr0_norm_le] end : core.
 
 Section pseudoMetricNormedZmod_numFieldType.
 Variables (R : numFieldType) (V : pseudoMetricNormedZmodType R).
@@ -777,39 +777,26 @@ Arguments cvgr_norm_gt {R V T F FF f}.
 Arguments cvgr_norm_ge {R V T F FF f}.
 Arguments cvgr_neq0 {R V T F FF f}.
 
-#[global] Hint Extern 0 (is_true (`|_ - ?x| < _)) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: cvgr_dist_lt end : core.
-#[global] Hint Extern 0 (is_true (`|?x - _| < _)) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: cvgr_distC_lt end : core.
-#[global] Hint Extern 0 (is_true (`|?x| < _)) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: cvgr0_norm_lt end : core.
-#[global] Hint Extern 0 (is_true (`|_ - ?x| <= _)) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: cvgr_dist_le end : core.
-#[global] Hint Extern 0 (is_true (`|?x - _| <= _)) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: cvgr_distC_le end : core.
-#[global] Hint Extern 0 (is_true (`|?x| <= _)) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: cvgr0_norm_le end : core.
-
 #[global] Hint Extern 0 (is_true (_ < ?x)) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: nbhs_right_gt end : core.
+  H : x \is_near _ |- _ => solve[near: x; now apply: nbhs_right_gt] end : core.
 #[global] Hint Extern 0 (is_true (?x < _)) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: nbhs_left_lt end : core.
+  H : x \is_near _ |- _ => solve[near: x; now apply: nbhs_left_lt] end : core.
 #[global] Hint Extern 0 (is_true (?x != _)) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: nbhs_right_neq end : core.
+  H : x \is_near _ |- _ => solve[near: x; now apply: nbhs_right_neq] end : core.
 #[global] Hint Extern 0 (is_true (?x != _)) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: nbhs_left_neq end : core.
+  H : x \is_near _ |- _ => solve[near: x; now apply: nbhs_left_neq] end : core.
 #[global] Hint Extern 0 (is_true (_ < ?x)) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: nbhs_left_gt end : core.
+  H : x \is_near _ |- _ => solve[near: x; now apply: nbhs_left_gt] end : core.
 #[global] Hint Extern 0 (is_true (?x < _)) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: nbhs_right_lt end : core.
+  H : x \is_near _ |- _ => solve[near: x; now apply: nbhs_right_lt] end : core.
 #[global] Hint Extern 0 (is_true (_ <= ?x)) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: nbhs_right_ge end : core.
+  H : x \is_near _ |- _ => solve[near: x; now apply: nbhs_right_ge] end : core.
 #[global] Hint Extern 0 (is_true (?x <= _)) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: nbhs_left_le end : core.
+  H : x \is_near _ |- _ => solve[near: x; now apply: nbhs_left_le] end : core.
 #[global] Hint Extern 0 (is_true (_ <= ?x)) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: nbhs_right_ge end : core.
+  H : x \is_near _ |- _ => solve[near: x; now apply: nbhs_right_ge] end : core.
 #[global] Hint Extern 0 (is_true (?x <= _)) => match goal with
-  H : x \is_near _ |- _ => near: x; exact: nbhs_left_le end : core.
+  H : x \is_near _ |- _ => solve[near: x; now apply: nbhs_left_le] end : core.
 
 #[global] Hint Extern 0 (ProperFilter _^'-) =>
   (apply: at_left_proper_filter) : typeclass_instances.


### PR DESCRIPTION
##### Motivation for this change

These are generalization of lemmas about the first derivative ported from [this branch](https://github.com/hoheinzollern/analysis/tree/sampling_20250324).
We introduce all combinations for different intervals to be able to discover them effectively.

@affeldt-aist @t6s 

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
