### PR TITLE
Adapt to https://github.com/math-comp/math-comp/pull/1545

### DIFF
--- a/analysis_stdlib/Rstruct_topology.v
+++ b/analysis_stdlib/Rstruct_topology.v
@@ -17,6 +17,7 @@ From mathcomp Require normedtype sequences.
 (* The following line is for RlnE. *)
 From mathcomp Require exp.
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/analysis_stdlib/showcase/uniform_bigO.v
+++ b/analysis_stdlib/showcase/uniform_bigO.v
@@ -5,6 +5,7 @@ From mathcomp Require Import ssrnat eqtype choice fintype bigop order ssralg ssr
 From mathcomp Require Import boolp reals Rstruct_topology ereal classical_sets.
 From mathcomp Require Import interval_inference topology normedtype landau.
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/classical/cardinality.v
+++ b/classical/cardinality.v
@@ -38,6 +38,7 @@ From mathcomp Require Import mathcomp_extra boolp classical_sets functions.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/classical/classical_orders.v
+++ b/classical/classical_orders.v
@@ -18,6 +18,7 @@ From mathcomp Require Import functions set_interval.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/classical/classical_sets.v
+++ b/classical/classical_sets.v
@@ -213,6 +213,7 @@ From mathcomp Require Import mathcomp_extra boolp wochoice.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/classical/contra.v
+++ b/classical/contra.v
@@ -2,6 +2,7 @@
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq.
 From mathcomp Require Import boolp.
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/classical/filter.v
+++ b/classical/filter.v
@@ -169,6 +169,7 @@ From mathcomp Require Import cardinality mathcomp_extra fsbigop set_interval.
 (*   variable                                                                 *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/classical/fsbigop.v
+++ b/classical/fsbigop.v
@@ -25,6 +25,7 @@ Reserved Notation "\sum_ ( i '\in' A ) F"
   (F at level 41, A at level 60,
     format "'[' \sum_ ( i  '\in'  A ) '/  '  F ']'").
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/classical/functions.v
+++ b/classical/functions.v
@@ -130,6 +130,7 @@ Add Search Blacklist "_mixin_".
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/classical/internal_Eqdep_dec.v
+++ b/classical/internal_Eqdep_dec.v
@@ -75,6 +75,7 @@ exact (fun Streicher_K p P x =>
 Qed.
 End Equivalences.
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 
 Section EqdepDec.

--- a/classical/mathcomp_extra.v
+++ b/classical/mathcomp_extra.v
@@ -15,6 +15,7 @@ From mathcomp Require Import all_ssreflect_compat finmap ssralg ssrnum ssrint.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/classical/set_interval.v
+++ b/classical/set_interval.v
@@ -38,6 +38,7 @@ From mathcomp Require Import functions.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/classical/unstable.v
+++ b/classical/unstable.v
@@ -30,6 +30,7 @@ From mathcomp Require Import archimedean interval.
 Attributes warn(note="The unstable.v file should only be used inside analysis.",
   cats="internal-analysis").
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/classical/wochoice.v
+++ b/classical/wochoice.v
@@ -33,6 +33,7 @@ From mathcomp Require Import boolp contra.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/experimental_reals/dedekind.v
+++ b/experimental_reals/dedekind.v
@@ -14,7 +14,7 @@ From Coq Require Import Setoid.
 Set   Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
-Unset SsrOldRewriteGoalsOrder.
+Unset SsrOldRewriteGoalsOrder.  (* remove this line when requiring MathComp >= 2.6 *)
 
 Import GRing.Theory Num.Theory.
 

--- a/experimental_reals/discrete.v
+++ b/experimental_reals/discrete.v
@@ -11,6 +11,7 @@ From mathcomp.classical Require Import boolp.
 From mathcomp Require Import xfinmap reals.
 
 (* -------------------------------------------------------------------- *)
+Set   SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set   Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/experimental_reals/distr.v
+++ b/experimental_reals/distr.v
@@ -12,7 +12,7 @@ From mathcomp Require Import realseq realsum.
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
-Unset SsrOldRewriteGoalsOrder.
+Unset SsrOldRewriteGoalsOrder.  (* remove this line when requiring MathComp >= 2.6 *)
 
 Import Order.TTheory GRing.Theory Num.Theory.
 

--- a/experimental_reals/realseq.v
+++ b/experimental_reals/realseq.v
@@ -13,7 +13,7 @@ From mathcomp Require Import xfinmap constructive_ereal reals discrete.
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
-Unset SsrOldRewriteGoalsOrder.
+Unset SsrOldRewriteGoalsOrder.  (* remove this line when requiring MathComp >= 2.6 *)
 
 Import Order.TTheory GRing.Theory Num.Theory BigEnough.
 

--- a/experimental_reals/realsum.v
+++ b/experimental_reals/realsum.v
@@ -11,7 +11,7 @@ From mathcomp.classical Require Import classical_sets functions.
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
-Unset SsrOldRewriteGoalsOrder.
+Unset SsrOldRewriteGoalsOrder.  (* remove this line when requiring MathComp >= 2.6 *)
 
 Import Order.TTheory GRing.Theory Num.Theory.
 

--- a/experimental_reals/xfinmap.v
+++ b/experimental_reals/xfinmap.v
@@ -7,6 +7,7 @@
 From mathcomp Require Import all_ssreflect_compat all_algebra.
 From mathcomp Require Export finmap.
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/reals/constructive_ereal.v
+++ b/reals/constructive_ereal.v
@@ -118,6 +118,7 @@ From mathcomp Require Import mathcomp_extra interval_inference.
 (* ```                                                                        *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/reals/prodnormedzmodule.v
+++ b/reals/prodnormedzmodule.v
@@ -11,6 +11,7 @@ From mathcomp Require Import interval_inference.
 (* The contents is likely to be moved elsewhere.                              *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/reals/real_interval.v
+++ b/reals/real_interval.v
@@ -9,6 +9,7 @@ From mathcomp Require Import reals interval_inference constructive_ereal.
 (* # Sets and intervals on $\overline{\mathbb{R}}$                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/reals/reals.v
+++ b/reals/reals.v
@@ -52,6 +52,7 @@ From mathcomp Require Import mathcomp_extra boolp classical_sets set_interval.
 Declare Scope real_scope.
 
 (* -------------------------------------------------------------------- *)
+Set   SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set   Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/reals/signed.v
+++ b/reals/signed.v
@@ -179,6 +179,7 @@ Reserved Notation "x %:nng" (format "x %:nng").
 
 Reserved Notation "!! x" (at level 100, only parsing).
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/reals_stdlib/Rstruct.v
+++ b/reals_stdlib/Rstruct.v
@@ -39,6 +39,7 @@ the economic rights, and the successive licensors have only limited
 liability. See the COPYING file for more details.
 *)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/borel_hierarchy.v
+++ b/theories/borel_hierarchy.v
@@ -14,6 +14,7 @@ From mathcomp Require Import measure lebesgue_measure.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/cantor.v
+++ b/theories/cantor.v
@@ -34,6 +34,7 @@ From mathcomp Require Import topology function_spaces.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/charge.v
+++ b/theories/charge.v
@@ -91,6 +91,7 @@ Reserved Notation "nu .-positive_set" (at level 2, format "nu .-positive_set").
 
 Declare Scope charge_scope.
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/convex.v
+++ b/theories/convex.v
@@ -33,6 +33,7 @@ From mathcomp Require Import reals topology.
 
 Reserved Notation "x <| p |> y" (format "x  <| p |>  y", at level 49).
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -43,6 +43,7 @@ From mathcomp Require Import prodnormedzmodule tvs normedtype landau.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/ereal.v
+++ b/theories/ereal.v
@@ -50,6 +50,7 @@ From mathcomp Require Export interval_inference topology constructive_ereal.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/ess_sup_inf.v
+++ b/theories/ess_sup_inf.v
@@ -15,6 +15,7 @@ From mathcomp Require Import measure lebesgue_measure.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/esum.v
+++ b/theories/esum.v
@@ -25,6 +25,7 @@ From mathcomp Require Import topology sequences normedtype numfun.
 Reserved Notation "\esum_ ( i 'in' P ) F"
   (at level 41, F at level 41, format "\esum_ ( i  'in'  P )  F").
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/exp.v
+++ b/theories/exp.v
@@ -34,6 +34,7 @@ From mathcomp Require Import sequences derive realfun convex.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/ftc.v
+++ b/theories/ftc.v
@@ -52,6 +52,7 @@ From mathcomp Require Import derive charge.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/function_spaces.v
+++ b/theories/function_spaces.v
@@ -108,6 +108,7 @@ Reserved Notation "{ 'compact-open' , U -> V }"
 Reserved Notation "{ 'compact-open' , F --> f }"
   (at level 0, F at level 69, format "{ 'compact-open' ,  F  -->  f }").
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/gauss_integral.v
+++ b/theories/gauss_integral.v
@@ -12,6 +12,7 @@ From mathcomp Require Import exp trigo lebesgue_integral derive charge ftc.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/hoelder.v
+++ b/theories/hoelder.v
@@ -43,6 +43,7 @@ From mathcomp Require Import lebesgue_integral numfun exp convex.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/homotopy_theory/continuous_path.v
+++ b/theories/homotopy_theory/continuous_path.v
@@ -23,6 +23,7 @@ From mathcomp Require Import function_spaces wedge_sigT.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/homotopy_theory/wedge_sigT.v
+++ b/theories/homotopy_theory/wedge_sigT.v
@@ -46,6 +46,7 @@ From mathcomp Require Import cardinality fsbigop reals topology function_spaces.
 (* - bipointed                                                                *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/kernel.v
+++ b/theories/kernel.v
@@ -75,6 +75,7 @@ From mathcomp Require Import numfun lebesgue_measure lebesgue_integral.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/landau.v
+++ b/theories/landau.v
@@ -97,6 +97,7 @@ From mathcomp Require Import prodnormedzmodule.
 (* transitivity, product of functions, etc.                                   *)
 (*                                                                            *)
 (******************************************************************************)
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/lebesgue_integral_theory/giry.v
+++ b/theories/lebesgue_integral_theory/giry.v
@@ -31,6 +31,7 @@ From mathcomp Require Import lebesgue_measure lebesgue_integral.
 
 Reserved Notation "m >>= f" (at level 49).
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/lebesgue_integral_theory/lebesgue_Rintegral.v
+++ b/theories/lebesgue_integral_theory/lebesgue_Rintegral.v
@@ -27,6 +27,7 @@ From mathcomp Require Import lebesgue_integral_dominated_convergence.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/lebesgue_integral_theory/lebesgue_integrable.v
+++ b/theories/lebesgue_integral_theory/lebesgue_integrable.v
@@ -33,6 +33,7 @@ From mathcomp Require Import lebesgue_integral_nonneg.
 
 Reserved Notation "mu .-integrable" (at level 2, format "mu .-integrable").
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/lebesgue_integral_theory/lebesgue_integral_definition.v
+++ b/theories/lebesgue_integral_theory/lebesgue_integral_definition.v
@@ -36,6 +36,7 @@ From mathcomp Require Import realfun function_spaces simple_functions.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/lebesgue_integral_theory/lebesgue_integral_differentiation.v
+++ b/theories/lebesgue_integral_theory/lebesgue_integral_differentiation.v
@@ -46,6 +46,7 @@ From mathcomp Require Import lebesgue_Rintegral.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/lebesgue_integral_theory/lebesgue_integral_dominated_convergence.v
+++ b/theories/lebesgue_integral_theory/lebesgue_integral_dominated_convergence.v
@@ -24,6 +24,7 @@ From mathcomp Require Import lebesgue_integrable.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/lebesgue_integral_theory/lebesgue_integral_fubini.v
+++ b/theories/lebesgue_integral_theory/lebesgue_integral_fubini.v
@@ -37,6 +37,7 @@ From mathcomp Require Import lebesgue_integral_nonneg lebesgue_integrable.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/lebesgue_integral_theory/lebesgue_integral_monotone_convergence.v
+++ b/theories/lebesgue_integral_theory/lebesgue_integral_monotone_convergence.v
@@ -19,6 +19,7 @@ From mathcomp Require Import lebesgue_integral_definition.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/lebesgue_integral_theory/lebesgue_integral_nonneg.v
+++ b/theories/lebesgue_integral_theory/lebesgue_integral_nonneg.v
@@ -31,6 +31,7 @@ From mathcomp Require Import lebesgue_integral_monotone_convergence.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/lebesgue_integral_theory/lebesgue_integral_under.v
+++ b/theories/lebesgue_integral_theory/lebesgue_integral_under.v
@@ -24,6 +24,7 @@ From mathcomp Require Import lebesgue_integral_dominated_convergence.
 
 Reserved Notation "'d1 f" (at level 10, f at next level, format "''d1'  f").
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/lebesgue_integral_theory/measurable_fun_approximation.v
+++ b/theories/lebesgue_integral_theory/measurable_fun_approximation.v
@@ -32,6 +32,7 @@ From mathcomp Require Import simple_functions.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/lebesgue_integral_theory/simple_functions.v
+++ b/theories/lebesgue_integral_theory/simple_functions.v
@@ -60,6 +60,7 @@ Reserved Notation "{ 'sfun' aT >-> T }"
 Reserved Notation "[ 'sfun' 'of' f ]"
   (at level 0, format "[ 'sfun'  'of'  f ]").
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -39,6 +39,7 @@ From mathcomp Require Export measurable_realfun lebesgue_stieltjes_measure.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/lebesgue_stieltjes_measure.v
+++ b/theories/lebesgue_stieltjes_measure.v
@@ -42,6 +42,7 @@ From mathcomp Require Import realfun.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/measurable_realfun.v
+++ b/theories/measurable_realfun.v
@@ -50,6 +50,7 @@ From mathcomp Require Export lebesgue_stieltjes_measure.
 (* ```                                                                        *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/measure_theory/counting_measure.v
+++ b/theories/measure_theory/counting_measure.v
@@ -13,6 +13,7 @@ From mathcomp Require Import sequences measurable_structure measure_function.
 (* ```                                                                        *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/measure_theory/dirac_measure.v
+++ b/theories/measure_theory/dirac_measure.v
@@ -18,6 +18,7 @@ From mathcomp Require Import measurable_structure measure_function.
 
 Reserved Notation "'\d_' a" (at level 8, a at level 2, format "'\d_' a").
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/measure_theory/measurable_function.v
+++ b/theories/measure_theory/measurable_function.v
@@ -24,6 +24,7 @@ Reserved Notation "{ 'mfun' aT >-> T }"
 Reserved Notation "[ 'mfun' 'of' f ]"
   (at level 0, format "[ 'mfun'  'of'  f ]").
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/measure_theory/measurable_structure.v
+++ b/theories/measure_theory/measurable_structure.v
@@ -118,6 +118,7 @@ From mathcomp Require Import ereal topology normedtype sequences.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/measure_theory/measure_extension.v
+++ b/theories/measure_theory/measure_extension.v
@@ -78,6 +78,7 @@ Reserved Notation "mu .-caratheodory" (format "mu .-caratheodory").
 Reserved Notation "mu .-cara" (format "mu .-cara").
 Reserved Notation "mu .-cara.-measurable" (format "mu .-cara.-measurable").
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/measure_theory/measure_function.v
+++ b/theories/measure_theory/measure_function.v
@@ -127,6 +127,7 @@ Reserved Notation "{ 'sigma_finite_measure' 'set' T '->' '\bar' R }"
 Reserved Notation "{ 'finite_measure' 'set' T '->' '\bar' R }"
   (T at level 37, format "{ 'finite_measure'  'set'  T  '->'  '\bar'  R }").
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/measure_theory/measure_negligible.v
+++ b/theories/measure_theory/measure_negligible.v
@@ -50,6 +50,7 @@ Reserved Notation "f = g %[ae mu ]"
 Reserved Notation "m .-null_set" (at level 2, format "m .-null_set").
 Reserved Notation "m1 `<< m2" (at level 51).
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/measure_theory/probability_measure.v
+++ b/theories/measure_theory/probability_measure.v
@@ -38,6 +38,7 @@ From mathcomp Require Import measurable_structure measure_function dirac_measure
 (* ```                                                                        *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/normedtype_theory/complete_normed_module.v
+++ b/theories/normedtype_theory/complete_normed_module.v
@@ -15,6 +15,7 @@ From mathcomp Require Import normed_module.
 (* ```                                                                        *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/normedtype_theory/ereal_normedtype.v
+++ b/theories/normedtype_theory/ereal_normedtype.v
@@ -29,6 +29,7 @@ From mathcomp Require Import real_interval num_normedtype.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/normedtype_theory/matrix_normedtype.v
+++ b/theories/normedtype_theory/matrix_normedtype.v
@@ -18,6 +18,7 @@ From mathcomp Require Import pseudometric_normed_Zmodule normed_module.
 (* ```                                                                        *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/normedtype_theory/normed_module.v
+++ b/theories/normedtype_theory/normed_module.v
@@ -64,6 +64,7 @@ Reserved Notation "k .-lipschitz f" (at level 2, format "k .-lipschitz  f").
 Reserved Notation "[ 'lipschitz' E | x 'in' A ]"
   (at level 0, x name, format "[ 'lipschitz'  E  |  x  'in'  A ]").
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/normedtype_theory/num_normedtype.v
+++ b/theories/normedtype_theory/num_normedtype.v
@@ -46,6 +46,7 @@ Reserved Notation "f @`] a , b [" (format "f  @`] a ,  b [").
 Reserved Notation "+oo_ R" (at level 3, left associativity, format "+oo_ R").
 Reserved Notation "-oo_ R" (at level 3, left associativity, format "-oo_ R").
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/normedtype_theory/pseudometric_normed_Zmodule.v
+++ b/theories/normedtype_theory/pseudometric_normed_Zmodule.v
@@ -64,6 +64,7 @@ From mathcomp Require Import num_normedtype.
 Reserved Notation "[ 'bounded' E | x 'in' A ]"
   (at level 0, x name, format "[ 'bounded'  E  |  x  'in'  A ]").
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/normedtype_theory/urysohn.v
+++ b/theories/normedtype_theory/urysohn.v
@@ -32,6 +32,7 @@ From mathcomp Require Import pseudometric_normed_Zmodule normed_module.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/normedtype_theory/vitali_lemma.v
+++ b/theories/normedtype_theory/vitali_lemma.v
@@ -34,6 +34,7 @@ From mathcomp Require Import pseudometric_normed_Zmodule normed_module.
 
 Reserved Notation "k *` A" (at level 40, left associativity, format "k  *`  A").
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/numfun.v
+++ b/theories/numfun.v
@@ -43,6 +43,7 @@ Reserved Notation "{ 'nnfun' aT >-> T }"
 Reserved Notation "[ 'nnfun' 'of' f ]"
   (at level 0, format "[ 'nnfun'  'of'  f ]").
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/pi_irrational.v
+++ b/theories/pi_irrational.v
@@ -14,6 +14,7 @@ From mathcomp Require Import realfun lebesgue_integral derive charge ftc trigo.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/probability_theory/bernoulli_distribution.v
+++ b/theories/probability_theory/bernoulli_distribution.v
@@ -21,6 +21,7 @@ From mathcomp Require Import kernel.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/probability_theory/beta_distribution.v
+++ b/theories/probability_theory/beta_distribution.v
@@ -29,6 +29,7 @@ From mathcomp Require Import bernoulli_distribution.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/probability_theory/binomial_distribution.v
+++ b/theories/probability_theory/binomial_distribution.v
@@ -24,6 +24,7 @@ From mathcomp Require Import bernoulli_distribution.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/probability_theory/exponential_distribution.v
+++ b/theories/probability_theory/exponential_distribution.v
@@ -17,6 +17,7 @@ From mathcomp Require Import lebesgue_integral ftc.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/probability_theory/normal_distribution.v
+++ b/theories/probability_theory/normal_distribution.v
@@ -21,6 +21,7 @@ From mathcomp Require Import lebesgue_integral ftc gauss_integral.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/probability_theory/poisson_distribution.v
+++ b/theories/probability_theory/poisson_distribution.v
@@ -16,6 +16,7 @@ From mathcomp Require Import lebesgue_measure lebesgue_integral.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/probability_theory/random_variable.v
+++ b/theories/probability_theory/random_variable.v
@@ -59,6 +59,7 @@ Reserved Notation "'M_ P X" (at level 5, P, X at level 4, format "''M_' P  X").
 Reserved Notation "{ 'dmfun' aT >-> T }" (format "{ 'dmfun'  aT  >->  T }").
 Reserved Notation "'{' 'dRV' P >-> R '}'" (format "'{' 'dRV'  P  '>->'  R '}'").
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/probability_theory/uniform_distribution.v
+++ b/theories/probability_theory/uniform_distribution.v
@@ -18,6 +18,7 @@ From mathcomp Require Import lebesgue_integral.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/realfun.v
+++ b/theories/realfun.v
@@ -43,6 +43,7 @@ From mathcomp Require Import sequences real_interval numfun.
 (* ```                                                                        *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/sequences.v
+++ b/theories/sequences.v
@@ -116,6 +116,7 @@ From mathcomp Require Import ereal topology tvs normedtype landau.
 (* ```                                                                        *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/showcase/pnt.v
+++ b/theories/showcase/pnt.v
@@ -18,6 +18,7 @@ Import Order.POrderTheory GRing.Theory Num.Theory.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/showcase/summability.v
+++ b/theories/showcase/summability.v
@@ -10,6 +10,7 @@ From mathcomp Require Import ereal reals topology normedtype.
 (* `realsum.v`).                                                              *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/topology_theory/bool_topology.v
+++ b/theories/topology_theory/bool_topology.v
@@ -10,6 +10,8 @@ From mathcomp Require Import discrete_topology.
 (* This file equips bool with the discrete pseudometric.                      *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
+
 Import Order.TTheory GRing.Theory Num.Theory.
 
 Local Open Scope classical_set_scope.

--- a/theories/topology_theory/compact.v
+++ b/theories/topology_theory/compact.v
@@ -33,6 +33,7 @@ From mathcomp Require Import uniform_structure pseudometric_structure.
 
 Import Order.TTheory GRing.Theory Num.Theory.
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/topology_theory/connected.v
+++ b/theories/topology_theory/connected.v
@@ -15,6 +15,7 @@ From mathcomp Require Import topology_structure.
 (* ```                                                                        *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/topology_theory/discrete_topology.v
+++ b/theories/topology_theory/discrete_topology.v
@@ -24,6 +24,9 @@ From mathcomp Require Import order_topology pseudometric_structure compact.
 (*                                  topology, uniformity, and pseudometric    *)
 (* ```                                                                        *)
 (******************************************************************************)
+
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
+
 Import Order.TTheory GRing.Theory Num.Def Num.Theory.
 
 Local Open Scope classical_set_scope.

--- a/theories/topology_theory/initial_topology.v
+++ b/theories/topology_theory/initial_topology.v
@@ -30,6 +30,7 @@ From mathcomp Require Import pseudometric_structure.
 
 Import Order.TTheory GRing.Theory Num.Theory.
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/topology_theory/matrix_topology.v
+++ b/theories/topology_theory/matrix_topology.v
@@ -20,6 +20,8 @@ From mathcomp Require Import uniform_structure pseudometric_structure.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
+
 Import Order.TTheory GRing.Theory Num.Theory.
 
 Local Open Scope classical_set_scope.

--- a/theories/topology_theory/metric_structure.v
+++ b/theories/topology_theory/metric_structure.v
@@ -22,6 +22,7 @@ From mathcomp Require Import num_topology product_topology separation_axioms.
 (* ```                                                                        *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/topology_theory/nat_topology.v
+++ b/theories/topology_theory/nat_topology.v
@@ -11,6 +11,8 @@ From mathcomp Require Import discrete_topology.
 (* Natural numbers `nat` are endowed with the structure of topology.          *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
+
 Import Order.TTheory GRing.Theory Num.Theory.
 
 Local Open Scope classical_set_scope.

--- a/theories/topology_theory/num_topology.v
+++ b/theories/topology_theory/num_topology.v
@@ -15,6 +15,7 @@ From mathcomp Require Import order_topology matrix_topology.
 
 Import Order.TTheory GRing.Theory Num.Theory.
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/topology_theory/one_point_compactification.v
+++ b/theories/topology_theory/one_point_compactification.v
@@ -15,6 +15,8 @@ From mathcomp Require Import pseudometric_structure compact initial_topology.
 (*                                      as an alias of `option X`             *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
+
 Local Open Scope classical_set_scope.
 Local Open Scope ring_scope.
 

--- a/theories/topology_theory/order_topology.v
+++ b/theories/topology_theory/order_topology.v
@@ -22,6 +22,7 @@ From mathcomp Require Import product_topology pseudometric_structure.
 
 Import Order.TTheory GRing.Theory Num.Theory.
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/topology_theory/product_topology.v
+++ b/theories/topology_theory/product_topology.v
@@ -17,6 +17,7 @@ From mathcomp Require Import uniform_structure pseudometric_structure compact.
 
 Import Order.TTheory GRing.Theory Num.Theory.
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/topology_theory/pseudometric_structure.v
+++ b/theories/topology_theory/pseudometric_structure.v
@@ -45,6 +45,7 @@ From mathcomp Require Import uniform_structure.
 
 Import Order.TTheory GRing.Theory Num.Theory.
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/topology_theory/quotient_topology.v
+++ b/theories/topology_theory/quotient_topology.v
@@ -13,6 +13,7 @@ From mathcomp Require Import topology_structure.
 (* ```                                                                        *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/topology_theory/separation_axioms.v
+++ b/theories/topology_theory/separation_axioms.v
@@ -53,6 +53,7 @@ From mathcomp Require Import connected supremum_topology sigT_topology.
 (* ```                                                                        *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/topology_theory/sigT_topology.v
+++ b/theories/topology_theory/sigT_topology.v
@@ -15,6 +15,8 @@ From mathcomp Require Import topology_structure compact subspace_topology.
 (* ```                                                                        *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
+
 Local Open Scope classical_set_scope.
 Local Open Scope ring_scope.
 

--- a/theories/topology_theory/subspace_topology.v
+++ b/theories/topology_theory/subspace_topology.v
@@ -33,6 +33,7 @@ From mathcomp Require Import product_topology.
 Reserved Notation "{ 'within' A , 'continuous' f }"
   (format "{ 'within'  A ,  'continuous'  f }").
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/topology_theory/subtype_topology.v
+++ b/theories/topology_theory/subtype_topology.v
@@ -26,6 +26,8 @@ From mathcomp Require Import product_topology subspace_topology.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
+
 Local Open Scope classical_set_scope.
 Local Open Scope ring_scope.
 

--- a/theories/topology_theory/supremum_topology.v
+++ b/theories/topology_theory/supremum_topology.v
@@ -14,6 +14,7 @@ From mathcomp Require Import topology_structure uniform_structure.
 (* `sup_topology` is equipped with the `Uniform` structure                    *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/topology_theory/topology_structure.v
+++ b/theories/topology_theory/topology_structure.v
@@ -82,6 +82,7 @@ Reserved Notation "A °" (format "A °").
 Reserved Notation "[ 'locally' P ]" (format "[ 'locally'  P ]").
 Reserved Notation "x ^'" (format "x ^'").
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/topology_theory/uniform_structure.v
+++ b/theories/topology_theory/uniform_structure.v
@@ -42,6 +42,7 @@ From mathcomp Require Import topology_structure.
 (* ```                                                                        *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/trigo.v
+++ b/theories/trigo.v
@@ -37,6 +37,7 @@ From mathcomp Require Import measure lebesgue_measure lebesgue_integral ftc.
 (*                                                                            *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/tvs.v
+++ b/theories/tvs.v
@@ -53,6 +53,7 @@ From mathcomp Require Import topology function_spaces.
 (* - The product of two Tvs is endowed with the structure of Tvs.             *)
 (******************************************************************************)
 
+Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.


### PR DESCRIPTION
Adapt to https://github.com/math-comp/math-comp/pull/1545

This was automatically generated with
```
for f in $(find . -name "*.v") ; do awk -i inplace -f add_set_reworder.awk $f ; done
```
where `add_set_reworder.awk` is the following awk script
```
BEGIN {
  seen_mc_require= 0
  done= 0
}

/From mathcomp Require/ {
  seen_mc_require= 1
}

/^\r?$/ {
  if (seen_mc_require == 1 && done == 0) {
    print("Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)")
  }
  done= 1
}

{
  print($0)
}
```
