### PR TITLE
lemmas for integrals on increasing set sequences

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -81,7 +81,7 @@
   + lemma `measurable_behead`
 
 - in `lebesgue_integral_theory/lebesgue_integral_nonneg.v`:
-  + lemmas `ge0_nondecreasing_set_seq_nondecreasing_integral_seq`,
+  + lemmas `ge0_nondecreasing_set_nondecreasing_integral`,
            `ge0_nondecreasing_set_seq_cvg_integral`,
            `le0_nondecreasing_set_seq_nonincreasing_integral_seq`,
 	   `le0_nondecreasing_set_seq_cvg_integral`

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -82,9 +82,9 @@
 
 - in `lebesgue_integral_theory/lebesgue_integral_nonneg.v`:
   + lemmas `ge0_nondecreasing_set_nondecreasing_integral`,
-           `ge0_nondecreasing_set_seq_cvg_integral`,
-           `le0_nondecreasing_set_seq_nonincreasing_integral_seq`,
-	   `le0_nondecreasing_set_seq_cvg_integral`
+           `ge0_nondecreasing_set_cvg_integral`,
+           `le0_nondecreasing_set_nonincreasing_integral`,
+	   `le0_nondecreasing_set_cvg_integral`
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -80,6 +80,12 @@
   + lemma `measurable_cons`
   + lemma `measurable_behead`
 
+- in `lebesgue_integral_theory/lebesgue_integral_nonneg.v`:
+  + lemmas `ge0_nondecreasing_set_seq_nondecreasing_integral_seq`,
+           `ge0_nondecreasing_set_seq_cvg_integral`,
+           `le0_nondecreasing_set_seq_nonincreasing_integral_seq`,
+	   `le0_nondecreasing_set_seq_cvg_integral`
+
 ### Changed
 
 - in `convex.v`:

--- a/theories/lebesgue_integral_theory/lebesgue_integral_nonneg.v
+++ b/theories/lebesgue_integral_theory/lebesgue_integral_nonneg.v
@@ -1560,8 +1560,9 @@ End lebesgue_measure_integral.
 Arguments integral_Sset1 {R f A} r.
 
 Section ge0_nondecreasing_set_seq_cvg_integral.
-Context {R : realType}.
-Variables (S : (set R)^nat) (f : R -> \bar R).
+Context {d : measure_display} {T : measurableType d} {R : realType}.
+Variables (S : (set T)^nat) (f : T -> \bar R).
+Variable (mu : measure T R).
 
 Local Open Scope ereal_scope.
 
@@ -1569,13 +1570,11 @@ Hypotheses (nndS : nondecreasing_seq S) (mS : (forall i, measurable (S i))).
 Hypothesis (mf : (forall i, measurable_fun (S i) f)).
 Hypothesis (f0 : forall i x, S i x -> 0 <= f x).
 
-Notation mu := lebesgue_measure.
-
 Lemma ge0_nondecreasing_set_seq_nondecreasing_integral_seq :
   nondecreasing_seq (fun i => \int[mu]_(x in S i) f x).
 Proof.
 apply/nondecreasing_seqP => n.
-apply: ge0_subset_integral => //=; [exact: mS|exact: mS|exact: mf| |].
+apply: ge0_subset_integral => //=.
 - by move=> ?; exact: f0.
 - by rewrite -subsetEset; exact: nndS.
 Qed.
@@ -1617,8 +1616,9 @@ Qed.
 End ge0_nondecreasing_set_seq_cvg_integral.
 
 Section le0_nondecreasing_set_seq_cvg_integral.
-Context {R : realType}.
-Variables (S : (set R)^nat) (f : R -> \bar R).
+Context {d : measure_display} {T : measurableType d} {R : realType}.
+Variables (S : (set T)^nat) (f : T -> \bar R).
+Variable (mu : measure T R).
 
 Local Open Scope ereal_scope.
 

--- a/theories/lebesgue_integral_theory/lebesgue_integral_nonneg.v
+++ b/theories/lebesgue_integral_theory/lebesgue_integral_nonneg.v
@@ -1559,107 +1559,92 @@ Qed.
 End lebesgue_measure_integral.
 Arguments integral_Sset1 {R f A} r.
 
-Section ge0_nondecreasing_set_seq_cvg_integral.
+Section ge0_nondecreasing_set_cvg_integral.
 Context {d : measure_display} {T : measurableType d} {R : realType}.
-Variables (S : (set T)^nat) (f : T -> \bar R).
-Variable (mu : measure T R).
-
+Variables (F : (set T)^nat) (f : T -> \bar R) (mu : measure T R).
 Local Open Scope ereal_scope.
+Hypotheses (nndF : nondecreasing_seq F) (mF : forall i, measurable (F i)).
+Hypothesis mf : forall i, measurable_fun (F i) f.
+Hypothesis f0 : forall i x, F i x -> 0 <= f x.
 
-Hypotheses (nndS : nondecreasing_seq S) (mS : (forall i, measurable (S i))).
-Hypothesis (mf : (forall i, measurable_fun (S i) f)).
-Hypothesis (f0 : forall i x, S i x -> 0 <= f x).
-
-Lemma ge0_nondecreasing_set_seq_nondecreasing_integral_seq :
-  nondecreasing_seq (fun i => \int[mu]_(x in S i) f x).
+Lemma ge0_nondecreasing_set_nondecreasing_integral :
+  nondecreasing_seq (fun i => \int[mu]_(x in F i) f x).
 Proof.
-apply/nondecreasing_seqP => n.
-apply: ge0_subset_integral => //=.
+apply/nondecreasing_seqP => n; apply: ge0_subset_integral => //=.
 - by move=> ?; exact: f0.
-- by rewrite -subsetEset; exact: nndS.
+- by rewrite -subsetEset; exact: nndF.
 Qed.
 
-Lemma ge0_nondecreasing_set_seq_cvg_integral :
-  \int[mu]_(x in (S i)) f x @[i --> \oo] -->
-    \int[mu]_(x in \bigcup_i S i) f x.
+Lemma ge0_nondecreasing_set_cvg_integral :
+  \int[mu]_(x in F i) f x @[i --> \oo] --> \int[mu]_(x in \bigcup_i F i) f x.
 Proof.
 apply: cvg_toP.
   apply: ereal_nondecreasing_is_cvgn.
-  exact: ge0_nondecreasing_set_seq_nondecreasing_integral_seq.
+  exact: ge0_nondecreasing_set_nondecreasing_integral.
 under eq_fun do rewrite integral_mkcond/=.
 rewrite -monotone_convergence//=; last 3 first.
 - by move=> n; apply/(measurable_restrictT f).
-- by move=> n x _; apply: erestrict_ge0 => {}x Snx; apply: f0 Snx.
+- by move=> n x _; apply: erestrict_ge0 => {}x; exact: f0.
 - move=> x _; apply/nondecreasing_seqP => n; apply: restrict_lee => //.
-    by move=> {}x Snx; apply: f0 Snx.
-  by rewrite -subsetEset; exact: nndS.
+    by move=> {}x; exact: f0.
+  by rewrite -subsetEset; exact: nndF.
 rewrite [RHS]integral_mkcond/=.
 apply: eq_integral => /=; rewrite /g_sigma_algebraType/ocitv_type => x _.
-transitivity (ereal_sup (range (fun n => (f \_ (S n)) x))).
+transitivity (ereal_sup (range (fun n => (f \_ (F n)) x))).
   apply/cvg_lim => //.
   apply/ereal_nondecreasing_cvgn/nondecreasing_seqP => n; apply: restrict_lee.
-    by move=> {}x Snx; apply: f0 Snx.
-  by rewrite -subsetEset; exact: nndS.
+    by move=> {}x; exact: f0.
+  by rewrite -subsetEset; exact: nndF.
 apply/eqP; rewrite eq_le; apply/andP; split.
 - apply: ub_ereal_sup => _/= [n _ <-].
-  apply: restrict_lee => //; last exact: bigcup_sup.
-  by move=> ? [? _ Smy]; apply: f0 Smy.
+  apply: restrict_lee; last exact: bigcup_sup.
+  by move=> ? [? _]; exact: f0.
 - rewrite patchE; case: ifPn=> [|/negP].
-    rewrite inE => -[n _ Snx].
-    apply: ereal_sup_le; exists (f \_ (S n) x) => //.
-    by rewrite patchE mem_set.
-  rewrite inE -[X in X -> _]/((~` _) x) setC_bigcup => nSx.
-  apply/ereal_sup_le; exists point => //=; exists 0%R => //.
-  by rewrite patchE memNset//; exact: nSx.
+    rewrite inE => -[n _ Fnx].
+    by apply: ereal_sup_ge; exists (f \_ (F n) x) => //; rewrite patchE mem_set.
+  rewrite inE -[X in X -> _]/((~` _) x) setC_bigcup => nFx.
+  apply/ereal_sup_ge; exists point => //=; exists 0%R => //.
+  by rewrite patchE memNset//; exact: nFx.
 Qed.
 
-End ge0_nondecreasing_set_seq_cvg_integral.
+End ge0_nondecreasing_set_cvg_integral.
 
-Section le0_nondecreasing_set_seq_cvg_integral.
+Section le0_nondecreasing_set_cvg_integral.
 Context {d : measure_display} {T : measurableType d} {R : realType}.
-Variables (S : (set T)^nat) (f : T -> \bar R).
-Variable (mu : measure T R).
-
+Variables (F : (set T)^nat) (f : T -> \bar R) (mu : measure T R).
 Local Open Scope ereal_scope.
+Hypotheses (nndF : nondecreasing_seq F) (mF : forall i, measurable (F i)).
+Hypothesis mf : forall i, measurable_fun (F i) f.
+Hypothesis f0 : forall i x, F i x -> f x <= 0.
 
-Hypotheses (nndS : nondecreasing_seq S) (mS : (forall i, measurable (S i))).
-Hypothesis (mf : (forall i, measurable_fun (S i) f)).
-Hypothesis (f0 : forall i x, S i x -> f x <= 0).
-
-Notation mu := lebesgue_measure.
-
-Let intNS n : (- \int[mu]_(x in S n) f x) = \int[mu]_(x in S n) - f x.
+Let intNS n : (- \int[mu]_(x in F n) f x) = \int[mu]_(x in F n) - f x.
 Proof.
-apply/esym; apply: integralN => /=.
-apply: fin_num_adde_defr.
-rewrite integral0_eq// => x Snx.
-by rewrite (@le0_funeposE _ _ (S n))// ?inE//; apply: f0.
+apply/esym; apply: integralN => /=; apply: fin_num_adde_defr.
+rewrite integral0_eq// => x Fnx.
+by rewrite (@le0_funeposE _ _ (F n)) ?inE//; exact: f0.
 Qed.
 
-Let mNf i : measurable_fun (S i) (\- f).
+Let mNf i : measurable_fun (F i) (\- f).
 Proof. by apply: measurableT_comp => //; exact: mf. Qed.
 
-Let Nf_ge0 i x: S i x -> 0%R <= - f x.
+Let Nf_ge0 i x: F i x -> 0%R <= - f x.
 Proof. by move=> Six; rewrite leeNr oppe0; exact: f0 Six. Qed.
 
-Lemma le0_nondecreasing_set_seq_nonincreasing_integral_seq :
-  nonincreasing_seq (fun i => \int[mu]_(x in S i) f x).
+Lemma le0_nondecreasing_set_nonincreasing_integral :
+  nonincreasing_seq (fun i => \int[mu]_(x in F i) f x).
 Proof.
 move=> m n mn; rewrite -leeN2 2!intNS.
-exact: ge0_nondecreasing_set_seq_nondecreasing_integral_seq.
+exact: ge0_nondecreasing_set_nondecreasing_integral.
 Qed.
 
-Lemma le0_nondecreasing_set_seq_cvg_integral :
- \int[mu]_(x in (S i)) f x @[i --> \oo] -->
-  \int[mu]_(x in \bigcup_i S i) f x.
+Lemma le0_nondecreasing_set_cvg_integral :
+ \int[mu]_(x in F i) f x @[i --> \oo] --> \int[mu]_(x in \bigcup_i F i) f x.
 Proof.
-apply/cvgeNP.
-rewrite -integralN/=; last first.
-  apply: fin_num_adde_defr.
-  rewrite integral0_eq// => x [n _ Snx].
+apply/cvgeNP; rewrite -integralN/=; last first.
+  apply: fin_num_adde_defr; rewrite integral0_eq// => x [n _ Fnx].
   by rewrite (le0_funeposE (@f0 n))// inE.
 under eq_cvg do rewrite intNS.
-exact: ge0_nondecreasing_set_seq_cvg_integral.
+exact: ge0_nondecreasing_set_cvg_integral.
 Qed.
 
-End le0_nondecreasing_set_seq_cvg_integral.
+End le0_nondecreasing_set_cvg_integral.


### PR DESCRIPTION
##### Motivation for this change
Add lemmas for integration on nondecreasing set sequences.

Although these lemmas are similar to `ge0_integral_bigcup`, but I believe that it is worth adding because these lemmas can be used for not pairwise disjoint but nondecreasing sets sequences.
It is especially useful for handling improper integrals, which are often read as an approximation by increasing sequence of sets in paper proofs.  

I'm concerned that the names of lemmas are quite long. Are there shorter names for them? 
Or, should we introduce an abbreviation for `nondecreasing` like `ndecr`?

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
