### PR TITLE
fixes #1687

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,7 +5,7 @@
 - [The Coq Proof Assistant version ≥ 8.20 / Rocq Prover version ≥ 9.0](https://rocq-prover.org)
 - [Mathematical Components version ≥ 2.2.0](https://github.com/math-comp/math-comp)
 - [Finmap library version ≥ 2.1.0](https://github.com/math-comp/finmap)
-- [Hierarchy builder version ≥ 1.7.0](https://github.com/math-comp/hierarchy-builder)
+- [Hierarchy builder version ≥ 1.8.0](https://github.com/math-comp/hierarchy-builder)
 - [bigenough ≥ 1.0.0](https://github.com/math-comp/bigenough)
 
 These requirements can be installed in a custom way, or through

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ In terms of [opam](https://opam.ocaml.org/doc/Install.html), it comes as the fol
   - [MathComp field 2.1.0 or later](https://math-comp.github.io)
   - [MathComp finmap 2.0.0](https://github.com/math-comp/finmap)
   - [MathComp bigenough 1.0.0](https://github.com/math-comp/bigenough)
-  - [Hierarchy Builder 1.7.0 or later](https://github.com/math-comp/hierarchy-builder)
+  - [Hierarchy Builder 1.8.0 or later](https://github.com/math-comp/hierarchy-builder)
 - Coq/Rocq namespace: `mathcomp.analysis`
 
 ## Building and installation instructions

--- a/coq-mathcomp-classical.opam
+++ b/coq-mathcomp-classical.opam
@@ -21,7 +21,7 @@ depends: [
   "coq-mathcomp-fingroup"
   "coq-mathcomp-algebra"
   "coq-mathcomp-finmap" { (>= "2.1.0") }
-  "coq-hierarchy-builder" { (>= "1.7.0") }
+  "coq-hierarchy-builder" { (>= "1.8.0") }
 ]
 
 tags: [


### PR DESCRIPTION
##### Motivation for this change

fixes #1687 

I just observed that MathComp-Analysis 1.12.0 fails to compile with HB 1.7.0 and 1.7.1.
We could put the restriction in the opam file of `analysis` but since the restriction
is already in `classical`, I chose to modify `classical` only for the sake of simplicity, wdyt?

##### Checklist

- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
