### PR TITLE
Generalize gt0_cvgMly/Ny

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -189,7 +189,7 @@
 - in `sequences.v`:
   + lemma `nneseries_recl` genralized with a filtering predicate `P`
 - in `normedtype.v`:
-  + lemmas "gt0_cvgMlNy", "gt0_cvgMly"
+  + lemmas `gt0_cvgMlNy`, `gt0_cvgMly`
 
 ### Deprecated
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -188,6 +188,8 @@
 
 - in `sequences.v`:
   + lemma `nneseries_recl` genralized with a filtering predicate `P`
+- in `normedtype.v`:
+  + lemmas "gt0_cvgMlNy", "gt0_cvgMly"
 
 ### Deprecated
 

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -885,15 +885,17 @@ Lemma cvgenyP {R : realType} {T} {F : set_system T} {FF : Filter F} (f : T -> na
    (((f n)%:R : R)%:E @[n --> F] --> +oo%E) <-> (f @ F --> \oo).
 Proof. by rewrite cvgeryP cvgrnyP. Qed.
 
-Lemma gt0_cvgMlNy {R : realFieldType} (M : R) (f : R -> R) : (0 < M)%R ->
-  (f r) @[r --> -oo] --> -oo -> (f r * M)%R @[r --> -oo] --> -oo.
+Lemma gt0_cvgMlNy {R : realFieldType} {F : set_system R} {FF : Filter F} (M : R)
+  (f : R -> R) :
+  (0 < M)%R -> (f r) @[r --> F] --> -oo -> (f r * M)%R @[r --> F] --> -oo.
 Proof.
 move=> M0 /cvgrNyPle fy; apply/cvgrNyPle => A.
 by apply: filterS (fy (A / M)) => x; rewrite ler_pdivlMr.
 Qed.
 
-Lemma gt0_cvgMly {R : realFieldType} (M : R) (f : R -> R) : (0 < M)%R ->
-  f r @[r --> +oo] --> +oo -> (f r * M)%R @[r --> +oo] --> +oo.
+Lemma gt0_cvgMly {R : realFieldType} {F : set_system R} {FF : Filter F} (M : R)
+  (f : R -> R) :
+  (0 < M)%R -> f r @[r --> F] --> +oo -> (f r * M)%R @[r --> F] --> +oo.
 Proof.
 move=> M0 /cvgryPge fy; apply/cvgryPge => A.
 apply: filterS (fy (A / M)) => x.

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -898,8 +898,7 @@ Lemma gt0_cvgMly {R : realFieldType} {F : set_system R} {FF : Filter F} (M : R)
   (0 < M)%R -> f r @[r --> F] --> +oo -> (f r * M)%R @[r --> F] --> +oo.
 Proof.
 move=> M0 /cvgryPge fy; apply/cvgryPge => A.
-apply: filterS (fy (A / M)) => x.
-by rewrite ler_pdivrMr.
+by apply: filterS (fy (A / M)) => x; rewrite ler_pdivrMr.
 Qed.
 
 (** Modules with a norm depending on a numDomain*)


### PR DESCRIPTION
##### Motivation for this change
generalized `gt0_cvgMly` and `gt0_cvgMlNy` from `@[x --> +oo]`/`@[x --> -oo]` to `@[x --> F]` for any filter F.
<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
