### PR TITLE
add monotonicity for nonnegative lebesgue integrals w.r.t. measures

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -85,6 +85,7 @@
            `ge0_nondecreasing_set_cvg_integral`,
            `le0_nondecreasing_set_nonincreasing_integral`,
 	   `le0_nondecreasing_set_cvg_integral`
+  + lemmas `sintegral_le_measure`, `ge0_integral_le_measure`
 
 - in `set_interval.v`:
   + lemma `memB_itv`, `memB_itv0`

--- a/theories/lebesgue_integral_theory/lebesgue_integral_nonneg.v
+++ b/theories/lebesgue_integral_theory/lebesgue_integral_nonneg.v
@@ -1648,3 +1648,35 @@ exact: ge0_nondecreasing_set_cvg_integral.
 Qed.
 
 End le0_nondecreasing_set_cvg_integral.
+
+Section ge0_integral_le_measure.
+Local Open Scope ereal_scope.
+Local Open Scope classical_set_scope.
+Context {d} {T : measurableType d} [R : realType].
+Variables (mu1 mu2 : measure T R).
+Hypothesis (Hml : (forall S, measurable S -> mu1 S <= mu2 S)).
+
+Import HBNNSimple. 
+
+Lemma sintegral_le_measure (h : {nnsfun T >-> R}):
+  sintegral mu1 h <= sintegral mu2 h.
+Proof.
+rewrite !sintegralE /=. 
+apply/ lee_fsum => // i [a Ha <-]. 
+apply: lee_pmul => //; first by apply/ lee_tofin.
+by apply: Hml.
+Qed.
+
+Lemma ge0_integral_le_measure (f : T -> \bar R) S (Hms: measurable S): 
+  (forall x, 0 <= f x) -> 
+  measurable_fun setT f ->
+  (\int[mu1]_(x in S) f x <= \int[mu2]_(x in S) f x).
+Proof.
+move=> Hf0 Hfm.
+rewrite !ge0_integralE //=. 
+apply: ub_ereal_sup => x [h Hh] /= <-.
+apply: ereal_sup_ge; exists (sintegral mu2 h) => //=; first by eexists. 
+by apply: sintegral_le_measure.
+Qed.
+
+End ge0_integral_le_measure.


### PR DESCRIPTION
##### Motivation for this change
To add some lemmas for comparing integrals based on the measure.
<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
