### PR TITLE
Fix some notation levels w.r.t. Corelib

### DIFF
--- a/classical/filter.v
+++ b/classical/filter.v
@@ -211,8 +211,8 @@ Reserved Notation "'\near' x & y , P"
   (at level 200, x, y at level 99, P at level 200,
    format "'\near'  x  &  y ,  P", only parsing).
 (*Reserved Notation "[ 'filter' 'of' x ]" (format "[ 'filter'  'of'  x ]").*)
-Reserved Notation "F `=>` G" (at level 70, format "F  `=>`  G").
-Reserved Notation "F --> G" (at level 70, format "F  -->  G").
+Reserved Notation "F `=>` G" (at level 55, format "F  `=>`  G").
+Reserved Notation "F --> G" (at level 55, format "F  -->  G").
 Reserved Notation "[ 'lim' F 'in' T ]" (format "[ 'lim'  F  'in'  T ]").
 Reserved Notation "[ 'cvg' F 'in' T ]" (format "[ 'cvg'  F  'in'  T ]").
 Reserved Notation "x \is_near F" (at level 10, format "x  \is_near  F").
@@ -220,10 +220,10 @@ Reserved Notation "E @[ x --> F ]"
   (at level 60, x name, format "E  @[ x  -->  F ]").
 Reserved Notation "E @[ x \oo ]"
   (at level 60, x name, format "E  @[ x  \oo ]").
-Reserved Notation "f @ F" (at level 60, format "f  @  F").
+Reserved Notation "f @ F" (at level 52, format "f  @  F").
 Reserved Notation "E `@[ x --> F ]"
   (at level 60, x name, format "E  `@[ x  -->  F ]").
-Reserved Notation "f `@ F" (at level 60, format "f  `@  F").
+Reserved Notation "f `@ F" (at level 52, format "f  `@  F").
 
 HB.mixin Record isFiltered U T := {
   nbhs : T -> set_system U

--- a/theories/topology_theory/function_spaces.v
+++ b/theories/topology_theory/function_spaces.v
@@ -90,27 +90,27 @@ From mathcomp Require Import product_topology.
 (******************************************************************************)
 
 Reserved Notation "{ 'uniform`' A -> V }"
-  (at level 0, A at level 69, format "{ 'uniform`'  A  ->  V }").
+  (at level 0, A at level 53, format "{ 'uniform`'  A  ->  V }").
 Reserved Notation "{ 'uniform' U -> V }"
-  (at level 0, U at level 69, format "{ 'uniform'  U  ->  V }").
+  (at level 0, U at level 53, format "{ 'uniform'  U  ->  V }").
 Reserved Notation "{ 'uniform' A , F --> f }"
-  (at level 0, A at level 69, F at level 69,
+  (at level 0, A at level 53, F at level 53,
    format "{ 'uniform'  A ,  F  -->  f }").
 Reserved Notation "{ 'uniform' , F --> f }"
-  (at level 0, F at level 69,
+  (at level 0, F at level 53,
    format "{ 'uniform' ,  F  -->  f }").
 Reserved Notation "{ 'ptws' U -> V }"
-  (at level 0, U at level 69, format "{ 'ptws'  U  ->  V }").
+  (at level 0, U at level 53, format "{ 'ptws'  U  ->  V }").
 Reserved Notation "{ 'ptws' , F --> f }"
-  (at level 0, F at level 69, format "{ 'ptws' ,  F  -->  f }").
+  (at level 0, F at level 53, format "{ 'ptws' ,  F  -->  f }").
 Reserved Notation "{ 'family' fam , U -> V }"
-  (at level 0, U at level 69, format "{ 'family'  fam ,  U  ->  V }").
+  (at level 0, U at level 53, format "{ 'family'  fam ,  U  ->  V }").
 Reserved Notation "{ 'family' fam , F --> f }"
-  (at level 0, F at level 69, format "{ 'family'  fam ,  F  -->  f }").
+  (at level 0, F at level 53, format "{ 'family'  fam ,  F  -->  f }").
 Reserved Notation "{ 'compact-open' , U -> V }"
-  (at level 0, U at level 69, format "{ 'compact-open' ,  U  ->  V }").
+  (at level 0, U at level 53, format "{ 'compact-open' ,  U  ->  V }").
 Reserved Notation "{ 'compact-open' , F --> f }"
-  (at level 0, F at level 69, format "{ 'compact-open' ,  F  -->  f }").
+  (at level 0, F at level 53, format "{ 'compact-open' ,  F  -->  f }").
 
 Unset SsrOldRewriteGoalsOrder.  (* remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.


### PR DESCRIPTION
##### Motivation for this change

Fixes #2041

I'm trying to use both Setoid rewrite and math-comp classical. But importing both is impossible due to a conflict in the notation declaration:
```
From Corelib Require Import Setoid.
From mathcomp Require Import filter.
```
raise the error
```
Error: Notation "_ --> _" is already defined at level 55 with arguments constr
at next level, constr at level 55 while it is now required to be at level 70
with arguments constr at next level, constr at next level.
```

##### Checklist

- [~] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [~] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
