### PR TITLE
fix: forgotten lemma about derivability of sqrt

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- in `realfun.v`:
+  + lemma `derivable_sqrt`
+
 ### Changed
 
 ### Renamed

--- a/theories/realfun.v
+++ b/theories/realfun.v
@@ -1943,9 +1943,12 @@ rewrite -[x]sqrtK//; apply: (@is_derive_inverse _ (fun x => x ^+ 2)).
 - by rewrite mulf_neq0// gt_eqF// sqrtr_gt0 exprn_gt0// sqrtr_gt0.
 Unshelve. all: by end_near. Qed.
 
+Lemma derivable_sqrt {K : realType} (x : K) : 0 < x -> derivable Num.sqrt x 1.
+Proof.  by move=> x0; exact/ex_derive/is_derive1_sqrt. Qed.
+
 Lemma derive_sqrt {K : realType} (r : K) : 0 < r ->
   'D_1 Num.sqrt r = (2 * Num.sqrt r)^-1.
-Proof. by move=> r0; apply: derive_val; exact: is_derive1_sqrt. Qed.
+Proof. by move=> r0; exact/derive_val/is_derive1_sqrt. Qed.
 
 #[global] Hint Extern 0 (is_derive _ _ (fun _ => (_ _)^-1) _) =>
   (eapply is_deriveV; first by []) : typeclass_instances.


### PR DESCRIPTION
##### Motivation for this change

Should the naming be rather:

`derivable_sqrt` -> `derivable1_sqrt`

and

`derive_sqrt` -> `derive1_sqrt`

? @CohenCyril @holgerthies

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
