### PR TITLE
mv mathcomp_{extra,compat}

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -66,6 +66,7 @@
 
 - in `lebesgue_integral_nonneg.v`:
   + `summable_integral_dirac` -> `esummable_integral_dirac`
+- `mathcomp_extra.v` -> `mathcomp_compat.v`
 
 ### Generalized
 

--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -15,6 +15,8 @@
 
 ### Renamed
 
+- `mathcomp_extra.v` -> `mathcomp_compat.v`
+
 ### Generalized
 
 ### Deprecated

--- a/_CoqProject
+++ b/_CoqProject
@@ -20,6 +20,7 @@ classical/boolp.v
 classical/contra.v
 classical/wochoice.v
 classical/classical_sets.v
+classical/mathcomp_compat.v
 classical/mathcomp_extra.v
 classical/unstable.v
 classical/functions.v

--- a/classical/Make
+++ b/classical/Make
@@ -14,6 +14,7 @@ boolp.v
 contra.v
 wochoice.v
 classical_sets.v
+mathcomp_compat.v
 mathcomp_extra.v
 unstable.v
 functions.v

--- a/classical/all_classical.v
+++ b/classical/all_classical.v
@@ -1,7 +1,7 @@
+From mathcomp Require Export mathcomp_compat.
 From mathcomp Require Export boolp.
 From mathcomp Require Export contra.
 From mathcomp Require Export classical_sets.
-From mathcomp Require Export mathcomp_extra.
 From mathcomp Require Export functions.
 From mathcomp Require Export cardinality.
 From mathcomp Require Export fsbigop.

--- a/classical/boolp.v
+++ b/classical/boolp.v
@@ -8,7 +8,6 @@ From HB Require Import structures.
 From mathcomp Require Import boot order.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import mathcomp_extra.
 From mathcomp Require internal_Eqdep_dec.
 
 (**md**************************************************************************)

--- a/classical/cardinality.v
+++ b/classical/cardinality.v
@@ -1,7 +1,7 @@
 (* mathcomp analysis (c) 2026 Inria and AIST. License: CeCILL-C.              *)
 From HB Require Import structures.
 From mathcomp Require Import boot order finmap ssralg ssrnum ssrint rat.
-From mathcomp Require Import mathcomp_extra boolp classical_sets functions.
+From mathcomp Require Import boolp classical_sets functions.
 
 (**md**************************************************************************)
 (* # Cardinality                                                              *)

--- a/classical/classical_orders.v
+++ b/classical/classical_orders.v
@@ -1,7 +1,6 @@
-From mathcomp Require Import boot order ssralg ssrnum interval.
-From mathcomp Require Import mathcomp_extra boolp classical_sets.
 From HB Require Import structures.
-From mathcomp Require Import functions set_interval.
+From mathcomp Require Import boot order ssralg ssrnum interval.
+From mathcomp Require Import boolp classical_sets functions set_interval.
 
 (**md**************************************************************************)
 (* # classical orders                                                         *)

--- a/classical/classical_sets.v
+++ b/classical/classical_sets.v
@@ -4,7 +4,7 @@ From mathcomp Require Import boot order ssralg matrix finmap ssrnum.
 From mathcomp Require Import ssrint rat interval.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import mathcomp_extra boolp wochoice.
+From mathcomp Require Import boolp wochoice.
 
 (**md**************************************************************************)
 (* # Set Theory                                                               *)

--- a/classical/filter.v
+++ b/classical/filter.v
@@ -1,8 +1,8 @@
 (* mathcomp analysis (c) 2026 Inria and AIST. License: CeCILL-C.              *)
 From HB Require Import structures.
 From mathcomp Require Import boot order algebra finmap.
-From mathcomp Require Import boolp classical_sets functions wochoice.
-From mathcomp Require Import cardinality mathcomp_extra fsbigop set_interval.
+From mathcomp Require Import boolp classical_sets functions wochoice
+  cardinality fsbigop set_interval.
 
 (**md**************************************************************************)
 (* # Filters                                                                  *)

--- a/classical/fsbigop.v
+++ b/classical/fsbigop.v
@@ -2,8 +2,7 @@
 From mathcomp Require Import boot order ssralg ssrnum ssrint interval finmap.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import mathcomp_extra boolp classical_sets.
-From mathcomp Require Import functions cardinality.
+From mathcomp Require Import boolp classical_sets functions cardinality.
 
 (**md**************************************************************************)
 (* # Finitely-supported big operators                                         *)

--- a/classical/functions.v
+++ b/classical/functions.v
@@ -3,7 +3,7 @@ From mathcomp Require Import boot order finmap ssralg ssrnum ssrint rat.
 From HB Require Import structures.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import mathcomp_extra boolp classical_sets.
+From mathcomp Require Import boolp classical_sets.
 Add Search Blacklist "__canonical__".
 Add Search Blacklist "__functions_".
 Add Search Blacklist "_factory_".

--- a/classical/mathcomp_compat.v
+++ b/classical/mathcomp_compat.v
@@ -1,0 +1,22 @@
+(* mathcomp analysis (c) 2026 Inria and AIST. License: CeCILL-C.              *)
+From HB Require Import structures.
+From mathcomp Require Import boot order finmap algebra.
+
+(**md**************************************************************************)
+(* # Compatibility layer with recent MathComp versions                        *)
+(*                                                                            *)
+(* This files contains lemmas and definitions recently added in mathcomp,     *)
+(* in order to be able to compile analysis with older versions of mathcomp.   *)
+(*                                                                            *)
+(******************************************************************************)
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+
+Import Order.TTheory GRing.Theory Num.Theory.
+Local Open Scope ring_scope.
+
+(**************************)
+(* MathComp 2.7 additions *)
+(**************************)

--- a/classical/mathcomp_extra.v
+++ b/classical/mathcomp_extra.v
@@ -1,22 +1,5 @@
 (* mathcomp analysis (c) 2026 Inria and AIST. License: CeCILL-C.              *)
-From HB Require Import structures.
-From mathcomp Require Import boot order finmap algebra.
+From mathcomp Require Import mathcomp_compat.
 
-(**md**************************************************************************)
-(* # MathComp extra                                                           *)
-(*                                                                            *)
-(* This files contains lemmas and definitions recently added in mathcomp,     *)
-(* in order to be able to compile analysis with older versions of mathcomp.   *)
-(*                                                                            *)
-(******************************************************************************)
-
-Set Implicit Arguments.
-Unset Strict Implicit.
-Unset Printing Implicit Defensive.
-
-Import Order.TTheory GRing.Theory Num.Theory.
-Local Open Scope ring_scope.
-
-(**************************)
-(* MathComp 2.7 additions *)
-(**************************)
+Attributes deprecated(since="mathcomp-analysis 1.18.0",
+  note="use `mathcomp_compat.v` instead.").

--- a/classical/set_interval.v
+++ b/classical/set_interval.v
@@ -3,8 +3,7 @@ From HB Require Import structures.
 From mathcomp Require Import boot order ssralg ssrnum interval.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import mathcomp_extra boolp classical_sets.
-From mathcomp Require Import functions.
+From mathcomp Require Import boolp classical_sets functions.
 
 (**md**************************************************************************)
 (* # Sets and Intervals                                                       *)

--- a/experimental_reals/distr.v
+++ b/experimental_reals/distr.v
@@ -5,9 +5,9 @@
 
 (* -------------------------------------------------------------------- *)
 From mathcomp Require Import boot order algebra.
-From mathcomp.classical Require Import boolp classical_sets mathcomp_extra.
-From mathcomp Require Import xfinmap constructive_ereal reals discrete.
-From mathcomp Require Import realseq realsum.
+From mathcomp Require Import boolp classical_sets.
+From mathcomp Require Import constructive_ereal reals.
+From mathcomp Require Import xfinmap discrete realseq realsum.
 
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/experimental_reals/realseq.v
+++ b/experimental_reals/realseq.v
@@ -6,9 +6,9 @@
 (* -------------------------------------------------------------------- *)
 From mathcomp Require Import boot order algebra.
 From mathcomp Require Import bigenough.
-From mathcomp.classical Require Import boolp classical_sets functions.
-From mathcomp.classical Require Import mathcomp_extra.
-From mathcomp Require Import xfinmap constructive_ereal reals discrete.
+From mathcomp Require Import boolp classical_sets functions
+  constructive_ereal reals.
+From mathcomp Require Import xfinmap discrete.
 
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/experimental_reals/realsum.v
+++ b/experimental_reals/realsum.v
@@ -4,14 +4,13 @@
 (* Copyright (c) - 2015--2018 - Inria                                   *)
 (* Copyright (c) - 2016--2018 - Polytechnique                           *)
 (* -------------------------------------------------------------------- *)
-From mathcomp Require Import boot order algebra.
+From mathcomp Require Import boot order algebra interval_inference.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import boolp fsbigop classical_sets functions.
-From mathcomp Require Import cardinality.
-From mathcomp Require Import constructive_ereal reals.
+From mathcomp Require Import boolp fsbigop classical_sets functions cardinality.
+From mathcomp Require Import reals.
+From mathcomp Require Import ereal esum numfun.
 From mathcomp Require Import xfinmap discrete realseq.
-From mathcomp Require Import esum ereal numfun.
 
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/reals/constructive_ereal.v
+++ b/reals/constructive_ereal.v
@@ -10,8 +10,7 @@
    incorporate it into mathcomp proper where it could then be used for
    bounds of intervals*)
 From HB Require Import structures.
-From mathcomp Require Import boot order algebra finmap.
-From mathcomp Require Import mathcomp_extra interval_inference.
+From mathcomp Require Import boot order algebra finmap interval_inference.
 
 (**md**************************************************************************)
 (* # Extended real numbers $\overline{R}$                                     *)

--- a/reals/reals.v
+++ b/reals/reals.v
@@ -4,6 +4,11 @@
 (* Copyright (c) - 2015--2018 - Inria                                   *)
 (* Copyright (c) - 2016--2018 - Polytechnique                           *)
 (* -------------------------------------------------------------------- *)
+From HB Require Import structures.
+From mathcomp Require Import boot order algebra.
+#[warning="-warn-library-file-internal-analysis"]
+From mathcomp Require Import unstable.
+From mathcomp Require Import boolp classical_sets contra set_interval.
 
 (**md**************************************************************************)
 (* # An axiomatization of real numbers $\mathbb{R}$                           *)
@@ -42,13 +47,6 @@
 (* ```                                                                        *)
 (*                                                                            *)
 (******************************************************************************)
-
-From HB Require Import structures.
-From mathcomp Require Import boot order algebra.
-#[warning="-warn-library-file-internal-analysis"]
-From mathcomp Require Import unstable.
-From mathcomp Require Import mathcomp_extra boolp classical_sets contra
-  set_interval.
 
 Declare Scope real_scope.
 

--- a/theories/cantor.v
+++ b/theories/cantor.v
@@ -1,8 +1,8 @@
-(* mathcomp analysis (c) 2017 Inria and AIST. License: CeCILL-C.              *)
+(* mathcomp analysis (c) 2026 Inria and AIST. License: CeCILL-C.              *)
 From HB Require Import structures.
 From mathcomp Require Import boot order ssralg ssrint ssrnum interval.
 From mathcomp Require Import rat finmap.
-From mathcomp Require Import mathcomp_extra unstable boolp classical_sets.
+From mathcomp Require Import unstable boolp classical_sets.
 From mathcomp Require Import functions cardinality reals topology.
 
 (**md**************************************************************************)

--- a/theories/charge.v
+++ b/theories/charge.v
@@ -4,7 +4,7 @@ From mathcomp Require Import boot order ssralg ssrnum ssrint interval.
 From mathcomp Require Import interval_inference finmap fingroup perm rat.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import mathcomp_extra boolp classical_sets cardinality.
+From mathcomp Require Import boolp classical_sets cardinality.
 From mathcomp Require Import functions fsbigop set_interval reals ereal.
 From mathcomp Require Import topology numfun normedtype derive sequences esum.
 From mathcomp Require Import measure realfun measurable_realfun.

--- a/theories/convex.v
+++ b/theories/convex.v
@@ -4,7 +4,7 @@ From mathcomp Require Import boot order finmap ssralg ssrint ssrnum interval.
 From mathcomp Require Import interval_inference.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import mathcomp_extra boolp classical_sets set_interval.
+From mathcomp Require Import boolp classical_sets set_interval.
 From mathcomp Require Import reals topology.
 
 (**md**************************************************************************)

--- a/theories/derive.v
+++ b/theories/derive.v
@@ -1,12 +1,12 @@
 (* mathcomp analysis (c) 2026 Inria and AIST. License: CeCILL-C.              *)
 From HB Require Import structures.
-From mathcomp Require Import boot order ssralg ssrnum matrix interval.
+From mathcomp Require Import boot order ssralg ssrnum matrix interval
+  interval_inference.
 From mathcomp Require Import poly sesquilinear.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import mathcomp_extra boolp contra classical_sets.
-From mathcomp Require Import functions reals interval_inference topology.
-From mathcomp Require Import prodnormedzmodule tvs normedtype landau.
+From mathcomp Require Import boolp contra classical_sets functions reals.
+From mathcomp Require Import topology prodnormedzmodule tvs normedtype landau.
 
 (**md**************************************************************************)
 (* # Differentiation                                                          *)

--- a/theories/ereal.v
+++ b/theories/ereal.v
@@ -5,12 +5,14 @@
 (* Copyright (c) - 2016--2018 - Polytechnique                           *)
 (* -------------------------------------------------------------------- *)
 From HB Require Import structures.
-From mathcomp Require Import boot order algebra finmap.
+From mathcomp Require Import boot order algebra interval_inference finmap.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import mathcomp_extra boolp classical_sets functions.
-From mathcomp Require Import fsbigop cardinality set_interval reals.
-From mathcomp Require Export interval_inference topology constructive_ereal.
+From mathcomp Require Import boolp classical_sets functions fsbigop cardinality
+  set_interval.
+From mathcomp Require Import reals.
+From mathcomp Require Export constructive_ereal.
+From mathcomp Require Import topology.
 
 (**md**************************************************************************)
 (* # Extended real numbers, classical part ($\overline{\mathbb{R}}$)          *)

--- a/theories/esum.v
+++ b/theories/esum.v
@@ -1,10 +1,9 @@
 (* mathcomp analysis (c) 2026 Inria and AIST. License: CeCILL-C.              *)
-From mathcomp Require Import boot order ssralg ssrnum finmap.
+From mathcomp Require Import boot order ssralg ssrnum interval_inference finmap.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import mathcomp_extra boolp classical_sets functions.
-From mathcomp Require Import cardinality fsbigop reals ereal interval_inference.
-From mathcomp Require Import topology sequences normedtype numfun.
+From mathcomp Require Import boolp classical_sets functions cardinality fsbigop.
+From mathcomp Require Import reals topology ereal sequences normedtype numfun.
 
 (**md**************************************************************************)
 (* # Summation over classical sets                                            *)

--- a/theories/exp.v
+++ b/theories/exp.v
@@ -3,9 +3,9 @@ From mathcomp Require Import boot order ssralg ssrint ssrnum matrix.
 From mathcomp Require Import interval rat interval_inference.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import boolp classical_sets functions mathcomp_extra.
-From mathcomp Require Import reals topology ereal tvs normedtype landau.
-From mathcomp Require Import sequences derive realfun convex.
+From mathcomp Require Import boolp classical_sets functions.
+From mathcomp Require Import reals convex ereal topology tvs normedtype landau.
+From mathcomp Require Import sequences derive realfun.
 
 (**md**************************************************************************)
 (* # Theory of exponential/logarithm functions                                *)

--- a/theories/ftc.v
+++ b/theories/ftc.v
@@ -4,12 +4,10 @@ From mathcomp Require Import boot order ssralg ssrnum ssrint interval.
 From mathcomp Require Import interval_inference finmap archimedean.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import mathcomp_extra boolp classical_sets functions.
-From mathcomp Require Import cardinality fsbigop reals ereal topology tvs.
-From mathcomp Require Import normedtype sequences real_interval esum measure.
-From mathcomp Require Import lebesgue_measure numfun realfun measurable_realfun.
-From mathcomp Require Import interval_inference real_interval lebesgue_integral.
-From mathcomp Require Import derive.
+From mathcomp Require Import boolp classical_sets functions cardinality fsbigop.
+From mathcomp Require Import reals real_interval topology ereal tvs normedtype
+  derive sequences esum measure lebesgue_measure numfun realfun
+  measurable_realfun lebesgue_integral.
 
 (**md**************************************************************************)
 (* # Fundamental Theorem of Calculus and Consequences                         *)

--- a/theories/functional_analysis/hahn_banach_theorem.v
+++ b/theories/functional_analysis/hahn_banach_theorem.v
@@ -1,10 +1,9 @@
 From HB Require Import structures.
-From mathcomp Require Import boot order algebra.
-From mathcomp Require Import interval_inference.
+From mathcomp Require Import boot order algebra interval_inference.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import mathcomp_extra boolp contra classical_sets filter.
-From mathcomp Require Import topology convex reals normedtype.
+From mathcomp Require Import boolp contra classical_sets filter.
+From mathcomp Require Import reals convex topology normedtype.
 
 (**md**************************************************************************)
 (* # The Hahn-Banach theorem                                                  *)

--- a/theories/gauss_integral.v
+++ b/theories/gauss_integral.v
@@ -1,9 +1,9 @@
 (* mathcomp analysis (c) 2026 Inria and AIST. License: CeCILL-C.              *)
 From HB Require Import structures.
-From mathcomp Require Import boot order ssralg ssrnum ssrint interval.
-From mathcomp Require Import finmap.
-From mathcomp Require Import mathcomp_extra boolp classical_sets functions.
-From mathcomp Require Import cardinality fsbigop reals interval_inference ereal.
+From mathcomp Require Import boot order ssralg ssrnum ssrint interval_inference
+  interval finmap.
+From mathcomp Require Import boolp classical_sets functions cardinality fsbigop.
+From mathcomp Require Import reals ereal.
 From mathcomp Require Import topology tvs normedtype sequences real_interval.
 From mathcomp Require Import esum measure measurable_realfun numfun realfun.
 From mathcomp Require Import exp trigo lebesgue_measure lebesgue_integral.

--- a/theories/hoelder.v
+++ b/theories/hoelder.v
@@ -4,9 +4,9 @@ From mathcomp Require Import boot order ssralg ssrnum ssrint interval.
 From mathcomp Require Import interval_inference finmap.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import mathcomp_extra boolp classical_sets functions.
-From mathcomp Require Import cardinality convex fsbigop reals ereal topology.
-From mathcomp Require Import normedtype sequences real_interval esum measure.
+From mathcomp Require Import boolp classical_sets functions cardinality fsbigop.
+From mathcomp Require Import convex reals real_interval ereal topology.
+From mathcomp Require Import normedtype sequences esum measure.
 From mathcomp Require Import ess_sup_inf measurable_realfun lebesgue_measure.
 From mathcomp Require Import lebesgue_integral numfun exp.
 

--- a/theories/homotopy_theory/continuous_path.v
+++ b/theories/homotopy_theory/continuous_path.v
@@ -1,9 +1,8 @@
 (* mathcomp analysis (c) 2026 Inria and AIST. License: CeCILL-C.              *)
 From HB Require Import structures.
-From mathcomp Require Import boot order generic_quotient algebra.
-From mathcomp Require Import finmap.
-From mathcomp Require Import mathcomp_extra boolp classical_sets functions.
-From mathcomp Require Import cardinality fsbigop reals topology wedge_sigT.
+From mathcomp Require Import boot order generic_quotient algebra finmap.
+From mathcomp Require Import boolp classical_sets functions cardinality fsbigop.
+From mathcomp Require Import reals topology wedge_sigT.
 
 (**md**************************************************************************)
 (* # Paths                                                                    *)

--- a/theories/homotopy_theory/wedge_sigT.v
+++ b/theories/homotopy_theory/wedge_sigT.v
@@ -1,10 +1,9 @@
 (* mathcomp analysis (c) 2026 Inria and AIST. License: CeCILL-C.              *)
 From HB Require Import structures.
-From mathcomp Require Import boot order algebra generic_quotient.
-From mathcomp Require Import finmap.
+From mathcomp Require Import boot order algebra generic_quotient finmap.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import mathcomp_extra boolp classical_sets functions.
+From mathcomp Require Import boolp classical_sets functions.
 From mathcomp Require Import cardinality fsbigop reals topology.
 
 (**md**************************************************************************)

--- a/theories/independence.v
+++ b/theories/independence.v
@@ -2,10 +2,10 @@
 From HB Require Import structures.
 From mathcomp Require Import boot order interval_inference.
 From mathcomp Require Import ssralg poly ssrnum ssrint interval finmap.
-From mathcomp Require Import mathcomp_extra boolp classical_sets functions.
-From mathcomp Require Import cardinality fsbigop.
+From mathcomp Require Import boolp classical_sets functions cardinality fsbigop.
+From mathcomp Require Import reals.
+From mathcomp Require Import ereal topology normedtype sequences.
 From mathcomp Require Import exp numfun lebesgue_measure lebesgue_integral.
-From mathcomp Require Import reals ereal topology normedtype sequences.
 From mathcomp Require Import esum measure exp numfun lebesgue_measure.
 From mathcomp Require Import measurable_realfun lebesgue_integral kernel.
 From mathcomp Require Import hoelder probability.

--- a/theories/kernel.v
+++ b/theories/kernel.v
@@ -2,10 +2,9 @@
 From HB Require Import structures.
 From mathcomp Require Import boot order ssralg ssrnum ssrint interval.
 From mathcomp Require Import interval_inference archimedean finmap.
-From mathcomp Require Import mathcomp_extra boolp classical_sets functions.
-From mathcomp Require Import cardinality fsbigop reals ereal topology.
-From mathcomp Require Import normedtype sequences esum measure.
-From mathcomp Require Import measurable_realfun numfun lebesgue_measure.
+From mathcomp Require Import boolp classical_sets functions cardinality fsbigop.
+From mathcomp Require Import reals topology ereal normedtype sequences esum.
+From mathcomp Require Import measure measurable_realfun numfun lebesgue_measure.
 From mathcomp Require Import lebesgue_integral.
 
 (**md**************************************************************************)

--- a/theories/landau.v
+++ b/theories/landau.v
@@ -1,9 +1,8 @@
-(* mathcomp analysis (c) 2017 Inria and AIST. License: CeCILL-C.              *)
+(* mathcomp analysis (c) 2026 Inria and AIST. License: CeCILL-C.              *)
 From HB Require Import structures.
-From mathcomp Require Import boot order ssralg ssrnum.
-From mathcomp Require Import mathcomp_extra boolp classical_sets functions.
-From mathcomp Require Import ereal reals interval_inference topology normedtype.
-From mathcomp Require Import prodnormedzmodule.
+From mathcomp Require Import boot order ssralg interval_inference ssrnum.
+From mathcomp Require Import boolp classical_sets functions reals.
+From mathcomp Require Import ereal topology normedtype prodnormedzmodule.
 
 (**md**************************************************************************)
 (* # Bachmann-Landau notations: $f=o(e)$, $f=O(e)$                            *)

--- a/theories/lebesgue_integral_theory/giry.v
+++ b/theories/lebesgue_integral_theory/giry.v
@@ -1,6 +1,7 @@
 From HB Require Import structures.
-From mathcomp Require Import boot order algebra boolp classical_sets.
-From mathcomp Require Import fsbigop functions reals topology separation_axioms.
+From mathcomp Require Import boot order algebra interval_inference.
+From mathcomp Require Import boolp classical_sets fsbigop functions.
+From mathcomp Require Import reals topology separation_axioms.
 From mathcomp Require Import ereal sequences numfun measure measurable_realfun.
 From mathcomp Require Import lebesgue_measure lebesgue_integral.
 

--- a/theories/lebesgue_integral_theory/lebesgue_Rintegral.v
+++ b/theories/lebesgue_integral_theory/lebesgue_Rintegral.v
@@ -2,9 +2,9 @@
 From HB Require Import structures.
 From mathcomp Require Import boot order ssralg ssrnum ssrint interval.
 From mathcomp Require Import interval_inference archimedean finmap.
-From mathcomp Require Import mathcomp_extra boolp classical_sets functions.
-From mathcomp Require Import cardinality reals fsbigop ereal topology tvs.
-From mathcomp Require Import normedtype sequences real_interval esum measure.
+From mathcomp Require Import boolp classical_sets functions cardinality fsbigop.
+From mathcomp Require Import reals real_interval topology ereal tvs.
+From mathcomp Require Import normedtype sequences esum measure.
 From mathcomp Require Import lebesgue_measure numfun realfun measurable_realfun.
 From mathcomp Require Import simple_functions measurable_fun_approximation.
 From mathcomp Require Import lebesgue_integral_definition.

--- a/theories/lebesgue_integral_theory/lebesgue_integrable.v
+++ b/theories/lebesgue_integral_theory/lebesgue_integrable.v
@@ -4,9 +4,9 @@ From mathcomp Require Import boot order ssralg ssrnum ssrint interval.
 From mathcomp Require Import archimedean interval_inference finmap.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import mathcomp_extra boolp classical_sets functions.
-From mathcomp Require Import cardinality reals fsbigop topology ereal tvs.
-From mathcomp Require Import normedtype sequences real_interval esum measure.
+From mathcomp Require Import boolp classical_sets functions cardinality fsbigop.
+From mathcomp Require Import reals real_interval topology ereal tvs.
+From mathcomp Require Import normedtype sequences esum measure.
 From mathcomp Require Import lebesgue_measure numfun realfun simple_functions.
 From mathcomp Require Import measurable_realfun measurable_fun_approximation.
 From mathcomp Require Import lebesgue_integral_definition.

--- a/theories/lebesgue_integral_theory/lebesgue_integral_definition.v
+++ b/theories/lebesgue_integral_theory/lebesgue_integral_definition.v
@@ -4,9 +4,9 @@ From mathcomp Require Import boot order ssralg ssrnum ssrint interval.
 From mathcomp Require Import interval_inference finmap.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import mathcomp_extra boolp classical_sets functions.
-From mathcomp Require Import cardinality reals fsbigop ereal topology tvs.
-From mathcomp Require Import normedtype sequences real_interval esum measure.
+From mathcomp Require Import boolp classical_sets functions cardinality fsbigop.
+From mathcomp Require Import reals real_interval topology ereal tvs.
+From mathcomp Require Import normedtype sequences esum measure.
 From mathcomp Require Import lebesgue_measure numfun realfun simple_functions.
 From mathcomp Require Import measurable_realfun.
 

--- a/theories/lebesgue_integral_theory/lebesgue_integral_differentiation.v
+++ b/theories/lebesgue_integral_theory/lebesgue_integral_differentiation.v
@@ -2,9 +2,9 @@
 From HB Require Import structures.
 From mathcomp Require Import boot order ssralg ssrnum ssrint interval.
 From mathcomp Require Import interval_inference archimedean finmap.
-From mathcomp Require Import mathcomp_extra boolp classical_sets functions.
-From mathcomp Require Import cardinality reals fsbigop ereal topology tvs.
-From mathcomp Require Import normedtype sequences real_interval esum measure.
+From mathcomp Require Import boolp classical_sets functions cardinality fsbigop.
+From mathcomp Require Import reals real_interval topology ereal tvs.
+From mathcomp Require Import normedtype sequences esum measure.
 From mathcomp Require Import lebesgue_measure numfun realfun simple_functions.
 From mathcomp Require Import measurable_realfun measurable_fun_approximation.
 From mathcomp Require Import lebesgue_integral_definition.

--- a/theories/lebesgue_integral_theory/lebesgue_integral_dominated_convergence.v
+++ b/theories/lebesgue_integral_theory/lebesgue_integral_dominated_convergence.v
@@ -2,9 +2,9 @@
 From HB Require Import structures.
 From mathcomp Require Import boot order ssralg ssrnum ssrint interval.
 From mathcomp Require Import interval_inference archimedean finmap.
-From mathcomp Require Import mathcomp_extra boolp classical_sets functions.
-From mathcomp Require Import cardinality reals fsbigop ereal topology tvs.
-From mathcomp Require Import normedtype sequences real_interval esum measure.
+From mathcomp Require Import boolp classical_sets functions cardinality fsbigop.
+From mathcomp Require Import reals real_interval topology ereal tvs.
+From mathcomp Require Import normedtype sequences esum measure.
 From mathcomp Require Import lebesgue_measure numfun realfun simple_functions.
 From mathcomp Require Import measurable_realfun measurable_fun_approximation.
 From mathcomp Require Import lebesgue_integral_definition.

--- a/theories/lebesgue_integral_theory/lebesgue_integral_fubini.v
+++ b/theories/lebesgue_integral_theory/lebesgue_integral_fubini.v
@@ -2,9 +2,9 @@
 From HB Require Import structures.
 From mathcomp Require Import boot order ssralg ssrnum ssrint interval.
 From mathcomp Require Import interval_inference archimedean finmap.
-From mathcomp Require Import mathcomp_extra boolp classical_sets functions.
-From mathcomp Require Import cardinality reals fsbigop ereal topology tvs.
-From mathcomp Require Import normedtype sequences real_interval esum measure.
+From mathcomp Require Import boolp classical_sets functions cardinality fsbigop.
+From mathcomp Require Import reals real_interval topology ereal tvs.
+From mathcomp Require Import normedtype sequences esum measure.
 From mathcomp Require Import lebesgue_measure numfun realfun simple_functions.
 From mathcomp Require Import measurable_realfun measurable_fun_approximation.
 From mathcomp Require Import lebesgue_integral_definition.

--- a/theories/lebesgue_integral_theory/lebesgue_integral_monotone_convergence.v
+++ b/theories/lebesgue_integral_theory/lebesgue_integral_monotone_convergence.v
@@ -4,9 +4,9 @@ From mathcomp Require Import boot order ssralg ssrnum ssrint interval.
 From mathcomp Require Import interval_inference archimedean finmap.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import mathcomp_extra boolp classical_sets functions.
-From mathcomp Require Import cardinality reals fsbigop topology ereal tvs.
-From mathcomp Require Import normedtype sequences real_interval esum measure.
+From mathcomp Require Import boolp classical_sets functions cardinality fsbigop.
+From mathcomp Require Import reals real_interval topology ereal tvs.
+From mathcomp Require Import normedtype sequences esum measure.
 From mathcomp Require Import lebesgue_measure numfun realfun simple_functions.
 From mathcomp Require Import measurable_realfun measurable_fun_approximation.
 From mathcomp Require Import lebesgue_integral_definition.

--- a/theories/lebesgue_integral_theory/lebesgue_integral_nonneg.v
+++ b/theories/lebesgue_integral_theory/lebesgue_integral_nonneg.v
@@ -4,9 +4,9 @@ From mathcomp Require Import boot order ssralg ssrnum ssrint interval.
 From mathcomp Require Import interval_inference finmap archimedean.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import mathcomp_extra boolp classical_sets functions.
-From mathcomp Require Import cardinality reals fsbigop topology ereal tvs.
-From mathcomp Require Import normedtype sequences real_interval esum measure.
+From mathcomp Require Import boolp classical_sets functions cardinality fsbigop.
+From mathcomp Require Import reals real_interval topology ereal tvs.
+From mathcomp Require Import normedtype sequences esum measure.
 From mathcomp Require Import lebesgue_measure numfun realfun simple_functions.
 From mathcomp Require Import measurable_realfun measurable_fun_approximation.
 From mathcomp Require Import lebesgue_integral_definition.

--- a/theories/lebesgue_integral_theory/lebesgue_integral_under.v
+++ b/theories/lebesgue_integral_theory/lebesgue_integral_under.v
@@ -2,14 +2,14 @@
 From HB Require Import structures.
 From mathcomp Require Import boot order ssralg ssrnum ssrint interval.
 From mathcomp Require Import interval_inference archimedean finmap.
-From mathcomp Require Import mathcomp_extra boolp classical_sets functions.
-From mathcomp Require Import cardinality reals fsbigop  ereal topology tvs.
-From mathcomp Require Import normedtype sequences real_interval derive esum.
+From mathcomp Require Import boolp classical_sets functions cardinality fsbigop.
+From mathcomp Require Import reals real_interval ereal topology tvs.
+From mathcomp Require Import normedtype sequences derive esum.
 From mathcomp Require Import measure lebesgue_measure numfun realfun.
 From mathcomp Require Import measurable_realfun simple_functions.
-From mathcomp Require Import lebesgue_integral_definition lebesgue_integral_nonneg.
-From mathcomp Require Import lebesgue_integrable lebesgue_Rintegral.
-From mathcomp Require Import lebesgue_integral_dominated_convergence.
+From mathcomp Require Import lebesgue_integral_definition
+  lebesgue_integral_nonneg lebesgue_integrable lebesgue_Rintegral
+  lebesgue_integral_dominated_convergence.
 
 (**md**************************************************************************)
 (* # Continuity and differentiation under the integral sign                   *)

--- a/theories/lebesgue_integral_theory/measurable_fun_approximation.v
+++ b/theories/lebesgue_integral_theory/measurable_fun_approximation.v
@@ -4,9 +4,9 @@ From mathcomp Require Import boot order ssralg ssrnum ssrint interval.
 From mathcomp Require Import interval_inference archimedean finmap.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import mathcomp_extra boolp classical_sets functions.
-From mathcomp Require Import cardinality reals fsbigop topology ereal tvs.
-From mathcomp Require Import normedtype sequences real_interval esum measure.
+From mathcomp Require Import boolp classical_sets functions cardinality fsbigop.
+From mathcomp Require Import reals real_interval topology ereal tvs.
+From mathcomp Require Import normedtype sequences esum measure.
 From mathcomp Require Import lebesgue_measure numfun realfun exp.
 From mathcomp Require Import measurable_realfun simple_functions.
 

--- a/theories/lebesgue_integral_theory/radon_nikodym.v
+++ b/theories/lebesgue_integral_theory/radon_nikodym.v
@@ -4,10 +4,10 @@ From mathcomp Require Import boot order ssralg ssrnum ssrint interval.
 From mathcomp Require Import interval_inference finmap fingroup perm rat.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import mathcomp_extra boolp classical_sets cardinality.
-From mathcomp Require Import functions fsbigop set_interval reals ereal.
-From mathcomp Require Import topology numfun normedtype derive sequences esum.
-From mathcomp Require Import measure realfun measurable_realfun.
+From mathcomp Require Import boolp classical_sets cardinality functions fsbigop
+  set_interval reals.
+From mathcomp Require Import topology ereal numfun normedtype derive sequences.
+From mathcomp Require Import esum measure realfun measurable_realfun.
 From mathcomp Require Import lebesgue_measure.
 From mathcomp Require Import lebesgue_integral_definition lebesgue_integrable
   lebesgue_integral_nonneg lebesgue_Rintegral

--- a/theories/lebesgue_integral_theory/simple_functions.v
+++ b/theories/lebesgue_integral_theory/simple_functions.v
@@ -2,9 +2,9 @@
 From HB Require Import structures.
 From mathcomp Require Import boot order ssralg ssrnum ssrint interval.
 From mathcomp Require Import interval_inference archimedean finmap.
-From mathcomp Require Import mathcomp_extra boolp classical_sets functions.
-From mathcomp Require Import cardinality reals fsbigop ereal topology tvs.
-From mathcomp Require Import normedtype sequences real_interval esum measure.
+From mathcomp Require Import boolp classical_sets functions cardinality fsbigop.
+From mathcomp Require Import reals real_interval topology ereal tvs.
+From mathcomp Require Import normedtype sequences esum measure.
 From mathcomp Require Import lebesgue_measure numfun realfun measurable_realfun.
 
 (**md**************************************************************************)

--- a/theories/lebesgue_measure.v
+++ b/theories/lebesgue_measure.v
@@ -4,10 +4,10 @@ From mathcomp Require Import boot order finmap ssralg ssrnum ssrint.
 From mathcomp Require Import interval interval_inference archimedean rat.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import mathcomp_extra boolp classical_sets functions.
-From mathcomp Require Import cardinality fsbigop reals ereal topology numfun.
-From mathcomp Require Import tvs normedtype sequences esum measure.
-From mathcomp Require Import real_interval realfun exp measurable_realfun.
+From mathcomp Require Import boolp classical_sets functions cardinality fsbigop
+  reals real_interval.
+From mathcomp Require Import topology ereal numfun tvs normedtype sequences
+  esum measure realfun exp measurable_realfun.
 From mathcomp Require Export lebesgue_stieltjes_measure.
 
 (**md**************************************************************************)

--- a/theories/measure_theory/dirac_measure.v
+++ b/theories/measure_theory/dirac_measure.v
@@ -1,10 +1,9 @@
 (* mathcomp analysis (c) 2026 Inria and AIST. License: CeCILL-C.              *)
 From HB Require Import structures.
-From mathcomp Require Import boot order algebra finmap.
-From mathcomp Require Import mathcomp_extra boolp classical_sets.
-From mathcomp Require Import functions cardinality fsbigop reals.
-From mathcomp Require Import interval_inference ereal topology normedtype.
-From mathcomp Require Import sequences esum numfun.
+From mathcomp Require Import boot order algebra interval_inference finmap.
+From mathcomp Require Import boolp classical_sets functions cardinality fsbigop
+  reals.
+From mathcomp Require Import topology ereal normedtype sequences esum numfun.
 From mathcomp Require Import measurable_structure measure_function.
 
 (**md**************************************************************************)

--- a/theories/measure_theory/measure_function.v
+++ b/theories/measure_theory/measure_function.v
@@ -1,11 +1,10 @@
 (* mathcomp analysis (c) 2026 Inria and AIST. License: CeCILL-C.              *)
 From HB Require Import structures.
-From mathcomp Require Import boot order algebra finmap.
+From mathcomp Require Import boot order algebra interval_inference finmap.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
 From mathcomp Require Import boolp classical_sets functions cardinality fsbigop.
-From mathcomp Require Import reals interval_inference ereal topology normedtype.
-From mathcomp Require Import sequences esum.
+From mathcomp Require Import reals ereal topology normedtype sequences esum.
 From mathcomp Require Import measurable_structure measurable_function.
 
 (**md**************************************************************************)

--- a/theories/measure_theory/signed_measure.v
+++ b/theories/measure_theory/signed_measure.v
@@ -4,10 +4,10 @@ From mathcomp Require Import boot order ssralg ssrnum ssrint interval.
 From mathcomp Require Import interval_inference finmap fingroup perm rat.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import mathcomp_extra boolp classical_sets cardinality.
-From mathcomp Require Import functions fsbigop set_interval reals ereal.
-From mathcomp Require Import topology numfun normedtype derive sequences esum.
-From mathcomp Require Import measurable_structure measurable_function.
+From mathcomp Require Import boolp classical_sets cardinality functions fsbigop.
+From mathcomp Require Import set_interval reals.
+From mathcomp Require Import topology ereal numfun normedtype derive sequences.
+From mathcomp Require Import esum measurable_structure measurable_function.
 From mathcomp Require Import measure_function measure_negligible.
 
 (**md**************************************************************************)

--- a/theories/normedtype_theory/ereal_normedtype.v
+++ b/theories/normedtype_theory/ereal_normedtype.v
@@ -1,9 +1,9 @@
 (* mathcomp analysis (c) 2026 Inria and AIST. License: CeCILL-C.              *)
 From HB Require Import structures.
-From mathcomp Require Import boot order ssralg ssrnum interval.
-From mathcomp Require Import interval_inference.
-From mathcomp Require Import boolp classical_sets ereal reals topology.
-From mathcomp Require Import real_interval num_normedtype.
+From mathcomp Require Import boot order ssralg ssrnum interval
+  interval_inference.
+From mathcomp Require Import boolp classical_sets ereal reals real_interval.
+From mathcomp Require Import topology ereal num_normedtype.
 
 (**md**************************************************************************)
 (* # Preliminaries for norm-related notions                                   *)
@@ -41,7 +41,7 @@ Local Open Scope classical_set_scope.
 Local Open Scope ring_scope.
 
 Section limf_esup_einf.
-Variables (T : choiceType) (X : filteredType T) (R : realFieldType).
+Context {T : choiceType} {X : filteredType T} {R : realFieldType}.
 Implicit Types (f : X -> \bar R) (F : set_system X).
 Local Open Scope ereal_scope.
 

--- a/theories/normedtype_theory/normed_module.v
+++ b/theories/normedtype_theory/normed_module.v
@@ -1,13 +1,14 @@
 (* mathcomp analysis (c) 2026 Inria and AIST. License: CeCILL-C.              *)
 From HB Require Import structures.
-From mathcomp Require Import boot order finmap ssralg ssrnum ssrint.
-From mathcomp Require Import archimedean rat interval zmodp vector.
+From mathcomp Require Import boot order finmap ssralg ssrnum ssrint
+  interval_inference archimedean rat interval zmodp vector.
 #[warning="-warn-library-file-internal-analysis"]
-From mathcomp Require Import mathcomp_extra unstable.
-From mathcomp Require Import boolp classical_sets filter functions cardinality.
-From mathcomp Require Import set_interval ereal reals topology real_interval.
-From mathcomp Require Import convex prodnormedzmodule tvs num_normedtype.
-From mathcomp Require Import ereal_normedtype pseudometric_normed_Zmodule.
+From mathcomp Require Import unstable.
+From mathcomp Require Import boolp classical_sets filter functions cardinality
+  set_interval.
+From mathcomp Require Import reals real_interval ereal topology convex
+  prodnormedzmodule tvs num_normedtype ereal_normedtype
+  pseudometric_normed_Zmodule.
 
 (**md**************************************************************************)
 (* # Normed modules                                                           *)

--- a/theories/normedtype_theory/num_normedtype.v
+++ b/theories/normedtype_theory/num_normedtype.v
@@ -3,7 +3,7 @@ From mathcomp Require Import boot order finmap ssralg ssrnum ssrint.
 From mathcomp Require Import interval interval_inference archimedean rat.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import mathcomp_extra boolp classical_sets functions.
+From mathcomp Require Import boolp classical_sets functions.
 From mathcomp Require Import cardinality set_interval reals real_interval.
 From mathcomp Require Import topology prodnormedzmodule.
 

--- a/theories/normedtype_theory/urysohn.v
+++ b/theories/normedtype_theory/urysohn.v
@@ -5,9 +5,9 @@ From mathcomp Require Import interval interval_inference archimedean.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
 From mathcomp Require Import boolp classical_sets functions cardinality.
-From mathcomp Require Import set_interval ereal reals topology tvs.
-From mathcomp Require Import num_normedtype pseudometric_normed_Zmodule.
-From mathcomp Require Import normed_module.
+From mathcomp Require Import set_interval reals.
+From mathcomp Require Import topology ereal tvs num_normedtype.
+From mathcomp Require Import pseudometric_normed_Zmodule normed_module.
 
 (**md**************************************************************************)
 (* # Urysohn's lemma                                                          *)

--- a/theories/numfun.v
+++ b/theories/numfun.v
@@ -4,9 +4,9 @@ From mathcomp Require Import boot order ssralg ssrnum ssrint interval.
 From mathcomp Require Import interval_inference finmap.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import mathcomp_extra boolp classical_sets fsbigop.
-From mathcomp Require Import functions cardinality set_interval reals ereal.
-From mathcomp Require Import topology normedtype sequences.
+From mathcomp Require Import boolp classical_sets fsbigop functions cardinality
+  set_interval reals.
+From mathcomp Require Import topology ereal normedtype sequences.
 
 (**md**************************************************************************)
 (* # Numerical functions                                                      *)

--- a/theories/pi_irrational.v
+++ b/theories/pi_irrational.v
@@ -1,10 +1,8 @@
 (* mathcomp analysis (c) 2026 Inria and AIST. License: CeCILL-C.              *)
-From mathcomp Require Import boot order algebra.
-From mathcomp Require Import interval_inference.
-From mathcomp Require Import mathcomp_extra boolp classical_sets.
-From mathcomp Require Import functions cardinality fsbigop.
-From mathcomp Require Import reals ereal topology normedtype sequences.
-From mathcomp Require Import real_interval esum measure measurable_realfun.
+From mathcomp Require Import boot order algebra interval_inference.
+From mathcomp Require Import boolp classical_sets functions cardinality fsbigop.
+From mathcomp Require Import reals real_interval topology ereal normedtype.
+From mathcomp Require Import sequences esum measure measurable_realfun.
 From mathcomp Require Import numfun realfun lebesgue_measure lebesgue_integral.
 From mathcomp Require Import derive ftc trigo.
 

--- a/theories/probability_theory/bernoulli_distribution.v
+++ b/theories/probability_theory/bernoulli_distribution.v
@@ -4,9 +4,8 @@ From mathcomp Require Import boot order ssralg ssrnum ssrint interval.
 From mathcomp Require Import archimedean finmap interval_inference.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import mathcomp_extra.
 From mathcomp Require Import boolp classical_sets functions cardinality fsbigop.
-From mathcomp Require Import reals ereal topology normedtype sequences esum.
+From mathcomp Require Import reals topology ereal normedtype sequences esum.
 From mathcomp Require Import measure numfun measurable_realfun lebesgue_measure.
 From mathcomp Require Import lebesgue_integral kernel.
 

--- a/theories/probability_theory/beta_distribution.v
+++ b/theories/probability_theory/beta_distribution.v
@@ -4,9 +4,8 @@ From mathcomp Require Import boot order ssralg poly ssrnum ssrint.
 From mathcomp Require Import archimedean finmap interval interval_inference.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import mathcomp_extra.
 From mathcomp Require Import boolp classical_sets functions cardinality fsbigop.
-From mathcomp Require Import reals ereal topology normedtype sequences derive.
+From mathcomp Require Import reals topology ereal normedtype sequences derive.
 From mathcomp Require Import measure exp numfun realfun measurable_realfun.
 From mathcomp Require Import lebesgue_measure lebesgue_integral ftc.
 From mathcomp Require Import uniform_distribution bernoulli_distribution.

--- a/theories/probability_theory/binomial_distribution.v
+++ b/theories/probability_theory/binomial_distribution.v
@@ -4,9 +4,8 @@ From mathcomp Require Import boot order ssralg ssrnum ssrint interval.
 From mathcomp Require Import archimedean finmap interval_inference.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import mathcomp_extra.
 From mathcomp Require Import boolp classical_sets functions cardinality fsbigop.
-From mathcomp Require Import reals ereal topology normedtype sequences esum.
+From mathcomp Require Import reals topology ereal normedtype sequences esum.
 From mathcomp Require Import measure measurable_realfun lebesgue_measure.
 From mathcomp Require Import lebesgue_integral bernoulli_distribution.
 

--- a/theories/realfun.v
+++ b/theories/realfun.v
@@ -4,10 +4,10 @@ From mathcomp Require Import boot order finmap ssralg ssrnum ssrint.
 From mathcomp Require Import archimedean interval interval_inference.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import mathcomp_extra boolp classical_sets functions.
-From mathcomp Require Import cardinality contra reals convex ereal.
-From mathcomp Require Import topology prodnormedzmodule tvs normedtype derive.
-From mathcomp Require Import sequences real_interval numfun.
+From mathcomp Require Import boolp classical_sets functions cardinality contra.
+From mathcomp Require Import reals convex.
+From mathcomp Require Import topology ereal prodnormedzmodule tvs normedtype.
+From mathcomp Require Import derive sequences real_interval numfun.
 
 (**md**************************************************************************)
 (* # Real-valued functions over reals                                         *)

--- a/theories/sequences.v
+++ b/theories/sequences.v
@@ -4,9 +4,9 @@ From mathcomp Require Import boot order ssralg ssrnum ssrint.
 From mathcomp Require Import interval interval_inference archimedean.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import mathcomp_extra boolp contra classical_sets.
-From mathcomp Require Import functions cardinality set_interval reals.
-From mathcomp Require Import ereal topology tvs normedtype landau.
+From mathcomp Require Import boolp contra classical_sets functions cardinality
+  set_interval reals.
+From mathcomp Require Import topology ereal tvs normedtype landau.
 
 (**md**************************************************************************)
 (* # Definitions and lemmas about sequences                                   *)

--- a/theories/showcase/pnt.v
+++ b/theories/showcase/pnt.v
@@ -1,9 +1,9 @@
-From mathcomp Require Import boot order ssralg ssrnum ssrint interval.
+From mathcomp Require Import boot order ssralg ssrnum ssrint interval
+  interval_inference.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
 From mathcomp Require Import classical_sets boolp topology.
-From mathcomp Require Import ereal sequences reals.
-Import Order.POrderTheory GRing.Theory Num.Theory.
+From mathcomp Require Import reals ereal sequences.
 
 (**md**************************************************************************)
 (* # The Prime Number Theorem                                                 *)
@@ -26,6 +26,8 @@ Unset Printing Implicit Defensive.
 Local Open Scope classical_set_scope.
 Local Open Scope set_scope.
 Local Open Scope nat_scope.
+
+Import Order.POrderTheory GRing.Theory Num.Theory.
 
 Section prime_seq.
 

--- a/theories/topology_theory/function_spaces.v
+++ b/theories/topology_theory/function_spaces.v
@@ -1,16 +1,14 @@
 (* mathcomp analysis (c) 2026 Inria and AIST. License: CeCILL-C.              *)
 From HB Require Import structures.
-From mathcomp Require Import boot order algebra finmap.
-From mathcomp Require Import generic_quotient.
+From mathcomp Require Import boot order algebra interval_inference.
+From mathcomp Require Import generic_quotient finmap.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import mathcomp_extra boolp classical_sets functions.
-From mathcomp Require Import cardinality fsbigop reals interval_inference.
-From mathcomp Require Import topology_structure uniform_structure.
-From mathcomp Require Import supremum_topology initial_topology.
-From mathcomp Require Import pseudometric_structure separation_axioms.
-From mathcomp Require Import compact connected subspace_topology.
-From mathcomp Require Import product_topology.
+From mathcomp Require Import boolp classical_sets functions cardinality fsbigop.
+From mathcomp Require Import reals.
+From mathcomp Require Import topology_structure uniform_structure
+  supremum_topology initial_topology pseudometric_structure separation_axioms
+  compact connected subspace_topology product_topology.
 
 (**md**************************************************************************)
 (* # The topology of functions spaces                                         *)

--- a/theories/topology_theory/metric_structure.v
+++ b/theories/topology_theory/metric_structure.v
@@ -5,10 +5,9 @@ From mathcomp Require Import interval_inference rat interval zmodp vector.
 From mathcomp Require Import fieldext falgebra archimedean finmap.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import mathcomp_extra boolp classical_sets.
-From mathcomp Require Import contra reals topology_structure.
-From mathcomp Require Import uniform_structure pseudometric_structure.
-From mathcomp Require Import num_topology product_topology separation_axioms.
+From mathcomp Require Import boolp classical_sets contra reals.
+From mathcomp Require Import topology_structure uniform_structure
+  pseudometric_structure num_topology product_topology separation_axioms.
 
 (**md**************************************************************************)
 (* # Metric spaces                                                            *)

--- a/theories/topology_theory/separation_axioms.v
+++ b/theories/topology_theory/separation_axioms.v
@@ -1,14 +1,12 @@
 (* mathcomp analysis (c) 2026 Inria and AIST. License: CeCILL-C.              *)
 From HB Require Import structures.
-From mathcomp Require Import boot order algebra finmap.
+From mathcomp Require Import boot order algebra interval_inference finmap.
 From mathcomp Require Import boolp classical_sets functions wochoice.
-From mathcomp Require Import cardinality fsbigop.
-From mathcomp Require Import set_interval filter reals interval_inference.
-From mathcomp Require Import topology_structure compact subspace_topology.
-From mathcomp Require Import discrete_topology order_topology.
-From mathcomp Require Import pseudometric_structure num_topology.
-From mathcomp Require Import one_point_compactification uniform_structure.
-From mathcomp Require Import connected supremum_topology sigT_topology.
+From mathcomp Require Import cardinality fsbigop set_interval filter reals.
+From mathcomp Require Import topology_structure compact subspace_topology
+  discrete_topology order_topology pseudometric_structure num_topology
+  one_point_compactification uniform_structure connected supremum_topology
+  sigT_topology.
 
 (**md**************************************************************************)
 (* # Separation Axioms                                                        *)
@@ -59,7 +57,6 @@ Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
 Import Order.TTheory GRing.Theory Num.Theory.
-From mathcomp Require Import mathcomp_extra.
 Local Open Scope classical_set_scope.
 Local Open Scope ring_scope.
 

--- a/theories/trigo.v
+++ b/theories/trigo.v
@@ -1,11 +1,11 @@
 (* mathcomp analysis (c) 2026 Inria and AIST. License: CeCILL-C.              *)
 From HB Require Import structures.
-From mathcomp Require Import boot order ssralg ssrint ssrnum matrix.
-From mathcomp Require Import interval rat.
+From mathcomp Require Import boot order ssralg ssrint ssrnum matrix
+  interval_inference interval rat.
 #[warning="-warn-library-file-internal-analysis"]
 From mathcomp Require Import unstable.
-From mathcomp Require Import mathcomp_extra boolp classical_sets functions.
-From mathcomp Require Import reals ereal interval_inference topology normedtype.
+From mathcomp Require Import boolp classical_sets functions.
+From mathcomp Require Import reals topology ereal normedtype.
 From mathcomp Require Import landau sequences derive realfun exp realfun.
 From mathcomp Require Import measure lebesgue_measure lebesgue_integral ftc.
 


### PR DESCRIPTION
##### Motivation for this change

Rename `mathcomp_extra.v` to `mathcomp_compat.v` as discussed on zulip.
In the process, make the imports a bit more systematic.
For example, `interval_inference.v` is systematically put together with the MathComp imports,
not importing `lebesgue_stieltjes_measure.v` or `constructive_ereal.v`
when resp. `lebesgue_measure.v` or `ereal.v` is already imported.
Also it looks like `interval_inference.v` was exported by mistake,
this PR fixes it.

##### Checklist

- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- rebasing often messes with CHANGELOG_UNRELEASED.md -->
<!-- consider using a temporary CHANGELOG_PR1234.md instead -->
<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [ ] added corresponding documentation in the headers~~

Reference: [How to document](https://github.com/math-comp/math-comp/wiki/How-to-document)

<!-- Cross-out the above items using ~crossed out item~ when irrelevant -->

##### Merge policy

As a rule of thumb:
- PRs with several commits that make sense individually and that
  all compile are preferentially merged into master.
- PRs with disorganized commits are very likely to be squash-rebased.

##### Reminder to reviewers

- Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs)
- Put a milestone if possible
- Check labels
