### PR TITLE
add zerofctE and onefctE; rename scalrfctE to scalerfctE

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Renamed
+- in `functions.v`
+  + lemma `scalrfctE` -> `scalerfctE` (deprecating `scalrfctE`)
+
+### Changed
+- in `functions.v`
+  + lemma `fctE` (include `zerofctE` and `onefctE`)
+
+### Added
+- in `functions.v`:
+  + lemmas `zerofctE`, `onefctE`
+
 ### Added
 - in `set_interval.v`:
   + lemmas `setU_itvob1`, `setU_1itvob`

--- a/classical/functions.v
+++ b/classical/functions.v
@@ -2740,9 +2740,15 @@ Lemma mulrfctE (T : Type) (K : pzRingType) (f g : T -> K) :
   f * g = (fun x => f x * g x).
 Proof. by []. Qed.
 
-Lemma scalrfctE (T : Type) (K : pzRingType) (L : lmodType K)
+Lemma scalerfctE (T : Type) (K : pzRingType) (L : lmodType K)
     k (f : T -> L) :
   k *: f = (fun x : T => k *: f x).
+Proof. by []. Qed.
+
+Lemma zerofctE (T : Type) (K : nmodType) : (0 : T -> K) = (fun=> 0).
+Proof. by []. Qed.
+
+Lemma onefctE (T : Type) (K : pzRingType) : (1 : T -> K) = (fun=> 1).
 Proof. by []. Qed.
 
 Lemma cstE (T T': Type) (x : T) : cst x = fun _: T' => x.
@@ -2757,9 +2763,13 @@ Lemma compE (T1 T2 T3 : Type) (f : T1 -> T2) (g : T2 -> T3) :
 Proof. by []. Qed.
 
 Definition fctE :=
-  (cstE, compE, opprfctE, addrfctE, mulrfctE, scalrfctE, exprfctE).
+  (cstE, compE, opprfctE, addrfctE, mulrfctE, scalerfctE, exprfctE,
+   zerofctE, onefctE).
 
 End function_space_lemmas.
+
+#[deprecated(since="mathcomp-analysis 1.17.0", use=scalerfctE)]
+Notation scalrfctE := scalerfctE.
 
 Lemma inv_funK T (R : unitRingType) (f : T -> R) : (f\^-1\^-1)%R = f.
 Proof. by apply/funeqP => x; rewrite /inv_fun/= GRing.invrK. Qed.

--- a/classical/functions.v
+++ b/classical/functions.v
@@ -2745,10 +2745,10 @@ Lemma scalerfctE (T : Type) (K : pzRingType) (L : lmodType K)
   k *: f = (fun x : T => k *: f x).
 Proof. by []. Qed.
 
-Lemma zerofctE (T : Type) (K : nmodType) : (0 : T -> K) = (fun=> 0).
+Lemma zerofctE (T : Type) (K : nmodType) x : (0 : T -> K) x = 0.
 Proof. by []. Qed.
 
-Lemma onefctE (T : Type) (K : pzRingType) : (1 : T -> K) = (fun=> 1).
+Lemma onefctE (T : Type) (K : pzRingType) x : (1 : T -> K) x = 1.
 Proof. by []. Qed.
 
 Lemma cstE (T T': Type) (x : T) : cst x = fun _: T' => x.


### PR DESCRIPTION
##### Motivation for this change

This PR adds computation lemmas for 0 and 1 in function rings:
`zerofctE ` : 0 is the constantly zero function
`onefctE ` : 1 is the constantly one function
They are added to the all-catch lemma `fctE`.

One naming fix is also included: `scalrfctE` -> `scalerfctE`.

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~- [ ] added corresponding documentation in the headers~

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
