### PR TITLE
asymmetrize the notation for convex combinations

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -4,7 +4,7 @@
 
 ### Added
 - in `convex.v`
-  + reserved notation `a <| p *> b`
+  + notation `a <| p *> b`
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -3,6 +3,15 @@
 ## [Unreleased]
 
 ### Added
+- in `convex.v`
+  + reserved notation `a <| p *> b`
+
+### Changed
+
+- in `convex.v`
+  + notation `a <| p |> b` -> `a <* p |> a`
+
+### Added
 
 - in `unstable.v`:
   + lemma `sqrtK`

--- a/theories/convex.v
+++ b/theories/convex.v
@@ -21,6 +21,7 @@ From HB Require Import structures.
 (*                              The HB class is ConvexSpace.                  *)
 (*               a <* t |> b == convexity operator with weight t on the       *)
 (*                              first summand a (and 1-t on b)                *)
+(*               a <| t *> b == similar, but weight t on b                    *)
 (* ```                                                                        *)
 (*                                                                            *)
 (* For `R : numDomainType`, `E : lmodType R` and `R` itself are shown to be   *)
@@ -115,7 +116,8 @@ HB.mixin Record isConvexSpace (R : numDomainType) T := {
 HB.structure Definition ConvexSpace (R : numDomainType) :=
   {T of isConvexSpace R T & Choice T}.
 
-Notation "a <* p |> b" := (conv p a b) : convex_scope.
+Notation "a <| p *> b" := (conv p b a) : convex_scope.
+Notation "a <* p |> b" := (b <| p *> a) : convex_scope.
 
 Section convex_space_lemmas.
 Context R (A : convType R).
@@ -222,10 +224,8 @@ Let convRCE (a b : R^o) (t : {i01 R}) :
   a <* t |> b = `1-(t%:inum) * b + t%:inum * a.
 Proof. by rewrite addrC convRE. Qed.
 
-Local Notation "x <| p *> y" := (line_path x y p%:num).
-
 Lemma convR_line_path (a b : R^o) (p : {i01 R}) :
-  a <* p |> b = b <| p *> a.
+  a <| p *> b = line_path a b p%:num.
 Proof. by rewrite convRCE. Qed.
 
 End conv_numDomainType.

--- a/theories/exp.v
+++ b/theories/exp.v
@@ -552,7 +552,7 @@ Qed.
 
 Local Open Scope convex_scope.
 Lemma convex_expR (t : {i01 R}) (a b : R^o) :
-  expR (a <| t |> b) <= (expR a : R^o) <| t |> (expR b : R^o).
+  expR (a <* t |> b) <= (expR a : R^o) <* t |> (expR b : R^o).
 Proof.
 have [ab|/ltW ba] := leP a b.
 - apply: second_derivative_convex => //.
@@ -794,7 +794,7 @@ Unshelve. all: by end_near. Qed.
 
 Local Open Scope convex_scope.
 Lemma concave_ln (t : {i01 R}) (a b : R^o) : 0 < a -> 0 < b ->
-  (ln a : R^o) <| t |> (ln b : R^o) <= ln (a <| t |> b).
+  (ln a : R^o) <* t |> (ln b : R^o) <= ln (a <* t |> b).
 Proof.
 move=> a0 b0; have := convex_expR t (ln a) (ln b).
 by rewrite !lnK// -(@ler_ln) ?posrE ?expR_gt0 ?convR_gt0// expRK.


### PR DESCRIPTION
##### Motivation for this change

The notation `a <| p |> b` for the convex combination operation has not been showing 
its asymmetric nature.  This PR changes it to `a <* p |> b`, making explicit that p is multiplied to a.

I also suggest closing issue #860 by this PR.

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
