### PR TITLE
Allow rocq 9.1

### DIFF
--- a/coq-mathcomp-classical.opam
+++ b/coq-mathcomp-classical.opam
@@ -16,7 +16,7 @@ build: [make "-C" "classical" "-j%{jobs}%"]
 install: [make "-C" "classical" "install"]
 depends: [
   ("coq" {>= "8.20" & < "8.21~"}
-  | "coq-core" { (>= "9.0" & < "9.1~") | (= "dev") })
+  | "coq-core" { (>= "9.0" & < "9.2~") | (= "dev") })
   "coq-mathcomp-ssreflect" { (>= "2.4.0" & < "2.6~") | (= "dev") }
   "coq-mathcomp-fingroup"
   "coq-mathcomp-algebra"


### PR DESCRIPTION
##### Motivation for this change

The opam specification for mathcomp-classic does not allow rocq 9.1, but there seems to be no specific incompatibility.

##### Checklist

- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
