### PR TITLE
remove unused (and probably useless) lemmas inl_inj and inr_inj

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -58,6 +58,9 @@
   + definition `almost_everywhere_notation`
   + lemma `ess_sup_ge0`
 
+- in `mathcomp_extra.v`:
+  + lemmas `inr_inj`, `inl_inj`
+
 ### Infrastructure
 
 ### Misc

--- a/classical/mathcomp_extra.v
+++ b/classical/mathcomp_extra.v
@@ -464,9 +464,3 @@ End trunc_floor_ceil.
 
 Lemma natr_int {R : archiNumDomainType} n : n%:R \is a @Num.int R.
 Proof. by rewrite Num.Theory.intrEge0. Qed.
-
-Lemma inr_inj {A B} : injective (@inr A B).
-Proof. by move=>  ? ? []. Qed.
-
-Lemma inl_inj {A B} : injective (@inl A B).
-Proof. by move=>  ? ? []. Qed.


### PR DESCRIPTION
##### Motivation for this change

Lemmas `in{l,r}_inj` are not used, and they just do an idiomatic case analysis.
This PR removes them.

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->


Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
