### PR TITLE
rename cvgeMl and cvgeMr

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -237,6 +237,12 @@
   + `set_itv_pinfty_bnd` -> `set_itv_ybnd`
   + `set_itv_bnd_ninfty` -> `set_itv_bndNy`
 
+- in `normed_module.v` (new file):
+  + `cvgeMl` -> `cvgeZl`
+  + `is_cvgeMl` -> `is_cvgeZl`
+  + `cvgeMr` -> `cvgeZr`
+  + `is_cvgeMr` -> `is_cvgeZr`
+
 ### Generalized
 
 - in `constructive_ereal.v`:

--- a/theories/charge.v
+++ b/theories/charge.v
@@ -417,7 +417,7 @@ move=> F mF tF mUF; rewrite /cscale; rewrite [X in X @ _ --> _](_ : _ =
 rewrite /mscale; have [->|r0] := eqVneq r 0%R.
   rewrite mul0e [X in X @ _ --> _](_ : _ = (fun=> 0)); first exact: cvg_cst.
   by under eq_fun do rewrite mul0e.
-by apply: cvgeMl => //; apply: charge_semi_sigma_additive.
+by apply: cvgeZl => //; exact: charge_semi_sigma_additive.
 Qed.
 
 HB.instance Definition _ := isCharge.Build _ _ _ cscale
@@ -665,7 +665,7 @@ Proof.
 move=> u0 h.
 have u2 n : u n = 2%:E * (u n * 2^-1%:E) by rewrite muleCA -EFinM divff ?mule1.
 rewrite (eq_cvg _ _ u2) -[X in _ --> X]/(nbhs 0).
-rewrite -(mule0 2%:E); apply: cvgeMl => //.
+rewrite -(mule0 2%:E); apply: cvgeZl => //.
 by apply: (mine_cvg_0_cvg_0 lte01) => // n; rewrite mule_ge0.
 Qed.
 
@@ -1927,8 +1927,8 @@ have -> : \int[nu]_(x in E) f x =
   - by move=> x Ex a b ab; rewrite lee_fin; exact/lefP/nd_nnsfun_approx.
 have -> : \int[mu]_(x in E) (f \* g) x =
     lim (\int[mu]_(x in E) ((EFin \o h n) \* g) x @[n --> \oo]).
-  have fg x :E x -> f x * g x = lim (((EFin \o h n) \* g) x @[n --> \oo]).
-    by move=> Ex; apply/esym/cvg_lim => //; apply: cvgeMr;
+  have fg x : E x -> f x * g x = lim (((EFin \o h n) \* g) x @[n --> \oo]).
+    by move=> Ex; apply/esym/cvg_lim => //; apply: cvgeZr;
       [exact: f_fin_num|exact: cvg_nnsfun_approx].
   under eq_integral => x /[!inE] /fg -> //.
   apply: monotone_convergence => [//| | |].

--- a/theories/lebesgue_integral_theory/lebesgue_integral_definition.v
+++ b/theories/lebesgue_integral_theory/lebesgue_integral_definition.v
@@ -284,7 +284,7 @@ have cg1g n : c%:E * sintegral mu (g1 c n) <= sintegral mu (g n).
 suff {cg1g}<- : limn (fun n => sintegral mu (g1 c n)) = sintegral mu f.
   have is_cvg_g1 : cvgn (fun n => sintegral mu (g1 c n)).
     by apply: is_cvg_sintegral => //= x m n /(le_ffleg c)/lefP/(_ x).
-  rewrite -limeMl // lee_lim//; first exact: is_cvgeMl.
+  rewrite -limeMl // lee_lim//; first exact: is_cvgeZl.
   - by apply: is_cvg_sintegral => // m n mn; apply/lefP => t; apply: nd_g.
   - exact/nearW/cg1g.
 suff : sintegral mu (g1 c n) @[n \oo] --> sintegral mu f by apply/cvg_lim.
@@ -316,7 +316,7 @@ rewrite sintegralE fsbig_finite//=.
 apply: cvg_nnesum=> [r _|r _].
   near=> A; apply: (mulemu_ge0 (fun x => f @^-1` [set x] `&` fleg c A)) => r0.
   by rewrite preimage_nnfun0// set0I.
-apply: cvgeMl => //=; rewrite [X in _ --> X](_ : _ =
+apply: cvgeZl => //=; rewrite [X in _ --> X](_ : _ =
     mu (\bigcup_n (f @^-1` [set r] `&` fleg c n))); last first.
   by rewrite -setI_bigcupr bigcup_fleg// setIT.
 have ? k i : measurable (f @^-1` [set k] `&` fleg c i) by exact: measurableI.

--- a/theories/measure.v
+++ b/theories/measure.v
@@ -2426,7 +2426,7 @@ move=> F mF tF mUF; rewrite [X in X @ \oo --> _](_ : _ =
 rewrite /mscale; have [->|r0] := eqVneq r%:num 0%R.
   rewrite mul0e [X in X @ \oo --> _](_ : _ = cst 0); first exact: cvg_cst.
   by under eq_fun do rewrite mul0e.
-by apply: cvgeMl => //; exact: measure_semi_sigma_additive.
+by apply: cvgeZl => //; exact: measure_semi_sigma_additive.
 Qed.
 
 HB.instance Definition _ := isMeasure.Build _ _ _ mscale
@@ -3628,7 +3628,7 @@ case: ifPn => [_|_]; first exact: measure_semi_sigma_additive.
 rewrite [X in X @ _ --> _](_ : _ = (fun n => \sum_(0 <= i < n) mu (F i)) \*
                                cst (fine (mu setT))^-1%:E); last first.
   by apply/funext => n; rewrite -ge0_sume_distrl.
-by apply: cvgeMr => //; exact: measure_semi_sigma_additive.
+by apply: cvgeZr => //; exact: measure_semi_sigma_additive.
 Qed.
 
 HB.instance Definition _ := isMeasure.Build _ _ _ mnormalize

--- a/theories/normedtype_theory/normed_module.v
+++ b/theories/normedtype_theory/normed_module.v
@@ -745,23 +745,23 @@ move=> [s||]/=.
   by move=> x xru; apply: uA; move: xru; rewrite EFinM lte_pdivlMl.
 Unshelve. all: by end_near. Qed.
 
-Lemma cvgeMl f x y : y \is a fin_num ->
+Lemma cvgeZl f x y : y \is a fin_num ->
   f @ F --> x -> (fun n => y * f n) @ F --> y * x.
 Proof. by move: y => [r| |]// _ /cvg_comp; apply; exact: mule_continuous. Qed.
 
-Lemma is_cvgeMl f y : y \is a fin_num ->
+Lemma is_cvgeZl f y : y \is a fin_num ->
   cvg (f @ F) -> cvg ((fun n => y * f n) @ F).
-Proof. by move=> fy /(cvgeMl fy)/cvgP. Qed.
+Proof. by move=> fy /(cvgeZl fy)/cvgP. Qed.
 
-Lemma cvgeMr f x y : y \is a fin_num ->
+Lemma cvgeZr f x y : y \is a fin_num ->
   f @ F --> x -> (fun n => f n * y) @ F --> x * y.
 Proof.
-by move=> ? ?; rewrite muleC; under eq_fun do rewrite muleC; exact: cvgeMl.
+by move=> ? ?; rewrite muleC; under eq_fun do rewrite muleC; exact: cvgeZl.
 Qed.
 
-Lemma is_cvgeMr f y : y \is a fin_num ->
+Lemma is_cvgeZr f y : y \is a fin_num ->
   cvg (f @ F) -> cvg ((fun n => f n * y) @ F).
-Proof. by move=> fy /(cvgeMr fy)/cvgP. Qed.
+Proof. by move=> fy /(cvgeZr fy)/cvgP. Qed.
 
 Lemma cvg_abse0P f : abse \o f @ F --> 0 <-> f @ F --> 0.
 Proof.
@@ -869,6 +869,14 @@ Unshelve. all: end_near. Qed.
 End ecvg_realFieldType.
 #[deprecated(since="mathcomp-analysis 1.9.0", note="renamed to `sube_cvg0`")]
 Notation cvge_sub0 := sube_cvg0 (only parsing).
+#[deprecated(since="mathcomp-analysis 1.10.0", note="renamed to `cvgeZl`")]
+Notation cvgeMl := cvgeZl (only parsing).
+#[deprecated(since="mathcomp-analysis 1.10.0", note="renamed to `is_cvgeZl`")]
+Notation is_cvgeMl := is_cvgeZl (only parsing).
+#[deprecated(since="mathcomp-analysis 1.10.0", note="renamed to `cvgeZr`")]
+Notation cvgeMr := cvgeZr (only parsing).
+#[deprecated(since="mathcomp-analysis 1.10.0", note="renamed to `is_cvgeZr`")]
+Notation is_cvgeMr := is_cvgeZr (only parsing).
 
 Section max_cts.
 Context {R : realType} {T : topologicalType}.
@@ -940,11 +948,11 @@ Proof. by move=> cf cg fg; apply/cvg_lim => //; exact: cvgeD. Qed.
 
 Lemma limeMl f y : y \is a fin_num -> cvg (f @ F) ->
   lim ((fun n => y * f n) @ F) = y * lim (f @ F).
-Proof. by move=> yfn cf; apply/cvg_lim => //; exact: cvgeMl. Qed.
+Proof. by move=> yfn cf; apply/cvg_lim => //; exact: cvgeZl. Qed.
 
 Lemma limeMr f y : y \is a fin_num -> cvg (f @ F) ->
   lim ((fun n => f n * y) @ F) = lim (f @ F) * y.
-Proof. by move=> yfn cf; apply/cvg_lim => //; apply: cvgeMr. Qed.
+Proof. by move=> yfn cf; apply/cvg_lim => //; apply: cvgeZr. Qed.
 
 Lemma is_cvgeM f g :
   lim (f @ F) *? lim (g @ F) -> cvg (f @ F) -> cvg (g @ F) -> cvg (f \* g @ F).

--- a/theories/realfun.v
+++ b/theories/realfun.v
@@ -2558,7 +2558,7 @@ apply: fine_cvg; rewrite /neg_tv fineM // ?fin_numB ?xbfin //= EFinM.
 under eq_fun => i do rewrite EFinN.
 apply: (@cvg_trans _ (((TV a n f - (f n)%:E) * 2^-1%:E)%E @[n --> x^'+])).
   exact: cvg_id.
-apply: cvgeMr; first by [].
+apply: cvgeZr; first by [].
 rewrite fineD; [|by []..].
 rewrite EFinB; apply: cvgeB; [by []| |].
   apply/ fine_cvgP; split; first exists (b - x).


### PR DESCRIPTION
##### Motivation for this change

This is the uncontroversial part of issue #1463 

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
