### PR TITLE
rename continuousFunType

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -307,6 +307,10 @@
 - in `convex.v`:
   + definition `convex_function` (from a realType as domain to a convex_lmodType as domain)
 
+- in `subspace_topology.v`:
+  + `continuousFunType` -> `continuousSubspaceType`
+  + `ContinuousFun` -> `ContinuousSubspace`
+
 ### Deprecated
 
 - in `lebesgue_integral_nonneg.v`:

--- a/theories/topology_theory/subspace_topology.v
+++ b/theories/topology_theory/subspace_topology.v
@@ -9,22 +9,22 @@ From mathcomp Require Import product_topology.
 (* # Subspaces of topological spaces                                          *)
 (*                                                                            *)
 (* ```                                                                        *)
-(*               subspace A == for (A : set T), this is a copy of T with a    *)
-(*                             topology that ignores points outside A         *)
-(*          incl_subspace x == with x of type subspace A with (A : set T),    *)
-(*                             inclusion of subspace A into T                 *)
-(*          nbhs_subspace x == filter associated with x : subspace A          *)
-(*        from_subspace A f == function of type `subspace A -> U` given a     *)
-(*                             function f of type `A -> U`                    *)
-(*                             The purpose of this definition is to preserve  *)
-(*                             the pretty-printing of the notation            *)
-(*                             {within _, continuous _} below. Its use is     *)
-(*                             however likely to be later superseded by a     *)
-(*                             better (compositional) mechanism.              *)
-(* {within A, continuous f} := continuous (from_subspace A f))                *)
-(*           subspace_ent A == subspace entourages                            *)
-(*          subspace_ball A == balls of the pseudometric subspace structure   *)
-(*    continuousFunType A B == type of continuous functions from set A to     *)
+(*                 subspace A == for (A : set T), this is a copy of T with a  *)
+(*                               topology that ignores points outside A       *)
+(*            incl_subspace x == with x of type subspace A with (A : set T),  *)
+(*                               inclusion of subspace A into T               *)
+(*            nbhs_subspace x == filter associated with x : subspace A        *)
+(*          from_subspace A f == function of type `subspace A -> U` given a   *)
+(*                               function f of type `A -> U`                  *)
+(*                               The purpose of this definition is to         *)
+(*                               preserve the pretty-printing of the notation *)
+(*                               {within _, continuous _} below. Its use is   *)
+(*                               however likely to be later superseded by a   *)
+(*                               better (compositional) mechanism.            *)
+(*   {within A, continuous f} := continuous (from_subspace A f))              *)
+(*             subspace_ent A == subspace entourages                          *)
+(*            subspace_ball A == balls of the pseudometric subspace structure *)
+(* continuousSubspaceType A B == type of continuous functions from set A to   *)
 (*                             set B with domain subspace A                   *)
 (*                             The HB structure is ContinuousFun.             *)
 (* ```                                                                        *)
@@ -686,14 +686,19 @@ by split; rewrite continuous_subspace_in => + x ABx U nfxU => /(_ x ABx U nfxU);
 Qed.
 End subspace_product.
 
-#[short(type = "continuousFunType")]
-HB.structure Definition ContinuousFun {X Y : topologicalType}
+#[short(type = "continuousSubspaceType")]
+HB.structure Definition ContinuousSubspace {X Y : topologicalType}
     (A : set X) (B : set Y) :=
   {f of @isFun (subspace A) Y A B f & @Continuous (subspace A) Y f }.
 
+#[deprecated(since="mathcomp-analysis 1.16.0", note="renamed to `continuousSubspaceType`")]
+Notation continuousFunType := continuousSubspaceType.
+#[deprecated(since="mathcomp-analysis 1.16.0", note="renamed to `ContinuousSubspace`")]
+Notation ContinuousFun A B := (ContinuousSubspace A B).
+
 Section continuous_fun_comp.
 Context {X Y Z : topologicalType} (A : set X) (B : set Y) (C : set Z).
-Context {f : continuousFunType A B} {g : continuousFunType B C}.
+Context {f : continuousSubspaceType A B} {g : continuousSubspaceType B C}.
 
 Local Lemma continuous_comp_subproof : continuous (g \o f : subspace A -> Z).
 Proof.


### PR DESCRIPTION
##### Motivation for this change

fixes #1811 

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
