### PR TITLE
Rocqnavi: :bug: Fix broken links caused

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -119,5 +119,5 @@ html: build $(DOCDIR)/dependency_graph.dot
         -index-blacklist etc/rocqnavi_index-blacklist \
         -show-type-information-using-coqtop-process \
 	-external https://math-comp.github.io/htmldoc_2_5_0/ mathcomp.order \
-	-external https://math-comp.github.io/htmldoc_2_5_0/ mathcomp.ssreflect \
+	-external https://math-comp.github.io/htmldoc_2_5_0/ mathcomp.boot \
 	-external https://math-comp.github.io/htmldoc_2_5_0/ mathcomp.algebra


### PR DESCRIPTION
##### Motivation for this change

<!-- if this PR fixes an issue, use "fixes #XYZ" -->
fixes [rocqnavi/#168](https://github.com/affeldt-aist/rocqnavi/issues/168)

<!-- you may also explain what remains to do if the fix is incomplete -->
Fix broken links caused by the separation of the ssreflect namespace in Math-Comp 2.5 (issue-168)

See also: https://github.com/math-comp/math-comp/releases/tag/mathcomp-2.5.0

##### Checklist

- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
