### PR TITLE
EVT for rV

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -60,6 +60,11 @@
 
 - in `normed_module.v`:
   + lemma `within_continuous_compN`
+- in `normed_module.v`:
+  + lemma `compact_has_sup`
+
+- in `derive.v`:
+  + lemmas `compact_EVT_max`, `compact_EVT_min`, `EVT_max_rV`, `EVT_min_rV`
 
 ### Changed
 - in `set_interval.v`

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -1426,14 +1426,6 @@ Lemma exp_derive1 {R : numFieldType} n x :
   (@GRing.exp R ^~ n)^`() x = n%:R *: x ^+ n.-1.
 Proof. by rewrite derive1E exp_derive [LHS]mulr1. Qed.
 
-(* TODO: move *)
-Lemma compact_has_sup (R : realType) (A : set R) :
-  A !=set0 -> compact A -> has_sup A.
-Proof.
-move=> A0 cA; split => //; have [M [_ MA]] := compact_bounded cA.
-by exists (M + 1) => y /MA My; rewrite (le_trans _ (My _ _)) ?ler_norm ?ltrDl.
-Qed.
-
 Lemma compact_EVT_max (T : topologicalType) (R : realType) (f : T -> R)
     (A : set T) :
   A !=set0 -> compact A -> {within A, continuous f} ->

--- a/theories/normedtype_theory/normed_module.v
+++ b/theories/normedtype_theory/normed_module.v
@@ -2028,6 +2028,13 @@ have : n \in enum_fset D by [].
 by rewrite enum_fsetE => /mapP[/= i iD ->]; exact/le_bigmax.
 Qed.
 
+Lemma compact_has_sup (R : realType) (A : set R) :
+  A !=set0 -> compact A -> has_sup A.
+Proof.
+move=> A0 cA; split => //; have [M [_ MA]] := compact_bounded cA.
+by exists (M + 1) => y /MA My; rewrite (le_trans _ (My _ _)) ?ler_norm ?ltrDl.
+Qed.
+
 Section Closed_Ball_normedModType.
 
 Lemma closed_closed_ball_ (R : realFieldType) (V : normedModType R)


### PR DESCRIPTION
##### Motivation for this change

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

This is a generalization of the Extreme Value Theorem already present for real-valued functions to R^n.
Should we keep both statements ?

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
