### PR TITLE
Add Lemma `cvge_ninftyP`

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -36,6 +36,8 @@
 - in `exp.v`:
   + lemmas `lnNy`, `powR_cvg0`, `derivable_powR`, `powR_derive1`
   + Instance `is_derive1_powR`
+- in `realfun.v`:
+	+ lemma `cvge_ninftyP`
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -37,7 +37,7 @@
   + lemmas `lnNy`, `powR_cvg0`, `derivable_powR`, `powR_derive1`
   + Instance `is_derive1_powR`
 - in `realfun.v`:
-	+ lemma `cvge_ninftyP`
+  + lemma `cvge_ninftyP`
 
 ### Changed
 

--- a/theories/realfun.v
+++ b/theories/realfun.v
@@ -374,6 +374,19 @@ move /not_near_inftyP => eps_sep; exists (PosNum eps_gt0) => A /=.
 by case: (eps_sep _ (num_real A)) => x ? ?; exists x.
 Unshelve. all: by end_near. Qed.
 
+(* NB: almost the same proof as cvg_ninftyP *)
+Lemma cvge_ninftyP (f : R -> \bar R) (l : \bar R) :
+  f x @[x --> -oo] --> l <->
+    forall u : R^nat, (u n @[n --> \oo] --> -oo) -> f (u n) @[n --> \oo] --> l.
+Proof.
+rewrite cvgNy_compNP cvge_pinftyP/= (@bij_forall R^nat _ -%R)//.
+have u_opp (u : R^nat) :
+    ((- u) n @[n --> \oo] --> +oo) = (u n @[n --> \oo] --> -oo).
+  by rewrite propeqE cvgNry.
+by under eq_forall do
+  (rewrite u_opp; under (eq_cvg _ (nbhs l)) do rewrite opprK).
+Qed.
+
 End cvge_fun_dvg_seq.
 
 Section fun_cvg_realType.


### PR DESCRIPTION
##### Motivation for this change

In the pull request #1543, I added the lemma `cvge_pinfty_p`, but the negative counterpart was missing.
In this pull request, I add the lemma `cvge_ninfty_p`.

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
