### PR TITLE
is_derive1_sqrt lemma

### DIFF
--- a/theories/realfun.v
+++ b/theories/realfun.v
@@ -1763,6 +1763,42 @@ Unshelve. all: by end_near. Qed.
 
 End is_derive_inverse.
 
+Global Instance is_derive1_sqrt {K : realType} (x : K) : 0 < x -> is_derive x 1 Num.sqrt (2 * Num.sqrt x)^-1.
+Proof.
+move=> x_gt0.
+have sqrtK : {in Num.pos, cancel (@Num.sqrt K) (fun x => x ^+ 2)}.
+  by move=> a a0; rewrite sqr_sqrtr// ltW.
+rewrite -[x]sqrtK//.
+apply: (@is_derive_inverse K (fun x => x ^+ 2)).
+- near=> z.
+  rewrite sqrtr_sqr gtr0_norm//.
+  have [xz|zx|->] := ltgtP z (Num.sqrt x); last first.
+  + by rewrite sqrtr_gt0.
+  + by rewrite (lt_trans _ zx)// sqrtr_gt0.
+  + move: xz.
+    near: z.
+    exists (Num.sqrt x / 2).
+      rewrite /=.
+      rewrite mulr_gt0 //.
+      by rewrite sqrtr_gt0 x_gt0.
+    move=> r/=.
+    move=> /[swap] rx.
+    rewrite gtr0_norm ?subr_gt0//ltrBlDl -ltrBlDr.
+    apply: le_lt_trans.
+    rewrite subr_ge0 ger_pMr.
+      rewrite invf_le1.
+        by rewrite ler1n.
+      by [].
+    by rewrite sqrtr_gt0.
+- near=> z.
+  exact: exprn_continuous.
+- rewrite !sqrtK//; split.
+    exact: exprn_derivable.
+  by rewrite exp_derive expr1 scaler1.
+- by rewrite mulf_neq0 ?pnatr_eq0// gt_eqF// sqrtr_gt0 exprn_gt0// sqrtr_gt0.
+Unshelve. all: by end_near. 
+Qed.
+
 #[global] Hint Extern 0 (is_derive _ _ (fun _ => (_ _)^-1) _) =>
   (eapply is_deriveV; first by []) : typeclass_instances.
 


### PR DESCRIPTION
Co-authored with @affeldt-aist 
##### Motivation for this change

This PR introduces the lemma is_derive1_sqrt, establishing the derivability of the square root function at any strictly positive real number and provides its derivative formula.
This result is essential to prove of the derivability of the norm function and such calculations.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->
<!-- you may also explain what remains to do if the fix is incomplete -->

##### Checklist

- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
