### PR TITLE
doc: fix typo 'Compnent' -> 'Components' in classical/boolp.v header comment

### DIFF
--- a/classical/boolp.v
+++ b/classical/boolp.v
@@ -13,7 +13,7 @@ From mathcomp Require internal_Eqdep_dec.
 (* # Classical Logic                                                          *)
 (*                                                                            *)
 (* This file provides the axioms of classical logic and tools to perform      *)
-(* classical reasoning in the Mathematical Compnent framework. The three      *)
+(* classical reasoning in the Mathematical Components framework. The three    *)
 (* axioms are taken from the standard library of Coq, more details can be     *)
 (* found in Section 5 of                                                      *)
 (* - R. Affeldt, C. Cohen, D. Rouhling. Formalization Techniques for          *)


### PR DESCRIPTION
Closes #1965 by correcting "Compnent" to "Components" in the Markdown-rendered header comment of `classical/boolp.v` while preserving the 80-column comment alignment.
