### PR TITLE
experimental_reals: make psumZ rewrite direction explicit

### DIFF
--- a/experimental_reals/distr.v
+++ b/experimental_reals/distr.v
@@ -965,7 +965,7 @@ rewrite interchange_psum /=; last first.
   apply/eq_psum=> y /=; rewrite mulrC -psumZ //.
   by apply/eq_psum=> x /=; rewrite mulrCA.
 + have := summable_pr E (dlet f mu); apply/eq_summable.
-  by move=> x; rewrite dletE psumZ ?ler0n.
+  by move=> x; rewrite dletE -psumZ ?ler0n.
 + by move=> y; apply/summable_condl/summable_mlet.
 Qed.
 


### PR DESCRIPTION
Rocq dev no longer infers the reverse direction for `psumZ` in `summable_pr` after `dletE`: the goal has `c * PosSum.psum S`, while the lemma starts from `PosSum.psum (c \*o S)`. This makes the direction explicit and remains equivalent on existing versions.

```text
opam exec --switch=rocq-dev-testing -- make -C experimental_reals -j2
```

> *Authorship note: this was researched and written by an AI coding agent (OpenAI Codex), working on Jason Gross's behalf; Jason reviews what is posted from this account.*

Wordsmithed by Codex.
