### PR TITLE
integral_sum and fix integrable_sum

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -88,6 +88,8 @@
 
 - in `set_interval.v`:
   + lemma `memB_itv`, `memB_itv0`
+- in `lebesgue_integrable.v`:
+  + lemma `integral_sum`
 
 ### Changed
 
@@ -236,6 +238,9 @@
 
 - in `derive.v`:
   + lemmas `is_deriveX`, `deriveX`, `exp_derive`, `exp_derive1`
+
+- in `lebesgue_integrable.v`:
+  + lemma `integrable_sum`
 
 ### Deprecated
 


### PR DESCRIPTION
##### Motivation for this change

`integral_sum` was a missing lemma that we noticed when doing the `sampling` branch,
this triggered a generation of `integrable_sum`, we do not use them in `sampling` but
look nice to have around

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [ ] added corresponding documentation in the headers~~

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
