### PR TITLE
CI: Use extr-dev opam repository while generating the Rocqnavi doc

### DIFF
--- a/.github/workflows/deploy-docs-gh-pages.yml
+++ b/.github/workflows/deploy-docs-gh-pages.yml
@@ -24,8 +24,9 @@ jobs:
         with:
           ocaml-compiler: 4.14
           opam-repositories: |
-            coq-released: https://coq.inria.fr/opam/released
             default: https://github.com/ocaml/opam-repository.git
+            rocq-released: https://rocq-prover.org/opam/released
+            rocq-extra-dev: https://rocq-prover.org/opam/extra-dev
 
       - name: Build Mathcomp Analysis
         run: opam install -y --deps-only . --with-doc && opam exec -- make -j 4

--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -1,3 +1,5 @@
+name: Generate HTML doc using Rocqnavi
+
 on:
   push:
     branches-ignore: ["gh-pages"]
@@ -31,8 +33,9 @@ jobs:
         with:
           ocaml-compiler: 4.14
           opam-repositories: |
-            coq-released: https://coq.inria.fr/opam/released
             default: https://github.com/ocaml/opam-repository.git
+            rocq-released: https://rocq-prover.org/opam/released
+            rocq-extra-dev: https://rocq-prover.org/opam/extra-dev
 
       - name: Build Mathcomp Analysis
         run: opam install -y --deps-only . --with-doc && opam exec -- make -j 4

--- a/rocq-mathcomp-classical.opam
+++ b/rocq-mathcomp-classical.opam
@@ -16,10 +16,10 @@ build: [make "-C" "classical" "-j%{jobs}%"]
 install: [make "-C" "classical" "install"]
 depends: [
   "rocq-core" { (>= "9.0" & < "9.2~") | (= "dev") }
-  "rocq-mathcomp-ssreflect" { (>= "2.5.0" & < "2.6~") | (= "dev") }
+  "rocq-mathcomp-ssreflect" { (= "dev") }
   "rocq-mathcomp-fingroup"
   "rocq-mathcomp-algebra"
-  "rocq-mathcomp-finmap" { (>= "2.1.0") }
+  "rocq-mathcomp-finmap" { (= "dev") }
   "rocq-hierarchy-builder" { (>= "1.8.0") }
 ]
 


### PR DESCRIPTION
##### Motivation for this change

<!-- if this PR fixes an issue, use "fixes #XYZ" -->
fixes #2006 

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Checklist

- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
