### PR TITLE
revert references from Corelib to Coq, simplify build

### DIFF
--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -1,8 +1,0 @@
-pre-all::
-	if command -v coqc > /dev/null && (coqc --version | grep -q '8.20') ; then \
-	  for f in $(shell grep "From Corelib" $$(find . -name "*.v") | cut -d: -f1) ; do \
-	     sed -i.bak 's/From Corelib/From Coq/' $${f} ; \
-	     sed -i.bak 's/PosDef/PArith/' $${f} ; \
-	     $(RM) $${f}.bak ; \
-	  done ; \
-	fi

--- a/experimental_reals/Makefile.coq.local
+++ b/experimental_reals/Makefile.coq.local
@@ -1,8 +1,0 @@
-pre-all::
-	if command -v coqc > /dev/null && (coqc --version | grep -q '8.20') ; then \
-	  for f in $(shell grep "From Corelib" $$(find . -name "*.v") | cut -d: -f1) ; do \
-	     sed -i.bak 's/From Corelib/From Coq/' $${f} ; \
-	     sed -i.bak 's/PosDef/PArith/' $${f} ; \
-	     $(RM) $${f}.bak ; \
-	  done ; \
-	fi

--- a/experimental_reals/discrete.v
+++ b/experimental_reals/discrete.v
@@ -4,7 +4,7 @@
 (* Copyright (c) - 2016--2018 - Polytechnique                           *)
 
 (* -------------------------------------------------------------------- *)
-From Corelib Require Setoid.
+From Coq Require Setoid.
 From HB Require Import structures.
 From mathcomp Require Import all_ssreflect all_algebra.
 From mathcomp.classical Require Import boolp.

--- a/reals/Makefile.coq.local
+++ b/reals/Makefile.coq.local
@@ -1,8 +1,0 @@
-pre-all::
-	if command -v coqc > /dev/null && (coqc --version | grep -q '8.20') ; then \
-	  for f in $(shell grep "From Corelib" $$(find . -name "*.v") | cut -d: -f1) ; do \
-	     sed -i.bak 's/From Corelib/From Coq/' $${f} ; \
-	     sed -i.bak 's/PosDef/PArith/' $${f} ; \
-	     $(RM) $${f}.bak ; \
-	  done ; \
-	fi

--- a/reals/reals.v
+++ b/reals/reals.v
@@ -38,7 +38,7 @@
 (*                                                                            *)
 (******************************************************************************)
 
-From Corelib Require Import Setoid.
+From Coq Require Import Setoid.
 From HB Require Import structures.
 From mathcomp Require Import all_ssreflect all_algebra archimedean.
 From mathcomp Require Import boolp classical_sets set_interval.


### PR DESCRIPTION
##### Motivation for this change

fixes #1612 

##### Checklist

- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
