### PR TITLE
making is_derive_mx instance causes loops

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -13,6 +13,9 @@
 
 ### Changed
 
+- in `derive.v`:
+  + instance `is_derive_mx` is now a lemma
+
 ### Renamed
 
 ### Generalized

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -2408,7 +2408,7 @@ rewrite (le_trans (ler_normD _ _))// (splitr e) lerD//.
   by rewrite sub0r normrN; near: x; exact: dnbhs0_lt.
 Unshelve. all: by end_near. Qed.
 
-Global Instance is_derive_mx {m n : nat} (M : V -> 'M[R]_(m, n))
+Lemma is_derive_mx {m n : nat} (M : V -> 'M[R]_(m, n))
     (dM : 'M[R]_(m, n)) (x v : V) :
   (forall i j, is_derive x v (fun t => M t i j) (dM i j)) ->
   is_derive x v M dM.


### PR DESCRIPTION
##### Motivation for this change

Can be mitigated with
```coq
Remove Hints is_derive_mx : typeclass_instances.
```

fyi: @yosakaon @holgerthies 

<!-- if this PR fixes an issue, use "fixes #XYZ" -->

<!-- you may also explain what remains to do if the fix is incomplete -->

##### Checklist

- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

- [ ] added corresponding documentation in the headers

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
