### PR TITLE
fixes #1939

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -69,6 +69,9 @@
   + mixin ` PseudoMetricNormedZmod_Tvs_isNormedModule` ->
     ` PseudoMetricNormedZmod_ConvexTvs_isNormedModule`
 
+- in `measurable_structure.v`:
+  + `measurable_prod_measurableType` -> `prod_measurable_rectangle`
+
 ### Generalized
 
 - in `measurable_structure.v`:

--- a/theories/kernel.v
+++ b/theories/kernel.v
@@ -1,4 +1,4 @@
-(* mathcomp analysis (c) 2025 Inria and AIST. License: CeCILL-C.              *)
+(* mathcomp analysis (c) 2026 Inria and AIST. License: CeCILL-C.              *)
 From HB Require Import structures.
 From mathcomp Require Import all_ssreflect_compat ssralg ssrnum ssrint interval.
 From mathcomp Require Import interval_inference archimedean finmap.
@@ -600,10 +600,9 @@ Lemma measurable_prod_subset_xsection_kernel :
     (forall x, exists M, forall X, measurable X -> kD x X < M%:E) ->
   measurable `<=` XY.
 Proof.
-move=> kD_ub; rewrite measurable_prod_measurableType.
-set C := rectangle (@measurable _ X) (@measurable _ Y).
-have CI : setI_closed C.
-  by apply: setI_closed_rectangle => E F mE MF; exact: measurableI.
+move=> kD_ub.
+rewrite prod_measurable_rectangle; set C := rectangle _ _.
+have CI : setI_closed C by apply: setI_closed_rectangle=> *; exact: measurableI.
 have CT : C setT by rewrite -setXTT; exact: rectangle_setX.
 have CXY : C `<=` XY.
   move=> _ [A mA [B mB <-]]; split; first exact: measurableX.
@@ -615,7 +614,7 @@ split => //; [exact: CXY| |exact: xsection_ndseq_closed].
 move=> A B BA [mA mphiA] [mB mphiB]; split; first exact: measurableD.
 suff : phi (A `\` B) = (fun x => phi A x - phi B x).
   by move=> ->; exact: emeasurable_funB.
-rewrite funeqE => x; rewrite /phi/= xsectionD// measureD.
+rewrite funeqE => x; rewrite /phi/= xsectionD// measureD/=.
 - exact: measurable_xsection.
 - exact: measurable_xsection.
 - have [M kM] := kD_ub x.
@@ -1387,13 +1386,12 @@ apply: (emeasurable_fun_cvg (fun n => K (EFin \o f_ n))); last first.
 move=> m.
 have DE : D = @measurable _ (T1 * T2)%type.
   apply/seteqP; split => [/= A []//|].
-  rewrite measurable_prod_measurableType.
+  rewrite prod_measurable_rectangle.
   apply: lambda_system_subset => //=.
-    by apply: setI_closed_rectangle => ? ? ? ?; exact: measurableI.
+    by apply: setI_closed_rectangle => *; exact: measurableI.
   move=> C [A mA [B mB] <-].
   split; [exact: measurableX|rewrite /K kfcompkg//].
-  apply: emeasurable_funM; first exact/measurable_EFinP.
-  exact: measurable_kernel.
+  by apply: emeasurable_funM; [exact/measurable_EFinP|exact: measurable_kernel].
 have mK1 (A : set (T1 * T2)) : measurable A ->
     measurable_fun setT (K (EFin \o \1_A)).
   by rewrite -DE => -[].
@@ -1409,8 +1407,7 @@ rewrite /I/= [X in measurable_fun _ X](_ : _ = (fun x =>
   rewrite /= ge0_integral_fsum//=.
     move=> r.
     under eq_fun do rewrite EFinM.
-    apply: emeasurable_funM => //.
-    by apply/measurable_EFinP; exact: measurableT_comp.
+    by apply: emeasurable_funM => //; exact/measurable_EFinP/measurableT_comp.
   by move=> r y _; rewrite EFinM nnfun_muleindic_ge0.
 apply: emeasurable_fsum => // r.
 rewrite [X in measurable_fun _ X](_ : _ = (fun x =>
@@ -1425,7 +1422,7 @@ rewrite [X in measurable_fun _ X](_ : _ = (fun x =>
   pose H3 := isSigmaFinite.Build _ _ _ _ (finite_measure_sigma_finite
     (@kernel_finite_transition _ _ _ _ R k x)).
   pose kx' := HB.pack_for (FiniteMeasure.type T2 R) (Measure.sort kx) H1 H2 H3.
-  have kxE : kx = kx' by apply: eq_measure.
+  have kxE : kx = kx' by exact: eq_measure.
   rewrite -/kx kxE; apply: integrable_indic => //.
   by rewrite -[X in measurable X]xsectionE; exact: measurable_xsection.
 by apply: emeasurable_funM => //; exact: mK1.
@@ -1540,17 +1537,17 @@ Context d0 d1 d2 (T0 : measurableType d0)
   (T1 : measurableType d1) (T2 : measurableType d2) {R : realType}
   (k1 : R.-ftker T0 ~> T1) (k2 : R.-ftker (T0 * T1) ~> T2).
 
-Let kproduct0 x : kproduct k1 k2 x set0 = 0.
+#[local] Lemma kproduct0 x : kproduct k1 k2 x set0 = 0.
 Proof.
 by apply: integral0_eq => y _; apply: integral0_eq => z _; rewrite indic0.
 Qed.
 
-Let kproduct_ge0 x A : 0 <= kproduct k1 k2 x A.
+#[local] Lemma kproduct_ge0 x A : 0 <= kproduct k1 k2 x A.
 Proof.
 by apply: integral_ge0 => y _; apply: integral_ge0 => z _; rewrite lee_fin.
 Qed.
 
-Let kproduct_additive x : semi_sigma_additive (kproduct k1 k2 x).
+#[local] Lemma kproduct_additive x : semi_sigma_additive (kproduct k1 k2 x).
 Proof. exact: semi_sigma_additive_kproduct. Qed.
 
 HB.instance Definition _ x := isMeasure.Build
@@ -1641,7 +1638,7 @@ Context d0 d1 d2 (T0 : measurableType d0)
 Local Definition kernel_snd : (T0 * T1)%type -> {measure set T2 -> \bar R} :=
   k \o snd.
 
-Let measurable_kernel U : measurable U ->
+#[local] Lemma measurable_kernel_snd U : measurable U ->
   measurable_fun [set: _] (kernel_snd ^~ U).
 Proof.
 move=> mU; have /= mk1 := measurable_kernel k _ mU.
@@ -1653,9 +1650,9 @@ exact: measurableX.
 Qed.
 
 HB.instance Definition _ :=
-  @isKernel.Build _ _ _ _ _ kernel_snd measurable_kernel.
+  @isKernel.Build _ _ _ _ _ kernel_snd measurable_kernel_snd.
 
-Let measure_uub : measure_fam_uub kernel_snd.
+#[local] Lemma measure_uub_kernel_snd : measure_fam_uub kernel_snd.
 Proof.
 exists 2%R => /= -[x y].
 rewrite /kernel_snd/= (@le_lt_trans _ _ 1%:E) ?lte1n//.
@@ -1663,18 +1660,18 @@ exact: sprob_kernel_le1.
 Qed.
 
 HB.instance Definition _ :=
-  @Kernel_isFinite.Build _ _ _ _ _ kernel_snd measure_uub.
+  @Kernel_isFinite.Build _ _ _ _ _ kernel_snd measure_uub_kernel_snd.
 
-Let sprob_kernel :
+#[local] Lemma sprob_kernel_kernel_snd :
   ereal_sup [set kernel_snd z [set: _] | z in [set: _]] <= 1.
 Proof.
 by apply: (sprob_kernelP kernel_snd).2 => -[x y]; exact: sprob_kernel_le1.
 Qed.
 
 HB.instance Definition _ := isSubProbabilityKernel.Build _ _ _ _ _
-  kernel_snd sprob_kernel.
+  kernel_snd sprob_kernel_kernel_snd.
 
-Local Lemma intker_indic_snd (A : set T2) x y : measurable A ->
+#[local] Lemma intker_indic_snd (A : set T2) x y : measurable A ->
   intker_indic kernel_snd ([set: _] `*` A) (x, y) = k y A.
 Proof.
 move=> mA; rewrite intker_indicE//=; first exact: measurableX.
@@ -1701,13 +1698,14 @@ Context d0 d1 d2 (T0 : measurableType d0)
   (T1 : measurableType d1) (T2 : measurableType d2) {R : realType}
   (k1 : R.-spker T0 ~> T1) (k2 : R.-spker T1 ~> T2).
 
-Let kcomp_noparam0 x : kcomp_noparam k1 k2 x set0 = 0.
+#[local] Lemma kcomp_noparam0 x : kcomp_noparam k1 k2 x set0 = 0.
 Proof. by apply: integral0_eq => y _; rewrite measure0. Qed.
 
-Let kcomp_noparam_ge0 x A : 0 <= kcomp_noparam k1 k2 x A.
+#[local] Lemma kcomp_noparam_ge0 x A : 0 <= kcomp_noparam k1 k2 x A.
 Proof. by apply: integral_ge0 => y _; exact: measure_ge0. Qed.
 
-Let kcomp_noparam_additive x : semi_sigma_additive (kcomp_noparam k1 k2 x).
+#[local] Lemma kcomp_noparam_additive x :
+  semi_sigma_additive (kcomp_noparam k1 k2 x).
 Proof.
 move=> F mF tF mUF.
 rewrite kcomp_noparamE// (_ : (fun _ => _) = (fun n =>
@@ -1738,7 +1736,7 @@ HB.instance Definition _ x := isMeasure.Build d2 T2 R (kcomp_noparam k1 k2 x)
 Definition mkcomp_noparam :=
   (kcomp_noparam k1 k2 : T0 -> {measure set T2 -> \bar R}).
 
-Let measurable_kernel U :
+#[local] Lemma measurable_kernel_mkcomp_noparam U :
   measurable U -> measurable_fun [set: _] (mkcomp_noparam ^~ U).
 Proof.
 move=> mU.
@@ -1750,7 +1748,7 @@ by apply: measurable_kproduct; exact: measurableX.
 Qed.
 
 HB.instance Definition _ := @isKernel.Build _ _ _ _ R
-  mkcomp_noparam measurable_kernel.
+  mkcomp_noparam measurable_kernel_mkcomp_noparam.
 
 End kcomp_noparam_measure.
 
@@ -1778,11 +1776,11 @@ apply: ge0_le_integral => //; first exact: measurable_kernel.
 by move=> y _; exact: sprob_kernel_le1.
 Qed.
 
-Let sprob_kernel :
+#[local] Lemma sprob_kernel_kcomp_noparam :
   ereal_sup [set (kcomp_noparam k1 k2) x setT | x in [set: T0]] <= 1.
 Proof. by apply/sprob_kernelP => x; exact: sprob_mkcomp_noparam. Qed.
 
 HB.instance Definition _ := Kernel_isSubProbability.Build
-  _ _ _ _ R (mkcomp_noparam k1 k2) sprob_kernel.
+  _ _ _ _ R (mkcomp_noparam k1 k2) sprob_kernel_kcomp_noparam.
 
 End subprobability_kcomp_noparam.

--- a/theories/lebesgue_integral_theory/giry.v
+++ b/theories/lebesgue_integral_theory/giry.v
@@ -412,9 +412,9 @@ Lemma measurable_giry_prod :
   measurable_fun [set: giry T1 R * giry T2 R] giry_prod.
 Proof.
 apply: measurable_giry_codensity => //=.
-rewrite measurable_prod_measurableType.
+rewrite prod_measurable_rectangle.
 apply: dynkin_induction => /=.
-- by rewrite measurable_prod_measurableType.
+- by rewrite prod_measurable_rectangle.
 - move=> _ _ [A1 mA1 [A2 mA2 <-]] [B1 mB1 [B2 mB2 <-]].
   exists (A1 `&` B1); first exact: measurableI.
   exists (A2 `&` B2); first exact: measurableI.

--- a/theories/lebesgue_integral_theory/lebesgue_Rintegral.v
+++ b/theories/lebesgue_integral_theory/lebesgue_Rintegral.v
@@ -128,8 +128,8 @@ Lemma Rintegral_setU (A B : set T) (f : T -> R) :
     mu.-integrable (A `|` B) (EFin \o f) -> [disjoint A & B] ->
   \int[mu]_(x in (A `|` B)) f x = \int[mu]_(x in A) f x + \int[mu]_(x in B) f x.
 Proof.
-move=> mA mB mf AB; rewrite /Rintegral integral_setU_EFin//.
-  exact/measurable_EFinP/(measurable_int mu).
+move=> mA mB mf AB; rewrite /Rintegral integral_setU//.
+  exact/(measurable_int mu).
 have mAf :  mu.-integrable A (EFin \o f).
   by  apply: integrableS mf => //; exact: measurableU.
 have mBf :  mu.-integrable B (EFin \o f).

--- a/theories/lebesgue_integral_theory/lebesgue_integral_fubini.v
+++ b/theories/lebesgue_integral_theory/lebesgue_integral_fubini.v
@@ -1,4 +1,4 @@
-(* mathcomp analysis (c) 2025 Inria and AIST. License: CeCILL-C.              *)
+(* mathcomp analysis (c) 2026 Inria and AIST. License: CeCILL-C.              *)
 From HB Require Import structures.
 From mathcomp Require Import all_ssreflect_compat ssralg ssrnum ssrint interval.
 From mathcomp Require Import interval_inference archimedean finmap.
@@ -116,10 +116,8 @@ Lemma measurable_prod_subset_xsection
     (m2D_bounded : exists M, forall X, measurable X -> (m2D X < M%:E)%E) :
   measurable `<=` B.
 Proof.
-rewrite measurable_prod_measurableType.
-set C := rectangle (@measurable _ T1) (@measurable _ T2).
-have CI : setI_closed C.
-  by apply: setI_closed_rectangle => E F mE MF; exact: measurableI.
+rewrite prod_measurable_rectangle; set C := rectangle _ _.
+have CI : setI_closed C by apply: setI_closed_rectangle=> *; exact: measurableI.
 have CT : C setT by rewrite -setXTT; exact: rectangle_setX.
 have CB : C `<=` B.
   move=> X [X1 mX1 [X2 mX2 <-{X}]]; split; first exact: measurableX.
@@ -133,7 +131,7 @@ split => //; [exact: CB| |exact: xsection_ndseq_closed].
 move=> X Y XY [mX mphiX] [mY mphiY]; split; first exact: measurableD.
 suff -> : phi (X `\` Y) = (fun x => phi X x - phi Y x)%E.
   exact: emeasurable_funB.
-rewrite funeqE => x; rewrite /phi/= xsectionD// /m2D measureD.
+rewrite funeqE => x; rewrite /phi/= xsectionD// /m2D measureD/=.
 - exact: measurable_xsection.
 - exact: measurable_xsection.
 - move: m2D_bounded => [M m2M].
@@ -155,10 +153,8 @@ Lemma measurable_prod_subset_ysection
     (m1_bounded : exists M, forall X, measurable X -> (m1D X < M%:E)%E) :
   measurable `<=` B.
 Proof.
-rewrite measurable_prod_measurableType.
-set C := rectangle (@measurable _ T1) (@measurable _ T2).
-have CI : setI_closed C.
-  by apply: setI_closed_rectangle => E F mE MF; exact: measurableI.
+rewrite prod_measurable_rectangle; set C := rectangle _ _.
+have CI : setI_closed C by apply: setI_closed_rectangle=> *; exact: measurableI.
 have CT : C setT by rewrite -setXTT; exact: rectangle_setX.
 have CB : C `<=` B.
   move=> X [X1 mX1 [X2 mX2 <-{X}]]; split; first exact: measurableX.
@@ -171,7 +167,7 @@ suff lsystemB : lambda_system setT B by exact: lambda_system_subset.
 split => //; [exact: CB| |exact: ysection_ndseq_closed].
 move=> X Y XY [mX mphiX] [mY mphiY]; split; first exact: measurableD.
 rewrite (_ : psi _ = (psi X \- psi Y)%E); last exact: emeasurable_funB.
-rewrite funeqE => y; rewrite /psi/= ysectionD// /m1D measureD.
+rewrite funeqE => y; rewrite /psi/= ysectionD// /m1D measureD/=.
 - exact: measurable_ysection.
 - exact: measurable_ysection.
 - have [M m1M] := m1_bounded.
@@ -401,7 +397,7 @@ have CI : setI_closed C.
   rewrite -setXI; exists (X1 `&` Y1); split; first exact: measurableI.
   by exists (X2 `&` Y2); split => //; exact: measurableI.
 move=> X mX; apply: (measure_unique C (fun n => F n `*` G n)) => //.
-- rewrite measurable_prod_measurableType //; congr (<<s _ >>).
+- rewrite prod_measurable_rectangle//; congr (<<s _ >>).
   rewrite predeqE; split => [[A mA [B mB <-]]|[A [mA [B [mB ->]]]]].
     by exists A; split => //; exists B.
   by exists A => //; exists B.

--- a/theories/measure_theory/measurable_structure.v
+++ b/theories/measure_theory/measurable_structure.v
@@ -1648,12 +1648,13 @@ Context d1 d2 (T1 : algebraOfSetsType d1) (T2 : algebraOfSetsType d2).
 Let M1 := @measurable _ T1.
 Let M2 := @measurable _ T2.
 
-#[deprecated(since="mathcomp-analysis 1.17.0", note="use `g_sigma_algebra_rectangle` instead")]
-Lemma measurable_prod_measurableType :
+Lemma prod_measurable_rectangle :
   (d1, d2).-prod.-measurable = <<s rectangle M1 M2 >>.
 Proof. by rewrite g_sigma_algebra_rectangle//; exact: measurableT. Qed.
 
 End product_salgebra_algebraOfSetsType.
+#[deprecated(since="mathcomp-analysis 1.17.0", use=prod_measurable_rectangle)]
+Notation measurable_prod_measurableType := prod_measurable_rectangle (only parsing).
 
 Section product_salgebra_g_measurableTypeR.
 Context d1 (T1 : algebraOfSetsType d1) (T2 : pointedType) (C2 : set (set T2)).
@@ -1664,7 +1665,7 @@ Lemma __deprecated__measurable_prod_g_measurableTypeR :
   @measurable _ (T1 * g_sigma_algebraType C2)%type
   = <<s rectangle (@measurable _ T1) C2 >>.
 Proof.
-rewrite measurable_prod_measurableType //; congr (<<s _ >>).
+rewrite prod_measurable_rectangle//; congr (<<s _ >>).
 rewrite predeqE => X; split=> [[A mA] [B mB] <-{X}|[A C1A] [B C2B] <-{X}].
   by exists A => //; exists B => //; exact: setTC2.
 by exists A => //; exists B => //; exact: sub_sigma_algebra.
@@ -1681,7 +1682,7 @@ Lemma __deprecated__measurable_prod_g_measurableType :
   @measurable _ (g_sigma_algebraType C1 * g_sigma_algebraType C2)%type =
   <<s rectangle C1 C2 >>.
 Proof.
-rewrite -[LHS]g_sigma_algebra_rectangle//; congr (<<s _ >>).
+rewrite prod_measurable_rectangle//; congr (<<s _ >>).
 rewrite predeqE => X; split=> [[A mA] [B mB] <-{X}|[A C1A] [B C2B] <-{X}].
   by exists A; [exact: setTC1|exists B => //; exact: setTC2].
 by exists A; [exact: sub_sigma_algebra|exists B => //; exact: sub_sigma_algebra].


### PR DESCRIPTION
##### Motivation for this change

fixes #1939 

@shinya-katsumata

We deprecated `measurable_prod_measurableType` because
this was the same lemma as `g_sigma_algebra_rectangle`
modulo unfolding.
However, when this lemma is used, the identifier one wants to unfold
is hidden behind a notation and in addition, unfolding it reveals
implementation details.
Its deprecation was maybe not a good idea after all, this PR removes
the deprecation and change the name to `prod_measurable_rectangle`
which is easier to remember and search for.

Can you have a quick look and approve if possible?
(don't mind the `Let` -> `#[local] Lemma` changes, this is orthogonal)

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
