### PR TITLE
bigcup_ointsub disjoint

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -72,6 +72,16 @@
            `derivable_Nyo_continuousWoo`,
            `derivable_Nyo_continuousW`
 
+- in `num_normedtype.v`:
+  + lemmas `bigcup_ointsub_sup`, `bigcup_ointsub_mem`
+
+- in `normed_module.v`:
+  + lemma `bigcup_ointsubxx`, `nondisjoint_bigcup_ointsub`
+  + definition `open_disjoint_itv`
+  + lemmas `open_disjoint_itv_open`, `open_disjoint_itv_is_interval`,
+    `open_disjoint_itv_trivIset`, `open_disjoint_itv_bigcup`
+
+
 ### Changed
 
 - in `lebesgue_stieltjes_measure.v` specialized from `numFieldType` to `realFieldType`:

--- a/theories/normedtype_theory/num_normedtype.v
+++ b/theories/normedtype_theory/num_normedtype.v
@@ -21,7 +21,7 @@ From mathcomp Require Import prodnormedzmodule tvs.
 (*         ninfty_nbhs == filter for -oo (for a numFieldType)                 *)
 (*                        Notation: -oo (ring_scope)                          *)
 (*       is_interval E == the set E is an interval                            *)
-(*  bigcup_ointsub U q == union of open real interval included                *)
+(*  bigcup_ointsub U q == union of open real intervals included               *)
 (*                        in U and that contain the rational                  *)
 (*                        number q                                            *)
 (* ```                                                                        *)
@@ -807,6 +807,16 @@ Qed.
 Lemma bigcup_ointsub_sub U q : bigcup_ointsub U q `<=` U.
 Proof. by move=> y [A [[oA _ +] _ Ay]]; exact. Qed.
 
+Lemma bigcup_ointsub_sup U q A :
+  open A -> is_interval A -> A `<=` U -> A (ratr q) ->
+  A `<=` bigcup_ointsub U q.
+Proof. by move=> oA itvA AU Aq x Ax; exists A. Qed.
+
+Lemma bigcup_ointsub_mem U q r : bigcup_ointsub U q r -> ratr q \in U.
+Proof. by case => /= V [[oV Vitv VU] Vq Vr]; exact/mem_set/VU. Qed.
+
+(**md see `open_disjoint_itv` in `normed_module.v` for a cover of
+  disjoint open intervals *)
 Lemma open_bigcup_rat U : open U ->
   U = \bigcup_(q in [set q | ratr q \in U]) bigcup_ointsub U q.
 Proof.


### PR DESCRIPTION
##### Motivation for this change

This is a definition of the sequence of non-overlapping open intervals that covers an open interval of real numbers. It is used in particular to define contiguous intervals.

@IshiguroYoshihiro can you double-check?

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
