### PR TITLE
is_derive_mulmx

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -94,6 +94,9 @@
   + lemma `diffmx`
   + lemma `is_diff_mx`
   + instance `is_diff_mx`
+  + instance `is_derive_coord`
+  + instance `is_derive_mulmx`
+
 - in `realsum.v`:
   + lemma `esum_psum`
   + lemma `esum_sum`

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -2453,6 +2453,33 @@ pose gL : {linear _ -> _} := HB.pack g glM.
 by apply: (@diff_unique _ _ _ _ gL); have [? ?] := dmx dM.
 Qed.
 
+Global Instance is_derive_mx_coord n m
+    (f : V -> 'M[R]_(n, m)) (f' : 'M[R]_(n,m)) (t : V) w :
+  is_derive t w f f' ->
+  forall i j, is_derive t w (fun x => f x i j) (f' i j).
+Proof.
+move=> fD i j /=.
+have fDer : derivable f t w by case: fD.
+apply/DeriveDef; last by have [_ <-] := fD; rewrite derive_mx// mxE.
+  by move/derivable_mxP : fDer => /(_ i j).
+Qed.
+
+Global Instance is_derive_mulmx n m p
+    (M : V -> 'M[R]_(n, m)) M'
+    (N : V -> 'M[R]_(m, p)) N' (t : V) w :
+  is_derive t w M M'  -> is_derive t w N N' ->
+  is_derive t w (fun t => M t *m N t) ((M' *m N t) + (M t *m N')).
+Proof.
+move=> is_der_M' is_der_N'. 
+apply (@is_derive_mx ) => i j /=.
+rewrite !mxE /=.
+under eq_fun do rewrite mxE /=.
+rewrite -!big_split /= -fct_sumE.
+apply/is_derive_sum => j0.
+rewrite mulrC addrC.
+apply/is_deriveM.
+Qed.
+
 End pointwise_derive.
 
 Section Ris_diff_mx.
@@ -2474,9 +2501,10 @@ have [diffMij dMdM] := MdM i j.
 rewrite -deriveE//.
 move/(congr1 (fun f => f v)) : dMdM.
 rewrite -(deriveE _ diffMij) => <-.
-rewrite derive_mx ?mxE//=.
+rewrite derive_mx ?mxE /=.
 apply/derivable_mxP => i0 j0/=.
 by have [/diff_derivable-/(_ v)] := MdM i0 j0.
+done.
 Qed.
 
 End Ris_diff_mx.

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -2461,23 +2461,22 @@ Proof.
 move=> fD i j /=.
 have fDer : derivable f t w by case: fD.
 apply/DeriveDef; last by have [_ <-] := fD; rewrite derive_mx// mxE.
-  by move/derivable_mxP : fDer => /(_ i j).
+by move/derivable_mxP : fDer => /(_ i j).
 Qed.
 
 Global Instance is_derive_mulmx n m p
     (M : V -> 'M[R]_(n, m)) M'
     (N : V -> 'M[R]_(m, p)) N' (t : V) w :
   is_derive t w M M'  -> is_derive t w N N' ->
-  is_derive t w (fun t => M t *m N t) ((M' *m N t) + (M t *m N')).
+  is_derive t w (fun t => M t *m N t) (M' *m N t + M t *m N').
 Proof.
-move=> is_der_M' is_der_N'. 
-apply (@is_derive_mx ) => i j /=.
-rewrite !mxE /=.
-under eq_fun do rewrite mxE /=.
+move=> is_der_M' is_der_N'.
+apply is_derive_mx => i j /=.
+rewrite !mxE/=.
+under eq_fun do rewrite mxE/=.
 rewrite -!big_split /= -fct_sumE.
-apply/is_derive_sum => j0.
-rewrite mulrC addrC.
-apply/is_deriveM.
+apply/is_derive_sum => k.
+by rewrite mulrC addrC; exact/is_deriveM.
 Qed.
 
 End pointwise_derive.
@@ -2501,10 +2500,9 @@ have [diffMij dMdM] := MdM i j.
 rewrite -deriveE//.
 move/(congr1 (fun f => f v)) : dMdM.
 rewrite -(deriveE _ diffMij) => <-.
-rewrite derive_mx ?mxE /=.
+rewrite derive_mx; last by rewrite /= mxE.
 apply/derivable_mxP => i0 j0/=.
 by have [/diff_derivable-/(_ v)] := MdM i0 j0.
-done.
 Qed.
 
 End Ris_diff_mx.


### PR DESCRIPTION
##### Motivation for this change
This PR completes https://github.com/math-comp/analysis/pull/1891#event-25301034872 with is_derive for matrix multiplication. 
<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
