### PR TITLE
Fix '#[loca]' typo to '#[local]' in continuous_path.v

### DIFF
--- a/theories/homotopy_theory/continuous_path.v
+++ b/theories/homotopy_theory/continuous_path.v
@@ -116,7 +116,7 @@ Definition reparameterize := f \o phi.
 #[local] Lemma fphi_zero : reparameterize zero = x.
 Proof. by rewrite /reparameterize /= ?path_zero. Qed.
 
-#[loca] Lemma fphi_one : reparameterize one = y.
+#[local] Lemma fphi_one : reparameterize one = y.
 Proof. by rewrite /reparameterize /= ?path_one. Qed.
 
 #[local] Lemma fphi_cts : continuous reparameterize.


### PR DESCRIPTION
Fixes #1945.

The attribute on `Lemma fphi_one` in `theories/homotopy_theory/continuous_path.v:119` was written as `#[loca]` instead of `#[local]`. The neighboring `fphi_zero` and `fphi_cts` lemmas are both correctly marked `#[local]`, so without this fix `fphi_one` is the only one of the three that is not actually scoped to the section.