### PR TITLE
exponential_pdfNE

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+in `probability.v`:
+- lemma `exponential_pdfNE`.
+
 ### Changed
 
 ### Renamed

--- a/theories/probability.v
+++ b/theories/probability.v
@@ -1959,6 +1959,21 @@ Unshelve. end_near. Qed.
 
 End exponential_pdf.
 
+Section exponential_pdf_properties.
+Context {R : realType}.
+Notation mu := lebesgue_measure.
+Variable (mean : R).
+Hypothesis mean0 : (0 < mean)%R.
+
+Lemma exponential_pdfNE (x : R) : x < 0 ->
+  exponential_pdf mean x = 0.
+Proof.
+rewrite ltNge=> /negP x0; rewrite /exponential_pdf patchE ifF//.
+by apply/memNset; rewrite /= in_itv/= andbT.
+Qed.
+
+End exponential_pdf_properties.
+
 Definition exponential_prob {R : realType} (rate : R) :=
   fun V => (\int[lebesgue_measure]_(x in V) (exponential_pdf rate x)%:E)%E.
 


### PR DESCRIPTION
##### Motivation for this change

This PR add a lemma of property of `exponential_pdf` that `exponential_pdf m x` is 0 if x < 0.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
