### PR TITLE
slightly generalize fct_prodR and some other functions in functions.v

### DIFF
--- a/classical/functions.v
+++ b/classical/functions.v
@@ -2666,7 +2666,7 @@ Lemma fct_sumE (I T : Type) (M : nmodType) r (P : {pred I}) (f : I -> T -> M) :
   \sum_(i <- r | P i) f i = fun x => \sum_(i <- r | P i) f i x.
 Proof. by apply/funext => ?; elim/big_rec2: _ => //= i y ? Pi <-. Qed.
 
-Lemma fct_prodE (I : Type) (T : pointedType) (M : pzRingType) r (P : {pred I})
+Lemma fct_prodE (I T : Type) (M : pzRingType) r (P : {pred I})
     (f : I -> T -> M) :
   \prod_(i <- r | P i) f i = fun x => \prod_(i <- r | P i) f i x.
 Proof. by apply/funext => ?; elim/big_rec2: _ => //= i y ? Pi <-. Qed.
@@ -2689,7 +2689,7 @@ Lemma sumrfctE (T : Type) (K : nmodType) (s : seq (T -> K)) :
   \sum_(f <- s) f = (fun x => \sum_(f <- s) f x).
 Proof. exact: fct_sumE. Qed.
 
-Lemma prodrfctE (T : pointedType) (K : pzRingType) (s : seq (T -> K)) :
+Lemma prodrfctE (T : Type) (K : pzRingType) (s : seq (T -> K)) :
   \prod_(f <- s) f = (fun x => \prod_(f <- s) f x).
 Proof. exact: fct_prodE. Qed.
 
@@ -2700,7 +2700,7 @@ Proof. by elim: n => [//|n h]; rewrite funeqE=> ?; rewrite !mulrSr h. Qed.
 Lemma opprfctE (T : Type) (K : zmodType) (f : T -> K) : - f = (fun x => - f x).
 Proof. by []. Qed.
 
-Lemma mulrfctE (T : pointedType) (K : pzRingType) (f g : T -> K) :
+Lemma mulrfctE (T : Type) (K : pzRingType) (f g : T -> K) :
   f * g = (fun x => f x * g x).
 Proof. by []. Qed.
 
@@ -2712,7 +2712,7 @@ Proof. by []. Qed.
 Lemma cstE (T T': Type) (x : T) : cst x = fun _: T' => x.
 Proof. by []. Qed.
 
-Lemma exprfctE (T : pointedType) (K : pzRingType) (f : T -> K) n :
+Lemma exprfctE (T : Type) (K : pzRingType) (f : T -> K) n :
   f ^+ n = (fun x => f x ^+ n).
 Proof. by elim: n => [|n h]; rewrite funeqE=> ?; rewrite ?expr0 ?exprS ?h. Qed.
 


### PR DESCRIPTION
##### Motivation for this change

`functions.(fct_prodE, prodrfctE, mulrfctE, exprfctE)` has been stated with one of its type parameters in `pointedType`.
This PR simply removes this unnecessary restriction.
##### Checklist

~- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`~

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~- [ ] added corresponding documentation in the headers~

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
