### PR TITLE
include separation_axioms in topology

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -114,6 +114,10 @@
 
 ### Changed
 
+- file `separation_axioms.v` moved from `theories` to
+  `theories/topology_theory`
+- `topology` now exports `separation_axiom`
+
 - file `nsatz_realtype.v` moved from `reals` to `reals-stdlib` package
 - moved from `gauss_integral` to `trigo.v`:
   + `oneDsqr`, `oneDsqr_ge1`, `oneDsqr_inum`, `oneDsqrV_le1`,

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -116,7 +116,7 @@
 
 - file `separation_axioms.v` moved from `theories` to
   `theories/topology_theory`
-- `topology` now exports `separation_axiom`
+- `topology.v` now exports `separation_axioms`
 
 - file `nsatz_realtype.v` moved from `reals` to `reals-stdlib` package
 - moved from `gauss_integral` to `trigo.v`:

--- a/_CoqProject
+++ b/_CoqProject
@@ -63,12 +63,12 @@ theories/topology_theory/quotient_topology.v
 theories/topology_theory/one_point_compactification.v
 theories/topology_theory/sigT_topology.v
 theories/topology_theory/discrete_topology.v
+theories/topology_theory/separation_axioms.v
 
 theories/homotopy_theory/homotopy.v
 theories/homotopy_theory/wedge_sigT.v
 theories/homotopy_theory/continuous_path.v
 
-theories/separation_axioms.v
 theories/function_spaces.v
 theories/ereal.v
 theories/cantor.v

--- a/theories/Make
+++ b/theories/Make
@@ -29,12 +29,12 @@ topology_theory/quotient_topology.v
 topology_theory/one_point_compactification.v
 topology_theory/sigT_topology.v
 topology_theory/discrete_topology.v
+topology_theory/separation_axioms.v
 
 homotopy_theory/homotopy.v
 homotopy_theory/wedge_sigT.v
 homotopy_theory/continuous_path.v
 
-separation_axioms.v
 function_spaces.v
 cantor.v
 tvs.v

--- a/theories/cantor.v
+++ b/theories/cantor.v
@@ -4,7 +4,7 @@ From mathcomp Require Import all_ssreflect ssralg ssrint ssrnum interval rat.
 From mathcomp Require Import finmap.
 From mathcomp Require Import mathcomp_extra boolp classical_sets functions.
 From mathcomp Require Import cardinality reals.
-From mathcomp Require Import topology function_spaces separation_axioms.
+From mathcomp Require Import topology function_spaces.
 
 (**md**************************************************************************)
 (* # The Cantor Space and Applications                                        *)

--- a/theories/function_spaces.v
+++ b/theories/function_spaces.v
@@ -3,7 +3,7 @@ From HB Require Import structures.
 From mathcomp Require Import all_ssreflect all_algebra finmap generic_quotient.
 From mathcomp Require Import boolp classical_sets functions.
 From mathcomp Require Import cardinality mathcomp_extra unstable fsbigop reals.
-From mathcomp Require Import interval_inference topology separation_axioms.
+From mathcomp Require Import interval_inference topology.
 
 (**md**************************************************************************)
 (* # The topology of functions spaces                                         *)

--- a/theories/homotopy_theory/wedge_sigT.v
+++ b/theories/homotopy_theory/wedge_sigT.v
@@ -3,7 +3,7 @@ From HB Require Import structures.
 From mathcomp Require Import all_ssreflect all_algebra finmap generic_quotient.
 From mathcomp Require Import mathcomp_extra unstable boolp classical_sets.
 From mathcomp Require Import functions cardinality fsbigop reals topology.
-From mathcomp Require Import separation_axioms function_spaces.
+From mathcomp Require Import function_spaces.
 
 (**md**************************************************************************)
 (* # wedge sum for sigT                                                       *)

--- a/theories/normedtype.v
+++ b/theories/normedtype.v
@@ -7,7 +7,7 @@ From mathcomp Require Import archimedean.
 From mathcomp Require Import cardinality set_interval ereal reals.
 From mathcomp Require Import interval_inference topology prodnormedzmodule.
 From mathcomp Require Import function_spaces.
-From mathcomp Require Export real_interval separation_axioms tvs.
+From mathcomp Require Export real_interval tvs.
 
 (**md**************************************************************************)
 (* # Norm-related Notions                                                     *)

--- a/theories/topology_theory/separation_axioms.v
+++ b/theories/topology_theory/separation_axioms.v
@@ -5,7 +5,11 @@ From mathcomp Require Import archimedean.
 From mathcomp Require Import boolp classical_sets functions wochoice.
 From mathcomp Require Import cardinality mathcomp_extra unstable fsbigop.
 From mathcomp Require Import set_interval filter reals interval_inference.
-From mathcomp Require Import topology.
+From mathcomp Require Import topology_structure compact subspace_topology.
+From mathcomp Require Import discrete_topology order_topology.
+From mathcomp Require Import pseudometric_structure num_topology.
+From mathcomp Require Import one_point_compactification uniform_structure.
+From mathcomp Require Import connected supremum_topology sigT_topology.
 
 (**md**************************************************************************)
 (* # Separation Axioms                                                        *)

--- a/theories/topology_theory/topology.v
+++ b/theories/topology_theory/topology.v
@@ -18,3 +18,4 @@ From mathcomp Require Export weak_topology.
 From mathcomp Require Export one_point_compactification.
 From mathcomp Require Export sigT_topology.
 From mathcomp Require Export discrete_topology.
+From mathcomp Require Export separation_axioms.

--- a/theories/tvs.v
+++ b/theories/tvs.v
@@ -6,7 +6,6 @@ From mathcomp Require Import archimedean.
 From mathcomp Require Import boolp classical_sets functions cardinality.
 From mathcomp Require Import set_interval ereal reals interval_inference.
 From mathcomp Require Import topology prodnormedzmodule function_spaces.
-From mathcomp Require Import separation_axioms.
 
 (**md**************************************************************************)
 (* # Topological vector spaces                                                *)


### PR DESCRIPTION
##### Motivation for this change

`separation_axioms` has not been provided as a part of `topology` although
it provides basic definitions and properties for general topology.
This PR moves `separation_axioms.v` into `topology_theory` subdirectory
and makes `topology` export `separation_axioms`.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
