### PR TITLE
fixes #1973

### DIFF
--- a/theories/normedtype_theory/tvs.v
+++ b/theories/normedtype_theory/tvs.v
@@ -525,6 +525,14 @@ HB.instance Definition _ := Nbhs_isUniform_mixin.Build E
     entourage_filter entourage_refl
     entourage_inv entourage_split_ex
     nbhsE.
+
+
+HB.instance Definition _ := PreTopologicalNmodule_isTopologicalNmodule.Build E add_continuous.
+
+HB.instance Definition _ := TopologicalNmodule_isTopologicalLmodule.Build R E scale_continuous.
+
+HB.instance Definition _ := Uniform_isConvexTvs.Build R E locally_convex.
+
 HB.end.
 
 Section ConvexTvs_numDomain.


### PR DESCRIPTION
##### Motivation for this change
Fixes #1973 

There are missing instances at the end of the factory PreTopologicalLmod_isConvexTvs, so it only constructs a uniform space, not a ConvexTvs. This PR declares the missing instances via the PreTopologicalNmodule_isTopologicalNmodule, TopologicalNmodule_isTopologicalLmodule, and Uniform_isConvexTvs factories. 

##### Checklist

- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
