### PR TITLE
Dominated convergence for `Rintegral`

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -271,6 +271,8 @@
   + lemmas `dlet_dlet`, `dmargin_dlet`, `dlet_dmargin`, `dfst_dswap`,
     `dsnd_dswap`, `dsndE`, `pr_dlet` are no longer deprecated
 
+- in file `lebesgue_Rintegral.v`,
+  + new lemma `Rdominated_cvg`.
 
 ### Changed
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -271,8 +271,6 @@
   + lemmas `dlet_dlet`, `dmargin_dlet`, `dlet_dmargin`, `dfst_dswap`,
     `dsnd_dswap`, `dsndE`, `pr_dlet` are no longer deprecated
 
-- in file `lebesgue_Rintegral.v`,
-  + new lemma `Rdominated_cvg`.
 - in `lebesgue_Rintegral.v`:
   + lemma `Rdominated_cvg`
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -273,6 +273,8 @@
 
 - in file `lebesgue_Rintegral.v`,
   + new lemma `Rdominated_cvg`.
+- in `lebesgue_Rintegral.v`:
+  + lemma `Rdominated_cvg`
 
 ### Changed
 

--- a/theories/lebesgue_integral_theory/lebesgue_Rintegral.v
+++ b/theories/lebesgue_integral_theory/lebesgue_Rintegral.v
@@ -256,12 +256,11 @@ Section Rdominated_convergence.
 Context {d} {T : measurableType d} {R : realType}
   (mu : {measure set T -> \bar R}) (D : set T) (mD : measurable D)
   (f_ : (T -> R)^nat) (f g : T -> R).
+Import MeasurableR.
 Hypotheses (mf_ : forall n, measurable_fun D (f_ n))
   (f_f : forall x, D x -> f_ ^~ x @ \oo --> f x)
   (int_g : mu.-integrable D (EFin \o g))
   (absfg : forall n x, D x -> `|f_ n x| <= g x).
-
-Import MeasurableR.
 
 Lemma Rdominated_cvg :
   \int[mu]_(x in D) f_ n x @[n \oo] --> \int[mu]_(x in D) f x.

--- a/theories/lebesgue_integral_theory/lebesgue_Rintegral.v
+++ b/theories/lebesgue_integral_theory/lebesgue_Rintegral.v
@@ -251,3 +251,46 @@ End Rintegral_lebesgue_measure.
 Notation Rintegral_itv_bndo_bndc := Rintegral_itvbo_itvbc (only parsing).
 #[deprecated(since="mathcomp-analysis 1.17.0", use=Rintegral_itvob_itvcb)]
 Notation Rintegral_itv_obnd_cbnd := Rintegral_itvob_itvcb (only parsing).
+
+Section Rdominated_convergence.
+Context d (T : measurableType d) (R : realType).
+Variables (mu : {measure set T -> \bar R}) (D : set T) (mD : measurable D).
+Variables (f_ : (T -> R)^nat) (f g : T -> R).
+Hypothesis mf_ : forall n, measurable_fun D (f_ n).
+Hypothesis f_f : forall x, D x -> f_ ^~ x @ \oo --> f x.
+Hypothesis ig : integrable.body mu D (EFin \o g).
+Hypothesis absfg : forall n x, D x -> `|f_ n x| <= g x.
+
+Let mf_e n : measurable_fun D (EFin \o f_ n).
+Proof. by apply/measurable_EFinP. Qed.
+
+Let f_fe (x : T) : D x -> (f_ n x)%:E @[n --> \oo] --> (f x)%:E.
+Proof.
+move=> Dx.
+apply/fine_cvgP; split; first by apply: nearW.
+by apply: f_f.
+Qed.
+
+Let egi (x : T) : (g x)%:E \is a fin_num.
+Proof. by []. Qed.
+
+Let absfge (n : nat) (x : T) : D x -> (`|(f_ n x)%:E| <= (g x)%:E)%E.
+Proof.
+move=> Dx.
+rewrite abse_EFin lee_fin.
+by apply: absfg.
+Qed.
+
+Let mf : measurable_fun D (EFin \o f).
+Proof. by apply: emeasurable_fun_cvg; first by exact: mf_e. Qed.
+
+Lemma Rdominated_cvg : \int[mu]_(x in D) f_ n x @[n \oo] --> \int[mu]_(x in D) f x.
+Proof.
+rewrite /Rintegral.
+have := dominated_convergence mD mf_e mf (aeW _ f_fe) ig (aeW _ (fun x n Dx => absfge n Dx)).
+move=> /= [i_f _ +].
+rewrite -[X in _ --> X]fineK; first by apply: integrable_fin_num.
+by move/fine_cvg.
+Qed.
+
+End Rdominated_convergence.

--- a/theories/lebesgue_integral_theory/lebesgue_Rintegral.v
+++ b/theories/lebesgue_integral_theory/lebesgue_Rintegral.v
@@ -253,44 +253,25 @@ Notation Rintegral_itv_bndo_bndc := Rintegral_itvbo_itvbc (only parsing).
 Notation Rintegral_itv_obnd_cbnd := Rintegral_itvob_itvcb (only parsing).
 
 Section Rdominated_convergence.
-Context d (T : measurableType d) (R : realType).
-Variables (mu : {measure set T -> \bar R}) (D : set T) (mD : measurable D).
-Variables (f_ : (T -> R)^nat) (f g : T -> R).
-Hypothesis mf_ : forall n, measurable_fun D (f_ n).
-Hypothesis f_f : forall x, D x -> f_ ^~ x @ \oo --> f x.
-Hypothesis ig : integrable.body mu D (EFin \o g).
-Hypothesis absfg : forall n x, D x -> `|f_ n x| <= g x.
+Context {d} {T : measurableType d} {R : realType}
+  (mu : {measure set T -> \bar R}) (D : set T) (mD : measurable D)
+  (f_ : (T -> R)^nat) (f g : T -> R).
+Hypotheses (mf_ : forall n, measurable_fun D (f_ n))
+  (f_f : forall x, D x -> f_ ^~ x @ \oo --> f x)
+  (int_g : mu.-integrable D (EFin \o g))
+  (absfg : forall n x, D x -> `|f_ n x| <= g x).
 
-Let mf_e n : measurable_fun D (EFin \o f_ n).
-Proof. by apply/measurable_EFinP. Qed.
-
-Let f_fe (x : T) : D x -> (f_ n x)%:E @[n --> \oo] --> (f x)%:E.
-Proof.
-move=> Dx.
-apply/fine_cvgP; split; first by apply: nearW.
-by apply: f_f.
-Qed.
-
-Let egi (x : T) : (g x)%:E \is a fin_num.
-Proof. by []. Qed.
-
-Let absfge (n : nat) (x : T) : D x -> (`|(f_ n x)%:E| <= (g x)%:E)%E.
-Proof.
-move=> Dx.
-rewrite abse_EFin lee_fin.
-by apply: absfg.
-Qed.
-
-Let mf : measurable_fun D (EFin \o f).
-Proof. by apply: emeasurable_fun_cvg; first by exact: mf_e. Qed.
-
-Lemma Rdominated_cvg : \int[mu]_(x in D) f_ n x @[n \oo] --> \int[mu]_(x in D) f x.
+Lemma Rdominated_cvg :
+  \int[mu]_(x in D) f_ n x @[n \oo] --> \int[mu]_(x in D) f x.
 Proof.
 rewrite /Rintegral.
-have := dominated_convergence mD mf_e mf (aeW _ f_fe) ig (aeW _ (fun x n Dx => absfge n Dx)).
-move=> /= [i_f _ +].
-rewrite -[X in _ --> X]fineK; first by apply: integrable_fin_num.
-by move/fine_cvg.
+have []// := @dominated_convergence _ _ _ mu _ mD (fun n t => (f_ n t)%:E)
+    (EFin \o f) (EFin \o g).
+- by move=> n; exact/measurable_EFinP.
+- exact/measurable_EFinP/measurable_fun_cvg.
+- by apply: aeW => x Dx; apply/fine_cvgP; split; [exact: nearW|exact: f_f].
+- by apply: aeW => x n Dx/=; rewrite lee_fin absfg.
+by move=> int_f _/= int_f_f; apply/fine_cvg; rewrite fineK// integrable_fin_num.
 Qed.
 
 End Rdominated_convergence.

--- a/theories/lebesgue_integral_theory/lebesgue_Rintegral.v
+++ b/theories/lebesgue_integral_theory/lebesgue_Rintegral.v
@@ -261,6 +261,8 @@ Hypotheses (mf_ : forall n, measurable_fun D (f_ n))
   (int_g : mu.-integrable D (EFin \o g))
   (absfg : forall n x, D x -> `|f_ n x| <= g x).
 
+Import MeasurableR.
+
 Lemma Rdominated_cvg :
   \int[mu]_(x in D) f_ n x @[n \oo] --> \int[mu]_(x in D) f x.
 Proof.


### PR DESCRIPTION
##### Motivation for this change

Split from #2023.

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [x] ~added corresponding documentation in the headers~

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
