### PR TITLE
New `within_continuous*` lemmas

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -234,6 +234,12 @@
 - in `measurable_structure.v`:
   + lemmas `countable_bigcap_measurable`, `countable_bigcup_measurable`
 
+- in file `normed_module.v`,
+  + new lemmas `within_continuousZ`, `within_continuousM`, 
+    `within_continuousMl`, and `within_continuousMr`.
+- in file `pseudometric_normed_Zmodule.v`,
+  + new lemma `within_continuousN`.
+
 ### Changed
 
 - in `realsum.v`:

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -234,11 +234,11 @@
 - in `measurable_structure.v`:
   + lemmas `countable_bigcap_measurable`, `countable_bigcup_measurable`
 
-- in file `normed_module.v`,
+- in `normed_module.v`,
   + new lemmas `within_continuousZ`, `within_continuousM`, 
-    `within_continuousMl`, and `within_continuousMr`.
-- in file `pseudometric_normed_Zmodule.v`,
-  + new lemma `within_continuousN`.
+    `within_continuousMl`, and `within_continuousMr`
+- in `pseudometric_normed_Zmodule.v`
+  + new lemma `within_continuousN`
 
 ### Changed
 

--- a/theories/ftc.v
+++ b/theories/ftc.v
@@ -519,7 +519,7 @@ Let within_continuous_restrict f a b : (a < b)%R ->
 Proof.
 move=> ab + x xab; move=> /(_ x).
 rewrite {1}/continuous_at => xf.
-rewrite /prop_for /continuous_at  patchE.
+rewrite /prop_for /continuous_at patchE.
 rewrite mem_set ?mulr1 /=; first exact: subset_itv_oo_cc.
 exact: cvg_patch.
 Qed.

--- a/theories/normedtype_theory/normed_module.v
+++ b/theories/normedtype_theory/normed_module.v
@@ -604,8 +604,8 @@ Qed.
 
 End cvg_composition_normed.
 
-Lemma within_continuousZ (T : topologicalType) (A : set T) (K : numFieldType) (V : normedModType K)
-    (k : K) (f : T -> V) :
+Lemma within_continuousZ (T : topologicalType) (A : set T) (K : numFieldType)
+    (V : normedModType K) (k : K) (f : T -> V) :
   {within A, continuous f} -> {within A, continuous k *: f}.
 Proof. by move=> cf x; apply: cvgZl_tmp; exact: cf. Qed.
 
@@ -671,18 +671,6 @@ Qed.
 
 End cvg_composition_field.
 
-Lemma within_continuousM (T : topologicalType) (K : numFieldType) (A : set T) (f g : T -> K) :
-  {within A, continuous f} -> {within A, continuous g} -> {within A, continuous f * g}.
-Proof. by move=> cf cg x; apply: cvgM; [exact: cf | exact: cg]. Qed.
-
-Lemma within_continuousMl (T : topologicalType) (K : numFieldType) (A : set T) (c : K) (f : T -> K) :
-  {within A, continuous f} -> {within A, continuous (fun=> c) * f}.
-Proof. by move=> cf x; apply: cvgMl_tmp; exact: cf. Qed.
-
-Lemma within_continuousMr (T : topologicalType) (K : numFieldType) (A : set T) (c : K) (f : T -> K) :
-  {within A, continuous f} -> {within A, continuous f * (fun=> c)}.
-Proof. by move=> cf x; apply: cvgMr_tmp; exact: cf. Qed.
-
 #[deprecated(since="mathcomp-analysis 1.12.0", note="renamed to `cvgMr_tmp`")]
 Notation cvgMl := cvgMr_tmp (only parsing).
 #[deprecated(since="mathcomp-analysis 1.12.0", note="renamed to `cvgMl_tmp`")]
@@ -695,6 +683,24 @@ Notation is_cvgMl := is_cvgMr_tmp (only parsing).
 Notation is_cvgMlE := is_cvgMrE_tmp (only parsing).
 #[deprecated(since="mathcomp-analysis 1.12.0", note="renamed to `is_cvgMlE_tmp`")]
 Notation is_cvgMrE := is_cvgMlE_tmp (only parsing).
+
+Section within_continuous_lemmas.
+Context {T : topologicalType} {K : numFieldType} (A : set T).
+Implicit Types f g : T -> K.
+
+Lemma within_continuousM f g : {within A, continuous f} ->
+  {within A, continuous g} -> {within A, continuous f * g}.
+Proof. by move=> cf cg x; apply: cvgM; [exact: cf | exact: cg]. Qed.
+
+Lemma within_continuousMl (c : K) f :
+  {within A, continuous f} -> {within A, continuous cst c * f}.
+Proof. by move=> cf x; apply: cvgMl_tmp; exact: cf. Qed.
+
+Lemma within_continuousMr (c : K) f :
+  {within A, continuous f} -> {within A, continuous f * cst c}.
+Proof. by move=> cf x; apply: cvgMr_tmp; exact: cf. Qed.
+
+End within_continuous_lemmas.
 
 Section limit_composition_normed.
 Context {K : numFieldType} {V : normedModType K} {T : Type}.

--- a/theories/normedtype_theory/normed_module.v
+++ b/theories/normedtype_theory/normed_module.v
@@ -670,7 +670,6 @@ exact: is_cvgMlE_tmp.
 Qed.
 
 End cvg_composition_field.
-
 #[deprecated(since="mathcomp-analysis 1.12.0", note="renamed to `cvgMr_tmp`")]
 Notation cvgMl := cvgMr_tmp (only parsing).
 #[deprecated(since="mathcomp-analysis 1.12.0", note="renamed to `cvgMl_tmp`")]

--- a/theories/normedtype_theory/normed_module.v
+++ b/theories/normedtype_theory/normed_module.v
@@ -603,6 +603,12 @@ by under [_ \*: _]funext => x /= do rewrite scalerK//; apply: cvgP.
 Qed.
 
 End cvg_composition_normed.
+
+Lemma within_continuousZ (T : topologicalType) (A : set T) (K : numFieldType) (V : normedModType K)
+    (k : K) (f : T -> V) :
+  {within A, continuous f} -> {within A, continuous k *: f}.
+Proof. by move=> cf x; apply: cvgZl_tmp; exact: cf. Qed.
+
 #[deprecated(since="mathcomp-analysis 1.12.0", note="renamed to `cvgZr_tmp`")]
 Notation cvgZl := cvgZr_tmp (only parsing).
 #[deprecated(since="mathcomp-analysis 1.12.0", note="renamed to `is_cvgZr_tmp`")]
@@ -664,6 +670,19 @@ exact: is_cvgMlE_tmp.
 Qed.
 
 End cvg_composition_field.
+
+Lemma within_continuousM (T : topologicalType) (K : numFieldType) (A : set T) (f g : T -> K) :
+  {within A, continuous f} -> {within A, continuous g} -> {within A, continuous f * g}.
+Proof. by move=> cf cg x; apply: cvgM; [exact: cf | exact: cg]. Qed.
+
+Lemma within_continuousMl (T : topologicalType) (K : numFieldType) (A : set T) (c : K) (f : T -> K) :
+  {within A, continuous f} -> {within A, continuous (fun=> c) * f}.
+Proof. by move=> cf x; apply: cvgMl_tmp; exact: cf. Qed.
+
+Lemma within_continuousMr (T : topologicalType) (K : numFieldType) (A : set T) (c : K) (f : T -> K) :
+  {within A, continuous f} -> {within A, continuous f * (fun=> c)}.
+Proof. by move=> cf x; apply: cvgMr_tmp; exact: cf. Qed.
+
 #[deprecated(since="mathcomp-analysis 1.12.0", note="renamed to `cvgMr_tmp`")]
 Notation cvgMl := cvgMr_tmp (only parsing).
 #[deprecated(since="mathcomp-analysis 1.12.0", note="renamed to `cvgMl_tmp`")]

--- a/theories/normedtype_theory/pseudometric_normed_Zmodule.v
+++ b/theories/normedtype_theory/pseudometric_normed_Zmodule.v
@@ -1142,6 +1142,11 @@ Lemma within_continuousD {T : topologicalType} {K : numFieldType}
   {within A, continuous (f + g)}.
 Proof. by move=> cf cg x; apply: cvgD; [exact: cf|exact: cg]. Qed.
 
+Lemma within_continuousN {T : topologicalType} {K : numFieldType}
+    {V : pseudoMetricNormedZmodType K} (A : set T) (f : T -> V) :
+  {within A, continuous f} -> {within A, continuous -f}.
+Proof. move=> cf x; apply: cvgN; exact: cf. Qed.
+
 Section Closed_Ball.
 
 Definition closed_ball_ (R : numDomainType) (V : zmodType) (norm : V -> R)

--- a/theories/normedtype_theory/pseudometric_normed_Zmodule.v
+++ b/theories/normedtype_theory/pseudometric_normed_Zmodule.v
@@ -1130,22 +1130,26 @@ Proof. by rewrite norm_cvg0P. Qed.
 
 End cvg_composition_pseudometric.
 
-Lemma within_continuousB {T : topologicalType} {K : numFieldType}
-    {V : pseudoMetricNormedZmodType K} (A : set T) (f g : T -> V) :
+Section within_continuous_lemmas.
+Context {T : topologicalType} {K : numFieldType}
+  {V : pseudoMetricNormedZmodType K} (A : set T).
+Implicit Types f g : T -> V.
+
+Lemma within_continuousB f g :
   {within A, continuous f} -> {within A, continuous g} ->
   {within A, continuous (f - g)}.
 Proof. by move=> cf cg x; apply: cvgB; [exact: cf|exact: cg]. Qed.
 
-Lemma within_continuousD {T : topologicalType} {K : numFieldType}
-    {V : pseudoMetricNormedZmodType K} (A : set T) (f g : T -> V) :
+Lemma within_continuousD f g :
   {within A, continuous f} -> {within A, continuous g} ->
   {within A, continuous (f + g)}.
 Proof. by move=> cf cg x; apply: cvgD; [exact: cf|exact: cg]. Qed.
 
-Lemma within_continuousN {T : topologicalType} {K : numFieldType}
-    {V : pseudoMetricNormedZmodType K} (A : set T) (f : T -> V) :
-  {within A, continuous f} -> {within A, continuous -f}.
+Lemma within_continuousN f :
+  {within A, continuous f} -> {within A, continuous - f}.
 Proof. move=> cf x; apply: cvgN; exact: cf. Qed.
+
+End within_continuous_lemmas.
 
 Section Closed_Ball.
 


### PR DESCRIPTION
##### Motivation for this change

Split from #2023.

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] ~added corresponding documentation in the headers~

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
