### PR TITLE
integrability of normal_pdf

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -150,6 +150,19 @@
   + lemma `kcomp_noparamE`
   + definition `mkcomp_noparam`
   + theorem `sprob_mkcomp_noparam`
+- in `numfun.v`:
+  + lemma `bounded_indic`
+
+- in `lebesgue_integrable.v`:
+  + lemma `integrable_indic_itv`
+
+- in `probability.v`:
+  + definitions `normal_fun`, `normal_peak`
+  + lemmas `measurable_normal_fun`, `normal_fun_ge0`, `normal_fun_center`
+  + lemmas `normal_peak_ge0`, `normal_peak_gt0`
+  + lemma `normal_pdfE`
+  + lemma `normal_pdf_ge0`, `normal_pdf_ub`
+  + lemma `integrable_normal_pdf`
 
 ### Changed
 
@@ -192,6 +205,12 @@
 
 - the contents of `normedtype.v` (old file) can be found in the files in directory
   `normed_theory` unless stated otherwise
+
+- in `filter.v`:
+  + change implicit arguments of `cvg_comp`
+
+- in `probability.v`:
+  + definition `normal_pdf` changed to use `normal_fun` and `normal_peak`
 
 ### Renamed
 

--- a/classical/filter.v
+++ b/classical/filter.v
@@ -901,6 +901,7 @@ Lemma cvg_comp T U V (f : T -> U) (g : U -> V)
   (F : set_system T) (G : set_system U) (H : set_system V) :
   f @ F `=>` G -> g @ G `=>` H -> g \o f @ F `=>` H.
 Proof. by move=> fFG gGH; apply: cvg_trans gGH => P /fFG. Qed.
+Arguments cvg_comp {T U V} f g {F G H}.
 
 Lemma cvgi_comp T U V (f : T -> U) (g : U -> set V)
   (F : set_system T) (G : set_system U) (H : set_system V) :

--- a/theories/gauss_integral.v
+++ b/theories/gauss_integral.v
@@ -34,7 +34,7 @@ Proof. by rewrite -expR0 ler_expR lerNl oppr0 sqr_ge0. Qed.
 
 Lemma cvg_gauss_fun : gauss_fun x @[x --> +oo%R] --> (0:R).
 Proof.
-by apply: (@cvg_comp _ _ _ (fun x => x ^+ 2) (fun x => expR (- x)));
+by apply: (cvg_comp (fun x => x ^+ 2) (fun x => expR (- x)));
   [exact: cvgr_expr2|exact: cvgr_expR].
 Qed.
 
@@ -44,7 +44,7 @@ Proof. by apply: measurableT_comp => //; exact: measurableT_comp. Qed.
 Lemma continuous_gauss_fun : continuous gauss_fun.
 Proof.
 move=> x; apply: (@continuous_comp _ _ _ (fun x : R => - x ^+ 2) expR).
-  apply: cvgN; apply: (@cvg_comp _ _ _ (fun z => z) (fun z => z ^+ 2)).
+  apply: cvgN; apply: (cvg_comp (fun z => z) (fun z => z ^+ 2)).
     exact: cvg_id.
   exact: exprn_continuous.
 exact: continuous_expR.
@@ -109,7 +109,7 @@ Qed.
 Let continuous_NsqrM x : continuous (fun r : R => - (r * x) ^+ 2).
 Proof.
 move=> z; apply: cvgN => /=.
-apply: (@cvg_comp _ _ _ (fun z => z * x) (fun z => z ^+ 2)).
+apply: (cvg_comp (fun z => z * x) (fun z => z ^+ 2)).
   by apply: cvgMl; exact: cvg_id.
 exact: exprn_continuous.
 Qed.

--- a/theories/lebesgue_integral_theory/lebesgue_integrable.v
+++ b/theories/lebesgue_integral_theory/lebesgue_integrable.v
@@ -356,6 +356,22 @@ Qed.
 
 End measurable_bounded_integrable.
 
+Lemma integrable_indic_itv {R : realType} (a b : R) (b0 b1 : bool) :
+  let mu := lebesgue_measure in
+  mu.-integrable setT (EFin \o \1_[set` Interval (BSide b0 a) (BSide b1 b)]).
+Proof.
+have [ab|ba] := leP a b; last first.
+  rewrite set_itv_ge//; first by rewrite indic0//; exact: integrable0.
+  by rewrite -leNgt leBSide; move: b0 b1 => [] []//=; exact/ltW.
+set i := [set` _]; rewrite (_ : _ \o _ = (cst 1%E) \_ i); last first.
+  by apply/funext => r/=; rewrite indic_restrict restrict_EFin.
+rewrite {}/i; apply/integrable_restrict => //=.
+rewrite setTI; apply: measurable_bounded_integrable => //=.
+  rewrite lebesgue_measure_itv//=.
+  by case: ifPn => // _; rewrite -EFinB ltry.
+exact: bounded_cst.
+Qed.
+
 Section integrable_finite_measure.
 Context d (T : measurableType d) {R : realType}.
 Variable mu : {finite_measure set T -> \bar R}.

--- a/theories/lebesgue_integral_theory/lebesgue_integral_approximation.v
+++ b/theories/lebesgue_integral_theory/lebesgue_integral_approximation.v
@@ -336,7 +336,7 @@ have dvg_approx := dvg_approx Dx fxoo.
     by move=> m n mn; have := nd_approx mn => /lefP; exact.
   move/nondecreasing_dvgn_lt => /(_ dvg_approx).
   by rewrite fxoo => ?; apply/cvgeryP.
-rewrite -(@fineK _ (f x)); first exact: (cvg_comp (cvg_approx f0 Dx fxoo)).
+rewrite -(@fineK _ (f x)); first exact: (cvg_comp _ _ (cvg_approx f0 Dx fxoo)).
 by rewrite ge0_fin_numE// f0.
 Qed.
 

--- a/theories/normedtype_theory/normed_module.v
+++ b/theories/normedtype_theory/normed_module.v
@@ -702,14 +702,14 @@ Qed.
 Lemma abse_continuous : continuous (@abse R).
 Proof.
 case=> [r|A /= [r [rreal rA]]|A /= [r [rreal rA]]]/=.
-- exact/(cvg_comp (@norm_continuous _ R r)).
+- exact/(cvg_comp _ _ (@norm_continuous _ R r)).
 - by exists r; split => // y ry; apply: rA; rewrite (lt_le_trans ry)// lee_abs.
 - exists (- r)%R; rewrite realN; split => // y; rewrite EFinN -lteNr => yr.
   by apply: rA; rewrite (lt_le_trans yr)// -abseN lee_abs.
 Qed.
 
 Lemma cvg_abse f (a : \bar R) : f @ F --> a -> `|f x|%E @[x --> F] --> `|a|%E.
-Proof. by apply: continuous_cvg => //; apply: abse_continuous. Qed.
+Proof. by apply: continuous_cvg => //; exact: abse_continuous. Qed.
 
 Lemma is_cvg_abse (f : I -> \bar R) : cvg (f @ F) -> cvg (`|f x|%E @[x --> F]).
 Proof. by move/cvg_abse/cvgP. Qed.
@@ -919,10 +919,8 @@ Lemma EFin_lim (R : realFieldType) (f : nat -> R) : cvgn f ->
   limn (EFin \o f) = (limn f)%:E.
 Proof.
 move=> cf; apply: cvg_lim => //; move/cvg_ex : cf => [l fl].
-by apply: (cvg_comp fl); rewrite (cvg_lim _ fl).
+by apply: (cvg_comp _ _ fl); rewrite (cvg_lim _ fl).
 Qed.
-
-
 
 Section ecvg_realFieldType_proper.
 Context {I} {F : set_system I} {FF : ProperFilter F} {R : realFieldType}.

--- a/theories/numfun.v
+++ b/theories/numfun.v
@@ -308,7 +308,7 @@ Qed.
 Canonical indic_inum {T} {R : numDomainType} (A : set T) (x : T) :=
   Itv.mk (@num_spec_indic T R A x).
 
-Section indic_lemmas.
+Section indic_ringType.
 Context (T : Type) (R : ringType).
 Implicit Types A D : set T.
 
@@ -376,7 +376,7 @@ move=> x; rewrite fimfunE fsbig_finite//= (big_nth 0)/= big_mkord.
 exact: eq_bigr.
 Qed.
 
-End indic_lemmas.
+End indic_ringType.
 
 Lemma indic_bigcup T {R : realType} (A : (set T)^nat) (t : T) :
   trivIset [set: nat] A ->
@@ -425,6 +425,12 @@ Proof.
 apply/seteqP; split => [x/mem_set/=|x/=]; rewrite indicE.
   by rewrite mem_ysection => ->.
 by rewrite /ysection/=; case: (_ \in _) => //= /esym/eqP /[!oner_eq0].
+Qed.
+
+Lemma bounded_indic T {R : numFieldType} (A : set T) :
+  [bounded \1_A x : R^o | x in A].
+Proof.
+by exists 1; split => // r r1 t At/=; rewrite indicE mem_set//= normr1 ltW.
 Qed.
 
 Lemma indic_restrict {T : pointedType} {R : numFieldType} (A : set T) :

--- a/theories/probability.v
+++ b/theories/probability.v
@@ -1532,8 +1532,7 @@ Proof. by apply: measurable_funM => //=; exact: measurable_normal_fun. Qed.
 
 Lemma measurable_normal_pdf m s : measurable_fun setT (normal_pdf m s).
 Proof.
-rewrite /normal_pdf; have [_|s0] := eqVneq s 0; first exact: measurable_indic.
-exact: measurable_normal_pdf0.
+by rewrite /normal_pdf; have [_|] := eqVneq s 0; first exact: measurable_indic.
 Qed.
 
 Let continuous_normal_pdf0 m s : continuous (normal_pdf0 m s).
@@ -1555,18 +1554,13 @@ by rewrite invr_ge0 mulrn_wge0// sqr_ge0.
 Qed.
 
 Lemma normal_pdf_ge0 m s x : 0 <= normal_pdf m s x.
-Proof. by rewrite /normal_pdf; case: ifP => // _; exact: normal_pdf0_ge0. Qed.
+Proof. by rewrite /normal_pdf; case: ifP. Qed.
 
 Lemma continuous_normal_pdf m s : s != 0 -> continuous (normal_pdf m s).
-Proof.
-rewrite /normal_pdf; have [//|s0 _] := eqVneq s 0.
-exact: continuous_normal_pdf0.
-Qed.
+Proof. by rewrite /normal_pdf; have [|] := eqVneq s 0. Qed.
 
 Lemma normal_pdf_ub m s x : s != 0 -> normal_pdf m s x <= normal_peak s.
-Proof.
-by rewrite /normal_pdf; have [//|s0 _] := eqVneq s 0; exact: normal_pdf0_ub.
-Qed.
+Proof. by rewrite /normal_pdf; have [|] := eqVneq s 0. Qed.
 
 End normal_density.
 
@@ -1589,7 +1583,7 @@ congr expR; rewrite mulNr exprMn exprVn; congr (- (_ * _^-1)%R).
 by rewrite sqr_sqrtr// pmulrn_lge0// sqr_ge0.
 Qed.
 
-Lemma F'E : F^`()%classic = cst (Num.sqrt (sigma ^+ 2 *+ 2))^-1.
+Let F'E : F^`()%classic = cst (Num.sqrt (sigma ^+ 2 *+ 2))^-1.
 Proof.
 apply/funext => x; rewrite /F derive1E deriveM// deriveD// derive_cst scaler0.
 by rewrite add0r derive_id derive_cst addr0 scaler1.

--- a/theories/probability.v
+++ b/theories/probability.v
@@ -53,8 +53,11 @@ From mathcomp Require Import ftc gauss_integral.
 (*      uniform_pdf a b == uniform pdf over the interval [a,b]                *)
 (*  uniform_prob a b ab == uniform probability over the interval [a,b]        *)
 (*                         where ab0 a proof that 0 < b - a                   *)
+(*        normal_peak s := (sqrtr (s ^+ 2 * pi *+ 2))^-1                      *)
+(*     normal_fun m s x := expR (- (x - m) ^+ 2 / (s ^+ 2 *+ 2))              *)
 (*       normal_pdf m s == pdf of the normal distribution with mean m and     *)
 (*                         standard deviation s                               *)
+(*                         Using normal_peak and normal_pdf.                  *)
 (*      normal_prob m s == normal probability measure                         *)
 (* ```                                                                        *)
 (*                                                                            *)
@@ -1480,57 +1483,89 @@ Section normal_density.
 Context {R : realType}.
 Local Open Scope ring_scope.
 Local Import Num.ExtraDef.
+Implicit Types m s x : R.
 
-Definition normal_pdf (m s x : R) : R :=
-  if s == 0 then \1_`[0, 1] x else (* TODO: need the dirac delta function *)
-  (sqrtr (s ^+2 * pi *+ 2))^-1 * expR (- (x - m) ^+ 2 / (s ^+ 2*+ 2)).
+Definition normal_fun m s x := expR (- (x - m) ^+ 2 / (s ^+ 2 *+ 2)).
 
-Lemma normal_pdf_ge0 m s x : 0 <= normal_pdf m s x.
-Proof. by rewrite /normal_pdf; case: ifP. Qed.
-
-Lemma normal_pdf_gt0 m s x : s != 0 -> 0 < normal_pdf m s x.
+Lemma measurable_normal_fun m s : measurable_fun [set :R] (normal_fun m s).
 Proof.
-rewrite /normal_pdf; case: ifP => //.
-move/negP/negP => s0 _.
-set sigma := s ^+ 2.
-have sigma0 : 0 < sigma by rewrite exprn_even_gt0/=.
-rewrite mulr_gt0 ?expR_gt0// invr_gt0//.
-by rewrite sqrtr_gt0 pmulrn_rgt0// pmulr_rgt0// pi_gt0.
+apply: measurableT_comp => //=; apply: measurable_funM => //=.
+apply: measurableT_comp => //=; apply: measurable_funX => //=.
+exact: measurable_funB.
 Qed.
+
+Lemma normal_fun_ge0 m s x : 0 <= normal_fun m s x.
+Proof. exact: expR_ge0. Qed.
+
+Lemma normal_fun_center m s : normal_fun m s = normal_fun 0 s \o center m.
+Proof. by apply/funext => x/=; rewrite /normal_fun/= subr0. Qed.
+
+Definition normal_peak s := (sqrtr (s ^+ 2 * pi *+ 2))^-1.
+
+Lemma normal_peak_ge0 s : 0 <= normal_peak s. Proof. by rewrite invr_ge0. Qed.
+
+Lemma normal_peak_gt0 s : s != 0 -> 0 < normal_peak s.
+Proof.
+move=> s0; rewrite invr_gt0// sqrtr_gt0.
+by rewrite pmulrn_rgt0// mulr_gt0 ?pi_gt0// exprn_even_gt0/=.
+Qed.
+
+Let normal_pdf0 m s x : R := normal_peak s * normal_fun m s x.
+
+Definition normal_pdf m s x :=
+  if s == 0 then \1_`[0, 1] x else normal_pdf0 m s x.
+
+Lemma normal_pdfE m s : s != 0 -> normal_pdf m s = normal_pdf0 m s.
+Proof. by rewrite /normal_pdf; have [_|s0] := eqVneq s 0. Qed.
+
+Let normal_pdf0_center m s : normal_pdf0 m s = normal_pdf0 0 s \o center m.
+Proof. by rewrite /normal_pdf0 normal_fun_center. Qed.
+
+Let normal_pdf0_ge0 m s x : 0 <= normal_pdf0 m s x.
+Proof. by rewrite mulr_ge0 ?normal_peak_ge0 ?expR_ge0. Qed.
+
+Let normal_pdf0_gt0 m s x : s != 0 -> 0 < normal_pdf0 m s x.
+Proof. by move=> s0; rewrite mulr_gt0 ?expR_gt0// normal_peak_gt0. Qed.
+
+Let measurable_normal_pdf0 m s : measurable_fun setT (normal_pdf0 m s).
+Proof. by apply: measurable_funM => //=; exact: measurable_normal_fun. Qed.
 
 Lemma measurable_normal_pdf m s : measurable_fun setT (normal_pdf m s).
 Proof.
-rewrite /normal_pdf.
-have [_|s0] := eqVneq s 0; first exact: measurable_indic.
-apply: measurable_funM => //=; apply: measurableT_comp => //=.
-apply: measurable_funM => //=; apply: measurableT_comp => //=.
-apply: measurableT_comp (exprn_measurable _) _ => /=.
-exact: measurable_funD.
+rewrite /normal_pdf; have [_|s0] := eqVneq s 0; first exact: measurable_indic.
+exact: measurable_normal_pdf0.
 Qed.
 
-Lemma continuous_normal_pdf m s x : s != 0 ->
-  {for x, continuous (normal_pdf m s)}.
+Let continuous_normal_pdf0 m s : continuous (normal_pdf0 m s).
 Proof.
-rewrite /normal_pdf.
-have [|s0 _] := eqVneq s 0; first by [].
-apply: continuousM => //=; first exact: cvg_cst.
-apply: continuous_comp => /=; last exact: continuous_expR.
-apply: continuousM => //=; last exact: cvg_cst.
-apply: continuous_comp => //=; last exact: (@continuousN _ R^o).
-apply: (@continuous_comp _ _ _ _ (fun x : R => x ^+ 2)%R).
-  by apply: (@continuousD _ R^o) => //=; exact: cvg_cst.
-exact: exprn_continuous.
+move=> x; apply: cvgM; first exact: cvg_cst.
+apply: (cvg_comp _ expR); last exact: continuous_expR.
+apply: cvgM; last exact: cvg_cst.
+apply: (@cvgN _ R^o).
+apply: (cvg_comp (fun x => x - m) (fun x => x ^+ 2)).
+  by apply: (@cvgB _ R^o) => //; [exact: cvg_id|exact: cvg_cst].
+exact: sqr_continuous.
 Qed.
 
-Lemma normal_pdf_ub m s x : s != 0 ->
-  normal_pdf m s x <= (sqrtr (s ^+ 2 * pi *+ 2))^-1.
+Let normal_pdf0_ub m s x : normal_pdf0 m s x <= normal_peak s.
 Proof.
-rewrite /normal_pdf.
-have [|s0 _] := eqVneq s 0; first by [].
-rewrite -[leRHS]mulr1.
-rewrite ler_wpM2l ?invr_ge0// ?sqrtr_ge0.
+rewrite /normal_pdf0 ler_piMr ?normal_peak_ge0//.
 rewrite -[leRHS]expR0 ler_expR mulNr oppr_le0 mulr_ge0// ?sqr_ge0//.
 by rewrite invr_ge0 mulrn_wge0// sqr_ge0.
+Qed.
+
+Lemma normal_pdf_ge0 m s x : 0 <= normal_pdf m s x.
+Proof. by rewrite /normal_pdf; case: ifP => // _; exact: normal_pdf0_ge0. Qed.
+
+Lemma continuous_normal_pdf m s : s != 0 -> continuous (normal_pdf m s).
+Proof.
+rewrite /normal_pdf; have [//|s0 _] := eqVneq s 0.
+exact: continuous_normal_pdf0.
+Qed.
+
+Lemma normal_pdf_ub m s x : s != 0 -> normal_pdf m s x <= normal_peak s.
+Proof.
+by rewrite /normal_pdf; have [//|s0 _] := eqVneq s 0; exact: normal_pdf0_ub.
 Qed.
 
 End normal_density.
@@ -1543,66 +1578,85 @@ Variables (R : realType) (m sigma : R).
 Local Open Scope ring_scope.
 Notation mu := lebesgue_measure.
 
-Let integral_normal_pdf' : sigma != 0 ->
-  (\int[mu]_x (expR (- (x - m) ^+ 2 / (sigma ^+ 2 *+ 2)))%:E =
-  (Num.sqrt (sigma ^+ 2 * pi *+ 2))%:E)%E.
+Local Notation normal_peak := (normal_peak sigma).
+Local Notation normal_fun := (normal_fun m sigma).
+
+Let F (x : R^o) := (x - m) / (Num.sqrt (sigma ^+ 2 *+ 2)).
+
+Let normal_gauss_fun x : normal_fun x = gauss_fun (F x).
 Proof.
-move=> sigma_gt0.
-pose F (x : R^o) := (x - m) / (`|sigma| * Num.sqrt 2).
-have F'E : F^`()%classic = cst (`|sigma| * Num.sqrt 2)^-1.
-  apply/funext => x; rewrite /F derive1E deriveM// deriveD// derive_cst scaler0.
-  by rewrite add0r derive_id derive_cst addr0 scaler1.
-have := @integralT_gauss R.
-rewrite (@increasing_ge0_integration_by_substitutionT _ F gauss_fun)//=; first last.
-- by move=> x; rewrite gauss_fun_ge0.
-- exact: continuous_gauss_fun.
-- apply/gt0_cvgMly; last exact: cvg_addrr.
-  by rewrite invr_gt0// mulr_gt0// normr_gt0.
-- apply/gt0_cvgMlNy; last exact: cvg_addrr_Ny.
-  by rewrite invr_gt0// mulr_gt0// normr_gt0.
-- by rewrite F'E; exact: is_cvg_cst.
-- by rewrite F'E; exact: is_cvg_cst.
-- by rewrite F'E => ?; exact: cvg_cst.
-- by move=> x y; rewrite /F ltr_pM2r ?invr_gt0 ?mulr_gt0 ?normr_gt0// ltrBlDr subrK.
-move=> /(congr1 (fun x => x * (`|sigma| * Num.sqrt 2)%:E)%E).
-rewrite -ge0_integralZr//=; last first.
+congr expR; rewrite mulNr exprMn exprVn; congr (- (_ * _^-1)%R).
+by rewrite sqr_sqrtr// pmulrn_lge0// sqr_ge0.
+Qed.
+
+Lemma F'E : F^`()%classic = cst (Num.sqrt (sigma ^+ 2 *+ 2))^-1.
+Proof.
+apply/funext => x; rewrite /F derive1E deriveM// deriveD// derive_cst scaler0.
+by rewrite add0r derive_id derive_cst addr0 scaler1.
+Qed.
+
+Let integral_gaussFF' : sigma != 0 ->
+  (\int[mu]_x ((((gauss_fun \o F) *
+     (F^`())%classic) x)%:E * (Num.sqrt (sigma ^+ 2 *+ 2))%:E))%E =
+  normal_peak^-1%:E.
+Proof.
+move=> s0; rewrite /normal_peak invrK.
+rewrite -mulrnAr -[in RHS]mulr_natr sqrtrM ?(sqrtrM 2) ?sqr_ge0 ?pi_ge0// !EFinM.
+rewrite muleCA ge0_integralZr//=; first last.
   by move=> x _; rewrite lee_fin mulr_ge0//= ?gauss_fun_ge0// F'E/= invr_ge0.
   rewrite F'E; apply/measurable_EFinP/measurable_funM => //.
   apply/measurableT_comp => //; first exact: measurable_gauss_fun.
   by apply: measurable_funM => //; exact: measurable_funD.
-move=> int_gauss.
-apply: eq_trans.
-  apply: eq_trans; last exact: int_gauss.
-  apply: eq_integral => /= x _.
-  rewrite F'E !fctE/= EFinM -muleA -EFinM mulVf ?mulr1; last first.
-    by rewrite gt_eqF ?mulr_gt0 ?normr_gt0.
-  rewrite /gauss_fun /F exprMn exprVn -[in RHS]mulNr.
-  by rewrite exprMn real_normK ?num_real// sqr_sqrtr// mulr_natr.
-rewrite -mulrnAl sqrtrM ?mulrn_wge0 ?sqr_ge0//.
-by rewrite -[in RHS]mulr_natr sqrtrM ?sqr_ge0// sqrtr_sqr !EFinM muleC.
+congr *%E; last by rewrite -(mulr_natr (_ ^+ 2)) sqrtrM ?sqr_ge0.
+rewrite -increasing_ge0_integration_by_substitutionT//.
+- exact: integralT_gauss.
+- move=> x y xy; rewrite /F ltr_pM2r ?ltr_leB ?gt_eqF//.
+  by rewrite invr_gt0 ?sqrtr_gt0 ?pmulrn_lgt0 ?exprn_even_gt0.
+- by rewrite F'E => ?; exact: cvg_cst.
+- by rewrite F'E; exact: is_cvg_cst.
+- by rewrite F'E; exact: is_cvg_cst.
+- apply/gt0_cvgMlNy; last exact: cvg_addrr_Ny.
+  by rewrite invr_gt0// sqrtr_gt0 -mulr_natr mulr_gt0// exprn_even_gt0.
+- apply/gt0_cvgMly; last exact: cvg_addrr.
+  by rewrite invr_gt0// sqrtr_gt0 -mulr_natr mulr_gt0// exprn_even_gt0.
+- exact: continuous_gauss_fun.
+- by move=> x; rewrite gauss_fun_ge0.
+Qed.
+
+Let integral_normal_fun : sigma != 0 ->
+  (\int[mu]_x (normal_fun x)%:E)%E = normal_peak^-1%:E.
+Proof.
+move=> s0; rewrite -integral_gaussFF'//; apply: eq_integral => /= x _.
+rewrite F'E !fctE/= EFinM -muleA -EFinM mulVf ?mulr1.
+  by rewrite normal_gauss_fun.
+by rewrite gt_eqF// sqrtr_gt0 pmulrn_lgt0// exprn_even_gt0.
+Qed.
+
+Let integrable_normal_fun : sigma != 0 ->
+  mu.-integrable [set: R] (EFin \o normal_fun).
+Proof.
+move=> s0; apply/integrableP; split.
+  by apply/measurable_EFinP; exact: measurable_normal_fun.
+under eq_integral do rewrite /= ger0_norm ?expR_ge0//.
+by rewrite /= integral_normal_fun// ltry.
 Qed.
 
 Lemma integral_normal_pdf : (\int[mu]_x (normal_pdf m sigma x)%:E = 1%E)%E.
 Proof.
-rewrite /normal_pdf.
-have [_|s0] := eqVneq sigma 0.
+rewrite /normal_pdf; have [_|s0] := eqVneq sigma 0.
   by rewrite integral_indic//= setIT lebesgue_measure_itv/= lte01 oppr0 adde0.
 under eq_integral do rewrite EFinM.
-rewrite integralZl//=; last first.
-  apply/integrableP; split.
-    apply/measurable_EFinP => /=.
-    apply: measurableT_comp => //=.
-    apply: measurable_funM => //=.
-    apply: measurableT_comp => //=.
-    apply: measurable_funX => //=.
-    exact: measurable_funD.
-  under eq_integral.
-    move=> /= x _.
-    rewrite ger0_norm ?expR_ge0//.
-    over.
-  by rewrite /= integral_normal_pdf'// ltry.
-rewrite integral_normal_pdf'// -EFinM mulVf// sqrtr_eq0 -ltNge.
-by rewrite mulrn_wgt0// mulr_gt0 ?pi_gt0// exprn_even_gt0.
+rewrite integralZl//=; last exact: integrable_normal_fun.
+by rewrite integral_normal_fun// -EFinM divff// gt_eqF// normal_peak_gt0.
+Qed.
+
+Lemma integrable_normal_pdf : mu.-integrable [set: R]
+  (fun x => (normal_pdf m sigma x)%:E).
+Proof.
+apply/integrableP; split.
+  by apply/measurable_EFinP; exact: measurable_normal_pdf.
+apply/abse_integralP => //=; last by rewrite integral_normal_pdf abse1 ltry.
+by apply/measurable_EFinP; exact: measurable_normal_pdf.
 Qed.
 
 Local Notation normal_pdf := (normal_pdf m sigma).
@@ -1619,18 +1673,9 @@ Qed.
 
 Let normal_sigma_additive : semi_sigma_additive normal_prob.
 Proof.
-move=> /= F mF tF mUF.
+move=> /= A mA tA mUA.
 rewrite /normal_prob/= integral_bigcup//=; last first.
-  apply/integrableP; split.
-    apply/measurable_funTS/measurableT_comp => //.
-    exact: measurable_normal_pdf.
-  rewrite (_ : (fun x => _) = EFin \o normal_pdf); last first.
-    by apply/funext => x; rewrite gee0_abs// lee_fin normal_pdf_ge0 ?ltW.
-  apply: le_lt_trans.
-    apply: (@ge0_subset_integral _ _ _ _ _ setT) => //=.
-      by apply/measurable_EFinP; exact: measurable_normal_pdf.
-    by move=> ? _; rewrite lee_fin normal_pdf_ge0 ?ltW.
-  by rewrite integral_normal_pdf // ltey.
+  by apply: (integrableS _ _ (subsetT _)) => //; exact: integrable_normal_pdf.
 apply: is_cvg_ereal_nneg_natsum_cond => n _ _.
 by apply: integral_ge0 => /= x ?; rewrite lee_fin normal_pdf_ge0 ?ltW.
 Qed.
@@ -1649,28 +1694,18 @@ Proof.
 move=> A mA muA0; rewrite /normal_prob /normal_pdf.
 have [s0|s0] := eqVneq sigma 0.
   apply: null_set_integral => //=; apply: (integrableS measurableT) => //=.
-  apply/integrableP; split.
-    by apply/measurable_EFinP; exact: measurable_indic.
-  apply/abse_integralP => //.
-    by apply/measurable_EFinP; exact: measurable_indic.
-  rewrite integral_indic// setIT/= lebesgue_measure_itv/=.
-  by rewrite lte_fin ltr01 oppr0 addr0 abse1 ltry.
+  exact: integrable_indic_itv.
 apply/eqP; rewrite eq_le; apply/andP; split; last first.
-  apply: integral_ge0 => x _; rewrite lee_fin.
-  have := normal_pdf_ge0 m sigma x.
-  by rewrite /normal_pdf ifF//; apply/negP/negP.
-apply: (@le_trans _ _
-    (\int[mu]_(x in A) (Num.sqrt (sigma ^+ 2 * pi *+ 2))^-1%:E))%E; last first.
+  apply: integral_ge0 => x _.
+  by rewrite lee_fin mulr_ge0 ?normal_peak_ge0 ?normal_fun_ge0.
+apply: (@le_trans _ _ (\int[mu]_(x in A) (normal_peak)%:E))%E; last first.
   by rewrite integral_cst//= muA0 mule0.
 apply: ge0_le_integral => //=.
-- apply/measurable_funTS/measurableT_comp => //.
-  apply: measurable_funM => //; apply: measurableT_comp => //.
-  apply: measurable_funM => //; apply: measurableT_comp => //.
-  apply: measurableT_comp (exprn_measurable _) _ => /=.
-  exact: measurable_funD.
-- move=> x _; rewrite lee_fin -[leRHS]mulr1 ler_wpM2l ?invr_ge0// ?sqrtr_ge0.
-  rewrite -[leRHS]expR0 ler_expR mulNr oppr_le0 mulr_ge0// ?sqr_ge0//.
-  by rewrite invr_ge0 mulrn_wge0// sqr_ge0.
+- by move=> x _; rewrite lee_fin mulr_ge0 ?normal_peak_ge0 ?normal_fun_ge0.
+- apply/measurable_funTS/measurableT_comp => //=.
+  by apply: measurable_funM => //; exact: measurable_normal_fun.
+- by move=> x _; rewrite lee_fin normal_peak_ge0.
+- by move=> x _; have := normal_pdf_ub m x s0; rewrite /normal_pdf (negbTE s0).
 Qed.
 
 End normal_probability.

--- a/theories/sequences.v
+++ b/theories/sequences.v
@@ -2131,7 +2131,7 @@ move=> u_ub u_lb; have : sups (- u) @ \oo --> inf (range (sups (- u))).
   apply: cvg_sups_inf.
   - by move: u_lb => /has_lb_ubN; rewrite image_comp.
   - by move: u_ub => /has_ub_lbN; rewrite image_comp.
-rewrite /inf => /(@cvg_comp _ _ _ _ (fun x => - x)).
+rewrite /inf => /(cvg_comp _ (fun x => - x)).
 rewrite supsN /comp /= -[in X in _ -> X --> _](opprK (infs u)); apply.
 rewrite image_comp /comp /= -(opprK (sup (range (infs u)))); apply: cvgN.
 by rewrite (_ : [set _ | _ in setT] = (range (infs u))) // opprK.

--- a/theories/topology_theory/topology_structure.v
+++ b/theories/topology_theory/topology_structure.v
@@ -267,7 +267,7 @@ Lemma open_comp  {T U : topologicalType} (f : T -> U) (D : set U) :
   {in f @^-1` D, continuous f} -> open D -> open (f @^-1` D).
 Proof.
 rewrite !openE => fcont Dop x /= Dfx.
-by apply: fcont; [rewrite inE|apply: Dop].
+by apply: fcont; [rewrite inE|exact: Dop].
 Qed.
 
 Lemma cvg_fmap {T: topologicalType} {U : topologicalType}
@@ -295,7 +295,7 @@ Lemma continuous_cvg {T : Type} {V U : topologicalType}
   f @ F --> a -> (h \o f) @ F --> h a.
 Proof.
 move=> h_continuous fa fb; apply: (cvg_trans _ h_continuous).
-exact: (@cvg_comp _ _ _ _ h _ _ _ fa).
+exact: (cvg_comp _ h fa).
 Qed.
 
 Lemma continuous_is_cvg {T : Type} {V U : ptopologicalType} [F : set_system T]
@@ -314,7 +314,7 @@ Lemma continuous2_cvg {T : Type} {V W U : topologicalType}
   f @ F --> a -> g @ F --> b -> (fun x => h (f x) (g x)) @ F --> h a b.
 Proof.
 move=> h_continuous fa fb; apply: (cvg_trans _ h_continuous).
-exact: (@cvg_comp _ _ _ _ (fun x => h x.1 x.2) _ _ _ (cvg_pair fa fb)).
+exact: (cvg_comp _ (fun x => h x.1 x.2) (cvg_pair fa fb)).
 Qed.
 
 Lemma cvg_near_cst (T : Type) (U : topologicalType)
@@ -322,7 +322,7 @@ Lemma cvg_near_cst (T : Type) (U : topologicalType)
   (\forall x \near F, f x = l) -> f @ F --> l.
 Proof.
 move=> fFl P /=; rewrite !near_simpl => Pl.
-by apply: filterS fFl => _ ->; apply: nbhs_singleton.
+by apply: filterS fFl => _ ->; exact: nbhs_singleton.
 Qed.
 Arguments cvg_near_cst {T U} l {f F FF}.
 


### PR DESCRIPTION
- define normal_pdf using two intermediate functions normal_peak and normal_fun

The definition of `normal_pdf` using two intermediate functions turns out to come in handy
when proving more advanced properties of the normal distribution (to come in a later PR)

@IshiguroYoshihiro 

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
