### PR TITLE
test subNormedZmodType

### DIFF
--- a/theories/normedtype_theory/pseudometric_normed_Zmodule.v
+++ b/theories/normedtype_theory/pseudometric_normed_Zmodule.v
@@ -143,6 +143,22 @@ HB.structure Definition PseudoMetricNormedZmod (R : numDomainType) :=
   {T of Num.NormedZmodule R T & PseudoMetric R T
    & NormedZmod_PseudoMetric_eq R T & isPointed T}.
 
+HB.mixin Record Zmodule_isSubSemiNormed (R : numDomainType)
+    (M : semiNormedZmodType R) (S : pred M) T & SubType M S T
+    & Num.NormedZmodule R T := {
+  norm_valE : @Num.norm _ M \o (val : T -> M) = @Num.norm _ T
+}.
+
+#[short(type="subSemiNormedZmodType")]
+HB.structure Definition SubSemiNormedZmodule (R : numDomainType)
+    (V : semiNormedZmodType R) (S : pred V) :=
+  { W of GRing.SubZmodule V S W & Zmodule_isSubSemiNormed R V S W}.
+
+#[short(type="subNormedZmodType")]
+HB.structure Definition SubNormedZmodule (R : numDomainType)
+    (V : normedZmodType R) (S : pred V) :=
+  { U of SubChoice V S U & Num.NormedZmodule R U & @SubSemiNormedZmodule R V S U }.
+
 (* alternative definition of a PseudoMetricNormedZmod *)
 HB.factory Record NormedZmoduleMetric (R : numDomainType) T
     & Num.NormedZmodule R T & Metric R T & isPointed T := {


### PR DESCRIPTION
##### Motivation for this change

We are trying to define `SubNormedZmodule` like the `Sub` structures in MathComp
(we are doing this in MathComp-Analysis to test it because ultimately we want `SubNormedModule`
but we are not there yet)

Adding `SubNormedZmodule` just after `SubSemiNormedZmodule` seems to do what we want
in MathComp (see this branch https://github.com/affeldt-aist/math-comp/commits/numdomain_20240403/)
but in MathComp-Analysis it generates the following error message:
```
Structure pseudometric_normed_Zmodule_SubSemiNormedZmodule
contains the same mixins as SubNormedZmodule
```
when I tried to define `SubNormedZmodule` and in a context where
`pseudometric_normed_Zmodule_SubSemiNormedZmodule` does not exist yet

@mkerjean @CohenCyril 



<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Checklist

- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
