### PR TITLE
document weak_topology as initial topology

### DIFF
--- a/theories/topology_theory/weak_topology.v
+++ b/theories/topology_theory/weak_topology.v
@@ -6,7 +6,9 @@ From mathcomp Require Import uniform_structure order_topology.
 From mathcomp Require Import pseudometric_structure.
 
 (**md**************************************************************************)
-(* # Weak topology                                                            *)
+(* This file defines the weak topology on S with respect to a function        *)
+(*  whose domain is S. This topology is also known as initial topology on S   *)
+(*  with respect to f.                                                        *)
 (*                                                                            *)
 (* ```                                                                        *)
 (*         weak_topology f == weak topology by a function f : S -> T on S     *)

--- a/theories/topology_theory/weak_topology.v
+++ b/theories/topology_theory/weak_topology.v
@@ -1,4 +1,4 @@
-(* mathcomp analysis (c) 2017 Inria and AIST. License: CeCILL-C.              *)
+(* mathcomp analysis (c) 2025 Inria and AIST. License: CeCILL-C.              *)
 From HB Require Import structures.
 From mathcomp Require Import all_ssreflect all_algebra all_classical unstable.
 From mathcomp Require Import interval_inference reals topology_structure.
@@ -6,9 +6,10 @@ From mathcomp Require Import uniform_structure order_topology.
 From mathcomp Require Import pseudometric_structure.
 
 (**md**************************************************************************)
-(* This file defines the weak topology on S with respect to a function        *)
-(*  whose domain is S. This topology is also known as initial topology on S   *)
-(*  with respect to f.                                                        *)
+(* # Weak/initial topology                                                    *)
+(* This file defines the weak topology for `S` by a function `f` whose domain *)
+(* is `S`. This topology is also known as initial topology on `S` with        *)
+(* respect to `f`.                                                            *)
 (*                                                                            *)
 (* ```                                                                        *)
 (*         weak_topology f == weak topology by a function f : S -> T on S     *)

--- a/theories/topology_theory/weak_topology.v
+++ b/theories/topology_theory/weak_topology.v
@@ -7,9 +7,9 @@ From mathcomp Require Import pseudometric_structure.
 
 (**md**************************************************************************)
 (* # Weak/initial topology                                                    *)
-(* This file defines the weak topology for `S` by a function `f` whose domain *)
-(* is `S`. This topology is also known as initial topology on `S` with        *)
-(* respect to `f`.                                                            *)
+(* This file defines the weak topology for $S$ by a function $f$ whose domain *)
+(* is $S$. This topology is also known as initial topology on $S$ with        *)
+(* respect to $f$.                                                            *)
 (*                                                                            *)
 (* ```                                                                        *)
 (*         weak_topology f == weak topology by a function f : S -> T on S     *)


### PR DESCRIPTION
##### Motivation for this change

Documenting the topology defined in weak_topology.v as the initial topology, as the name "weak topology" often refers to "weak topology with respect to the dual".

##### Checklist

- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
