### PR TITLE
generalize fct_sumE

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -14,6 +14,9 @@
 
 ### Generalized
 
+- in `functions.v`
+  + lemma `fct_sumE` (from a pointwise equality to a functional one)
+
 ### Deprecated
 
 ### Removed

--- a/classical/functions.v
+++ b/classical/functions.v
@@ -2648,10 +2648,9 @@ Qed.
 HB.instance Definition _ := fct_lmodMixin.
 End fct_lmod.
 
-Lemma fct_sumE (I T : Type) (M : nmodType) r (P : {pred I}) (f : I -> T -> M)
-    (x : T) :
-  (\sum_(i <- r | P i) f i) x = \sum_(i <- r | P i) f i x.
-Proof. by elim/big_rec2: _ => //= i y ? Pi <-. Qed.
+Lemma fct_sumE (I T : Type) (M : nmodType) r (P : {pred I}) (f : I -> T -> M) :
+  \sum_(i <- r | P i) f i = fun x => \sum_(i <- r | P i) f i x.
+Proof. by apply/funext => ?; elim/big_rec2: _ => //= i y ? Pi <-. Qed.
 
 Lemma mul_funC (T : Type) {R : comSemiRingType} (f : T -> R) (r : R) :
   r \*o f = r \o* f.
@@ -2669,7 +2668,7 @@ Proof. by []. Qed.
 
 Lemma sumrfctE (T : Type) (K : nmodType) (s : seq (T -> K)) :
   \sum_(f <- s) f = (fun x => \sum_(f <- s) f x).
-Proof. by apply/funext => x; elim/big_ind2 : _ => // _ a _ b <- <-. Qed.
+Proof. exact: fct_sumE. Qed.
 
 Lemma natmulfctE (U : Type) (K : nmodType) (f : U -> K) n :
   f *+ n = (fun x => f x *+ n).


### PR DESCRIPTION
##### Motivation for this change

This PR generalizes lemma `fct_sumE` from a pointwise equality
```math
(\sum_k f_k)(x) = \sum_k f_k(x)
```
to the corresponding functional equality
```math
\sum_k f_k = \lambda x. \sum_k f_k(x),
```
which should be more easily usable.

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [ ] added corresponding documentation in the headers~~

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
