### PR TITLE
add lemma lt0_adde

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -13,6 +13,9 @@
 - in `num_normedtype.v`:
   + lemma `nbhs_infty_gtr`
 
+- in `constructive_ereal.v`:
+  + lemma `lt0_adde`
+
 ### Changed
 
 - in `lebesgue_stieltjes_measure.v` specialized from `numFieldType` to `realFieldType`:

--- a/reals/constructive_ereal.v
+++ b/reals/constructive_ereal.v
@@ -1743,6 +1743,17 @@ Qed.
 Lemma lte_add_pinfty x y : x < +oo -> y < +oo -> x + y < +oo.
 Proof. by move: x y => -[r [r'| |]| |] // ? ?; rewrite -EFinD ltry. Qed.
 
+Lemma lt0_adde x y : x + y < 0 -> (x < 0) || (y < 0).
+Proof.
+move: x y => [x| |] [y| |]//; rewrite ?lee_fin ?lte_fin.
+- rewrite !ltNge -negb_and; apply: contra.
+  by move=> /andP[? ?]; rewrite addr_ge0.
+- by move=> _; rewrite ltNyr orbT.
+- by move=> _; rewrite ltNyr.
+- by move=> _; rewrite ltNy0.
+- by rewrite ltNy0.
+Qed.
+
 Lemma lte_sum_pinfty I (s : seq I) (P : pred I) (f : I -> \bar R) :
   (forall i, P i -> f i < +oo) -> \sum_(i <- s | P i) f i < +oo.
 Proof.


### PR DESCRIPTION
##### Motivation for this change

fixes #1714 

@hoheinzollern In fact, this lemma is coming from Natalia's development.
But since it used there, it is fair to commit it to MCA.
I renamed it to `lt0_adde` since `adde_lt0` rather suggests a goal of the shape `_ + _ < 0`, which is not the case.

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [ ] added corresponding documentation in the headers~~

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
