### PR TITLE
lemma about !=set0

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -5,7 +5,7 @@
 ### Added
 
 - in `classical_sets.v`:
-  + lemma `not_nonemptyP`
+  + lemma `nonemptyPn`
 
 - in `cardinality.v`:
   + lemma `infinite_setD`

--- a/classical/classical_sets.v
+++ b/classical/classical_sets.v
@@ -834,7 +834,7 @@ apply: contrapT => /asboolPn/forallp_asboolPn A0; apply/A_neq0/eqP.
 by rewrite eqEsubset; split.
 Qed.
 
-Lemma not_nonemptyP A : ~ (A !=set0) <-> A = set0.
+Lemma nonemptyPn A : ~ (A !=set0) <-> A = set0.
 Proof. by split; [|move=> ->]; move/set0P/negP; [move/negbNE/eqP|]. Qed.
 
 Lemma setF_eq0 : (T -> False) -> all_equal_to (set0 : set T).
@@ -2983,10 +2983,10 @@ Lemma has_ub_set1 x : has_ubound [set x].
 Proof. by exists x; rewrite ub_set1. Qed.
 
 Lemma has_inf0 : ~ has_inf (@set0 T).
-Proof. by rewrite /has_inf not_andP; left; exact/not_nonemptyP. Qed.
+Proof. by rewrite /has_inf not_andP; left; exact/nonemptyPn. Qed.
 
 Lemma has_sup0 : ~ has_sup (@set0 T).
-Proof. by rewrite /has_sup not_andP; left; apply/not_nonemptyP. Qed.
+Proof. by rewrite /has_sup not_andP; left; exact/nonemptyPn. Qed.
 
 Lemma has_sup1 x : has_sup [set x].
 Proof. by split; [exists x | exists x => y ->]. Qed.
@@ -2995,10 +2995,10 @@ Lemma has_inf1 x : has_inf [set x].
 Proof. by split; [exists x | exists x => y ->]. Qed.
 
 Lemma subset_has_lbound A B : A `<=` B -> has_lbound B -> has_lbound A.
-Proof. by move=> AB [l Bl]; exists l => a Aa; apply/Bl/AB. Qed.
+Proof. by move=> AB [l Bl]; exists l => a Aa; exact/Bl/AB. Qed.
 
 Lemma subset_has_ubound A B : A `<=` B -> has_ubound B -> has_ubound A.
-Proof. by move=> AB [l Bl]; exists l => a Aa; apply/Bl/AB. Qed.
+Proof. by move=> AB [l Bl]; exists l => a Aa; exact/Bl/AB. Qed.
 
 Lemma downP A x : (exists2 y, A y & (x <= y)%O) <-> down A x.
 Proof. by split => [[y Ay xy]|[y [Ay xy]]]; [exists y| exists y]. Qed.
@@ -3121,7 +3121,6 @@ Fact set_display : Order.disp_t. Proof. by []. Qed.
 Module SetOrder.
 Module Internal.
 Section SetOrder.
-
 Context {T : Type}.
 Implicit Types A B : set T.
 
@@ -3150,7 +3149,7 @@ HB.instance Definition _ :=
     joinKI meetKU (@setIUl _) setIid.
 
 Lemma SetOrder_sub0set A : (set0 <= A)%O.
-Proof. by apply/asboolP; apply: sub0set. Qed.
+Proof. by apply/asboolP; exact: sub0set. Qed.
 
 Lemma SetOrder_setTsub A : (A <= setT)%O.
 Proof. exact/asboolP. Qed.

--- a/theories/normedtype_theory/pseudometric_normed_Zmodule.v
+++ b/theories/normedtype_theory/pseudometric_normed_Zmodule.v
@@ -418,7 +418,7 @@ Proof.
 rewrite ball_hausdorff => a b ab.
 have ab2 : 0 < `|a - b| / 2 by apply divr_gt0 => //; rewrite normr_gt0 subr_eq0.
 set r := PosNum ab2; exists (r, r) => /=.
-apply/eqP/not_nonemptyP => -[c] []; rewrite -ball_normE /ball_ => acr bcr.
+apply/eqP/nonemptyPn => -[c] []; rewrite -ball_normE /ball_ => acr bcr.
 have r22 : r%:num * 2 = r%:num + r%:num.
   by rewrite (_ : 2 = 1 + 1) // mulrDr mulr1.
 move: (ltrD acr bcr); rewrite -r22 (distrC b c).

--- a/theories/normedtype_theory/urysohn.v
+++ b/theories/normedtype_theory/urysohn.v
@@ -842,7 +842,7 @@ split.
 - by apply: bigcup_open => ? ?; exact: open_interior.
 - by move=> x ?; exists x => //; exact: nbhsx_ballx.
 - by move=> y ?; exists y => //; exact: nbhsx_ballx.
-- apply/not_nonemptyP => -[z [[x Ax /interior_subset Axe]]].
+- apply/nonemptyPn => -[z [[x Ax /interior_subset Axe]]].
   case=> y By /interior_subset Bye; have nAy : ~ A y.
     by move: AB0; rewrite setIC => /disjoints_subset; exact.
   have nBx : ~ B x by move/disjoints_subset: AB0; exact.

--- a/theories/normedtype_theory/vitali_lemma.v
+++ b/theories/normedtype_theory/vitali_lemma.v
@@ -474,7 +474,7 @@ have [[j Dj BiBj]|] :=
   move/forall2NP => H.
   have {}H j : (\bigcup_(i < n.+1) D i) j ->
                closure (B i) `&` closure (B j) = set0.
-   by have [//|/not_nonemptyP] := H j.
+   by have [//|/nonemptyPn] := H j.
   have H_i : (H_ n (\bigcup_(i < n) D i)) i.
     split => // s Hs si; apply: H => //.
     by move: Hs => [m /= nm Dms]; exists m => //=; rewrite (ltn_trans nm).

--- a/theories/topology_theory/connected.v
+++ b/theories/topology_theory/connected.v
@@ -1,4 +1,4 @@
-(* mathcomp analysis (c) 2017 Inria and AIST. License: CeCILL-C.              *)
+(* mathcomp analysis (c) 2025 Inria and AIST. License: CeCILL-C.              *)
 From HB Require Import structures.
 From mathcomp Require Import all_ssreflect all_algebra all_classical.
 From mathcomp Require Import topology_structure.
@@ -91,7 +91,7 @@ move=> AB CAB; have -> : C = (C `&` A) `|` (C `&` B).
   rewrite predeqE => x; split=> [Cx|[] [] //].
   by have [Ax|Bx] := CAB _ Cx; [left|right].
 move/connectedP/(_ (fun b => if b then C `&` B else C `&` A)) => /not_and3P[]//.
-  by move/existsNP => [b /not_nonemptyP]; case: b => ->;
+  by move/existsNP => [b /nonemptyPn]; case: b => ->;
     rewrite !(setU0,set0U); [left|right]; apply: subIset; right.
 case/not_andP => /eqP/set0P[x []].
 - move=> /closureI[cCx cAx] [Cx Bx]; exfalso.

--- a/theories/topology_theory/separation_axioms.v
+++ b/theories/topology_theory/separation_axioms.v
@@ -1,4 +1,4 @@
-(* mathcomp analysis (c) 2017 Inria and AIST. License: CeCILL-C.              *)
+(* mathcomp analysis (c) 2025 Inria and AIST. License: CeCILL-C.              *)
 From HB Require Import structures.
 From mathcomp Require Import all_ssreflect all_algebra finmap.
 From mathcomp Require Import boolp classical_sets functions wochoice.
@@ -128,7 +128,7 @@ have /compact_near_coveringP : compact (V `\` U).
 move=> /(_ _ (powerset_filter_from F) (fun W x => ~ W x))[].
   move=> z [Vz ?]; have zE : x <> z by move/nbhs_singleton: nbhsU => /[swap] ->.
   have : ~ cluster F z by move: zE; apply: contra_not; rewrite clFx1 => ->.
-  case/existsNP=> C /existsPNP [D] FC /existsNP [Dz] /not_nonemptyP.
+  case/existsNP=> C /existsPNP [D] FC /existsNP [Dz] /nonemptyPn.
   rewrite setIC => /disjoints_subset CD0; exists (D, [set W | F W /\ W `<=` C]).
     by split; rewrite //= nbhs_simpl; exact: powerset_filter_fromP.
   by case => t W [Dt] [FW] /subsetCP; apply; apply: CD0.

--- a/theories/topology_theory/subspace_topology.v
+++ b/theories/topology_theory/subspace_topology.v
@@ -1,4 +1,4 @@
-(* mathcomp analysis (c) 2017 Inria and AIST. License: CeCILL-C.              *)
+(* mathcomp analysis (c) 2025 Inria and AIST. License: CeCILL-C.              *)
 From HB Require Import structures.
 From mathcomp Require Import all_ssreflect all_algebra all_classical.
 From mathcomp Require Import topology_structure uniform_structure compact .
@@ -620,7 +620,7 @@ have ? : f @` closure (AfE b) `<=` closure (E b).
     have /(@preimage_subset _ _ f) A0cA0 := @subset_closure _ (E b).
     by apply: subset_trans A0cA0; apply: subIset; right.
   by move/subset_trans; apply; exact: image_preimage_subset.
-apply/not_nonemptyP => -[t [AfEb AfENb]].
+apply/nonemptyPn => -[t [AfEb AfENb]].
 have : f @` closure (AfE b) `&` f @` AfE (~~ b) = set0.
   by rewrite fAfE; exact: subsetI_eq0 cEIE.
 by rewrite predeqE => /(_ (f t)) [fcAfEb] _; apply: fcAfEb; split; exists t.

--- a/theories/topology_theory/subtype_topology.v
+++ b/theories/topology_theory/subtype_topology.v
@@ -1,3 +1,4 @@
+(* mathcomp analysis (c) 2025 Inria and AIST. License: CeCILL-C.              *)
 From HB Require Import structures.
 From mathcomp Require Import all_ssreflect all_algebra all_classical.
 From mathcomp Require Import reals topology_structure uniform_structure compact.


### PR DESCRIPTION
##### Motivation for this change

to replace the combined used of `set0P` et `negPn`

fyi @IshiguroYoshihiro 

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [ ] added corresponding documentation in the headers~~

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
