### PR TITLE
hint is_derive_mulmx

### DIFF
--- a/theories/derive.v
+++ b/theories/derive.v
@@ -2481,6 +2481,8 @@ Qed.
 
 End pointwise_derive.
 
+#[global] Hint Extern 0 (is_derive _ _ (fun x => _ *m _) _) => apply: is_derive_mulmx : typeclass_instances.
+
 Section Ris_diff_mx.
 Local Open Scope classical_set_scope.
 Context {R : realFieldType}.


### PR DESCRIPTION
##### Motivation for this change
Fixes https://github.com/math-comp/analysis/issues/2069.
It seems like the best course of action to me to be able to use typeclass inference, and syntax follows other hints about `is_derive` in the file, but notice https://github.com/math-comp/analysis/issues/2069#issuecomment-5139817523 (eapply works as well). `apply:` is also used in other hints so I guess it's ok. 
<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Checklist

- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
