### PR TITLE
fixes #1133

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -132,6 +132,10 @@
 - in `derive.v`:
   + lemmas `differentiable_rsubmx`, `differentiable_lsubmx`
 
+- in `unstable.v`:
+  + definitions `monotonic`, `strict_monotonic`
+  + lemma `strict_monotonicW`
+
 ### Changed
 
 - in `charge.v`:
@@ -238,6 +242,10 @@
     `continuous_within_itvNycP`
   + lemma `within_continuous_continuous`
   + lemmas `open_itvoo_subset`, `open_itvcc_subset`, `realFieldType`
+- in `num_normedtype.v`:
+  + weaken hypothesis in lemmas `mono_mem_image_segment`, `mono_surj_image_segment`,
+    `inc_surj_image_segment`, `dec_surj_image_segment`, `inc_surj_image_segmentP`,
+    `dec_surj_image_segmentP`, `mono_surj_image_segmentP`
 
 ### Deprecated
 
@@ -284,6 +292,9 @@
 
 - in `set_interval.v`:
   + lemma `interval_set1` (use `set_itv1` instead)
+
+- in `unstable.v`:
+  + definition `monotonous` (use `strict_monotonic` instead)
 
 ### Infrastructure
 

--- a/classical/unstable.v
+++ b/classical/unstable.v
@@ -1,4 +1,4 @@
-(* mathcomp analysis (c) 2022 Inria and AIST. License: CeCILL-C.              *)
+(* mathcomp analysis (c) 2026 Inria and AIST. License: CeCILL-C.              *)
 From mathcomp Require Import all_ssreflect finmap ssralg ssrnum ssrint.
 From mathcomp Require Import archimedean interval mathcomp_extra.
 
@@ -15,8 +15,10 @@ From mathcomp Require Import archimedean interval mathcomp_extra.
 (* ```                                                                        *)
 (*                 swap x := (x.2, x.1)                                       *)
 (*           map_pair f x := (f x.1, f x.2)                                   *)
-(*         monotonous A f := {in A &, {mono f : x y / x <= y}} \/             *)
-(*                           {in A &, {mono f : x y /~ x <= y}}               *)
+(*          monotonic A f := {in A &, {homo f : x y / x <= y}} \/             *)
+(*                           {in A &, {homo f : x y /~ x <= y}}               *)
+(*   strict_monotonic A f := {in A &, {homo f : x y / x < y}} \/              *)
+(*                           {in A &, {homo f : x y /~ x < y}}                *)
 (*             sigT_fun f := lifts a family of functions f into a function on *)
 (*                           the dependent sum                                *)
 (*                prodA x := sends (X * Y) * Z to X * (Y * Z)                 *)
@@ -164,8 +166,20 @@ rewrite -[X in (_ <= X)%N]prednK ?expn_gt0// -[X in (_ <= X)%N]addn1 leq_add2r.
 by rewrite (leq_trans h2)// -subn1 leq_subRL ?expn_gt0// add1n ltn_exp2l.
 Qed.
 
-Definition monotonous d (T : porderType d) (pT : predType T) (A : pT) (f : T -> T) :=
-  {in A &, {mono f : x y / (x <= y)%O}} \/ {in A &, {mono f : x y /~ (x <= y)%O}}.
+Definition monotonic d (T : porderType d) d' (T' : porderType d')
+    (pT : predType T) (A : pT) (f : T -> T') :=
+  {in A &, nondecreasing f} \/ {in A &, {homo f : x y /~ (x <= y)%O}}.
+
+Definition strict_monotonic d (T : porderType d) d' (T' : porderType d')
+    (pT : predType T) (A : pT) (f : T -> T') :=
+  {in A &, {homo f : x y / (x < y)%O}} \/ {in A &, {homo f : x y /~ (x < y)%O}}.
+
+Lemma strict_monotonicW d (T : orderType d) d' (T' : porderType d')
+    (pT : predType T) (A : pT) (f : T -> T') :
+  strict_monotonic A f -> monotonic A f.
+Proof.
+by move=> [/le_mono_in/monoW_in|/le_nmono_in/monoW_in]; [left|right].
+Qed.
 
 Lemma mono_leq_infl f : {mono f : m n / (m <= n)%N} -> forall n, (n <= f n)%N.
 Proof.

--- a/theories/normedtype_theory/num_normedtype.v
+++ b/theories/normedtype_theory/num_normedtype.v
@@ -80,7 +80,7 @@ Section image_interval.
 Variable R : realDomainType.
 Implicit Types (a b : R) (f : R -> R).
 
-Lemma mono_mem_image_segment a b f : monotonous `[a, b] f ->
+Lemma mono_mem_image_segment a b f : monotonic `[a, b] f ->
   {homo f : x / x \in `[a, b] >-> x \in f @`[a, b]}.
 Proof.
 move=> [fle|fge] x xab; have leab : a <= b by rewrite (itvP xab).
@@ -90,22 +90,22 @@ have: f a >= f b by rewrite fge ?bound_itvE.
 by case: leP => // fafb _; rewrite in_itv/= !fge ?(itvP xab).
 Qed.
 
-Lemma mono_mem_image_itvoo a b f : monotonous `[a, b] f ->
+Lemma mono_mem_image_itvoo a b f : strict_monotonic `[a, b] f ->
   {homo f : x / x \in `]a, b[ >-> x \in f @`]a, b[}.
 Proof.
-move=> []/[dup] => [/leW_mono_in|/leW_nmono_in] flt fle x xab;
+move=> []/[dup] => [/le_mono_in|/le_nmono_in] flt fle x xab;
     have ltab : a < b by rewrite (itvP xab).
-  have: f a <= f b by rewrite ?fle ?bound_itvE ?ltW.
-  by case: leP => // fafb _; rewrite in_itv/= ?flt ?in_itv/= ?(itvP xab, lexx).
-have: f a >= f b by rewrite fle ?bound_itvE ?ltW.
-by case: leP => // fafb _; rewrite in_itv/= ?flt ?in_itv/= ?(itvP xab, lexx).
+  have: f a <= f b by rewrite flt ?bound_itvE ltW.
+  by case: leP => // fafb _; rewrite in_itv/= !fle ?in_itv/= ?(itvP xab, lexx).
+have: f a >= f b by rewrite flt ?bound_itvE ?ltW.
+by case: leP => // fafb _; rewrite in_itv/= !fle ?in_itv/= ?(itvP xab, lexx).
 Qed.
 
 Lemma mono_surj_image_segment a b f : a <= b ->
-    monotonous `[a, b] f -> set_surj `[a, b] (f @`[a, b]) f ->
+    monotonic `[a, b] f -> set_surj `[a, b] (f @`[a, b]) f ->
   (f @` `[a, b] = f @`[a, b])%classic.
 Proof.
-move=> leab fmono; apply: surj_image_eq => _ /= [x xab <-];
+move=> leab fmono; apply: surj_image_eq => _ /= [x xab <-].
 exact: mono_mem_image_segment.
 Qed.
 
@@ -116,7 +116,7 @@ Lemma dec_segment_image a b f : f b <= f a -> f @`[a, b] = `[f b, f a].
 Proof. by case: ltrP. Qed.
 
 Lemma inc_surj_image_segment a b f : a <= b ->
-    {in `[a, b] &, {mono f : x y / x <= y}} ->
+    {in `[a, b] &, {homo f : x y / x <= y}} ->
     set_surj `[a, b] `[f a, f b] f ->
   f @` `[a, b] = `[f a, f b]%classic.
 Proof.
@@ -125,7 +125,7 @@ by rewrite mono_surj_image_segment ?inc_segment_image//; left.
 Qed.
 
 Lemma dec_surj_image_segment a b f : a <= b ->
-    {in `[a, b] &, {mono f : x y /~ x <= y}} ->
+    {in `[a, b] &, {homo f : x y /~ x <= y}} ->
     set_surj `[a, b] `[f b, f a] f ->
   f @` `[a, b] = `[f b, f a]%classic.
 Proof.
@@ -134,7 +134,7 @@ by rewrite mono_surj_image_segment ?dec_segment_image//; right.
 Qed.
 
 Lemma inc_surj_image_segmentP a b f : a <= b ->
-    {in `[a, b] &, {mono f : x y / x <= y}} ->
+    {in `[a, b] &, {homo f : x y / x <= y}} ->
     set_surj `[a, b] `[f a, f b] f ->
   forall y, reflect (exists2 x, x \in `[a, b] & f x = y) (y \in `[f a, f b]).
 Proof.
@@ -143,7 +143,7 @@ by apply/(equivP idP); symmetry.
 Qed.
 
 Lemma dec_surj_image_segmentP a b f : a <= b ->
-    {in `[a, b] &, {mono f : x y /~ x <= y}} ->
+    {in `[a, b] &, {homo f : x y /~ x <= y}} ->
     set_surj `[a, b] `[f b, f a] f ->
   forall y, reflect (exists2 x, x \in `[a, b] & f x = y) (y \in `[f b, f a]).
 Proof.
@@ -152,7 +152,7 @@ by apply/(equivP idP); symmetry.
 Qed.
 
 Lemma mono_surj_image_segmentP a b f : a <= b ->
-    monotonous `[a, b] f -> set_surj `[a, b] (f @`[a, b]) f ->
+    monotonic `[a, b] f -> set_surj `[a, b] (f @`[a, b]) f ->
   forall y, reflect (exists2 x, x \in `[a, b] & f x = y) (y \in f @`[a, b]).
 Proof.
 move=> /mono_surj_image_segment/[apply]/[apply]/predeqP + y => /(_ y) fab.


### PR DESCRIPTION
##### Motivation for this change

fixes #1133

the existing (ill-named) `monotonous` corresponds to
a strict version of monotonicity (using `mono`/ `<=`)

following the conversation in issue
https://github.com/math-comp/analysis/issues/1133
this PR:

- introduces the new definition `monotonic`
  (non strict, using `homo` instead of `mono`)
- renames `monotonous` into `strict_monotonic`
  and redefines it using `homo`/`<` instead of `mono`/`<=`
- adjust lemmas in `num_normedtype.v` and `realfun.v`
- in particular, in `num_normedtype.v`:
  + weaken hypo in lemma `mono_mem_image_segment`
  + weaken hypo in lemma `mono_surj_image_segment`
  + weaken hypo in lemma `inc_surj_image_segment`
  + weaken hypo in lemma `dec_surj_image_segment`
  + weaken hypo in lemma `inc_surj_image_segmentP`
  + weaken hypo in lemma `dec_surj_image_segmentP`
  + weaken hypo in lemma `mono_surj_image_segmentP`
##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
