### PR TITLE
CI: :memo: :construction_worker: `make html` generate hierarchy graph

### DIFF
--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -38,7 +38,7 @@ jobs:
         run: opam install -y --deps-only . && opam exec -- make -j 4
 
       - name: Install Rocqnavi
-        run: opam install -y rocq-navi
+        run: opam install -y rocq-navi.0.3.0
 
       - name: Generate Documents
         run: |

--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -38,7 +38,7 @@ jobs:
         run: opam install -y --deps-only . && opam exec -- make -j 4
 
       - name: Install Rocqnavi
-        run: opam install -y rocq-navi.0.3.0
+        run: opam install -y rocq-navi.0.3.1
 
       - name: Generate Documents
         run: |

--- a/Makefile.common
+++ b/Makefile.common
@@ -140,6 +140,8 @@ html: build $(DOCDIR)/dependency_graph.dot
 	-coqlib https://rocq-prover.org/doc/V8.20.1/stdlib/ \
 	-dependency-graph $(DOCDIR)/dependency_graph.dot \
 	-hierarchy-graph "hierarchy-graph.dot" \
+        -index-blacklist etc/rocqnavi_index-blacklist \
+        -show-type-information-using-coqtop-process \
 	-external https://math-comp.github.io/htmldoc_2_3_0/ mathcomp.ssreflect \
 	-external https://math-comp.github.io/htmldoc_2_3_0/ mathcomp.algebra
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -132,33 +132,14 @@ $(DOCDIR)/dependency_graph.dot: $(DOCDIR)/dependency_graph.pre
 	tred $(DOCDIR)/dependency_graph.pre > $(DOCDIR)/dependency_graph.dot
 
 html: build $(DOCDIR)/dependency_graph.dot
+	etc/rocqnavi_generate-hierarchy-graph.sh "hierarchy-graph.dot"
 	mkdir -p $(DOCDIR)
 	find . -not -path '*/.*' -name "*.v" -or -name "*.glob" | xargs rocqnavi \
 	-title "Mathcomp Analysis" \
 	-d $(DOCDIR) -base mathcomp -Q theories analysis \
 	-coqlib https://rocq-prover.org/doc/V8.20.1/stdlib/ \
 	-dependency-graph $(DOCDIR)/dependency_graph.dot \
+	-hierarchy-graph "hierarchy-graph.dot" \
 	-external https://math-comp.github.io/htmldoc_2_3_0/ mathcomp.ssreflect \
 	-external https://math-comp.github.io/htmldoc_2_3_0/ mathcomp.algebra
 
-machtml: build $(DOCDIR)/dependency_graph.dot
-	coqdep -f _CoqProject > depend.d
-	cat -n depend.d >&2
-	gsed -i 's/Classical/mathcomp\.classical/' depend.dot
-	gsed -i 's/Theories/mathcomp\.analysis/' depend.dot
-	gsed -i 's/Reals_stdlib/mathcomp\.reals_stdlib/' depend.dot
-	gsed -i 's/Experimental_reals/mathcomp\.experimental_reals/' depend.dot
-	gsed -i 's/Reals/mathcomp\.reals/' depend.dot
-	gsed -i 's/Analysis_stdlib/mathcomp\.analysis_stdlib/' depend.dot
-	gsed -i 's/\//\./g' depend.dot
-	../coq2html/tools/generate-hierarchy-graph.sh
-	rm test_interval_inference.glob
-	find . -not -path '*/.*' -name "*.v" -or -name "*.glob" | xargs ../coq2html/rocqnavi \
-	-title "Mathcomp Analysis" \
-	-d $(DOCDIR) -base mathcomp -Q theories analysis \
-	-coqlib https://rocq-prover.org/doc/V8.20.1/stdlib/ \
-	-hierarchy-graph "hierarchy-graph.dot" \
-	-dependency-graph $(DOCDIR)/dependency_graph.dot \
-	-external https://math-comp.github.io/htmldoc_2_3_0/ mathcomp.ssreflect \
-	-external https://math-comp.github.io/htmldoc_2_3_0/ mathcomp.algebra \
-	-index-blacklist ../coq2html/tools/index-blacklist

--- a/Makefile.common
+++ b/Makefile.common
@@ -132,14 +132,14 @@ $(DOCDIR)/dependency_graph.dot: $(DOCDIR)/dependency_graph.pre
 	tred $(DOCDIR)/dependency_graph.pre > $(DOCDIR)/dependency_graph.dot
 
 html: build $(DOCDIR)/dependency_graph.dot
-	etc/rocqnavi_generate-hierarchy-graph.sh "hierarchy-graph.dot"
+	etc/rocqnavi_generate-hierarchy-graph.sh $(DOCDIR)/hierarchy_graph.dot
 	mkdir -p $(DOCDIR)
 	find . -not -path '*/.*' -name "*.v" -or -name "*.glob" | xargs rocqnavi \
 	-title "Mathcomp Analysis" \
 	-d $(DOCDIR) -base mathcomp -Q theories analysis \
 	-coqlib https://rocq-prover.org/doc/V8.20.1/stdlib/ \
 	-dependency-graph $(DOCDIR)/dependency_graph.dot \
-	-hierarchy-graph "hierarchy-graph.dot" \
+	-hierarchy-graph $(DOCDIR)/hierarchy_graph.dot \
         -index-blacklist etc/rocqnavi_index-blacklist \
         -show-type-information-using-coqtop-process \
 	-external https://math-comp.github.io/htmldoc_2_3_0/ mathcomp.ssreflect \

--- a/etc/rocqnavi_generate-hierarchy-graph.sh
+++ b/etc/rocqnavi_generate-hierarchy-graph.sh
@@ -1,0 +1,12 @@
+DST=$1
+coqtop -Q classical mathcomp.classical -Q reals mathcomp.reals -Q reals_stdlib mathcomp.reals_stdlib -Q experimental_reals mathcomp.experimental_reals -Q theories mathcomp.analysis -Q analysis_stdlib mathcomp.analysis_stdlib <<EOF
+From HB Require Import structures.
+Require Import mathcomp.classical.all_classical.
+Require Import mathcomp.analysis.all_analysis.
+Require Import mathcomp.reals_stdlib.Rstruct.
+Require Import mathcomp.reals.all_reals.
+Import mathcomp.analysis.lebesgue_integral_theory.simple_functions.HBSimple.
+Import mathcomp.analysis.lebesgue_integral_theory.simple_functions.HBNNSimple.
+Require Import mathcomp.analysis_stdlib.Rstruct_topology.
+HB.graph "$DST".
+EOF

--- a/etc/rocqnavi_index-blacklist
+++ b/etc/rocqnavi_index-blacklist
@@ -1,0 +1,4 @@
+*__to__*
+*__canonical__*
+*_unnamed_factory_*
+*_unnamed_mixin_*


### PR DESCRIPTION
##### Motivation for this change

fixes #1702

<!-- you may also explain what remains to do if the fix is incomplete -->
The `make html` comman generates rocqnavi HTML, but we have now created an HB graph to display in the index.

##### Checklist

- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
