### PR TITLE
add lt_nbhs{r,l} variants

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -94,6 +94,7 @@
 
 - in `measurable_function.v`:
   + lemma `preimage_set_system_compS`
+  + lemmas `lt_le_nbhsr`, `lt_le_nbhsl`
 
 ### Changed
 
@@ -313,6 +314,8 @@
   + lemma `derivable_powR`
 - in `convex.v`:
   + definition `convex_function` (from a realType as domain to a convex_lmodType as domain)
+- in `num_topology.v`:
+  + lemma `lt_nbhsl`
 
 ### Deprecated
 

--- a/theories/topology_theory/num_topology.v
+++ b/theories/topology_theory/num_topology.v
@@ -399,13 +399,17 @@ exists x => // z /=; rewrite sub0r normrN.
 by apply: le_lt_trans; rewrite ler_norm.
 Qed.
 
-Lemma lt_nbhsl {R : realType} (x a : R) : x < a ->
+Lemma lt_nbhsl {R : realFieldType} (x a : R) : x < a ->
   \forall y \near nbhs x, y < a.
 Proof.
 move=> xb; exists ((a - x) / 2) => /=; first by rewrite divr_gt0// subr_gt0.
 move=> r/=; rewrite ltr_pdivlMr// ltrBrDr; apply: le_lt_trans.
 by rewrite -lerBlDr -normrN opprB (le_trans (ler_norm _))// ler_peMr// ler1n.
 Qed.
+
+Lemma lt_le_nbhsl {R : realFieldType} (t x : R) :
+  x < t -> \forall y \near nbhs x, y <= t.
+Proof. by move/lt_nbhsl; apply: filterS => y /ltW. Qed.
 
 Lemma Nlt_nbhsl {R : realType} (x a : R) :
   - x < a -> \forall y \near nbhs x, - y < a.
@@ -450,6 +454,10 @@ have [uz|uz] := leP u z.
   by rewrite ger0_norm ?subr_ge0// subrK.
 by rewrite ltr0_norm ?subr_lt0// opprB addrAC -lerBlDr opprK lerD// ?ltW.
 Qed.
+
+Lemma lt_le_nbhsr {R : realFieldType} (t x : R) :
+  t < x -> \forall y \near nbhs x, t <= y.
+Proof. by move/lt_nbhsr; apply: filterS => y /ltW. Qed.
 
 Global Instance Proper_dnbhs_regular_numFieldType (R : numFieldType) (x : R^o) :
   ProperFilter x^'.


### PR DESCRIPTION
- fixes #1879

##### Motivation for this change

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [ ] added corresponding documentation in the headers~~

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
