### PR TITLE
fixes #2043 (missing useful instances)

### DIFF
--- a/experimental_reals/distr.v
+++ b/experimental_reals/distr.v
@@ -525,9 +525,6 @@ Qed.
 
 End DLetDLet.
 
-#[deprecated(since="1.17.0", note="use `dlet_dlet` instead")]
-Notation __deprecated__dlet_dlet := dlet_dlet (only parsing).
-
 (* -------------------------------------------------------------------- *)
 Section DLetAlg.
 Context {T U : choiceType} (mu mu1 mu2 : {distr T / R}).
@@ -744,6 +741,8 @@ End Std.
 Notation __deprecated__dmargin_dlet := dmargin_dlet (only parsing).
 #[deprecated(since="1.17.0", note="use `dlet_dmargin` instead")]
 Notation __deprecated__dlet_dmargin := dlet_dmargin (only parsing).
+#[deprecated(since="1.17.0", note="use `dlet_dlet` instead")]
+Notation __deprecated__dlet_dlet := dlet_dlet (only parsing).
 
 Notation dfst mu := (dmargin fst mu).
 Notation dsnd mu := (dmargin snd mu).

--- a/theories/measure_theory/measurable_structure.v
+++ b/theories/measure_theory/measurable_structure.v
@@ -1319,6 +1319,9 @@ HB.instance Definition _ := @isMeasurable.Build (sigma_display G)
 
 End g_salgebra_instance.
 
+HB.instance Definition _ {T : pointedType} (G : set_system T) :=
+  Pointed.on (g_sigma_algebraType G).
+
 Notation "G .-sigma" := (sigma_display G) : measure_display_scope.
 Notation "G .-sigma.-measurable" :=
   (measurable : set_system (g_sigma_algebraType G)) : classical_set_scope.
@@ -1592,7 +1595,7 @@ Definition measure_prod_display :
 Proof. exact. Qed.
 
 Section product_salgebra_instance.
-Context d1 d2 (T1 : semiRingOfSetsType d1) (T2 : semiRingOfSetsType d2).
+Context {d1} {d2} {T1 : semiRingOfSetsType d1} {T2 : semiRingOfSetsType d2}.
 Let f1 := @fst T1 T2.
 Let f2 := @snd T1 T2.
 
@@ -1621,7 +1624,12 @@ Notation "p .-prod.-measurable" :=
   ((p.-prod).-measurable : set_system (_ * _)) :
     classical_set_scope.
 
-Lemma measurableX d1 d2 (T1 : semiRingOfSetsType d1) (T2 : semiRingOfSetsType d2)
+HB.instance Definition _
+    d d' (X : pmeasurableType d) (Y : pmeasurableType d') :=
+  Measurable.on (X * Y)%type.
+
+Lemma measurableX
+    d1 d2 (T1 : semiRingOfSetsType d1) (T2 : semiRingOfSetsType d2)
     (A : set T1) (B : set T2) :
   measurable A -> measurable B -> measurable (A `*` B).
 Proof.


### PR DESCRIPTION
##### Motivation for this change

The necessity for these additions have been observed when
rebasing the PR https://github.com/math-comp/analysis/pull/1712 .
It was the first time it was rebased after the elimination of
measurable types pointed by default.

##### Checklist

~~- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`~~

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [ ] added corresponding documentation in the headers~~

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
