### PR TITLE
Conv convention

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -4,7 +4,18 @@
 
 ### Added
 
+- in `unstable.v`:
+  + lemma `subrKC`
+
+- in `convex.v`:
+  + module `ConvexAssoc`
+  + lemmas `convR_itv`, `convR_line_path`, `le_convR`
+
 ### Changed
+
+- in `convex.v`:
+  + convex combination operator `a <| t |> b` changed from
+    `(1-t)a + tb` to `ta + (1-t)b`
 
 - in `sequences.v`:
   + lemma `subset_seqDU`
@@ -48,7 +59,13 @@
 - in `measure.v`
   + definition `ess_sup` moved to `ess_sup_inf.v`
 
+- in `convex.v`
+  + lemma `conv_gt0` to `convR_gt0`
+
 ### Generalized
+
+- in `convex.v`
+  + parameter `R` of `convType` from `realDomainType` to `numDomainType`
 
 ### Deprecated
 

--- a/classical/unstable.v
+++ b/classical/unstable.v
@@ -35,6 +35,11 @@ Unset Printing Implicit Defensive.
 Import Order.TTheory GRing.Theory Num.Theory.
 Local Open Scope ring_scope.
 
+Section ssralg.
+Lemma subrKC [V : zmodType] (x y : V) : x + (y - x) = y.
+Proof. by rewrite addrCA subrr addr0. Qed.
+End ssralg.
+
 (* NB: Coq 8.17.0 generalizes dependent_choice from Set to Type
    making the following lemma redundant *)
 Section dependent_choice_Type.

--- a/theories/convex.v
+++ b/theories/convex.v
@@ -14,15 +14,15 @@ From HB Require Import structures.
 (* completed with material from infotheo.                                     *)
 (*                                                                            *)
 (* ```                                                                        *)
-(*   isConvexSpace R T == interface for convex spaces                         *)
+(*   isConvexSpace R T == interface for convex spaces with R : numDomainType  *)
 (*       ConvexSpace R == structure of convex space                           *)
 (*         a <| t |> b == convexity operator                                  *)
 (* ```                                                                        *)
 (*                                                                            *)
-(* E : lmodType R with R : realDomainType and R : realDomainType are shown to *)
-(* be convex spaces with the following aliases:                               *)
-(*       convex_lmodType E == E : lmodType T as a convex spaces               *)
-(* convex_realDomainType R == R : realDomainType as a convex space            *)
+(* For R : numDomainType, E : lmodType R and R itself are shown to be convex  *)
+(* spaces with the following aliases:                                         *)
+(*       convex_lmodType E == E : lmodType R as a convex spaces               *)
+(*  convex_numDomainType R == R : numDomainType as a convex space             *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -42,18 +42,77 @@ Import numFieldNormedType.Exports.
 Declare Scope convex_scope.
 Local Open Scope convex_scope.
 
-HB.mixin Record isConvexSpace (R : realDomainType) T := {
+Module ConvexAssoc.
+Section def.
+Variables (R : numDomainType) (T : Type) (conv : {i01 R} -> T -> T -> T).
+Definition law :=
+  forall (p q r s : {i01 R}) (a b c : T),
+    p%:num = r%:num * s%:num -> `1- (s%:num) = `1- (p%:num) * `1- (q%:num) ->
+    conv p a (conv q b c) = conv s (conv r a b) c.
+End def.
+Section lemmas.
+Lemma pq_sr (R : comRingType) (p q r s : R) :
+  p = r * s ->
+  1 - s = (1 - p) * (1 - q) ->
+  (1 - p) * q = s * (1 - r).
+Proof.
+move=> prs spq.
+rewrite -[LHS]opprK -mulrN -[X in - X = _](addrK ((1 - p) * 1)).
+rewrite -mulrDr (addrC _ 1) -spq mulr1 prs.
+by rewrite !opprB addrC subrKA mulrDr mulr1 mulrN mulrC.
+Qed.
+Lemma pq_sr' (R : numDomainType) (p q r s : {i01 R}) :
+  p%:num = r%:num * s%:num ->
+  `1-(s%:num) = `1-(p%:num) * `1-(q%:num) ->
+  `1-(p%:num) * q%:num = s%:num * `1-(r%:num).
+Proof. exact: pq_sr. Qed.
+Lemma sE (R : ringType) (p q s : R) :
+  1 - s = (1 - p) * (1 - q) ->
+  s = 1 - (1 - p) * (1 - q).
+Proof. by move/eqP; rewrite subr_eq addrC -subr_eq => /eqP ->. Qed.
+Lemma sE' (R : numDomainType) (p q s : {i01 R}) :
+  `1-(s%:num) = `1-(p%:num) * `1-(q%:num) ->
+  s%:num = `1- (`1-(p%:num) * `1-(q%:num)).
+Proof. exact: sE. Qed.
+Lemma qE (R : comUnitRingType) (p q r s : R) :
+  (1 - p) \is a GRing.unit ->
+  p = r * s ->
+  1 - s = (1 - p) * (1 - q) ->
+  q = (s * (1 - r)) / (1 - p).
+Proof.
+move=> p1unit /pq_sr /[apply] /(congr1 ( *%R (1 - p)^-1)).
+by rewrite mulrA mulVr// mul1r mulrC.
+Qed.
+Lemma qE' (R : numDomainType) (p q r s : {i01 R}) :
+  `1-(p%:num) \is a GRing.unit ->
+  p%:num = r%:num * s%:num ->
+  `1-(s%:num) = `1-(p%:num) * `1-(q%:num) ->
+  q%:num = (s%:num * `1-(r%:num)) / `1-(p%:num).
+Proof. exact: qE. Qed.
+Lemma rE (R : unitRingType) (p r s : R) :
+  s \is a GRing.unit -> p = r * s -> r = p / s.
+Proof.
+move=> sunit /(congr1 ( *%R^~ s^-1)) ->.
+by rewrite -mulrA divrr// mulr1.
+Qed.
+Lemma rE' (R : numFieldType) (p r s : {i01 R}) :
+  s%:num \is a GRing.unit ->
+  p%:num = r%:num * s%:num ->
+  r%:num = p%:num / s%:num.
+Proof. exact: rE. Qed.
+End lemmas.
+End ConvexAssoc.
+
+HB.mixin Record isConvexSpace (R : numDomainType) T := {
   conv : {i01 R} -> T -> T -> T ;
   conv1 : forall a b, conv 1%:i01 a b = a ;
   convmm : forall (p : {i01 R}) a, conv p a a = a ;
   convC : forall (p : {i01 R}) a b, conv p a b = conv (1 - p%:inum)%:i01 b a;
-  convA : forall (p q r : {i01 R}) (a b c : T),
-    p%:inum * (`1-(q%:inum)) = (`1-(p%:inum * q%:inum)) * r%:inum ->
-    conv p a (conv q b c) = conv (p%:inum * q%:inum)%:i01 (conv r a b) c
+  convA : ConvexAssoc.law conv
 }.
 
 #[short(type=convType)]
-HB.structure Definition ConvexSpace (R : realDomainType) :=
+HB.structure Definition ConvexSpace (R : numDomainType) :=
   {T of isConvexSpace R T & Choice T}.
 
 Notation "a <| p |> b" := (conv p a b) : convex_scope.
@@ -72,10 +131,10 @@ End convex_space_lemmas.
 
 Local Open Scope convex_scope.
 
-Definition convex_lmodType {R : realDomainType} (E : lmodType R) : Type := E.
+Definition convex_lmodType {R : numDomainType} (E : lmodType R) : Type := E.
 
 Section lmodType_convex_space.
-Context {R : realDomainType} {E' : lmodType R}.
+Context {R : numDomainType} {E' : lmodType R}.
 Implicit Type p q r : {i01 R}.
 
 Let E := convex_lmodType E'.
@@ -91,70 +150,94 @@ Proof. by rewrite /avg -scalerDl/= add_onemK scale1r. Qed.
 Let avgC p x y : avg p x y = avg (1 - (p%:inum))%:i01 y x.
 Proof. by rewrite /avg onemK addrC. Qed.
 
-Let avgA p q r (a b c : E) :
-  p%:inum * (`1-(q%:inum)) = (`1-(p%:inum * q%:inum)) * r%:inum ->
-  avg p a (avg q b c) = avg (p%:inum * q%:inum)%:i01 (avg r a b) c.
+Let avgA : ConvexAssoc.law avg.
 Proof.
-move=> pq; rewrite /avg.
+move=> p q r s a b c prs spq; rewrite /avg.
 rewrite [in LHS]scalerDr [in LHS]addrA [in RHS]scalerDr; congr (_ + _ + _).
-- rewrite scalerA; congr (_ *: _) => /=.
-  by rewrite mulrDr mulr1 mulrN -pq mulrBr mulr1 opprB addrA subrK.
-- by rewrite 2!scalerA; congr (_ *: _).
-- by rewrite scalerA.
+- by rewrite scalerA mulrC prs.
+- by rewrite !scalerA; congr *:%R; rewrite (ConvexAssoc.pq_sr' prs).
+- by rewrite scalerA spq.
 Qed.
 
 HB.instance Definition _ := Choice.on E.
 
 HB.instance Definition _ :=
-  isConvexSpace.Build R E avg0 avgI avgC avgA.
+  isConvexSpace.Build R E avg1 avgI avgC avgA.
 
 End lmodType_convex_space.
 
-Definition convex_realDomainType (R : realDomainType) : Type := R^o.
+Definition convex_numDomainType (R : numDomainType) : Type := R^o.
 
-Section realDomainType_convex_space.
-Context {R : realDomainType}.
+Section numDomainType_convex_space.
+Context {R : numDomainType}.
 Implicit Types p q : {i01 R}.
 
-Let E := @convex_realDomainType R.
+Let E := @convex_numDomainType R.
+(* TODO: this E is not used. Why? *)
 
 Let avg p (a b : convex_lmodType R^o) := a <| p |> b.
 
-Let avg0 a b : avg 0%:i01 a b = a.
-Proof. by rewrite /avg conv0. Qed.
+Let avg1 a b : avg 1%:i01 a b = a.
+Proof. exact: conv1. Qed.
 
 Let avgI p x : avg p x x = x.
-Proof. by rewrite /avg convmm. Qed.
+Proof. exact: convmm. Qed.
 
 Let avgC p x y : avg p x y = avg (1 - (p%:inum))%:i01 y x.
-Proof. by rewrite /avg convC. Qed.
+Proof. exact: convC. Qed.
 
-Let avgA p q r (a b c : R) :
-  p%:inum * (`1-(q%:inum)) = (`1-(p%:inum * q%:inum)) * r%:inum ->
-  avg p a (avg q b c) = avg (p%:inum * q%:inum)%:i01 (avg r a b) c.
-Proof. by move=> h; rewrite /avg (convA _ _ r). Qed.
+Let avgA : ConvexAssoc.law avg.
+Proof. exact: convA. Qed.
 
 HB.instance Definition _ := @isConvexSpace.Build R R^o
-  _ avg0 avgI avgC avgA.
+  _ avg1 avgI avgC avgA.
 
-End realDomainType_convex_space.
+End numDomainType_convex_space.
 
-Section conv_realDomainType.
-Context {R : realDomainType}.
+Section conv_numDomainType.
+Context {R : numDomainType}.
 
-Lemma conv_gt0 (a b : R^o) (t : {i01 R}) : 0 < a -> 0 < b -> 0 < a <| t |> b.
+Lemma convR_gt0 (a b : R^o) (t : {i01 R}) : 0 < a -> 0 < b -> 0 < a <| t |> b.
 Proof.
 move=> a0 b0.
 have [->|t0] := eqVneq t 0%:i01; first by rewrite conv0.
 have [->|t1] := eqVneq t 1%:i01; first by rewrite conv1.
-rewrite addr_gt0// mulr_gt0//; last by rewrite lt_neqAle eq_sym t0/=.
-by rewrite onem_gt0// lt_neqAle t1/=.
+rewrite addr_gt0// mulr_gt0//; first by rewrite lt_neqAle eq_sym t0 ge0.
+by rewrite subr_gt0 lt_neqAle t1 le1.
 Qed.
 
-Lemma convRE (a b : R^o) (t : {i01 R}) : a <| t |> b = `1-(t%:inum) * a + t%:inum * b.
+Lemma convRE (a b : R^o) (t : {i01 R}) : a <| t |> b = t%:inum * a + `1-(t%:inum) * b.
 Proof. by []. Qed.
 
-End conv_realDomainType.
+Lemma convR_itv (a b : R^o) (t : {i01 R}) : a <= b ->  a <| t |> b \in `[a, b].
+Proof.
+move=> ab; rewrite convRE in_itv /=.
+rewrite -{1}(subrKC a b).
+rewrite mulrDr addrA -mulrDl.
+rewrite subrKC mul1r.
+rewrite lerDl mulr_ge0/=; [|by rewrite subr_ge0 le1|by rewrite subr_ge0].
+rewrite -[leRHS](convmm t b) convRE lerD//.
+by rewrite ler_wpM2l.
+Qed.
+
+Let convRCE (a b : R^o) (t : {i01 R}) : a <| t |> b = `1-(t%:inum) * b + t%:inum * a.
+Proof. by rewrite addrC convRE. Qed.
+
+Lemma convR_line_path (a b : R^o) (t : {i01 R}) : a <| t |> b = line_path b a t%:num.
+Proof. by rewrite convRCE. Qed.
+
+End conv_numDomainType.
+
+Section conv_numFieldType.
+Context {R : numFieldType}.
+
+Lemma le_convR (a b : R^o) : a < b -> increasing_fun (fun t => conv t b a).
+Proof.
+move/le_line_path => + t u => /(_ t%:num u%:num) /=.
+by rewrite !convR_line_path -num_le.
+Qed.
+
+End conv_numFieldType.
 
 Definition convex_function (R : realType) (D : set R) (f : R -> R^o) :=
   forall (t : {i01 R}), {in D &, forall (x y : R^o), (f (x <| t |> y) <= f x <| t |> f y)%R}.
@@ -183,10 +266,12 @@ Qed.
 Let convexf_ptP : a < b -> (forall x, a <= x <= b -> 0 <= L x - f x) ->
   forall t, f (a <| t |> b) <= f a <| t |> f b.
 Proof.
-move=> ab h t; set x := a <| t |> b; have /h : a <= x <= b.
-  by rewrite -(conv1 a b) -{1}(conv0 a b) /x !le_line_path//= ge0/=.
+move=> ba h t; set x := a <| t |> b; have /h : a <= x <= b.
+  by have:= convR_itv t (ltW ba); rewrite in_itv/=.
 rewrite subr_ge0 => /le_trans; apply.
-by rewrite LE// /x line_pathK ?lt_eqF// convC line_pathK ?gt_eqF.
+rewrite LE// /x convR_line_path.
+rewrite line_pathK ?gt_eqF//.
+by rewrite line_path_sym line_pathK// lt_eqF.
 Qed.
 
 Hypothesis HDf : {in `]a, b[, forall x, derivable f x 1}.

--- a/theories/convex.v
+++ b/theories/convex.v
@@ -44,7 +44,7 @@ Local Open Scope convex_scope.
 
 HB.mixin Record isConvexSpace (R : realDomainType) T := {
   conv : {i01 R} -> T -> T -> T ;
-  conv0 : forall a b, conv 0%:i01 a b = a ;
+  conv1 : forall a b, conv 1%:i01 a b = a ;
   convmm : forall (p : {i01 R}) a, conv p a a = a ;
   convC : forall (p : {i01 R}) a b, conv p a b = conv (1 - p%:inum)%:i01 b a;
   convA : forall (p q r : {i01 R}) (a b c : T),
@@ -62,10 +62,10 @@ Section convex_space_lemmas.
 Context R (A : convType R).
 Implicit Types a b : A.
 
-Lemma conv1 a b : a <| 1%:i01 |> b = b.
+Lemma conv0 a b : a <| 0%:i01 |> b = b.
 Proof.
-rewrite convC/= [X in _ <| X |> _](_ : _ = 0%:i01) ?conv0//.
-by apply/val_inj => /=; rewrite subrr.
+rewrite convC/= [X in _ <| X |> _](_ : _ = 1%:i01) ?conv1//.
+by apply/val_inj => /=; rewrite subr0.
 Qed.
 
 End convex_space_lemmas.
@@ -80,13 +80,13 @@ Implicit Type p q r : {i01 R}.
 
 Let E := convex_lmodType E'.
 
-Let avg p (a b : E) := `1-(p%:inum) *: a + p%:inum *: b.
+Let avg p (a b : E) := p%:inum *: a + `1-(p%:inum) *: b.
 
-Let avg0 a b : avg 0%:i01 a b = a.
-Proof. by rewrite /avg/= onem0 scale0r scale1r addr0. Qed.
+Let avg1 a b : avg 1%:i01 a b = a.
+Proof. by rewrite /avg/= onem1 scale0r scale1r addr0. Qed.
 
 Let avgI p x : avg p x x = x.
-Proof. by rewrite /avg -scalerDl/= addrC add_onemK scale1r. Qed.
+Proof. by rewrite /avg -scalerDl/= add_onemK scale1r. Qed.
 
 Let avgC p x y : avg p x y = avg (1 - (p%:inum))%:i01 y x.
 Proof. by rewrite /avg onemK addrC. Qed.

--- a/theories/exp.v
+++ b/theories/exp.v
@@ -786,7 +786,7 @@ Lemma concave_ln (t : {i01 R}) (a b : R^o) : 0 < a -> 0 < b ->
   (ln a : R^o) <| t |> (ln b : R^o) <= ln (a <| t |> b).
 Proof.
 move=> a0 b0; have := convex_expR t (ln a) (ln b).
-by rewrite !lnK// -(@ler_ln) ?posrE ?expR_gt0 ?conv_gt0// expRK.
+by rewrite !lnK// -(@ler_ln) ?posrE ?expR_gt0 ?convR_gt0// expRK.
 Qed.
 Local Close Scope convex_scope.
 
@@ -1026,11 +1026,13 @@ rewrite le_eqVlt => /predU1P[<-|b0] p0 q0 pq.
 have iq1 : q^-1 <= 1 by rewrite -pq ler_wpDl// invr_ge0 ltW.
 have ap0 : (0 < a `^ p)%R by rewrite powR_gt0.
 have bq0 : (0 < b `^ q)%R by rewrite powR_gt0.
-have := @concave_ln _ (Itv01 (eqbRL (invr_ge0 _) (ltW q0)) iq1) _ _ ap0 bq0.
+have := @concave_ln _ (Itv01 (eqbRL (invr_ge0 _) (ltW q0)) iq1) _ _ bq0 ap0.
+rewrite 2!(convC (Itv01 _ _)).
 have pq' : (p^-1 = 1 - q^-1)%R by rewrite -pq addrK.
+have qp' : (q^-1 = 1 - p^-1)%R by rewrite -pq addrAC subrr add0r.
 rewrite !convRE/= /onem -pq' -[_ <= ln _]ler_expR expRD (mulrC p^-1).
-rewrite ln_powR mulrAC divff ?mul1r ?gt_eqF// (mulrC q^-1).
 rewrite ln_powR mulrAC divff ?mul1r ?gt_eqF//.
+rewrite ln_powR -qp' mulrA mulVf ?gt_eqF// ?mul1r.
 rewrite lnK ?posrE// lnK ?posrE// => /le_trans; apply.
 rewrite lnK//; last by rewrite posrE addr_gt0// mulr_gt0// ?invr_gt0.
 by rewrite (mulrC _ p^-1) (mulrC _ q^-1).

--- a/theories/hoelder.v
+++ b/theories/hoelder.v
@@ -293,11 +293,11 @@ move=> p1 t x y /[!inE] /= /[!in_itv] /= /[!andbT] x_ge0 y_ge0.
 have p0 : 0 < p by rewrite (lt_le_trans _ p1).
 rewrite !convRE; set w1 := `1-(t%:inum); set w2 := t%:inum.
 have [->|w10] := eqVneq w1 0.
-  rewrite !mul0r !add0r; have [->|w20] := eqVneq w2 0.
+  rewrite !mul0r !addr0; have [->|w20] := eqVneq w2 0.
     by rewrite !mul0r powR0// gt_eqF.
   by rewrite ge1r_powRZ// /w2 lt_neqAle eq_sym w20/=; apply/andP.
 have [->|w20] := eqVneq w2 0.
-  by rewrite !mul0r !addr0 ge1r_powRZ// onem_le1// andbT lt0r w10 onem_ge0.
+  by rewrite !mul0r !add0r ge1r_powRZ// onem_le1// andbT lt0r w10 onem_ge0.
 have [->|p_neq1] := eqVneq p 1.
   by rewrite !powRr1// addr_ge0// mulr_ge0// /w2 ?onem_ge0.
 have {p_neq1} {}p1 : 1 < p by rewrite lt_neqAle eq_sym p_neq1.
@@ -307,26 +307,26 @@ have q0 : 0 < q by rewrite (lt_le_trans _ q1).
 have pq1 : p^-1 + q^-1 = 1.
   rewrite /q invf_div -{1}(div1r p) -mulrDl addrCA subrr addr0.
   by rewrite mulfV// gt_eqF.
-rewrite -(@powRr1 _ (w1 * x `^ p + w2 * y `^ p)); last first.
+rewrite -(@powRr1 _ (w2 * x `^ p + w1 * y `^ p)); last first.
   by rewrite addr_ge0// mulr_ge0// ?powR_ge0// /w2 ?onem_ge0// itv_ge0.
 have -> : 1 = p^-1 * p by rewrite mulVf ?gt_eqF.
 rewrite powRrM (ge0_ler_powR (le_trans _ (ltW p1)))//.
 - by rewrite nnegrE addr_ge0// mulr_ge0 /w2 ?onem_ge0.
 - by rewrite nnegrE powR_ge0.
-have -> : w1 * x + w2 * y = w1 `^ (p^-1) * w1 `^ (q^-1) * x +
-                            w2 `^ (p^-1) * w2 `^ (q^-1) * y.
+have -> : w2 * x + w1 * y = w2 `^ (p^-1) * w2 `^ (q^-1) * x +
+                            w1 `^ (p^-1) * w1 `^ (q^-1) * y.
   rewrite -!powRD pq1; [|exact/implyP..].
   by rewrite !powRr1// /w2 ?onem_ge0.
-apply: (@le_trans _ _ ((w1 * x `^ p + w2 * y `^ p) `^ (p^-1) *
-                       (w1 + w2) `^ q^-1)).
-  pose a1 := w1 `^ p^-1 * x. pose a2 := w2 `^ p^-1 * y.
-  pose b1 := w1 `^ q^-1. pose b2 := w2 `^ q^-1.
+apply: (@le_trans _ _ ((w2 * x `^ p + w1 * y `^ p) `^ (p^-1) *
+                       (w2 + w1) `^ q^-1)).
+  pose a1 := w2 `^ p^-1 * x. pose a2 := w1 `^ p^-1 * y.
+  pose b1 := w2 `^ q^-1. pose b2 := w1 `^ q^-1.
   have : a1 * b1 + a2 * b2 <= (a1 `^ p + a2 `^ p) `^ p^-1 *
                               (b1 `^ q + b2 `^ q) `^ q^-1.
     by apply: hoelder2 => //; rewrite ?mulr_ge0 ?powR_ge0.
   rewrite ?powRM ?powR_ge0 -?powRrM ?mulVf ?powRr1 ?gt_eqF ?onem_ge0/w2//.
   by rewrite mulrAC (mulrAC _ y) => /le_trans; exact.
-by rewrite {2}/w1 {2}/w2 subrK powR1 mulr1.
+by rewrite {2}/w1 {2}/w2 subrKC powR1 mulr1.
 Qed.
 
 End convex_powR.
@@ -343,8 +343,8 @@ Proof.
 move=> p1; rewrite (@le_trans _ _ ((2^-1 * `| f x | + 2^-1 * `| g x |) `^ p))//.
   rewrite ge0_ler_powR ?nnegrE ?(le_trans _ p1)//.
   by rewrite (le_trans (ler_normD _ _))// 2!normrM ger0_norm.
-rewrite {1 3}(_ : 2^-1 = 1 - 2^-1); last by rewrite {2}(splitr 1) div1r addrK.
-rewrite (@convex_powR _ _ p1 (Itv01 _ _))// ?inE/= ?in_itv/= ?normr_ge0 ?invr_ge0//.
+rewrite {2 4}(_ : 2^-1 = 1 - 2^-1); last by rewrite {2}(splitr 1) div1r addrK.
+apply: (convex_powR p1 (Itv01 _ _)); rewrite // ?inE/= ?in_itv/= ?normr_ge0//.
 by rewrite invf_le1 ?ler1n.
 Qed.
 


### PR DESCRIPTION
##### Motivation for this change
This PR changes the convention of the convex combination operation in `convex.v` from
`a <| t |> b = (1-t)a + tb`  to `ta + (1-t)b`, to make this compatible with infotheo (https://gihtub.com/affeldt-aist/infotheo).

There has been a discussion about these two options, and the former
has been chosen for its compatibility with the homotopical notion of paths,
while the latter is algebraically natural.

After a discussion in a analysis-dev meeting, a conclusion was made to change it to the latter.
Also, there is now a `line_path` in `set_interval.v` which essentially implements the former convention
and has an appropriately geometric name.

Therefore I think it is now reasonable to do this PR.

@CohenCyril @affeldt-aist 

##### Checklist

- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
