### PR TITLE
CI: :lipstick::memo::construction_worker: Bump up the version of Rocqnavi

### DIFF
--- a/.github/workflows/deploy-docs-gh-pages.yml
+++ b/.github/workflows/deploy-docs-gh-pages.yml
@@ -28,10 +28,7 @@ jobs:
             default: https://github.com/ocaml/opam-repository.git
 
       - name: Build Mathcomp Analysis
-        run: opam install -y --deps-only . && opam exec -- make -j 4
-
-      - name: Install Rocqnavi
-        run: opam install -y rocq-navi.0.3.1
+        run: opam install -y --deps-only . --with-doc && opam exec -- make -j 4
 
       - name: Generate Documents
         run: opam exec -- make html

--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -35,10 +35,7 @@ jobs:
             default: https://github.com/ocaml/opam-repository.git
 
       - name: Build Mathcomp Analysis
-        run: opam install -y --deps-only . && opam exec -- make -j 4
-
-      - name: Install Rocqnavi
-        run: opam install -y rocq-navi.0.3.1
+        run: opam install -y --deps-only . --with-doc && opam exec -- make -j 4
 
       - name: Generate Documents
         run: |

--- a/rocq-mathcomp-analysis.opam
+++ b/rocq-mathcomp-analysis.opam
@@ -19,6 +19,7 @@ depends: [
   "rocq-mathcomp-solvable"
   "rocq-mathcomp-field"
   "rocq-mathcomp-bigenough" { (>= "1.0.0") }
+  "rocq-navi" {= "0.4.1" & with-doc}
 ]
 
 conflicts: [ "coq-mathcomp-analysis" { < "1.16~" } ]


### PR DESCRIPTION
Bump up the version of Rocqnavi (0.3.1 → 0.4.1)

* Resolved the problem of daily publish the Rocqnavi doc

##### Motivation for this change

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Checklist

- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
