### PR TITLE
L'Hôpital's rule for ∞/∞ forms

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -252,6 +252,10 @@
 - in file `tvs.v`,
   + new lemmas `near_shiftE`, and `nearZE`.
 
+- in file `realfun.v`,
+  + new lemmas `lhopital_pinfty_at_right`, and 
+    `lhopital_pinfty_at_pinfty`.
+
 ### Changed
 
 - in `realsum.v`:

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -242,7 +242,7 @@
   + new lemma `near_infty_after`.
 - in file `num_topology.v`,
   + new lemmas `at_rightD`, `at_leftD`, `near_at_rightD`, `near_at_leftD`, 
-    `at_left_shift`, and `at_right_shift`.
+    `at_left_shift`, `at_right_shift`, `near_right_in_itv`, and `near_left_in_itv`.
 
 - in file `num_normedtype.v`,
   + new lemmas `pinftyV`, `ninftyV`, `cvgryV`, `cvgrNyV`, `lt0_cvgMlNy`, 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -236,6 +236,22 @@
 - in `measurable_structure.v`:
   + lemmas `countable_bigcap_measurable`, `countable_bigcup_measurable`
 
+- in file `function_spaces.v`,
+  + new lemma `within_continuous_big`.
+- in file `nat_topology.v`,
+  + new lemma `near_infty_after`.
+- in file `num_topology.v`,
+  + new lemmas `at_rightD`, `at_leftD`, `near_at_rightD`, `near_at_leftD`, 
+    `at_left_shift`, and `at_right_shift`.
+
+- in file `num_normedtype.v`,
+  + new lemmas `pinftyV`, `ninftyV`, `cvgryV`, `cvgrNyV`, `lt0_cvgMlNy`, 
+    `lt0_cvgMrNy`, `lt0_cvgMly`, and `lt0_cvgMry`.
+- in file `pseudometric_normed_Zmodule.v`,
+  + new lemmas `fmap_at_left0P`, and `fmap_at_right0E`.
+- in file `tvs.v`,
+  + new lemmas `near_shiftE`, and `nearZE`.
+
 ### Changed
 
 - in `realsum.v`:
@@ -355,6 +371,9 @@
 
 - in `classical_sets.v`
   + lemma `bigcupDr` -> `setD_bigcupr` (deprecating `bigcupDr`)
+
+- moved from `metric_structure.v` to `num_topology.v`: 
+  + lemma `cvg_at_right_left_dnbhs`, generalized to `topologicalType` from `metricType`.
 
 ### Renamed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -126,6 +126,8 @@
 
 - in `filter.v`:
   + mixin `isSubNbhs`, structure `SubNbhs`, notation `subNbhsType`
+  + new lemmas `near_eq_cvgE`, `near_eq_is_cvg`, `near_eq_lim`, 
+    `cvg_to_eq`, `cvg_to_withinP`, and `within_cvg_to_within`.
 
 - in `topology_structure.v`:
   + structure `SubTopological`, notation `subTopologicalType`

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -234,6 +234,13 @@
 - in `measurable_structure.v`:
   + lemmas `countable_bigcap_measurable`, `countable_bigcup_measurable`
 
+- in file `normed_module.v`,
+  + new lemmas `cvg1MC`, `cvg1M`, `cvgCM1`, `cvgM1`, `cvg0MC`, `cvg0M`, 
+    `cvgCM0`, and `cvgM0`.
+- in file `pseudometric_normed_Zmodule.v`,
+  + new lemmas `cvgDl`, `cvgDr`, `cvgBl`, `cvgBr`, `cvg0D`, `cvg0DC`, 
+    `cvgD0`, `cvgCD0`, `cvg0B`, `cvg0BC`, `cvgB0`, `cvgCB0`, and `cvgN0`.
+
 ### Changed
 
 - in `realsum.v`:

--- a/classical/filter.v
+++ b/classical/filter.v
@@ -1222,21 +1222,20 @@ Lemma cvg_to_withinP (T U : Type) {F : set_system T} {FF : Filter F} {G : set_sy
     (f : T -> U) (A : set U) :
   (f @ F --> within A G) <-> (f @ F --> G /\ \forall x \near F, A (f x)).
 Proof.
-  split.
-    move=> cvg_w; split.
-    - apply: (cvg_trans cvg_w).
-      exact: cvg_within.
-    - apply: cvg_w.
-      exact: withinT.
-  move=> [cvgT nearfA] P. 
-  rewrite !nbhs_nearE near_withinE.
-  move: cvgT => /[apply].
-  rewrite near_map appfilter nbhs_nearE => nearF_AP.
-  near=> x.
-  suff : A (f x) by near: x.
-  by near: x.
-  Unshelve. all: by end_near.
-Qed.
+split.
+  move=> cvg_w; split.
+  - apply: (cvg_trans cvg_w).
+    exact: cvg_within.
+  - apply: cvg_w.
+    exact: withinT.
+move=> [cvgT nearfA] P. 
+rewrite !nbhs_nearE near_withinE.
+move: cvgT => /[apply].
+rewrite near_map appfilter nbhs_nearE => nearF_AP.
+near=> x.
+suff : A (f x) by near: x.
+by near: x.
+Unshelve. all: by end_near. Qed.
 
 Global Instance within_filter T D F : Filter F -> Filter (@within T D F).
 Proof.
@@ -1255,12 +1254,12 @@ Lemma within_cvg_to_within (T U : Type) {F : set_system T} {FF : Filter F} {G : 
     (f : T -> U) (A : set T) (B : set U) :
   (\forall x \near F, A x -> B (f x)) -> f @ F --> G -> f @ within A F --> within B G.
 Proof.
-  move=> near_hom cvgT.
-  apply/cvg_to_withinP; split.
-  - apply: cvg_trans cvgT.
-    apply: cvg_app.
-    exact: cvg_within.
-  - by rewrite near_withinE.
+move=> near_hom cvgT.
+apply/cvg_to_withinP; split.
+- apply: cvg_trans cvgT.
+  apply: cvg_app.
+  exact: cvg_within.
+- by rewrite near_withinE.
 Qed. 
 
 Lemma filter_bigI_within T (I : choiceType) (D : {fset I}) (f : I -> set T)

--- a/classical/filter.v
+++ b/classical/filter.v
@@ -925,9 +925,22 @@ Lemma near_eq_cvg {T U} {F : set_system T} {FF : Filter F} (f g : T -> U) :
   {near F, f =1 g} -> g @ F `=>` f @ F.
 Proof. by move=> eq_fg P /=; apply: filterS2 eq_fg => x /= <-. Qed.
 
+Lemma near_eq_cvgE {T U} {F : set_system T} {FF : Filter F} (f g : T -> U) :
+  {near F, f =1 g} -> f @ F = g @ F.
+Proof.
+move=> eq_fg.
+apply/seteqP; split; apply: near_eq_cvg => //.
+by near do symmetry.
+Unshelve. all: by end_near.
+Qed.
+
 Lemma eq_cvg (T T' : Type) (F : set_system T) (f g : T -> T') (x : set_system T') :
   f =1 g -> (f @ F --> x) = (g @ F --> x).
 Proof. by move=> /funext->. Qed.
+
+Lemma near_eq_is_cvg (T : Type) (T' : pnbhsType) (F : set_system T) (f g : T -> T') : 
+  Filter F -> {near F, g =1 f} -> cvg (f x @[x --> F]) -> cvg(g x @[x --> F]).
+Proof. by move=> /@near_eq_cvgE /[apply] ->. Qed.
 
 Lemma eq_is_cvg_in (T T' : Type) (fT : pfilteredType T') (F : set_system T) (f g : T -> T') :
   f =1 g -> [cvg (f @ F) in fT] = [cvg (g @ F) in fT].
@@ -936,6 +949,14 @@ Proof. by move=> /funext->. Qed.
 Lemma eq_is_cvg (T : Type) (T' : pnbhsType) (F : set_system T) (f g : T -> T') :
   f =1 g -> cvg (f @ F) = cvg (g @ F).
 Proof. by move=> /funext->. Qed.
+
+Lemma near_eq_lim (T : Type) (T' : pnbhsType) {F : set_system T} {FF : Filter F} (f g : T -> T') :
+  {near F, f =1 g} -> lim (f @ F) = lim (g @ F).
+Proof. by move=> /near_eq_cvgE ->. Qed.
+
+Lemma cvg_to_eq {T : nbhsType} {F : set_system T} (l l' : T) :
+  F --> l' -> l = l' -> F --> l.
+Proof. by move=> + ->. Qed.
 
 Lemma neari_eq_loc {T U} {F : set_system T} {FF : Filter F} (f g : T -> set U) :
   {near F, f =2 g} -> g `@ F `=>` f `@ F.
@@ -1197,6 +1218,26 @@ Qed.
 
 End within.
 
+Lemma cvg_to_withinP (T U : Type) {F : set_system T} {FF : Filter F} {G : set_system U} {FG : Filter G} 
+    (f : T -> U) (A : set U) :
+  (f @ F --> within A G) <-> (f @ F --> G /\ \forall x \near F, A (f x)).
+Proof.
+  split.
+    move=> cvg_w; split.
+    - apply: (cvg_trans cvg_w).
+      exact: cvg_within.
+    - apply: cvg_w.
+      exact: withinT.
+  move=> [cvgT nearfA] P. 
+  rewrite !nbhs_nearE near_withinE.
+  move: cvgT => /[apply].
+  rewrite near_map appfilter nbhs_nearE => nearF_AP.
+  near=> x.
+  suff : A (f x) by near: x.
+  by near: x.
+  Unshelve. all: by end_near.
+Qed.
+
 Global Instance within_filter T D F : Filter F -> Filter (@within T D F).
 Proof.
 move=> FF; rewrite /within; constructor => /=.
@@ -1209,6 +1250,18 @@ Qed.
 
 Canonical within_filter_on T D (F : filter_on T) :=
   FilterType (within D F) (within_filter _ _).
+
+Lemma within_cvg_to_within (T U : Type) {F : set_system T} {FF : Filter F} {G : set_system U} {FG : Filter G}
+    (f : T -> U) (A : set T) (B : set U) :
+  (\forall x \near F, A x -> B (f x)) -> f @ F --> G -> f @ within A F --> within B G.
+Proof.
+  move=> near_hom cvgT.
+  apply/cvg_to_withinP; split.
+  - apply: cvg_trans cvgT.
+    apply: cvg_app.
+    exact: cvg_within.
+  - by rewrite near_withinE.
+Qed. 
 
 Lemma filter_bigI_within T (I : choiceType) (D : {fset I}) (f : I -> set T)
   (F : set_system T) (P : set T) :

--- a/theories/normedtype_theory/normed_module.v
+++ b/theories/normedtype_theory/normed_module.v
@@ -642,6 +642,30 @@ Proof. exact: cvgZr_tmp. Qed.
 Lemma cvgMl_tmp g a b : g @ F --> b -> a * g x @[x --> F] --> a * b.
 Proof. exact: cvgZl_tmp. Qed.
 
+Lemma cvg1MC f a : f @ F --> (1 :> K) -> f x * a @[x --> F] --> a.
+Proof. by move/(cvgMr_tmp (b := a)); rewrite mul1r. Qed.
+
+Lemma cvg1M f g a : f @ F --> (1 :> K) -> g @ F --> a -> f \* g @ F --> a.
+Proof. by move=> /cvgM /[apply]; rewrite mul1r. Qed.
+
+Lemma cvgCM1 f a : f @ F --> (1 :> K) -> a * f x @[x --> F] --> a.
+Proof. by move/(cvgMl_tmp (a := a)); rewrite mulr1. Qed.
+
+Lemma cvgM1 f g a : f @ F --> a -> g @ F --> (1 :> K) -> f \* g @ F --> a.
+Proof. by move=> /cvgM /[apply]; rewrite mulr1. Qed.
+
+Lemma cvg0MC f a : f @ F --> 0 -> f x * a @[x --> F] --> 0.
+Proof. by move/(cvgMr_tmp (b := a)); rewrite mul0r. Qed.
+
+Lemma cvg0M f g a : f @ F --> 0 -> g @ F --> a -> f \* g @ F --> 0.
+Proof. by move=> /cvgM /[apply]; rewrite mul0r. Qed.
+
+Lemma cvgCM0 f a : f @ F --> 0 -> a * f x @[x --> F] --> 0.
+Proof. by move/(cvgMl_tmp (a := a)); rewrite mulr0. Qed.
+
+Lemma cvgM0 f g a : f @ F --> a -> g @ F --> 0 -> f \* g @ F --> 0.
+Proof. by move=> /cvgM /[apply]; rewrite mulr0. Qed.
+
 Lemma is_cvgM f g : cvg (f @ F) -> cvg (g @ F) -> cvg (f \* g @ F).
 Proof. exact: is_cvgZ. Qed.
 

--- a/theories/normedtype_theory/num_normedtype.v
+++ b/theories/normedtype_theory/num_normedtype.v
@@ -245,6 +245,53 @@ apply/seteqP; split => [A [M [Mreal MA]]|A [M [Mreal MA]]].
 by exists (- M); rewrite ?realN; split=> // x; rewrite ltrNl => /MA.
 Qed.
 
+Lemma pinftyV (R : numFieldType) : x^-1 @[x --> +oo] = (0 : R)^'+.
+Proof.
+apply/seteqP; split=> [A [M [Mreal MA]]|A [r /= r0 rA]].
+- have mM1_gt0 : 0 < Num.max M 1.
+    case: (@real_leP _ M 1) => //.
+    by apply: lt_trans.
+  exists (Num.max M 1)^-1; first by rewrite /= invr_gt0.
+  move=> x /= /[swap] x_gt0.
+  rewrite distrC subr0 gtr0_norm// invf_pgt ?posrE// => mM1_lt_xV.
+  rewrite -(invrK x); apply: MA.
+  apply: le_lt_trans mM1_lt_xV.
+  by case: (@real_leP _ M 1).
+- exists r^-1; split; first by rewrite realV gtr0_real.
+  move=> x /[dup] rV_lt_x.
+  have x_gt0 : x > 0.
+    apply: lt_trans rV_lt_x.
+    by rewrite invr_gt0.
+  rewrite invf_plt// => xV_lt_r.
+  apply: rA; last by rewrite invr_gt0.
+  by rewrite /= distrC subr0 gtr0_norm// invr_gt0.
+Qed.
+
+Lemma ninftyV (R : numFieldType) : x^-1 @[x --> -oo] = (0 : R)^'-.
+Proof.
+apply/seteqP; split=> [A [M [Mreal MA]]|A [r /= r0 rA]].
+- pose M' := Num.min M (-1).
+  have M'_lt0 : M' < 0.
+    rewrite /M'.
+    case: (@real_leP _ M (-1)) => // /le_lt_trans.
+    by apply.
+  exists (-M')^-1; first by rewrite /= invr_gt0 oppr_gt0.
+  move=> x /= /[swap] x_lt0.
+  rewrite distrC subr0 ltr0_norm// invrN ltrN2 => x_gt_VM'.
+  rewrite -(invrK x); apply: MA.
+  apply: (lt_le_trans (y := M')).
+  + by rewrite invf_nlt.
+  + by rewrite /M'; case: (@real_ltP _ M (-1)).
+- exists (- r^-1); split; first by rewrite realN realV gtr0_real.
+  move=> x /[dup] x_lt_NrV.
+  have x_lt0 : x < 0.
+    apply: (lt_trans x_lt_NrV).
+    by rewrite oppr_lt0 invr_gt0.
+  rewrite ltrNr invf_plt// ?posrE ?oppr_gt0// => NxV_lt_r.
+  apply: rA; last by rewrite invr_lt0.
+  by rewrite /= distrC subr0 ltr0_norm ?invr_lt0// -invrN.
+Qed.
+
 Section infty_nbhs_instances.
 Context {R : numFieldType}.
 Implicit Types r : R.
@@ -441,6 +488,20 @@ Unshelve. all: end_near. Qed.
 Lemma cvgNrNy f : (- f @ F --> -oo) <-> (f @ F --> +oo).
 Proof. by rewrite -cvgNry opprK. Qed.
 
+Lemma cvgryV f : f @ F --> +oo -> (f x)^-1 @[x --> F] --> (0 : R).
+Proof.
+move=> cvgy.
+apply: cvg_comp; first exact: cvgy.
+by rewrite pinftyV; exact: cvg_within.
+Qed.
+
+Lemma cvgrNyV f : f @ F --> -oo -> (f x)^-1 @[x --> F] --> (0 : R).
+Proof.
+move=> cvgNy.
+apply: cvg_comp; first exact: cvgNy.
+by rewrite ninftyV; exact: cvg_within.
+Qed.
+
 End cvg_infty_numField.
 
 Section cvg_infty_realField.
@@ -525,6 +586,31 @@ Lemma gt0_cvgMry : f r @[r --> F] --> +oo -> (M * f r)%R @[r --> F] --> +oo.
 Proof. by move=> fy; under eq_fun do rewrite mulrC; exact: gt0_cvgMly. Qed.
 
 End gt0_cvg.
+
+Section lt0_cvg.
+Context {R : realFieldType} {F : set_system R} {FF : Filter F}.
+Variables (M : R) (f : R -> R).
+Hypothesis M0 : M < 0.
+
+Lemma lt0_cvgMlNy : (f r) @[r --> F] --> +oo -> (f r * M)%R @[r --> F] --> -oo.
+Proof.
+move=> /cvgryPge fy; apply/cvgrNyPle => A.
+by apply: filterS (fy (A / M)) => x; rewrite ler_ndivrMr.
+Qed.
+
+Lemma lt0_cvgMrNy : (f r) @[r --> F] --> +oo -> (M * f r)%R @[r --> F] --> -oo.
+Proof. by move=> fy; under eq_fun do rewrite mulrC; exact: lt0_cvgMlNy. Qed.
+
+Lemma lt0_cvgMly : f r @[r --> F] --> -oo -> (f r * M)%R @[r --> F] --> +oo.
+Proof.
+move=> /cvgrNyPle fNy; apply/cvgryPge => A.
+by apply: filterS (fNy (A / M)) => x; rewrite ler_ndivlMr.
+Qed.
+
+Lemma lt0_cvgMry : f r @[r --> F] --> -oo -> (M * f r)%R @[r --> F] --> +oo.
+Proof. by move=> fy; under eq_fun do rewrite mulrC; exact: lt0_cvgMly. Qed.
+
+End lt0_cvg.
 
 Lemma cvgNy_compNP {T : topologicalType} {R : numFieldType} (f : R -> T)
     (l : set_system T) :

--- a/theories/normedtype_theory/pseudometric_normed_Zmodule.v
+++ b/theories/normedtype_theory/pseudometric_normed_Zmodule.v
@@ -1098,6 +1098,45 @@ Qed.
 Lemma is_cvgDrE f g : cvg (f @ F) -> cvg ((f + g) @ F) = cvg (g @ F).
 Proof. by rewrite addrC; apply: is_cvgDlE. Qed.
 
+Lemma cvgDl f a b : f @ F --> b -> a + f x @[x --> F] --> a + b.
+Proof. apply: cvgD; exact: cvg_cst. Qed.
+
+Lemma cvgDr f a b : f @ F --> a -> f x + b @[x --> F] --> a + b.
+Proof. move/cvgD; apply; exact: cvg_cst. Qed.
+
+Lemma cvgBl f a b : f @ F --> b -> a - f x @[x --> F] --> a - b.
+Proof. by move/cvgN; apply: cvgDl. Qed.
+
+Lemma cvgBr f a b : f @ F --> a -> f x - b @[x --> F] --> a - b.
+Proof. exact: cvgDr. Qed.
+
+Lemma cvg0D f g a : f @ F --> 0 -> g @ F --> a -> f x + g x @[x --> F] --> a.
+Proof. by move=> /cvgD /[apply]; rewrite add0r. Qed.
+
+Lemma cvg0DC f a : f @ F --> 0 -> f x + a @[x --> F] --> a.
+Proof. by move=> /(cvgDr (b := a)); rewrite add0r. Qed.
+
+Lemma cvgD0 f g a : f @ F --> a -> g @ F --> 0 -> f x + g x @[x --> F] --> a.
+Proof. by move=> /cvgD /[apply]; rewrite addr0. Qed.
+
+Lemma cvgCD0 f a : f @ F --> 0 -> a + f x @[x --> F] --> a.
+Proof. by move/(@cvgDl _ a); rewrite addr0. Qed.
+
+Lemma cvg0B f g a : f @ F --> 0 -> g @ F --> a -> f x - g x @[x --> F] --> -a.
+Proof. by move=> /cvgB /[apply]; rewrite add0r. Qed.
+
+Lemma cvg0BC f a : f @ F --> 0 -> f x - a @[x --> F] --> -a.
+Proof. by move=> /(cvgBr (b := a)); rewrite add0r. Qed.
+
+Lemma cvgB0 f g a : f @ F --> a -> g @ F --> 0 -> f x - g x @[x --> F] --> a.
+Proof. by move=> /cvgB /[apply]; rewrite subr0. Qed.
+
+Lemma cvgCB0 f a : f @ F --> 0 -> a - f x @[x --> F] --> a.
+Proof. by move/(@cvgBl _ a); rewrite subr0. Qed.
+
+Lemma cvgN0 f : f @ F --> 0 -> - f @ F --> 0.
+Proof. by rewrite -{2}oppr0; exact: cvgN. Qed.
+
 Lemma cvg_sub0 f g a : (f - g) @ F --> (0 : V) -> g @ F --> a -> f @ F --> a.
 Proof.
 by move=> Cfg Cg; have := cvgD Cfg Cg; rewrite subrK add0r; apply.

--- a/theories/normedtype_theory/pseudometric_normed_Zmodule.v
+++ b/theories/normedtype_theory/pseudometric_normed_Zmodule.v
@@ -628,6 +628,22 @@ Proof.
 by rewrite at_leftN -?fmap_comp; under [_ \o _]eq_fun => ? do rewrite /= opprK.
 Qed.
 
+Lemma fmap_at_left0P {T : Type} {R : numFieldType} x (f : R -> T) : (f (x - e) @[e --> 0^'+]) = (f @ x^'-).
+Proof.
+rewrite -(subrr (-x)) at_right_shift at_rightN -fmap_comp.
+apply: near_eq_cvgE.
+apply: (nearW (F := x^'-)) => y /=.
+by rewrite opprB addNKr opprK.
+Qed.
+
+Lemma fmap_at_right0E {T : Type} {R : numFieldType} (x : R) (f : R -> T) : (f (x + e) @[e --> 0^'+]) = (f @ x^'+).
+Proof.
+rewrite -(subrr x) at_right_shift.
+apply: near_eq_cvgE.
+apply: (nearW (F := x^'+)) => y.
+by rewrite addrC subrK.
+Qed.
+
 Section at_left_right_pseudoMetricNormedZmod.
 Variables (R : numFieldType) (V : pseudoMetricNormedZmodType R).
 

--- a/theories/normedtype_theory/tvs.v
+++ b/theories/normedtype_theory/tvs.v
@@ -647,6 +647,19 @@ Proof. exact/nbhsB_subproof/add_continuous. Qed.
 
 End ConvexTvs_numDomain.
 
+Lemma near_shiftE (R : numDomainType) (E : convexTvsType R) (U : set E) (x a : E) :
+  (\forall y \near x + a, U y) = (\near x, U (x + a)).
+Proof.
+eqProp; rewrite -!nbhs_nearE.
+- move/(nbhsB (-a)).
+  rewrite addrC addrK.
+  apply: filterS => _ [y Uy <-].
+  by rewrite addrC addNKr.
+- move/(nbhsB a); rewrite addrC.
+  apply: filterS => ? [y Uya <-].
+  by rewrite addrC.
+Qed.
+
 Section ConvexTvs_numField.
 
 Lemma nbhs0Z (R : numFieldType) (E : convexTvsType R) (U : set E) (r : R) :
@@ -666,6 +679,20 @@ rewrite scalerA mulVf// scale1r =>/(_ U0)[] /= B [B1 B2] BU.
 near=> z; exists (r^-1 *: z); last by rewrite scalerA divff// scale1r.
 by apply: (BU (r^-1,z)); split; [exact: nbhs_singleton|near: z].
 Unshelve. all: by end_near. Qed.
+
+Lemma nearZE (R : numFieldType) (T : convexTvsType R) (c : R) (x : T) (P : set T) :
+  c != 0 -> (\forall y \near c *: x, P y) = (\near x, P (c *: x)).
+Proof.
+move=> c_neq0.
+have cinv_neq0 : c^-1 != 0 by apply: invr_neq0.
+eqProp.
+- move/(nbhsZ cinv_neq0).
+  rewrite scalerK//.
+  apply: filterS => ? [y Py <-].
+  by rewrite scalerKV.
+- move/(nbhsZ c_neq0).
+  by apply: filterS => ? [y Pcy <-].
+Qed.
 
 End ConvexTvs_numField.
 

--- a/theories/realfun.v
+++ b/theories/realfun.v
@@ -2933,3 +2933,165 @@ move=> fgcl; apply/(@cvg_at_right_left_dnbhs _ R^o).
 Qed.
 
 End lhopital.
+
+Section lhopital_pinfty_at_right.
+Context (R : realType) (f df g dg : R -> R) (a l : R).
+Hypothesis near_der_f : \forall x \near a^'+, is_derive x (1 :> R) f (df x).
+Hypothesis near_der_g : \forall x \near a^'+, is_derive x (1 :> R) g (dg x).
+Hypothesis g_cvgy : g @ a^'+ --> +oo.
+Hypothesis near_dg_neq0 : (\forall x \near a^'+, dg x != 0).
+Hypothesis dfdg_cvg : df x / dg x @[x --> a^'+] --> l.
+
+Lemma lhopital_pinfty_at_right : f x / g x @[x --> a^'+] --> l.
+Proof.
+have [b a_lt_b in_ab] : exists2 b : R, a < b & 
+      {in `]a, b[%R, forall (x : R), [/\ 
+      is_derive x 1 f (df x) , 
+      is_derive x 1 g (dg x) &
+      dg x != 0
+    ]}.
+  near a^'+ => b.
+  exists b => //.
+  near: b; apply/near_right_in_itv.
+  by near do split.
+apply/cvgrPdistC_lt => /= eps eps0.
+near (0 :> R)^'+ => d.
+move: dfdg_cvg => /cvgrPdistC_lt /(_ d) [] //=.
+move=> r r0 withinr_withind.
+near a^'+ => y; near=> x.
+have := @cauchy_MVT R f df g dg x y.
+have /[swap] /[apply] : x < y by done.
+have /[swap] /[apply] : {within `[x, y], continuous f}.
+  apply: (continuous_subspaceW (B := `]a, b[)).
+    by apply: subset_itv; rewrite bnd_simp.
+  rewrite continuous_open_subspace// => /= z /set_mem/= z_ab.
+  apply: differentiable_continuous.
+  apply/derivable1_diffP.
+  apply: ex_derive.
+  by apply in_ab.
+have /[swap] /[apply] : {within `[x, y], continuous g}.
+  apply: (continuous_subspaceW (B := `]a, b[)).
+    by apply: subset_itv; rewrite bnd_simp.
+  rewrite continuous_open_subspace// => /= z /set_mem/= z_ab.
+  apply: differentiable_continuous.
+  apply/derivable1_diffP.
+  apply: ex_derive.
+  by apply in_ab.
+have xy_and z : z \in `]x, y[%R -> 
+    [/\ is_derive z 1 f (df z), is_derive z 1 g (dg z) & dg z != 0].
+  rewrite in_itv/= => /andP[x_lt_z z_lt_y].
+  apply: in_ab.
+  rewrite in_itv/=.
+  apply/andP; split.
+  - by apply: lt_trans x_lt_z.
+  - by apply: (lt_trans z_lt_y).
+move=> /(_ (fun z z_xy => let (h, _, _) := xy_and z z_xy in h)).
+move=> /(_ (fun z z_xy => let (_, h, _) := xy_and z z_xy in h)).
+move=> /(_ (fun z z_xy => let (_, _, h) := xy_and z z_xy in h)).
+clear xy_and in_ab.
+move=> [c + +].
+rewrite in_itv/= => /andP[x_lt_c c_lt_y] dfdgc.
+have : `|(f y - f x) / (g y - g x) - l| < d.
+  rewrite -dfdgc.
+  have a_lt_c : a < c by apply: (lt_trans (y := x)).
+  apply: withinr_withind => //=.
+  rewrite ltr0_norm ?subr_lt0// opprB ltrBlDl.
+  apply: (lt_trans c_lt_y).
+  near: y.
+  apply: nbhs_right_lt.
+  by rewrite ltrDl.
+have gx_gt_gy : g x > g y.
+  near: x.
+  by apply: cvgry_gt.
+have gx_gt0 : 0 < g x.
+  near: x.
+  by apply: cvgry_gt.
+have -> : (f y - f x) / (g y - g x) = (f x / g x - f y / g x) / (1 - g y / g x).
+  rewrite -[LHS]divrNN !opprB.
+  rewrite -(@divrr _ (g x)) ?unitf_gt0// -!mulrBl.
+  by rewrite -mulf_div divrr ?unitrV ?unitf_gt0// mulr1.
+rewrite ltr_distl ltr_pdivlMr.
+  by rewrite subr_gt0 ltr_pdivrMr// mul1r.
+rewrite ltrBrDr ltr_pdivrMr.
+  by rewrite subr_gt0 ltr_pdivrMr// mul1r.
+rewrite ltrBlDr => /andP[fg_gt fg_lt].
+rewrite ltr_distl.
+apply/andP; split.
+- apply: lt_trans fg_gt.
+  near: x.
+  apply: (cvgr_gt (l - d)); last first.
+    rewrite ltrD2l ltrN2.
+    near: d.
+    by apply: nbhs_right_lt.
+  apply: cvgD0.
+  + apply: cvgCM1.
+    apply: cvgCB0.
+    apply: cvgCM0.
+    by apply: cvgryV.
+  + apply: cvgCM0.
+    by apply: cvgryV.
+- apply: (lt_trans fg_lt).
+  near: x.
+  apply: (cvgr_lt (l + d)); last first.
+    rewrite ltrD2l.
+    near: d.
+    by apply: nbhs_right_lt.
+  apply: cvgD0.
+  + apply: cvgCM1.
+    apply: cvgCB0.
+    apply: cvgCM0.
+    by apply: cvgryV.
+  + apply: cvgCM0.
+    by apply: cvgryV.
+Unshelve. all: by end_near. Qed.
+
+End lhopital_pinfty_at_right.
+
+Section lhopital_pinfty_at_pinfty.
+Context (R : realType) (f df g dg : R -> R) (a l : R).
+Hypothesis near_der_f : \forall x \near +oo, is_derive x (1 :> R) f (df x).
+Hypothesis near_der_g : \forall x \near +oo, is_derive x (1 :> R) g (dg x).
+Hypothesis g_cvgy : g @ +oo --> +oo.
+Hypothesis near_dg_neq0 : (\forall x \near +oo, dg x != 0).
+Hypothesis dfdg_cvg : df x / dg x @[x --> +oo] --> l.
+
+Lemma lhopital_pinfty_at_pinfty : f x / g x @[x --> +oo] --> l.
+Proof.
+apply: cvg_trans.
+  apply: (near_eq_cvg (f := fun x => f x^-1^-1 / g x^-1^-1)).
+  by near=> x; rewrite !invrK.
+apply: (cvg_comp _ (fun x => f x^-1 / g x^-1)); first by rewrite pinftyV.
+apply: lhopital_pinfty_at_right.
+- near=> x.
+  apply: (is_derive1_comp (a := df x^-1)).
+    near: x.
+    rewrite -pinftyV near_map.
+    by near do rewrite invrK.
+  by apply: is_deriveV.
+- near=> x.
+  apply: (is_derive1_comp (a := dg x^-1)).
+    near: x.
+    rewrite -pinftyV near_map.
+    by near do rewrite invrK.
+  by apply: is_deriveV.
+- apply: cvg_comp => //.
+  apply: cvg_trans g_cvgy.
+  apply: cvg_fmap2.
+  rewrite -pinftyV -fmap_comp /comp.
+  by under eq_cvg do rewrite invrK.
+- near=> x.
+  rewrite scaler1 mulrN oppr_eq0.
+  apply: mulf_neq0.
+  + near: x.
+    rewrite -pinftyV near_map.
+    by near do rewrite invrK.
+  + by rewrite invr_neq0// sqrf_eq0.
+- apply: cvg_trans dfdg_cvg.
+  rewrite -pinftyV -fmap_comp.
+  apply: near_eq_cvg.
+  near=> x => /=.
+  rewrite !invrK scaler1 !(mulrN, divrN, mulNr) opprK -mulf_div divrr ?mulr1//.
+  by rewrite unitrV unitrX// unitrV unitf_gt0.
+Unshelve. all: by end_near. Qed.
+
+End lhopital_pinfty_at_pinfty.

--- a/theories/realfun.v
+++ b/theories/realfun.v
@@ -2965,8 +2965,7 @@ have /[swap] /[apply] : {within `[x, y], continuous f}.
   apply: (continuous_subspaceW (B := `]a, b[)).
     by apply: subset_itv; rewrite bnd_simp.
   rewrite continuous_open_subspace// => /= z /set_mem/= z_ab.
-  apply: differentiable_continuous.
-  apply/derivable1_diffP.
+  apply: differentiable_continuous; apply/derivable1_diffP.
   apply: ex_derive.
   by apply in_ab.
 have /[swap] /[apply] : {within `[x, y], continuous g}.

--- a/theories/topology_theory/function_spaces.v
+++ b/theories/topology_theory/function_spaces.v
@@ -1600,6 +1600,11 @@ Proof.
 by move=> F_cont x; apply: cvg_big => // i /F_cont; exact.
 Qed.
 
+Lemma within_continuous_big (T : topologicalType) (A : set T) (r : seq I) (F : I -> T -> U) :
+	(forall (i : I), P i -> {within A, continuous (F i)}) ->
+	{within A, continuous (fun x : T => \big[op/x0]_(i <- r | P i) F i x)}.
+Proof. by move=> cont_F x; apply: continuous_big. Qed.
+
 End big_continuous.
 
 Definition eval {X Y : topologicalType} : continuousType X Y * X -> Y :=

--- a/theories/topology_theory/metric_structure.v
+++ b/theories/topology_theory/metric_structure.v
@@ -315,33 +315,6 @@ Unshelve. all: end_near. Qed.
 
 End cvg_nbhsP.
 
-Section cvg_at_right_left_dnbhs.
-Variables (R : realFieldType) (T : metricType R).
-
-Import metricType_numDomainType.
-
-Lemma cvg_at_right_left_dnbhs (f : R -> T) (p : R) (l : T) :
-  f x @[x --> p^'+] --> l -> f x @[x --> p^'-] --> l ->
-  f x @[x --> p^'] --> l.
-Proof.
-move=> /cvgrPdist_le fppl /cvgrPdist_le fpnl; apply/cvgrPdist_le => e e0.
-have {fppl}[a /= a0 fppl] := fppl (at_right_proper_filter p) _ e0.
-have {fpnl}[b /= b0 fpnl] := fpnl (at_left_proper_filter p) _ e0.
-near=> t.
-have : t != p by near: t; exact: nbhs_dnbhs_neq.
-rewrite neq_lt => /orP[tp|pt].
-- apply: fpnl => //=; near: t.
-  exists (b / 2) => //=; first by rewrite divr_gt0.
-  move=> z/= + _ => /lt_le_trans; apply.
-  by rewrite ler_pdivrMr// ler_pMr// ler1n.
-- apply: fppl =>//=; near: t.
-  exists (a / 2) => //=; first by rewrite divr_gt0.
-  move=> z/= + _ => /lt_le_trans; apply.
-  by rewrite ler_pdivrMr// ler_pMr// ler1n.
-Unshelve. all: by end_near. Qed.
-
-End cvg_at_right_left_dnbhs.
-
 Section at_left_rightR.
 Variable (R : numFieldType).
 

--- a/theories/topology_theory/nat_topology.v
+++ b/theories/topology_theory/nat_topology.v
@@ -93,6 +93,18 @@ Lemma near_inftyS (P : set nat) :
   (\forall x \near \oo, P (S x)) -> (\forall x \near \oo, P x).
 Proof. case=> N _ NPS; exists (S N) => // [[]]; rewrite /= ?ltn0 //. Qed.
 
+Lemma near_infty_after (P : set nat) :
+  (\forall n \near \oo, P n) <-> (\forall N \near \oo, forall n, (n >= N)%N -> P n).
+Proof.
+split.
+- move=> [N _ afterN].
+  exists N => // n /= /[swap] n' /leq_trans /[apply].
+  exact: afterN.
+- move=> [N _ afterN].
+  exists N => // n /=.
+  by apply: afterN => /=.
+Qed.  
+
 Section infty_nat.
 Local Open Scope nat_scope.
 

--- a/theories/topology_theory/num_topology.v
+++ b/theories/topology_theory/num_topology.v
@@ -241,6 +241,50 @@ split=> [pPf e|ex_notPx].
   by rewrite /ball/= ltr0_norm ?subr_lt0// opprB ltrBlDl.
 Unshelve. all: by end_near. Qed.
 
+Lemma at_rightD x a : (x + a)^'+ = (y + a @[y --> x^'+]).
+Proof.
+apply/seteqP; split=> P /=.
+- move=> [/= r r0 br_sub].
+  exists r => // y bxy x_lt_y.
+  apply: br_sub => /=.
+  + by rewrite (addrC y) addrKA.
+  + by rewrite ltrD2r.
+- move=> [/= r r0 br_sub].
+  exists r => // y bxay xDa_lt_y.
+  rewrite -(subrK a y).
+  apply: br_sub => /=.
+  + by rewrite opprB addrA.
+  + by rewrite ltrBrDr.
+Qed.
+
+Lemma at_leftD x a : (x + a)^'- = (y + a @[y --> x^'-]).
+Proof.
+apply/seteqP; split=> P /=.
+- move=> [/= r r0 br_sub].
+  exists r => // y bxy x_gt_y.
+  apply: br_sub => /=.
+  + by rewrite (addrC y) addrKA.
+  + by rewrite ltrD2r.
+- move=> [/= r r0 br_sub].
+  exists r => // y bxay xDa_gt_y.
+  rewrite -(subrK a y).
+  apply: br_sub => /=.
+  + by rewrite opprB addrA.
+  + by rewrite ltrBlDr.
+Qed.
+
+Lemma near_at_rightD x a (P : set R) : (\forall y \near (x + a)^'+, P y) = (\forall y \near x^'+, P (y + a)).
+Proof. by rewrite at_rightD near_map. Qed.
+
+Lemma near_at_leftD x a (P : set R) : (\forall y \near (x + a)^'-, P y) = (\forall y \near x^'-, P (y + a)).
+Proof. by rewrite at_leftD near_map. Qed.
+
+Lemma at_left_shift (T : Type) x a (f : R -> T) : (f @ (x + a)^'-) = (f (y + a) @[y --> x^'-]).
+Proof. by rewrite at_leftD. Qed.
+
+Lemma at_right_shift (T : Type) x a (f : R -> T) : (f @ (x + a)^'+) = (f (y + a) @[y --> x^'+]).
+Proof. by rewrite at_rightD. Qed.
+
 End at_left_right.
 #[global] Typeclasses Opaque at_left at_right.
 Notation "x ^'-" := (at_left x) : classical_set_scope.
@@ -251,6 +295,16 @@ Notation "x ^'+" := (at_right x) : classical_set_scope.
 
 #[global] Hint Extern 0 (Filter (nbhs _^'-)) =>
   (apply: at_left_proper_filter) : typeclass_instances.
+
+Lemma cvg_at_right_left_dnbhs (R : realFieldType) (T : topologicalType) (f : R -> T) (p : R) (l : T) :
+  f x @[x --> p^'+] --> l -> f x @[x --> p^'-] --> l -> f x @[x --> p^'] --> l.
+Proof.
+move=> + + U Uz => /(_ U Uz) + /(_ U Uz); near_simpl.
+rewrite !near_withinE !near_nbhs => lf rf.
+apply: filter_app lf; apply: filter_app rf.
+near=> t => xlt xgt.
+by case/lt_total/orP.
+Unshelve. all: by end_near. Qed.
 
 Lemma left_right_continuousP {R : realFieldType} {T : topologicalType}
     (f : R -> T) x :

--- a/theories/topology_theory/num_topology.v
+++ b/theories/topology_theory/num_topology.v
@@ -474,6 +474,46 @@ move=> r/=; rewrite ltr_pdivlMr// -ltrBlDr; apply: le_lt_trans.
 by rewrite -lerBlDr opprK addrC (le_trans (ler_norm _))// ler_peMr// ler1n.
 Qed.
 
+Lemma near_right_in_itv (R : realFieldType) (a : R) (P : set R) : 
+  (\forall b \near a^'+, {in `]a, b[, forall x, P x}) 
+  <-> {near a^'+, forall x, P x}.
+Proof.
+split=> [[/= r r0 hr]|[/= r r0 hr]].
+- exists (r / 2) => [|x /= /ltr_distlCDr x_lt_aDr2 a_lt_x].
+    by apply: divr_gt0.
+  apply: (hr (a + r / 2)) => /=.
+  + rewrite opprD addNKr normrN gtr0_norm// ?divr_gt0//.
+    by rewrite gtr_pMr// invf_plt ?posrE// invr1 ltrDl.
+  + by rewrite ltrDl divr_gt0.
+  + by rewrite in_itv/= a_lt_x/=.
+- exists r => // x /= /ltr_distlCDr x_lt_aDr a_lt_x y.
+  rewrite in_itv/= => /andP[a_lt_y y_lt_x].
+  apply: hr => //=.
+  rewrite distrC gtr0_norm ?subr_gt0// ltrBlDl.
+  by apply: lt_trans x_lt_aDr.
+Qed.
+
+Lemma near_left_in_itv (R : realFieldType) (b : R) (P : set R) : 
+  (\forall a \near b^'-, {in `]a, b[, forall x, P x}) 
+  <-> {near b^'-, forall x, P x}.
+Proof.
+split=> [[/= r r0 hr]|[/= r r0 hr]].
+- exists (r / 2) => [|x /= /ltr_distlDr b_lt_xDr2 x_lt_b].
+    by apply: divr_gt0.
+  apply: (hr (b - r / 2)) => /=.
+  + rewrite subKr gtr0_norm ?divr_gt0//.
+    by rewrite gtr_pMr// invf_plt ?posrE// invr1 ltrDl.
+  + by rewrite gtrBl divr_gt0.
+  + by rewrite in_itv/= x_lt_b andbT ltrBlDr.
+- exists r => // x /= /ltr_distlDr b_lt_xDr x_lt_b y.
+  rewrite in_itv/= => /andP[x_lt_y y_lt_b].
+  apply: hr => //=.
+  rewrite gtr0_norm ?subr_gt0//.
+  rewrite ltrBlDl.
+  apply: (lt_trans b_lt_xDr).
+  by rewrite ltrD2r.
+Qed.
+
 Section nbhs_lt_le.
 Context {R : numFieldType}.
 Implicit Types x z : R.


### PR DESCRIPTION
##### Motivation for this change

Split from #2023. Depends on #2030.
Adds versions of l'Hôpital's rule for indeterminate forms of the kind $$\frac{+\infty}{+\infty}$$.

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`
- [ ] Merge #2030

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] ~added corresponding documentation in the headers~

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
