### PR TITLE
Doc: Deploy every midnights, and if executed manually, the action runs

### DIFF
--- a/.github/workflows/deploy-docs-gh-pages.yml
+++ b/.github/workflows/deploy-docs-gh-pages.yml
@@ -1,9 +1,9 @@
 name: Publish master GitHub Pages
 
 on:
-  push:
+  workflow_dispatch: ## Run the workflow manually
   schedule:
-    - cron: '0 0 * * *' # This cron expression means "at 00:00 (midnight) UTC, every day"
+    - cron: '0 18 * * *' # This cron expression means "at 03:00 (midnight) JST, every day"
 
 permissions:
   contents: write


### PR DESCRIPTION
##### Motivation for this change

<!-- if this PR fixes an issue, use "fixes #XYZ" -->
Currently, the deploy action runs on every push. We will stop this and restrict it to scheduled runs only.
Manual execution will remain possible.

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Checklist

- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
