### PR TITLE
To preserve the mathcomp CI (forward dependency) for PR#1611

### DIFF
--- a/classical/unstable.v
+++ b/classical/unstable.v
@@ -47,6 +47,20 @@ Unset Printing Implicit Defensive.
 Import Order.TTheory GRing.Theory Num.Theory.
 Local Open Scope ring_scope.
 
+(* Backward compatibility with math-comp < 2.6, which has no [conjFieldType]
+ (the common ancestor of [rcfType] and [numClosedFieldType]).  When it is
+ absent we alias it to [rcfType] via a global parsing-only abbreviation, so
+ that MCA files endowing [conjFieldType] with topological/normed  structures
+ still compile: those instances then become redundant copies of  the [rcfType]
+ ones (their [HB.no-new-instance] is silenced at each site). *)
+Elpi Command analysis_declare_conjFieldType_compat.
+Elpi Accumulate lp:{{
+  main [] :- coq.locate-all "Num.ConjField.type" L, L = [_|_], !.
+  main [] :- @global! => coq.notation.add-abbreviation "conjFieldType" 0
+               {{ Num.RealClosedField.type }} tt _.
+}}.
+Elpi analysis_declare_conjFieldType_compat.
+
 Section IntervalNumDomain.
 Variable R : numDomainType.
 Implicit Types x : R.

--- a/theories/normedtype_theory/normed_module.v
+++ b/theories/normedtype_theory/normed_module.v
@@ -221,6 +221,16 @@ HB.instance Definition _ := NormedModule.copy R R^o.
 HB.instance Definition _ := Num.ClosedField.on R.
 End numClosedFieldType.
 
+Section conjFieldType.
+Variable R : conjFieldType.
+#[export, non_forgetful_inheritance, warnings="-HB.no-new-instance"]
+HB.instance Definition _ := GRing.ComAlgebra.copy R R^o.
+#[export, non_forgetful_inheritance, warnings="-HB.no-new-instance"]
+HB.instance Definition _ := Vector.copy R R^o.
+#[export, non_forgetful_inheritance, warnings="-HB.no-new-instance"]
+HB.instance Definition _ := NormedModule.copy R R^o.
+End conjFieldType.
+
 Section numFieldType.
 Variable (R : numFieldType).
 #[export, non_forgetful_inheritance]

--- a/theories/topology_theory/num_topology.v
+++ b/theories/topology_theory/num_topology.v
@@ -1,6 +1,8 @@
 (* mathcomp analysis (c) 2026 Inria and AIST. License: CeCILL-C.              *)
 From HB Require Import structures.
 From mathcomp Require Import all_ssreflect_compat all_algebra all_classical.
+#[warning="-warn-library-file-internal-analysis"]
+From mathcomp Require Import unstable.
 From mathcomp Require Import interval_inference reals topology_structure.
 From mathcomp Require Import uniform_structure pseudometric_structure.
 From mathcomp Require Import order_topology matrix_topology.
@@ -128,6 +130,10 @@ HB.instance Definition _ (R : realFieldType) := PseudoPointedMetric.copy R R^o.
 
 #[export, non_forgetful_inheritance]
 HB.instance Definition _ (R : numClosedFieldType) :=
+  PseudoPointedMetric.copy R R^o.
+
+#[export, non_forgetful_inheritance, warnings="-HB.no-new-instance"]
+HB.instance Definition _ (R : conjFieldType) :=
   PseudoPointedMetric.copy R R^o.
 
 #[export, non_forgetful_inheritance]


### PR DESCRIPTION
Backward compatibility layer using Elpi.
Developed with the assistance of Claude Opus 4.8 (1M context).

##### Motivation for this change

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Checklist

- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
