### PR TITLE
simplify lemma lebesgue_measure_rat

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -54,6 +54,9 @@
 - in `classical_orders.v`:
   + lemma `big_lexi_order_prefix_closed_itv`
 
+- in `lebesgue_measure.v`:
+  + lemma `countable_lebesgue_measure0`
+
 ### Changed
 
 - moved from `pi_irrational.v` to `reals.v` and changed

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -654,6 +654,26 @@ rewrite measureU //; apply/seteqP; split => // x []/=.
 by rewrite in_itv/= => + xa; rewrite xa ltxx andbF.
 Qed.
 
+Lemma countable_lebesgue_measure0 (A : set R) :
+  countable A -> lebesgue_measure A = 0.
+Proof.
+move/countable_injP => [f injf].
+rewrite -(injpinv_image (fun=> 0) injf).
+rewrite [X in lebesgue_measure X](_ : _ = \bigcup_(x in f @` A)
+    [set 'pinv_(fun=> 0) A f x]); last first.
+  rewrite eqEsubset; split => [r [n]|r [n]].
+    by move=> [t At ftn] Afnr; exists n => //=; exists t.
+  by move=> [t At ftn] /= rAfn; exists n => //=; exists t.
+rewrite measure_bigcup/=; last 2 first.
+  by move=> ? _; exact: measurable_set1.
+  move=> i j [r Ar <-] [s As <-].
+  by rewrite !pinvKV ?inE// => -[x [/= <- <-]].
+apply: lim_near_cst => //.
+apply/nearW => n.
+under eq_bigr do rewrite lebesgue_measure_set1.
+by rewrite big_const_idem//= addr0.
+Qed.
+
 Let lebesgue_measure_itvoo (a b : R) :
   (lebesgue_measure (`]a, b[ : set R) = wlength idfun `]a, b[)%classic.
 Proof.
@@ -801,12 +821,8 @@ rewrite (_ : range _ = \bigcup_n [set ratr (f1 n)]); last first.
   apply/seteqP; split => [_ [q _ <-]|_ [n _ /= ->]]; last by exists (f1 n).
   exists (f q) => //=; rewrite /f1 pinvKV// ?in_setE// => x y _ _.
   by apply: bij_inj; rewrite -setTT_bijective.
-rewrite measure_bigcup//; last first.
-  apply/trivIsetP => i j _ _ ij; apply/seteqP; split => //= _ [/= ->].
-  move=> /fmorph_inj.
-  have /set_bij_inj /[apply] := bijpinv_bij (fun=> 0) bijf.
-  by rewrite in_setE => /(_ Logic.I Logic.I); exact/eqP.
-by rewrite eseries0// => n _ _; exact: lebesgue_measure_set1.
+apply/countable_lebesgue_measure0/bigcup_countable => //.
+exact: card_lexx.
 Qed.
 
 Section negligible_outer_measure.


### PR DESCRIPTION
##### Motivation for this change

The goal of this PR is to extract a lemma saying that a countable set has measure 0.

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [ ] added corresponding documentation in the headers~~

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
