### PR TITLE
add monotonicity for nonnegative lebesgue integrals w.r.t. measures [replaces PR #1669]

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -85,6 +85,7 @@
            `ge0_nondecreasing_set_cvg_integral`,
            `le0_nondecreasing_set_nonincreasing_integral`,
 	   `le0_nondecreasing_set_cvg_integral`
+  + lemmas `sintegral_le_measure`, `ge0_integral_le_measure`
 
 - in `set_interval.v`:
   + lemma `memB_itv`, `memB_itv0`

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -85,7 +85,6 @@
            `ge0_nondecreasing_set_cvg_integral`,
            `le0_nondecreasing_set_nonincreasing_integral`,
 	   `le0_nondecreasing_set_cvg_integral`
-  + lemmas `sintegral_le_measure`, `ge0_integral_le_measure`
 
 - in `set_interval.v`:
   + lemma `memB_itv`, `memB_itv0`
@@ -102,6 +101,9 @@
 
 - in `lebesgue_integral_nonneg.v`:
   + lemma `ge0_integral_ereal_sup` (was a `Let`)
+
+- in `lebesgue_integral_definition.v`:
+  + lemmas `le_measure_sintegral`, `ge0_le_measure_integral`
 
 ### Changed
 

--- a/theories/lebesgue_integral_theory/lebesgue_integral_definition.v
+++ b/theories/lebesgue_integral_theory/lebesgue_integral_definition.v
@@ -119,6 +119,22 @@ Lemma eq_sintegral d (T : sigmaRingType d) (R : numDomainType)
 Proof. by move=> /funext->. Qed.
 Arguments eq_sintegral {d T R mu} g.
 
+Section le_measure_sintegral.
+Local Open Scope ereal_scope.
+Context {d} {T : measurableType d} {R : realType}.
+Variables m1 m2 : {measure set T -> \bar R}.
+Hypothesis m12 : forall S, measurable S -> m1 S <= m2 S.
+
+Import HBNNSimple.
+
+Lemma le_measure_sintegral (f : {nnsfun T >-> R}) :
+  sintegral m1 f <= sintegral m2 f.
+Proof.
+by rewrite !sintegralE lee_fsum// => r [t _ <-]; rewrite lee_pmul ?lee_fin ?m12.
+Qed.
+
+End le_measure_sintegral.
+
 Section sintegralrM.
 Local Open Scope ereal_scope.
 Context d (T : sigmaRingType d) (R : realType).
@@ -450,6 +466,25 @@ Notation "\int [ mu ]_ ( x 'in' D ) f" :=
 Notation "\int [ mu ]_ x f" :=
   ((integral mu setT (fun x => f)%E))%E : ereal_scope.
 Arguments eq_integral {d T R mu D} g.
+
+Section ge0_le_measure_integral.
+Local Open Scope ereal_scope.
+Context {d} {T : measurableType d} {R : realType}.
+Variables m1 m2 : {measure set T -> \bar R}.
+Hypothesis m12 : forall S, measurable S -> m1 S <= m2 S.
+
+Import HBNNSimple.
+
+Lemma ge0_le_measure_integral (f : T -> \bar R) S : measurable S ->
+  (forall x, 0 <= f x) -> measurable_fun [set: T] f ->
+  \int[m1]_(x in S) f x <= \int[m2]_(x in S) f x.
+Proof.
+move=> ms f0 mf; rewrite !ge0_integralE //= ub_ereal_sup// => _ [h/= hfS] <-.
+by apply: ereal_sup_ge; exists (sintegral m2 h);
+  [exists h|exact: le_measure_sintegral].
+Qed.
+
+End ge0_le_measure_integral.
 
 Section integral_indic.
 Local Open Scope ereal_scope.

--- a/theories/lebesgue_integral_theory/lebesgue_integral_nonneg.v
+++ b/theories/lebesgue_integral_theory/lebesgue_integral_nonneg.v
@@ -1648,3 +1648,35 @@ exact: ge0_nondecreasing_set_cvg_integral.
 Qed.
 
 End le0_nondecreasing_set_cvg_integral.
+
+Section ge0_integral_le_measure.
+Local Open Scope ereal_scope.
+Local Open Scope classical_set_scope.
+Context {d} {T : measurableType d} [R : realType].
+Variables (mu1 mu2 : measure T R).
+Hypothesis (Hml : (forall S, measurable S -> mu1 S <= mu2 S)).
+
+Import HBNNSimple. 
+
+Lemma sintegral_le_measure (h : {nnsfun T >-> R}):
+  sintegral mu1 h <= sintegral mu2 h.
+Proof.
+rewrite !sintegralE /=. 
+apply/ lee_fsum => // i [a Ha <-]. 
+apply: lee_pmul => //; first by apply/ lee_tofin.
+by apply: Hml.
+Qed.
+
+Lemma ge0_integral_le_measure (f : T -> \bar R) S (Hms: measurable S): 
+  (forall x, 0 <= f x) -> 
+  measurable_fun setT f ->
+  (\int[mu1]_(x in S) f x <= \int[mu2]_(x in S) f x).
+Proof.
+move=> Hf0 Hfm.
+rewrite !ge0_integralE //=. 
+apply: ub_ereal_sup => x [h Hh] /= <-.
+apply: ereal_sup_ge; exists (sintegral mu2 h) => //=; first by eexists. 
+by apply: sintegral_le_measure.
+Qed.
+
+End ge0_integral_le_measure.

--- a/theories/lebesgue_integral_theory/lebesgue_integral_nonneg.v
+++ b/theories/lebesgue_integral_theory/lebesgue_integral_nonneg.v
@@ -1648,35 +1648,3 @@ exact: ge0_nondecreasing_set_cvg_integral.
 Qed.
 
 End le0_nondecreasing_set_cvg_integral.
-
-Section ge0_integral_le_measure.
-Local Open Scope ereal_scope.
-Local Open Scope classical_set_scope.
-Context {d} {T : measurableType d} [R : realType].
-Variables (mu1 mu2 : measure T R).
-Hypothesis (Hml : (forall S, measurable S -> mu1 S <= mu2 S)).
-
-Import HBNNSimple. 
-
-Lemma sintegral_le_measure (h : {nnsfun T >-> R}):
-  sintegral mu1 h <= sintegral mu2 h.
-Proof.
-rewrite !sintegralE /=. 
-apply/ lee_fsum => // i [a Ha <-]. 
-apply: lee_pmul => //; first by apply/ lee_tofin.
-by apply: Hml.
-Qed.
-
-Lemma ge0_integral_le_measure (f : T -> \bar R) S (Hms: measurable S): 
-  (forall x, 0 <= f x) -> 
-  measurable_fun setT f ->
-  (\int[mu1]_(x in S) f x <= \int[mu2]_(x in S) f x).
-Proof.
-move=> Hf0 Hfm.
-rewrite !ge0_integralE //=. 
-apply: ub_ereal_sup => x [h Hh] /= <-.
-apply: ereal_sup_ge; exists (sintegral mu2 h) => //=; first by eexists. 
-by apply: sintegral_le_measure.
-Qed.
-
-End ge0_integral_le_measure.


### PR DESCRIPTION
##### Motivation for this change

closed #1669

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [ ] added corresponding documentation in the headers~~

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
