### PR TITLE
Add a parser/printer for extended-real integer constants

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -25,6 +25,13 @@
 - in `uniform_structure.v`:
   + lemma `continuous_injective_withinNx`
 
+- in `constructive_ereal.v`:
+  + variants `Ione`, `Idummy_placeholder`
+  + inductives `Inatmul`, `IEFin`
+  + definition `parse`, `print`
+  + number notations in scopes `ereal_dual_scope` and `ereal_scope`
+  + notation `- 1` in scopes `ereal_dual_scope` and `ereal_scope`
+
 ### Changed
 
 - in `lebesgue_stieltjes_measure.v` specialized from `numFieldType` to `realFieldType`:

--- a/theories/ftc.v
+++ b/theories/ftc.v
@@ -99,7 +99,7 @@ apply: cvg_at_right_left_dnbhs.
     by rewrite -EFinD addrAC subrr add0r.
   have nice_E y : nicely_shrinking y (E y).
     split=> [n|]; first exact: measurable_itv.
-    exists (2, fun n => PosNum (d_gt0 n)); split => //= [n z|n].
+    exists (2%R, fun n => PosNum (d_gt0 n)); split => //= [n z|n].
       rewrite /E/= in_itv/= /ball/= ltr_distlC => /andP[yz ->].
       by rewrite (lt_le_trans _ yz)// ltrBlDr ltrDl.
     rewrite (lebesgue_measure_ball _ (ltW _))// -/mu muE -EFinM lee_fin.
@@ -153,7 +153,7 @@ apply: cvg_at_right_left_dnbhs.
     by rewrite ltrDl Nd_gt0 -EFinD opprD addrA subrr add0r.
   have nice_E y : nicely_shrinking y (E y).
     split=> [n|]; first exact: measurable_itv.
-    exists (2, (fun n => PosNum (Nd_gt0 n))); split => //=.
+    exists (2%R, (fun n => PosNum (Nd_gt0 n))); split => //=.
       by rewrite -oppr0; exact: cvgN.
     move=> n z.
       rewrite /E/= in_itv/= /ball/= => /andP[yz zy].

--- a/theories/kernel.v
+++ b/theories/kernel.v
@@ -1666,7 +1666,7 @@ HB.instance Definition _ :=
 
 Let measure_uub : measure_fam_uub kernel_snd.
 Proof.
-exists 2 => /= -[x y].
+exists 2%R => /= -[x y].
 rewrite /kernel_snd/= (@le_lt_trans _ _ 1%:E) ?lte1n//.
 exact: sprob_kernel_le1.
 Qed.


### PR DESCRIPTION
Addressing this discussion: https://github.com/math-comp/analysis/pull/1649#discussion_r2259033776
Cc @affeldt-aist 

##### Motivation for this change

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
